### PR TITLE
Add Claude agent automation for vertical slice development

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,69 @@
+name: Agent Task
+description: Feature request for automated implementation by Claude Code agent. Must be a vertical slice (Core + ViewModel + View + Tests).
+title: "[Agent] "
+labels: ["agent-task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue will be automatically picked up by the Claude Code agent.
+        The agent will implement a **complete vertical slice**: core logic, ViewModel, UI panel, and tests.
+        Just describe what you want — the agent handles the rest.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature should be implemented? Describe the desired behavior.
+      placeholder: |
+        Example: Calculate and display total loss budget from inputs to outputs,
+        helping identify bottlenecks and feasibility issues early.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Concrete, testable criteria. The agent will use these to verify completeness.
+      placeholder: |
+        - [ ] Calculate min/max/average loss for all input-to-output paths
+        - [ ] Display results in a panel in the UI
+        - [ ] Export results to CSV
+    validations:
+      required: true
+
+  - type: textarea
+    id: technical-notes
+    attributes:
+      label: Technical Notes
+      description: |
+        Optional hints for the agent: relevant files, existing code to reuse,
+        related classes, or suggested approach.
+      placeholder: |
+        - Use existing WaveguideConnection.TotalLossDb for loss data
+        - Follow ParameterSweepViewModel pattern for the UI panel
+        - See SimulationIntegrationTests.cs for integration test examples
+    validations:
+      required: false
+
+  - type: textarea
+    id: strategic-fit
+    attributes:
+      label: Strategic Fit
+      description: How does this feature support the tool's purpose of architecture exploration?
+      placeholder: "Answers the question: is this architecture feasible?"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: complexity
+    attributes:
+      label: Estimated Complexity
+      description: Helps the agent plan its approach.
+      options:
+        - Small (1-2 new files per layer)
+        - Medium (3-5 new files per layer)
+        - Large (6+ files, cross-cutting changes)
+    validations:
+      required: false

--- a/.github/workflows/claude-agent.yaml
+++ b/.github/workflows/claude-agent.yaml
@@ -1,0 +1,94 @@
+name: Claude Agent - Issue Implementation
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  implement-issue:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'agent-task') ||
+      (github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened') &&
+       contains(toJSON(github.event.issue.labels.*.name), 'agent-task'))
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Run Claude Code Agent
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          label_trigger: "agent-task"
+          prompt: |
+            You are implementing issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}
+
+            IMPORTANT: Read CLAUDE.md first. It contains the project conventions, architecture
+            patterns, and the CRITICAL vertical slice requirement.
+
+            ## Issue Body
+            ${{ github.event.issue.body }}
+
+            ## Your Task
+            Implement a COMPLETE VERTICAL SLICE for this issue. This means:
+
+            1. Core logic in Connect-A-Pic-Core/ (interface-first, max 250 lines/file)
+            2. ViewModel in CAP.Avalonia/ViewModels/ (ObservableObject with [ObservableProperty])
+            3. View/AXAML UI in CAP.Avalonia/Views/ or MainWindow.axaml right panel
+            4. DI wiring in CAP.Avalonia/App.axaml.cs if new services are needed
+            5. Unit tests in UnitTests/ for core logic
+            6. Integration tests in UnitTests/Integration/ for Core→ViewModel data flow
+
+            ## Code Quality
+            - Max 250 lines per file (split into smaller classes if needed)
+            - Follow SOLID principles (see CLAUDE.md for details)
+            - Clean Code: meaningful names, small methods, no magic numbers
+
+            ## Before Creating the PR
+            - Run: dotnet build
+            - Run: dotnet test ./UnitTests/UnitTests.csproj --logger:trx
+            - Both must pass with zero failures
+
+            ## PR Requirements
+            - Branch name: feature/issue-${{ github.event.issue.number }}-<short-description>
+            - PR body must include: Closes #${{ github.event.issue.number }}
+            - PR body must list what was implemented at each layer
+            - PR body must describe how to manually test the feature in the UI
+
+      - name: Label PR with agent-pr
+        if: always() && steps.claude.outputs.branch_name
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create label if it doesn't exist
+          gh label create agent-pr \
+            --description "PR created by Claude Code agent" \
+            --color "7057ff" 2>/dev/null || true
+
+          # Find and label the PR
+          PR_NUMBER=$(gh pr list \
+            --head "${{ steps.claude.outputs.branch_name }}" \
+            --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" --add-label "agent-pr"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,217 @@
+# CLAUDE.md — Instructions for Claude Code Agent
+
+## CRITICAL: Vertical Slice Requirement
+
+**Every feature implementation MUST be a complete vertical slice.**
+Do NOT submit backend-only or core-only code. Every PR must include user-testable UI.
+
+A complete vertical slice includes ALL of these layers:
+
+1. **Core logic** — New classes in `Connect-A-Pic-Core/` (interface-first design)
+2. **ViewModel** — `ObservableObject` in `CAP.Avalonia/ViewModels/` with `[ObservableProperty]` and `[RelayCommand]`
+3. **View / AXAML** — UI panel in `CAP.Avalonia/Views/` or a new section in `MainWindow.axaml`
+4. **DI wiring** — Register new services in `CAP.Avalonia/App.axaml.cs` if needed
+5. **Unit tests** — xUnit tests in `UnitTests/` for core logic
+6. **Integration tests** — Core + ViewModel integration tests in `UnitTests/Integration/`
+
+## Code Quality Rules
+
+- **Max 250 lines per file** — If a class exceeds 250 lines, split it into smaller, focused classes
+- **SOLID principles**:
+  - Single Responsibility: Each class has one reason to change
+  - Open/Closed: Extend via interfaces, not modification
+  - Liskov Substitution: Subtypes must be substitutable for base types
+  - Interface Segregation: Prefer small, focused interfaces
+  - Dependency Inversion: Depend on abstractions (inject interfaces, not concrete classes)
+- **Clean Code**:
+  - Meaningful, descriptive names (no abbreviations except well-known ones like `VM`, `DI`)
+  - Small methods (max ~20 lines per method)
+  - No magic numbers — use named constants
+  - No deep nesting (max 2-3 levels)
+  - Prefer early returns over nested if/else
+
+## Project Structure
+
+```
+Connect-A-Pic-Core/          # Core simulation engine (no UI dependencies)
+├── Components/              # Component models, pins, S-matrices, parametric
+├── Routing/                 # Waveguide routing, A* pathfinding
+├── LightCalculation/        # S-Matrix propagation, power flow analysis
+├── Analysis/                # Parameter sweep, sweep configuration
+├── Grid/                    # Component placement, connection management
+├── ExternalPorts/           # Light source configuration
+└── Helpers/                 # Utilities, collections
+
+CAP_Contracts/               # Shared interfaces (IDataAccessor, ILogger)
+
+CAP-DataAccess/              # JSON persistence, PDK loading
+├── Components/ComponentDraftMapper/  # PdkLoader, DTOs
+└── PDKs/                    # PDK JSON files (demo-pdk.json)
+
+CAP.Avalonia/                # Shared cross-platform UI
+├── ViewModels/              # MVVM ViewModels (MainViewModel, DesignCanvasViewModel, etc.)
+├── Views/                   # AXAML views (MainWindow.axaml, MainView.axaml)
+├── Commands/                # Undo/redo commands (IUndoableCommand, CommandManager)
+├── Services/                # SimulationService, SimpleNazcaExporter, FileDialogService
+├── Controls/                # Custom controls (DesignCanvas)
+└── Visualization/           # Power flow rendering
+
+CAP.Desktop/                 # Desktop entry point (Program.cs)
+CAP.Browser/                 # WebAssembly entry point (planned)
+UnitTests/                   # xUnit test suite
+```
+
+## Architecture Patterns
+
+### MVVM (CommunityToolkit.Mvvm)
+
+ViewModels inherit `ObservableObject`. Use source generators:
+
+```csharp
+public partial class MyFeatureViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _resultText = "";
+
+    [ObservableProperty]
+    private bool _isProcessing;
+
+    // Auto-generates OnResultTextChanged partial method
+    partial void OnResultTextChanged(string value) { }
+
+    [RelayCommand]
+    private async Task RunAnalysis() { }
+}
+```
+
+Reference: `CAP.Avalonia/ViewModels/ParameterSweepViewModel.cs`
+
+### Dependency Injection
+
+All services registered as singletons in `CAP.Avalonia/App.axaml.cs`:
+
+```csharp
+services.AddSingleton<SimulationService>();
+services.AddSingleton<MyNewService>();
+services.AddSingleton<MainViewModel>();
+```
+
+Use constructor injection. Access via `App.Services` only in code-behind when needed.
+
+### Command Pattern (Undo/Redo)
+
+Implement `IUndoableCommand` (in `CAP.Avalonia/Commands/ICommand.cs`):
+
+```csharp
+public class MyCommand : IUndoableCommand
+{
+    public string Description => "My action";
+    public void Execute() { }
+    public void Undo() { }
+}
+```
+
+Execute via `CommandManager.ExecuteCommand(cmd)`.
+
+### Views (Avalonia AXAML)
+
+- Use `x:DataType="vm:YourViewModel"` for compiled bindings
+- MainWindow layout: DockPanel with Top=toolbar, Bottom=status, Left=library, Right=properties, Center=canvas
+- New feature panels go in the Right panel (properties area) as collapsible sections
+- Follow the Parameter Sweep panel pattern in `MainWindow.axaml` (lines 193-229)
+
+### Unit Tests
+
+- xUnit with `[Fact]` and `[Theory]` attributes
+- Shouldly for assertions: `result.ShouldBe(expected)`, `value.ShouldBeGreaterThan(0)`
+- Moq for mocking: `new Mock<ILightCalculator>()`
+- Test helpers in `UnitTests/Helpers/TestComponentFactory.cs`
+- Reference: `UnitTests/Analysis/ParameterSweeperTests.cs`
+
+### Integration Tests (Core + ViewModel)
+
+Test that core services produce correct data and ViewModels expose it properly:
+
+```csharp
+[Fact]
+public void ViewModel_ReflectsCoreAnalysisResults()
+{
+    var coreService = new MyAnalyzer();
+    var vm = new MyFeatureViewModel(coreService);
+    vm.RunAnalysisCommand.Execute(null);
+    vm.ResultText.ShouldNotBeNullOrEmpty();
+}
+```
+
+Reference: `UnitTests/Simulation/SimulationIntegrationTests.cs`
+
+## Recipe: Adding a New Feature Panel
+
+Follow this step-by-step when implementing a new analysis/diagnostic feature:
+
+1. **Define interface** in `Connect-A-Pic-Core/` (e.g., `IMyAnalyzer`)
+2. **Implement core class** in `Connect-A-Pic-Core/Analysis/MyAnalyzer.cs` (max 250 lines)
+3. **Create ViewModel** in `CAP.Avalonia/ViewModels/MyFeatureViewModel.cs`
+   - Inherit `ObservableObject`
+   - Use `[ObservableProperty]` for bindable state
+   - Use `[RelayCommand]` for actions
+   - Follow `ParameterSweepViewModel` pattern
+4. **Add ViewModel as property** on `MainViewModel`:
+   ```csharp
+   public MyFeatureViewModel MyFeature { get; } = new();
+   ```
+5. **Add AXAML panel** in `MainWindow.axaml` right panel section:
+   ```xml
+   <StackPanel IsVisible="{Binding SomeCondition}">
+       <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
+       <TextBlock Text="My Feature:" Foreground="LightBlue" FontWeight="SemiBold"/>
+       <!-- UI elements bound to MyFeature.* -->
+   </StackPanel>
+   ```
+6. **Register in DI** (`App.axaml.cs`) if the core class needs to be a service
+7. **Write unit tests** in `UnitTests/` for the core analyzer class
+8. **Write integration test** in `UnitTests/Integration/` testing Core→ViewModel data flow
+
+## Build and Verify
+
+Always run before creating a PR:
+
+```bash
+dotnet build
+dotnet test ./UnitTests/UnitTests.csproj --logger:trx
+```
+
+## Branch and PR Conventions
+
+- **Branch naming**: `feature/issue-{number}-short-description`
+  - Example: `feature/issue-42-loss-budget-analyzer`
+- **PR body must include**:
+  - `Closes #{issue_number}`
+  - Vertical slice checklist (which layers were implemented)
+  - How to manually test the feature in the UI
+
+## Key File Reference
+
+| Purpose | Path |
+|---------|------|
+| DI container setup | `CAP.Avalonia/App.axaml.cs` |
+| Main ViewModel | `CAP.Avalonia/ViewModels/MainViewModel.cs` |
+| Main Window layout | `CAP.Avalonia/Views/MainWindow.axaml` |
+| Canvas ViewModel | `CAP.Avalonia/ViewModels/DesignCanvasViewModel.cs` |
+| Canvas control | `CAP.Avalonia/Controls/DesignCanvas.cs` |
+| Simulation service | `CAP.Avalonia/Services/SimulationService.cs` |
+| Command interfaces | `CAP.Avalonia/Commands/ICommand.cs` |
+| Command manager | `CAP.Avalonia/Commands/CommandManager.cs` |
+| Example ViewModel | `CAP.Avalonia/ViewModels/ParameterSweepViewModel.cs` |
+| Test helpers | `UnitTests/Helpers/TestComponentFactory.cs` |
+| Example unit tests | `UnitTests/Analysis/ParameterSweeperTests.cs` |
+| Example integration tests | `UnitTests/Simulation/SimulationIntegrationTests.cs` |
+| PDK data | `CAP-DataAccess/PDKs/demo-pdk.json` |
+
+## Setup Requirements
+
+To enable the automated agent workflow:
+
+1. Add `ANTHROPIC_API_KEY` to repository secrets (Settings > Secrets > Actions)
+2. Install Claude GitHub App: https://github.com/apps/claude
+3. Create `agent-pr` label: `gh label create agent-pr --description "PR created by Claude agent" --color "7057ff"`


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Agent instruction file that enforces vertical slice requirements (Core + ViewModel + View + Tests), SOLID principles, 250-line file limit, and documents all architecture patterns with concrete examples
- **claude-agent.yaml**: GitHub Actions workflow using `anthropics/claude-code-action@v1` that triggers automatically when issues are labeled `agent-task`. Passes issue context + vertical slice instructions to Claude, which creates feature branches and PRs
- **agent-task.yml**: GitHub issue form template with structured fields (description, acceptance criteria, technical notes, complexity) that auto-applies the `agent-task` label

## How It Works
1. Create an issue using the "Agent Task" template on GitHub
2. The workflow triggers automatically (on `agent-task` label)
3. Claude reads CLAUDE.md, implements a full vertical slice, runs build+tests, and opens a PR labeled `agent-pr`

## Setup Required
After merging, you need to:
1. Add `ANTHROPIC_API_KEY` to repository secrets (Settings > Secrets > Actions)
2. Install the [Claude GitHub App](https://github.com/apps/claude)
3. The `agent-pr` label is auto-created by the workflow on first run

## Test plan
- [x] Merge this PR
- [ ] Add `ANTHROPIC_API_KEY` secret to repo
- [ ] Install Claude GitHub App
- [ ] Create a test issue using the "Agent Task" template
- [ ] Verify the workflow triggers and Claude creates a PR with all vertical slice layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)