### PR TITLE
Agent: [Agent] Export routed waveguide paths as Nazca bend/straight segments

### DIFF
--- a/CAP.Avalonia/CAP.Avalonia.csproj
+++ b/CAP.Avalonia/CAP.Avalonia.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.1" />
     <PackageReference Include="Avalonia.Skia" Version="11.2.1" />

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using CAP.Avalonia.ViewModels;
 using CAP_Core.Components;
+using CAP_Core.Routing;
 
 namespace CAP.Avalonia.Services;
 
@@ -11,11 +12,23 @@ namespace CAP.Avalonia.Services;
 /// </summary>
 public class SimpleNazcaExporter
 {
+    /// <summary>
+    /// Exports the full design to a Python/Nazca script.
+    /// </summary>
     public string Export(DesignCanvasViewModel canvas)
     {
         var sb = new StringBuilder();
 
-        // Header
+        AppendHeader(sb);
+        var componentNames = AppendComponents(sb, canvas);
+        AppendConnections(sb, canvas, componentNames);
+        AppendFooter(sb);
+
+        return sb.ToString();
+    }
+
+    private static void AppendHeader(StringBuilder sb)
+    {
         sb.AppendLine("import nazca as nd");
         sb.AppendLine("from nazca.interconnects import Interconnect");
         sb.AppendLine();
@@ -29,8 +42,11 @@ public class SimpleNazcaExporter
         sb.AppendLine("def create_design():");
         sb.AppendLine("    with nd.Cell(name='ConnectAPIC_Design') as design:");
         sb.AppendLine();
+    }
 
-        // Export components
+    private static Dictionary<Component, string> AppendComponents(
+        StringBuilder sb, DesignCanvasViewModel canvas)
+    {
         sb.AppendLine("        # Components");
         var componentNames = new Dictionary<Component, string>();
         int compIndex = 0;
@@ -50,54 +66,131 @@ public class SimpleNazcaExporter
         }
 
         sb.AppendLine();
+        return componentNames;
+    }
 
-        // Export connections
-        if (canvas.Connections.Count > 0)
+    private static void AppendConnections(
+        StringBuilder sb,
+        DesignCanvasViewModel canvas,
+        Dictionary<Component, string> componentNames)
+    {
+        if (canvas.Connections.Count == 0)
+            return;
+
+        sb.AppendLine("        # Waveguide Connections");
+        foreach (var connVm in canvas.Connections)
         {
-            sb.AppendLine("        # Waveguide Connections");
-            foreach (var connVm in canvas.Connections)
+            var conn = connVm.Connection;
+            var segments = conn.GetPathSegments();
+
+            if (segments.Count > 0)
             {
-                var conn = connVm.Connection;
-                var startComp = conn.StartPin.ParentComponent;
-                var endComp = conn.EndPin.ParentComponent;
-
-                if (componentNames.TryGetValue(startComp, out var startName) &&
-                    componentNames.TryGetValue(endComp, out var endName))
-                {
-                    var startPin = conn.StartPin.Name;
-                    var endPin = conn.EndPin.Name;
-
-                    sb.AppendLine($"        ic.strt_p2p({startName}.pin['{startPin}'], {endName}.pin['{endPin}']).put()");
-                }
+                AppendSegmentExport(sb, segments);
             }
-            sb.AppendLine();
+            else
+            {
+                AppendFallbackExport(sb, conn, componentNames);
+            }
         }
+        sb.AppendLine();
+    }
 
+    /// <summary>
+    /// Appends segment-by-segment Nazca export for a routed connection.
+    /// </summary>
+    internal static void AppendSegmentExport(
+        StringBuilder sb, IReadOnlyList<PathSegment> segments)
+    {
+        foreach (var segment in segments)
+        {
+            sb.AppendLine(FormatSegment(segment));
+        }
+    }
+
+    /// <summary>
+    /// Formats a single path segment as a Nazca Python call.
+    /// </summary>
+    internal static string FormatSegment(PathSegment segment)
+    {
+        var ci = CultureInfo.InvariantCulture;
+
+        return segment switch
+        {
+            StraightSegment straight => FormatStraightSegment(straight, ci),
+            BendSegment bend => FormatBendSegment(bend, ci),
+            _ => $"        # Unknown segment type: {segment.GetType().Name}"
+        };
+    }
+
+    private static string FormatStraightSegment(
+        StraightSegment straight, CultureInfo ci)
+    {
+        var length = straight.LengthMicrometers.ToString("F2", ci);
+        var x = straight.StartPoint.X.ToString("F2", ci);
+        var y = straight.StartPoint.Y.ToString("F2", ci);
+        var angle = straight.StartAngleDegrees.ToString("F2", ci);
+
+        return $"        nd.strt(length={length}).put({x}, {y}, {angle})";
+    }
+
+    private static string FormatBendSegment(BendSegment bend, CultureInfo ci)
+    {
+        var radius = bend.RadiusMicrometers.ToString("F2", ci);
+        var sweepAngle = bend.SweepAngleDegrees.ToString("F2", ci);
+        var x = bend.StartPoint.X.ToString("F2", ci);
+        var y = bend.StartPoint.Y.ToString("F2", ci);
+        var angle = bend.StartAngleDegrees.ToString("F2", ci);
+
+        return $"        nd.bend(radius={radius}, angle={sweepAngle}).put({x}, {y}, {angle})";
+    }
+
+    private static void AppendFallbackExport(
+        StringBuilder sb,
+        WaveguideConnection conn,
+        Dictionary<Component, string> componentNames)
+    {
+        var startComp = conn.StartPin.ParentComponent;
+        var endComp = conn.EndPin.ParentComponent;
+
+        if (componentNames.TryGetValue(startComp, out var startName) &&
+            componentNames.TryGetValue(endComp, out var endName))
+        {
+            var startPin = conn.StartPin.Name;
+            var endPin = conn.EndPin.Name;
+
+            sb.AppendLine(
+                $"        ic.sbend_p2p({startName}.pin['{startPin}'], " +
+                $"{endName}.pin['{endPin}']).put()");
+        }
+    }
+
+    private static void AppendFooter(StringBuilder sb)
+    {
         sb.AppendLine("    return design");
         sb.AppendLine();
         sb.AppendLine("# Create and export the design");
         sb.AppendLine("design = create_design()");
         sb.AppendLine("design.put()");
         sb.AppendLine("nd.export_gds()");
-
-        return sb.ToString();
     }
 
-    private string GetNazcaFunction(Component comp)
+    /// <summary>
+    /// Maps a component to its Nazca function call string.
+    /// </summary>
+    internal static string GetNazcaFunction(Component comp)
     {
-        // Map component type to Nazca function
         var name = comp.NazcaFunctionName?.ToLower() ?? comp.Identifier.ToLower();
 
         if (name.Contains("straight") || name.Contains("waveguide"))
             return "nd.strt(length=250)";
         if (name.Contains("splitter") || name.Contains("1x2"))
             return "nd.mmi1x2()";
+        if (name.Contains("grating"))
+            return "nd.grating()";
         if (name.Contains("coupler") || name.Contains("2x2"))
             return "nd.mmi2x2()";
         if (name.Contains("phase") || name.Contains("shifter"))
             return "nd.eopm(length=500)";
-        if (name.Contains("grating"))
-            return "nd.grating()";
         if (name.Contains("detector") || name.Contains("photo"))
             return "nd.pd()";
         if (name.Contains("bend"))
@@ -105,7 +198,6 @@ public class SimpleNazcaExporter
         if (name.Contains("y-junction") || name.Contains("yjunction"))
             return "nd.Yjunction()";
 
-        // Default: generic component
         return $"nd.strt(length={comp.WidthMicrometers.ToString(CultureInfo.InvariantCulture)})";
     }
 }

--- a/UnitTests/Services/SimpleNazcaExporterTests.cs
+++ b/UnitTests/Services/SimpleNazcaExporterTests.cs
@@ -1,0 +1,196 @@
+using CAP.Avalonia.Services;
+using CAP_Core.Components;
+using CAP_Core.Components.FormulaReading;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Services;
+
+/// <summary>
+/// Tests for the SimpleNazcaExporter segment export and component mapping.
+/// </summary>
+public class SimpleNazcaExporterTests
+{
+    [Fact]
+    public void FormatSegment_StraightSegment_OutputsNdStrt()
+    {
+        // Arrange
+        var segment = new StraightSegment(0, 0, 100, 0, 0);
+
+        // Act
+        var result = SimpleNazcaExporter.FormatSegment(segment);
+
+        // Assert
+        result.ShouldContain("nd.strt(length=100.00)");
+        result.ShouldContain(".put(0.00, 0.00, 0.00)");
+    }
+
+    [Fact]
+    public void FormatSegment_BendSegment_OutputsNdBend()
+    {
+        // Arrange
+        var segment = new BendSegment(50, 0, 50, 0, 90);
+
+        // Act
+        var result = SimpleNazcaExporter.FormatSegment(segment);
+
+        // Assert
+        result.ShouldContain("nd.bend(radius=50.00, angle=90.00)");
+        result.ShouldContain(".put(");
+    }
+
+    [Fact]
+    public void FormatSegment_NegativeSweepAngle_PreservesSign()
+    {
+        // Arrange
+        var segment = new BendSegment(50, 0, 25, 180, -90);
+
+        // Act
+        var result = SimpleNazcaExporter.FormatSegment(segment);
+
+        // Assert
+        result.ShouldContain("angle=-90.00");
+        result.ShouldContain("radius=25.00");
+    }
+
+    [Fact]
+    public void AppendSegmentExport_MixedSegments_OutputsAllSegments()
+    {
+        // Arrange
+        var segments = new List<PathSegment>
+        {
+            new StraightSegment(0, 0, 50, 0, 0),
+            new BendSegment(50, 50, 50, 0, 90),
+            new StraightSegment(50, 100, 50, 200, 90)
+        };
+        var sb = new System.Text.StringBuilder();
+
+        // Act
+        SimpleNazcaExporter.AppendSegmentExport(sb, segments);
+        var result = sb.ToString();
+
+        // Assert
+        result.ShouldContain("nd.strt(length=");
+        result.ShouldContain("nd.bend(radius=50.00, angle=90.00)");
+        var strtCount = CountOccurrences(result, "nd.strt(");
+        var bendCount = CountOccurrences(result, "nd.bend(");
+        strtCount.ShouldBe(2);
+        bendCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GetNazcaFunction_GratingCoupler_ReturnsGrating()
+    {
+        // Arrange - a component with "grating coupler" in its name
+        var comp = CreateComponentWithName("grating_coupler");
+
+        // Act
+        var result = SimpleNazcaExporter.GetNazcaFunction(comp);
+
+        // Assert - should map to nd.grating(), NOT nd.mmi2x2()
+        result.ShouldBe("nd.grating()");
+    }
+
+    [Fact]
+    public void GetNazcaFunction_DirectionalCoupler_ReturnsMmi2x2()
+    {
+        // Arrange
+        var comp = CreateComponentWithName("directional_coupler");
+
+        // Act
+        var result = SimpleNazcaExporter.GetNazcaFunction(comp);
+
+        // Assert
+        result.ShouldBe("nd.mmi2x2()");
+    }
+
+    [Fact]
+    public void GetNazcaFunction_Splitter_ReturnsMmi1x2()
+    {
+        var comp = CreateComponentWithName("splitter_1x2");
+        var result = SimpleNazcaExporter.GetNazcaFunction(comp);
+        result.ShouldBe("nd.mmi1x2()");
+    }
+
+    [Fact]
+    public void GetNazcaFunction_PhaseShifter_ReturnsEopm()
+    {
+        var comp = CreateComponentWithName("phase_shifter");
+        var result = SimpleNazcaExporter.GetNazcaFunction(comp);
+        result.ShouldBe("nd.eopm(length=500)");
+    }
+
+    [Fact]
+    public void GetNazcaFunction_Photodetector_ReturnsPd()
+    {
+        var comp = CreateComponentWithName("photodetector");
+        var result = SimpleNazcaExporter.GetNazcaFunction(comp);
+        result.ShouldBe("nd.pd()");
+    }
+
+    [Fact]
+    public void FormatSegment_StraightWithAngle_IncludesAngle()
+    {
+        // Arrange - angled straight segment
+        var angle = 45.0;
+        var segment = new StraightSegment(10, 20, 80.71, 90.71, angle);
+
+        // Act
+        var result = SimpleNazcaExporter.FormatSegment(segment);
+
+        // Assert
+        result.ShouldContain(".put(10.00, 20.00, 45.00)");
+    }
+
+    [Fact]
+    public void FormatSegment_BendWithStartPoint_UsesCorrectCoordinates()
+    {
+        // Arrange
+        var bend = new BendSegment(100, 0, 50, 0, 90);
+
+        // Act
+        var result = SimpleNazcaExporter.FormatSegment(bend);
+
+        // Assert
+        result.ShouldContain("nd.bend(radius=50.00, angle=90.00)");
+        // Start angle should be 0
+        result.ShouldContain(", 0.00)");
+    }
+
+    private static Component CreateComponentWithName(string nazcaFunctionName)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+
+        var component = new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: nazcaFunctionName,
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: nazcaFunctionName,
+            rotationCounterClock: DiscreteRotation.R0
+        );
+
+        component.WidthMicrometers = 50;
+        component.HeightMicrometers = 50;
+
+        return component;
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(pattern, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
Automated implementation for #42

---
*Generated by autonomous agent using Claude Code.*