### PR TITLE
Fix: block rotation when footprint collides, ensure path recalculation

### DIFF
--- a/CAP.Avalonia/Commands/RotateComponentCommand.cs
+++ b/CAP.Avalonia/Commands/RotateComponentCommand.cs
@@ -5,11 +5,13 @@ namespace CAP.Avalonia.Commands;
 
 /// <summary>
 /// Command for rotating a component 90° counter-clockwise.
+/// Rotation is rejected when the rotated footprint would overlap another component.
 /// </summary>
 public class RotateComponentCommand : IUndoableCommand
 {
     private readonly DesignCanvasViewModel _canvas;
     private readonly ComponentViewModel _component;
+    private bool _applied;
 
     public RotateComponentCommand(DesignCanvasViewModel canvas, ComponentViewModel component)
     {
@@ -19,13 +21,34 @@ public class RotateComponentCommand : IUndoableCommand
 
     public string Description => $"Rotate {_component.Name}";
 
+    /// <summary>
+    /// Whether the last Execute() call actually applied the rotation.
+    /// False if the rotation was blocked due to a collision.
+    /// </summary>
+    public bool WasApplied => _applied;
+
     public void Execute()
     {
+        var comp = _component.Component;
+
+        // After 90° CCW rotation, width and height dimensions swap.
+        double rotatedWidth = comp.HeightMicrometers;
+        double rotatedHeight = comp.WidthMicrometers;
+
+        if (!_canvas.CanPlaceComponent(_component.X, _component.Y, rotatedWidth, rotatedHeight, _component))
+        {
+            _applied = false;
+            return;
+        }
+
+        _applied = true;
         RotateComponent90();
     }
 
     public void Undo()
     {
+        if (!_applied) return;
+
         // Rotate 3 times to undo (270° = -90°)
         RotateComponent90();
         RotateComponent90();
@@ -75,7 +98,7 @@ public class RotateComponentCommand : IUndoableCommand
         _component.NotifyDimensionsChanged();
 
         // Update obstacle in pathfinding grid
-        var router = CAP_Core.Components.WaveguideConnection.SharedRouter;
+        var router = WaveguideConnection.SharedRouter;
         router.UpdateComponentObstacle(comp);
 
         // Recalculate paths for any connected waveguides

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -488,7 +488,9 @@ public partial class MainViewModel : ObservableObject
         {
             var cmd = new RotateComponentCommand(Canvas, SelectedComponent);
             CommandManager.ExecuteCommand(cmd);
-            StatusText = $"Rotated: {SelectedComponent.Name}";
+            StatusText = cmd.WasApplied
+                ? $"Rotated: {SelectedComponent.Name}"
+                : $"Cannot rotate: {SelectedComponent.Name} would overlap another component";
         }
     }
 

--- a/UnitTests/Commands/RotateComponentCommandTests.cs
+++ b/UnitTests/Commands/RotateComponentCommandTests.cs
@@ -1,0 +1,143 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels;
+using CAP_Core.Components;
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Commands;
+
+/// <summary>
+/// Tests for <see cref="RotateComponentCommand"/> collision detection and path recalculation.
+/// </summary>
+public class RotateComponentCommandTests
+{
+    /// <summary>
+    /// Verifies that rotation is blocked when the rotated footprint would overlap another component.
+    /// </summary>
+    [Fact]
+    public void Execute_WhenRotatedFootprintCollidesWithNeighbour_RotationIsBlocked()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        // Component A: 100µm × 50µm at (100, 100) — occupies x:[100,200], y:[100,150]
+        var compA = CreateComponent(widthMicrometers: 100, heightMicrometers: 50, x: 100, y: 100);
+        var vmA = canvas.AddComponent(compA);
+
+        // Component B placed so rotated A (50µm × 100µm at (100,100)) would overlap it.
+        // Rotated A would reach y=200. B at y=160 overlaps that range.
+        var compB = CreateComponent(widthMicrometers: 100, heightMicrometers: 100, x: 130, y: 160);
+        canvas.AddComponent(compB);
+
+        var cmd = new RotateComponentCommand(canvas, vmA);
+
+        cmd.Execute();
+
+        cmd.WasApplied.ShouldBeFalse("Rotation must be rejected when the rotated footprint overlaps another component");
+        compA.WidthMicrometers.ShouldBe(100, "Width must remain unchanged when rotation is blocked");
+        compA.HeightMicrometers.ShouldBe(50, "Height must remain unchanged when rotation is blocked");
+    }
+
+    /// <summary>
+    /// Verifies that rotation succeeds when there is no collision in the rotated footprint.
+    /// </summary>
+    [Fact]
+    public void Execute_WhenRotatedFootprintIsFree_RotationSucceeds()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        // Component A: 100µm × 50µm — rotates to 50µm × 100µm
+        var compA = CreateComponent(widthMicrometers: 100, heightMicrometers: 50, x: 100, y: 100);
+        var vmA = canvas.AddComponent(compA);
+
+        // Component B is far away — no overlap with rotated A
+        var compB = CreateComponent(widthMicrometers: 100, heightMicrometers: 100, x: 1000, y: 1000);
+        canvas.AddComponent(compB);
+
+        var cmd = new RotateComponentCommand(canvas, vmA);
+        double originalWidth = compA.WidthMicrometers;
+        double originalHeight = compA.HeightMicrometers;
+
+        cmd.Execute();
+
+        cmd.WasApplied.ShouldBeTrue("Rotation must succeed when space is free");
+        compA.WidthMicrometers.ShouldBe(originalHeight, "Width must equal the original height after 90° rotation");
+        compA.HeightMicrometers.ShouldBe(originalWidth, "Height must equal the original width after 90° rotation");
+    }
+
+    /// <summary>
+    /// Verifies that after a successful rotation, pin positions are updated to reflect
+    /// the new orientation, which triggers path recalculation for connected waveguides.
+    /// </summary>
+    [Fact]
+    public void Execute_AfterSuccessfulRotation_PinPositionsAndRotationStateAreUpdated()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        // Component with a pin at the left edge midpoint (0, 25) of a 100µm × 50µm footprint
+        var physicalPins = new List<PhysicalPin>
+        {
+            new() { Name = "a0", OffsetXMicrometers = 0, OffsetYMicrometers = 25 },
+        };
+        var compA = CreateComponent(widthMicrometers: 100, heightMicrometers: 50, x: 200, y: 200,
+            physicalPins: physicalPins);
+        var vmA = canvas.AddComponent(compA);
+
+        double pinOffsetXBefore = compA.PhysicalPins[0].OffsetXMicrometers;
+        double pinOffsetYBefore = compA.PhysicalPins[0].OffsetYMicrometers;
+
+        var cmd = new RotateComponentCommand(canvas, vmA);
+        cmd.Execute();
+
+        cmd.WasApplied.ShouldBeTrue("Rotation must succeed in free space");
+
+        // RotationDegrees must reflect the 90° CCW rotation
+        compA.RotationDegrees.ShouldBe(90, "RotationDegrees must be updated to 90° after one CCW rotation");
+
+        // Pin offsets must have changed — new positions drive path recalculation
+        double pinOffsetXAfter = compA.PhysicalPins[0].OffsetXMicrometers;
+        double pinOffsetYAfter = compA.PhysicalPins[0].OffsetYMicrometers;
+
+        bool pinMoved = Math.Abs(pinOffsetXAfter - pinOffsetXBefore) > 0.001
+                     || Math.Abs(pinOffsetYAfter - pinOffsetYBefore) > 0.001;
+        pinMoved.ShouldBeTrue("Physical pin offsets must change after rotation to reflect new port positions");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static Component CreateComponent(
+        double widthMicrometers,
+        double heightMicrometers,
+        double x = 0,
+        double y = 0,
+        List<PhysicalPin>? physicalPins = null)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>
+        {
+            new("west0", 0, MatterType.Light, RectSide.Left),
+            new("east0", 1, MatterType.Light, RectSide.Right),
+        });
+
+        var component = new Component(
+            new Dictionary<int, CAP_Core.LightCalculation.SMatrix>(),
+            new List<Slider>(),
+            "test_component",
+            "",
+            parts,
+            0,
+            "TestComp",
+            DiscreteRotation.R0,
+            physicalPins);
+
+        component.WidthMicrometers = widthMicrometers;
+        component.HeightMicrometers = heightMicrometers;
+        component.PhysicalX = x;
+        component.PhysicalY = y;
+
+        return component;
+    }
+}


### PR DESCRIPTION
## Summary

- **Collision check before rotation**: `RotateComponentCommand.Execute()` now calls `CanPlaceComponent` with the swapped dimensions before applying any rotation. If another component occupies the target space, the rotation is silently rejected (no-op).
- **`WasApplied` property**: Callers (e.g. `MainViewModel`) can inspect this to show an appropriate status message ("Cannot rotate: … would overlap another component").
- **Undo guard**: `Undo()` skips the 3× counter-rotation when `Execute()` was itself a no-op, keeping the undo stack clean.
- **Path recalculation**: already present in the existing `RotateComponent90()` helper — obstacle grid update and `RecalculateTransmissionsForComponent` are called on every successful rotation.

Closes #46

## Vertical slice checklist

- [x] Core logic — reuses existing `CanPlaceComponent` in `DesignCanvasViewModel`
- [x] ViewModel — `RotateComponentCommand` (in `CAP.Avalonia/Commands/`)
- [x] View / AXAML — status bar text updated in `MainViewModel.RotateSelected`
- [ ] DI wiring — no new services needed
- [x] Unit tests — `UnitTests/Commands/RotateComponentCommandTests.cs` (3 new tests)
- [x] Integration — tests exercise `DesignCanvasViewModel` + `RotateComponentCommand` together

## How to manually test

1. Open the app and place two components close together (e.g. drag component B right next to the bottom edge of component A).
2. Select component A and press **R** (or use the rotate toolbar button).
3. **Expected**: rotation is blocked; the status bar shows *"Cannot rotate: … would overlap another component"*. Component A stays in its original orientation.
4. Move component B away to give A enough room, then rotate A again.
5. **Expected**: rotation succeeds; status bar shows *"Rotated: …"*. Any connected waveguides are immediately re-routed to the new pin positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)