### PR TITLE
Agent: Add Create Group and Ungroup Commands (MVVM)

### DIFF
--- a/CAP.Avalonia/Commands/CreateGroupCommand.cs
+++ b/CAP.Avalonia/Commands/CreateGroupCommand.cs
@@ -1,0 +1,260 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
+
+namespace CAP.Avalonia.Commands;
+
+/// <summary>
+/// Command to create a ComponentGroup from selected components.
+/// Captures current positions and waveguide paths as frozen geometry.
+/// </summary>
+public class CreateGroupCommand : IUndoableCommand
+{
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly List<Component> _components;
+    private ComponentGroup? _createdGroup;
+    private ComponentViewModel? _groupViewModel;
+    private readonly List<WaveguideConnection> _internalConnections = new();
+    private readonly List<WaveguideConnection> _externalConnections = new();
+    private readonly List<WaveguideConnectionViewModel> _internalConnectionViewModels = new();
+    private readonly Dictionary<Component, (double x, double y)> _originalPositions = new();
+
+    public CreateGroupCommand(DesignCanvasViewModel canvas, List<ComponentViewModel> components)
+    {
+        _canvas = canvas;
+        _components = components.Select(c => c.Component).ToList();
+
+        // Store original positions
+        foreach (var comp in _components)
+        {
+            _originalPositions[comp] = (comp.PhysicalX, comp.PhysicalY);
+        }
+    }
+
+    public string Description => $"Create group from {_components.Count} components";
+
+    public void Execute()
+    {
+        if (_components.Count < 2)
+            return;
+
+        // Don't group locked components
+        if (_components.Any(c => c.IsLocked))
+            return;
+
+        // 1. Calculate bounding box for selected components
+        double minX = _components.Min(c => c.PhysicalX);
+        double minY = _components.Min(c => c.PhysicalY);
+        double maxX = _components.Max(c => c.PhysicalX + c.WidthMicrometers);
+        double maxY = _components.Max(c => c.PhysicalY + c.HeightMicrometers);
+
+        // 2. Identify internal vs external waveguide connections
+        var componentSet = new HashSet<Component>(_components);
+        _internalConnections.Clear();
+        _externalConnections.Clear();
+
+        foreach (var conn in _canvas.ConnectionManager.Connections)
+        {
+            bool startInGroup = componentSet.Contains(conn.StartPin.ParentComponent);
+            bool endInGroup = componentSet.Contains(conn.EndPin.ParentComponent);
+
+            if (startInGroup && endInGroup)
+            {
+                _internalConnections.Add(conn);
+            }
+            else if (startInGroup || endInGroup)
+            {
+                _externalConnections.Add(conn);
+            }
+        }
+
+        // 3. Create ComponentGroup
+        _createdGroup = new ComponentGroup($"Group_{DateTime.Now:HHmmss}")
+        {
+            PhysicalX = minX,
+            PhysicalY = minY,
+            Description = $"Group of {_components.Count} components"
+        };
+
+        // 4. Add child components to group
+        foreach (var comp in _components)
+        {
+            _createdGroup.AddChild(comp);
+        }
+
+        // 5. Create frozen paths for internal connections
+        foreach (var conn in _internalConnections)
+        {
+            if (conn.RoutedPath != null)
+            {
+                var frozenPath = new FrozenWaveguidePath
+                {
+                    Path = ClonePath(conn.RoutedPath),
+                    StartPin = conn.StartPin,
+                    EndPin = conn.EndPin
+                };
+                _createdGroup.AddInternalPath(frozenPath);
+            }
+        }
+
+        // 6. Create GroupPins for external connections
+        foreach (var conn in _externalConnections)
+        {
+            PhysicalPin internalPin;
+            if (componentSet.Contains(conn.StartPin.ParentComponent))
+                internalPin = conn.StartPin;
+            else
+                internalPin = conn.EndPin;
+
+            var (pinX, pinY) = internalPin.GetAbsolutePosition();
+            var groupPin = new GroupPin
+            {
+                Name = $"{internalPin.ParentComponent.Identifier}_{internalPin.Name}",
+                InternalPin = internalPin,
+                RelativeX = pinX - _createdGroup.PhysicalX,
+                RelativeY = pinY - _createdGroup.PhysicalY,
+                AngleDegrees = internalPin.GetAbsoluteAngle()
+            };
+            _createdGroup.AddExternalPin(groupPin);
+        }
+
+        try
+        {
+            _canvas.BeginCommandExecution();
+
+            // 7. Remove individual components from canvas
+            var componentsToRemove = _canvas.Components
+                .Where(cvm => _components.Contains(cvm.Component))
+                .ToList();
+
+            // Store internal connection ViewModels before removing
+            _internalConnectionViewModels.Clear();
+            foreach (var conn in _internalConnections)
+            {
+                var connVm = _canvas.Connections.FirstOrDefault(c => c.Connection == conn);
+                if (connVm != null)
+                {
+                    _internalConnectionViewModels.Add(connVm);
+                }
+            }
+
+            // Remove internal connections from canvas (they're now frozen in the group)
+            foreach (var conn in _internalConnections)
+            {
+                var connVm = _canvas.Connections.FirstOrDefault(c => c.Connection == conn);
+                if (connVm != null)
+                {
+                    _canvas.Connections.Remove(connVm);
+                    _canvas.ConnectionManager.RemoveConnectionDeferred(conn);
+                }
+            }
+
+            foreach (var compVm in componentsToRemove)
+            {
+                // Remove pins from AllPins
+                var pinsToRemove = _canvas.AllPins
+                    .Where(p => p.ParentComponentViewModel == compVm)
+                    .ToList();
+                foreach (var pin in pinsToRemove)
+                {
+                    _canvas.AllPins.Remove(pin);
+                }
+
+                // Remove from Components collection
+                _canvas.Components.Remove(compVm);
+            }
+
+            // 8. Add group to canvas
+            _groupViewModel = _canvas.AddComponent(_createdGroup);
+        }
+        finally
+        {
+            _canvas.EndCommandExecution();
+        }
+
+        // Recalculate routes for external connections
+        _ = _canvas.RecalculateRoutesAsync();
+        _canvas.InvalidateSimulation();
+    }
+
+    public void Undo()
+    {
+        if (_createdGroup == null || _groupViewModel == null)
+            return;
+
+        try
+        {
+            _canvas.BeginCommandExecution();
+
+            // Remove the group
+            _canvas.RemoveComponent(_groupViewModel);
+
+            // Restore individual components at their original positions
+            foreach (var comp in _components)
+            {
+                if (_originalPositions.TryGetValue(comp, out var pos))
+                {
+                    comp.PhysicalX = pos.x;
+                    comp.PhysicalY = pos.y;
+                }
+                comp.ParentGroup = null;
+                _canvas.AddComponent(comp);
+            }
+
+            // Restore internal connections
+            foreach (var conn in _internalConnections)
+            {
+                _canvas.ConnectionManager.AddExistingConnection(conn);
+                var connVm = new WaveguideConnectionViewModel(conn);
+                _canvas.Connections.Add(connVm);
+            }
+        }
+        finally
+        {
+            _canvas.EndCommandExecution();
+        }
+
+        // Recalculate routes
+        _ = _canvas.RecalculateRoutesAsync();
+        _canvas.InvalidateSimulation();
+    }
+
+    /// <summary>
+    /// Creates a deep clone of a RoutedPath.
+    /// </summary>
+    private RoutedPath ClonePath(RoutedPath source)
+    {
+        var cloned = new RoutedPath
+        {
+            IsBlockedFallback = source.IsBlockedFallback,
+            IsInvalidGeometry = source.IsInvalidGeometry
+        };
+
+        foreach (var segment in source.Segments)
+        {
+            if (segment is BendSegment bend)
+            {
+                cloned.Segments.Add(new BendSegment(
+                    bend.Center.X,
+                    bend.Center.Y,
+                    bend.RadiusMicrometers,
+                    bend.StartAngleDegrees,
+                    bend.SweepAngleDegrees
+                ));
+            }
+            else if (segment is StraightSegment straight)
+            {
+                cloned.Segments.Add(new StraightSegment(
+                    straight.StartPoint.X,
+                    straight.StartPoint.Y,
+                    straight.EndPoint.X,
+                    straight.EndPoint.Y,
+                    straight.StartAngleDegrees
+                ));
+            }
+        }
+
+        return cloned;
+    }
+}

--- a/CAP.Avalonia/Commands/UngroupCommand.cs
+++ b/CAP.Avalonia/Commands/UngroupCommand.cs
@@ -1,0 +1,141 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+
+namespace CAP.Avalonia.Commands;
+
+/// <summary>
+/// Command to explode a ComponentGroup back to individual components.
+/// Unfreezes internal paths and restores waveguide connections.
+/// </summary>
+public class UngroupCommand : IUndoableCommand
+{
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly ComponentGroup _group;
+    private ComponentViewModel? _groupViewModel;
+    private readonly List<ComponentViewModel> _restoredComponentViewModels = new();
+    private readonly List<WaveguideConnection> _restoredConnections = new();
+    private readonly double _groupX;
+    private readonly double _groupY;
+
+    public UngroupCommand(DesignCanvasViewModel canvas, ComponentGroup group)
+    {
+        _canvas = canvas;
+        _group = group;
+        _groupX = group.PhysicalX;
+        _groupY = group.PhysicalY;
+    }
+
+    public string Description => $"Ungroup {_group.GroupName}";
+
+    public void Execute()
+    {
+        // Find the group's ViewModel
+        _groupViewModel = _canvas.Components.FirstOrDefault(c => c.Component == _group);
+        if (_groupViewModel == null)
+            return;
+
+        try
+        {
+            _canvas.BeginCommandExecution();
+
+            // 1. Extract child components from group
+            var children = _group.ChildComponents.ToList();
+            _restoredComponentViewModels.Clear();
+
+            foreach (var child in children)
+            {
+                child.ParentGroup = null;
+                var childVm = _canvas.AddComponent(child);
+                _restoredComponentViewModels.Add(childVm);
+            }
+
+            // 2. Convert frozen paths back to WaveguideConnections
+            _restoredConnections.Clear();
+            foreach (var frozenPath in _group.InternalPaths)
+            {
+                // Create a new connection with the frozen path as its route
+                var connection = new WaveguideConnection
+                {
+                    StartPin = frozenPath.StartPin,
+                    EndPin = frozenPath.EndPin
+                };
+
+                // Add the connection with the cached route
+                _canvas.ConnectionManager.AddConnectionWithCachedRoute(
+                    frozenPath.StartPin,
+                    frozenPath.EndPin,
+                    frozenPath.Path
+                );
+
+                var connVm = new WaveguideConnectionViewModel(connection);
+                _canvas.Connections.Add(connVm);
+                _restoredConnections.Add(connection);
+            }
+
+            // 3. Remove the group from canvas
+            _canvas.RemoveComponent(_groupViewModel);
+        }
+        finally
+        {
+            _canvas.EndCommandExecution();
+        }
+
+        // Update routes for the restored connections
+        _ = _canvas.RecalculateRoutesAsync();
+        _canvas.InvalidateSimulation();
+    }
+
+    public void Undo()
+    {
+        if (_groupViewModel == null)
+            return;
+
+        try
+        {
+            _canvas.BeginCommandExecution();
+
+            // Remove restored connections
+            foreach (var conn in _restoredConnections)
+            {
+                var connVm = _canvas.Connections.FirstOrDefault(c => c.Connection == conn);
+                if (connVm != null)
+                {
+                    _canvas.Connections.Remove(connVm);
+                    _canvas.ConnectionManager.RemoveConnectionDeferred(conn);
+                }
+            }
+
+            // Remove individual components
+            foreach (var compVm in _restoredComponentViewModels)
+            {
+                // Set component back as child of group
+                compVm.Component.ParentGroup = _group;
+
+                // Remove pins
+                var pinsToRemove = _canvas.AllPins
+                    .Where(p => p.ParentComponentViewModel == compVm)
+                    .ToList();
+                foreach (var pin in pinsToRemove)
+                {
+                    _canvas.AllPins.Remove(pin);
+                }
+
+                _canvas.Components.Remove(compVm);
+            }
+
+            // Re-add the group
+            _group.PhysicalX = _groupX;
+            _group.PhysicalY = _groupY;
+            _groupViewModel = _canvas.AddComponent(_group);
+        }
+        finally
+        {
+            _canvas.EndCommandExecution();
+        }
+
+        // Recalculate routes
+        _ = _canvas.RecalculateRoutesAsync();
+        _canvas.InvalidateSimulation();
+    }
+}

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -745,6 +745,46 @@ public partial class MainViewModel : ObservableObject
         }
     }
 
+    [RelayCommand(CanExecute = nameof(CanCreateGroup))]
+    private void CreateGroup()
+    {
+        var selectedComponents = Canvas.Selection.SelectedComponents.ToList();
+        var cmd = new CreateGroupCommand(Canvas, selectedComponents);
+        CommandManager.ExecuteCommand(cmd);
+        Canvas.Selection.ClearSelection();
+        StatusText = $"Created group from {selectedComponents.Count} components";
+    }
+
+    private bool CanCreateGroup()
+    {
+        // Requires at least 2 components selected
+        return Canvas.Selection.SelectedComponents.Count >= 2;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanUngroup))]
+    private void Ungroup()
+    {
+        var selectedGroup = Canvas.Selection.SelectedComponents
+            .Select(c => c.Component)
+            .OfType<CAP_Core.Components.Core.ComponentGroup>()
+            .FirstOrDefault();
+
+        if (selectedGroup != null)
+        {
+            var cmd = new UngroupCommand(Canvas, selectedGroup);
+            CommandManager.ExecuteCommand(cmd);
+            Canvas.Selection.ClearSelection();
+            StatusText = $"Ungrouped: {selectedGroup.GroupName}";
+        }
+    }
+
+    private bool CanUngroup()
+    {
+        // Requires exactly 1 ComponentGroup selected
+        return Canvas.Selection.SelectedComponents.Count == 1 &&
+               Canvas.Selection.SelectedComponents.First().Component is CAP_Core.Components.Core.ComponentGroup;
+    }
+
     [RelayCommand]
     private async Task RunSimulation()
     {

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -53,6 +53,27 @@
 
                 <Separator Width="1" Background="Gray" Margin="10,5"/>
 
+                <!-- Group/Ungroup -->
+                <Button Command="{Binding CreateGroupCommand}"
+                        Width="85" Margin="2" Background="#3d3d3d" ToolTip.Tip="Create Group (Ctrl+G)">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <PathIcon Data="M4,4 L12,4 L12,12 L4,12 Z M6,6 L10,6 L10,10 L6,10 Z"
+                                  Width="16" Height="16" Foreground="LightBlue"/>
+                        <TextBlock Text="Group" Foreground="LightBlue"/>
+                    </StackPanel>
+                </Button>
+
+                <Button Command="{Binding UngroupCommand}"
+                        Width="95" Margin="2" Background="#3d3d3d" ToolTip.Tip="Ungroup (Ctrl+Shift+G)">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <PathIcon Data="M4,4 L6,4 L6,6 L4,6 Z M10,4 L12,4 L12,6 L10,6 Z M4,10 L6,10 L6,12 L4,12 Z M10,10 L12,10 L12,12 L10,12 Z"
+                                  Width="16" Height="16" Foreground="Orange"/>
+                        <TextBlock Text="Ungroup" Foreground="Orange"/>
+                    </StackPanel>
+                </Button>
+
+                <Separator Width="1" Background="Gray" Margin="10,5"/>
+
                 <!-- File Operations -->
                 <Button Content="📂" Command="{Binding LoadDesignCommand}"
                         Width="36" Margin="2" Background="#3d3d3d" ToolTip.Tip="Load design"/>

--- a/Connect-A-Pic-Core/Components/Core/Component.cs
+++ b/Connect-A-Pic-Core/Components/Core/Component.cs
@@ -34,6 +34,13 @@ public class Component : ICloneable
     /// </summary>
     public bool IsLocked { get; set; }
 
+    /// <summary>
+    /// Reference to the parent ComponentGroup if this component is part of a group.
+    /// Null if this is a top-level component.
+    /// </summary>
+    [JsonIgnore]
+    public object? ParentGroup { get; set; }
+
     public Part[,] Parts { get; protected set; }
     public List<PhysicalPin> PhysicalPins { get; protected set; } = new();
     public Dictionary<int, SMatrix> WaveLengthToSMatrixMap { get; set; }

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -1,0 +1,313 @@
+using System.Text.Json.Serialization;
+using CAP_Core.Components.Creation;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+
+namespace CAP_Core.Components.Core;
+
+/// <summary>
+/// Represents a hierarchical group of components with frozen waveguide paths.
+/// Follows IPKISS-style transparent hierarchy where groups contain child components
+/// at fixed relative positions with frozen waveguide paths.
+/// </summary>
+public class ComponentGroup : Component
+{
+    /// <summary>
+    /// Child components contained in this group with relative positions.
+    /// </summary>
+    public List<Component> ChildComponents { get; private set; } = new();
+
+    /// <summary>
+    /// Frozen waveguide paths between child components (don't recalculate during group moves).
+    /// </summary>
+    public List<FrozenWaveguidePath> InternalPaths { get; private set; } = new();
+
+    /// <summary>
+    /// External pins exposed by this group for connections to outside components.
+    /// </summary>
+    public List<GroupPin> ExternalPins { get; private set; } = new();
+
+    /// <summary>
+    /// Human-readable name for this group.
+    /// </summary>
+    public string GroupName { get; set; }
+
+    /// <summary>
+    /// Optional description of this group's purpose.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Reference to parent group if this group is nested within another group.
+    /// Null if this is a top-level group.
+    /// </summary>
+    [JsonIgnore]
+    public new ComponentGroup? ParentGroup { get; set; }
+
+    /// <summary>
+    /// Creates an empty ComponentGroup with default S-matrices.
+    /// Use AddChild() and AddInternalPath() to populate the group.
+    /// </summary>
+    public ComponentGroup(string groupName = "Unnamed Group")
+        : base(
+            new Dictionary<int, SMatrix>(),
+            new List<Slider>(),
+            "group",
+            "",
+            new Part[1, 1] { { new Part() } },
+            -1,
+            $"group_{Guid.NewGuid():N}",
+            new DiscreteRotation(),
+            new List<PhysicalPin>()
+        )
+    {
+        GroupName = groupName;
+        Description = "";
+    }
+
+    /// <summary>
+    /// Adds a child component to this group.
+    /// The child's position is stored as relative to the group origin.
+    /// </summary>
+    /// <param name="component">Component to add to the group.</param>
+    public void AddChild(Component component)
+    {
+        if (component == null)
+            throw new ArgumentNullException(nameof(component));
+
+        if (ChildComponents.Contains(component))
+            throw new InvalidOperationException("Component is already a child of this group.");
+
+        component.ParentGroup = this;
+
+        // If the component is itself a group, also set its typed ParentGroup property
+        if (component is ComponentGroup childGroup)
+        {
+            childGroup.ParentGroup = this;
+        }
+
+        ChildComponents.Add(component);
+        UpdateGroupBounds();
+    }
+
+    /// <summary>
+    /// Removes a child component from this group.
+    /// </summary>
+    /// <param name="component">Component to remove.</param>
+    /// <returns>True if the component was removed, false if it wasn't in the group.</returns>
+    public bool RemoveChild(Component component)
+    {
+        if (component == null) return false;
+
+        bool removed = ChildComponents.Remove(component);
+        if (removed)
+        {
+            component.ParentGroup = null;
+            UpdateGroupBounds();
+        }
+        return removed;
+    }
+
+    /// <summary>
+    /// Adds a frozen waveguide path between two child components.
+    /// </summary>
+    /// <param name="path">The frozen path to add.</param>
+    public void AddInternalPath(FrozenWaveguidePath path)
+    {
+        if (path == null)
+            throw new ArgumentNullException(nameof(path));
+
+        InternalPaths.Add(path);
+    }
+
+    /// <summary>
+    /// Removes a frozen waveguide path from this group.
+    /// </summary>
+    /// <param name="path">The path to remove.</param>
+    /// <returns>True if the path was removed.</returns>
+    public bool RemoveInternalPath(FrozenWaveguidePath path)
+    {
+        return InternalPaths.Remove(path);
+    }
+
+    /// <summary>
+    /// Adds an external pin that exposes an internal component's pin.
+    /// </summary>
+    /// <param name="pin">The group pin to add.</param>
+    public void AddExternalPin(GroupPin pin)
+    {
+        if (pin == null)
+            throw new ArgumentNullException(nameof(pin));
+
+        ExternalPins.Add(pin);
+    }
+
+    /// <summary>
+    /// Moves the entire group and all children by the specified delta.
+    /// Internal waveguide paths are translated, not re-routed.
+    /// </summary>
+    /// <param name="deltaX">X offset in micrometers.</param>
+    /// <param name="deltaY">Y offset in micrometers.</param>
+    public void MoveGroup(double deltaX, double deltaY)
+    {
+        // Move group origin
+        PhysicalX += deltaX;
+        PhysicalY += deltaY;
+
+        // Move all children (they use absolute positions that need to be offset)
+        foreach (var child in ChildComponents)
+        {
+            child.PhysicalX += deltaX;
+            child.PhysicalY += deltaY;
+
+            // If child is also a group, recursively move its descendants
+            if (child is ComponentGroup childGroup)
+            {
+                // Recursively move all descendants of the child group
+                MoveChildrenRecursively(childGroup, deltaX, deltaY);
+            }
+        }
+
+        // Translate frozen paths without re-routing
+        foreach (var path in InternalPaths)
+        {
+            path.TranslateBy(deltaX, deltaY);
+        }
+    }
+
+    /// <summary>
+    /// Recursively moves all children of a group without moving the group itself.
+    /// Used when a nested group's position has already been updated.
+    /// </summary>
+    private void MoveChildrenRecursively(ComponentGroup group, double deltaX, double deltaY)
+    {
+        foreach (var child in group.ChildComponents)
+        {
+            child.PhysicalX += deltaX;
+            child.PhysicalY += deltaY;
+
+            if (child is ComponentGroup childGroup)
+            {
+                MoveChildrenRecursively(childGroup, deltaX, deltaY);
+            }
+        }
+
+        // Also translate the group's internal paths
+        foreach (var path in group.InternalPaths)
+        {
+            path.TranslateBy(deltaX, deltaY);
+        }
+    }
+
+    /// <summary>
+    /// Rotates the entire group and all children by 90 degrees counter-clockwise.
+    /// Updates child positions and frozen path geometries.
+    /// </summary>
+    public void RotateGroupBy90CounterClockwise()
+    {
+        // Rotate the group itself
+        RotateBy90CounterClockwise();
+
+        double groupX = PhysicalX;
+        double groupY = PhysicalY;
+
+        // Rotate each child around the group origin
+        foreach (var child in ChildComponents)
+        {
+            // Calculate relative position
+            double relX = child.PhysicalX - groupX;
+            double relY = child.PhysicalY - groupY;
+
+            // Rotate 90° counter-clockwise: (x, y) → (-y, x)
+            double newRelX = -relY;
+            double newRelY = relX;
+
+            // Update child position
+            child.PhysicalX = groupX + newRelX;
+            child.PhysicalY = groupY + newRelY;
+
+            // Rotate the child component itself
+            child.RotateBy90CounterClockwise();
+        }
+
+        // Rotate frozen paths (each segment needs rotation around group origin)
+        foreach (var frozenPath in InternalPaths)
+        {
+            RotatePathSegmentsBy90(frozenPath, groupX, groupY);
+        }
+
+        UpdateGroupBounds();
+    }
+
+    /// <summary>
+    /// Rotates all segments in a frozen path by 90 degrees counter-clockwise around a center point.
+    /// </summary>
+    private void RotatePathSegmentsBy90(FrozenWaveguidePath frozenPath, double centerX, double centerY)
+    {
+        if (frozenPath?.Path?.Segments == null) return;
+
+        foreach (var segment in frozenPath.Path.Segments)
+        {
+            segment.StartPoint = RotatePoint(segment.StartPoint.X, segment.StartPoint.Y, centerX, centerY);
+            segment.EndPoint = RotatePoint(segment.EndPoint.X, segment.EndPoint.Y, centerX, centerY);
+
+            if (segment is BendSegment bend)
+            {
+                bend.Center = RotatePoint(bend.Center.X, bend.Center.Y, centerX, centerY);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rotates a point by 90 degrees counter-clockwise around a center.
+    /// </summary>
+    private (double X, double Y) RotatePoint(double x, double y, double centerX, double centerY)
+    {
+        double relX = x - centerX;
+        double relY = y - centerY;
+
+        // Rotate 90° counter-clockwise: (x, y) → (-y, x)
+        double newRelX = -relY;
+        double newRelY = relX;
+
+        return (centerX + newRelX, centerY + newRelY);
+    }
+
+    /// <summary>
+    /// Updates the group's bounding box based on child components.
+    /// </summary>
+    private void UpdateGroupBounds()
+    {
+        if (ChildComponents.Count == 0)
+        {
+            WidthMicrometers = 0;
+            HeightMicrometers = 0;
+            return;
+        }
+
+        double minX = ChildComponents.Min(c => c.PhysicalX);
+        double minY = ChildComponents.Min(c => c.PhysicalY);
+        double maxX = ChildComponents.Max(c => c.PhysicalX + c.WidthMicrometers);
+        double maxY = ChildComponents.Max(c => c.PhysicalY + c.HeightMicrometers);
+
+        WidthMicrometers = maxX - minX;
+        HeightMicrometers = maxY - minY;
+    }
+
+    /// <summary>
+    /// Gets all components recursively (including nested group children).
+    /// </summary>
+    public List<Component> GetAllComponentsRecursive()
+    {
+        var allComponents = new List<Component>();
+        foreach (var child in ChildComponents)
+        {
+            allComponents.Add(child);
+            if (child is ComponentGroup childGroup)
+            {
+                allComponents.AddRange(childGroup.GetAllComponentsRecursive());
+            }
+        }
+        return allComponents;
+    }
+}

--- a/Connect-A-Pic-Core/Components/Core/FrozenWaveguidePath.cs
+++ b/Connect-A-Pic-Core/Components/Core/FrozenWaveguidePath.cs
@@ -1,0 +1,107 @@
+using CAP_Core.Routing;
+
+namespace CAP_Core.Components.Core;
+
+/// <summary>
+/// Represents a waveguide path that is frozen (fixed geometry).
+/// Unlike regular RoutedPath, these don't recalculate during group moves.
+/// The path geometry is stored in absolute coordinates and translated when the group moves.
+/// </summary>
+public class FrozenWaveguidePath : ICloneable
+{
+    /// <summary>
+    /// The routed path segments with fixed geometry.
+    /// </summary>
+    public RoutedPath Path { get; set; }
+
+    /// <summary>
+    /// Physical pin where this frozen path starts.
+    /// </summary>
+    public PhysicalPin StartPin { get; set; }
+
+    /// <summary>
+    /// Physical pin where this frozen path ends.
+    /// </summary>
+    public PhysicalPin EndPin { get; set; }
+
+    /// <summary>
+    /// Unique identifier for this frozen path.
+    /// </summary>
+    public Guid PathId { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Translates all segments in the path by the specified delta.
+    /// Used when moving the containing ComponentGroup.
+    /// </summary>
+    /// <param name="deltaX">X offset in micrometers.</param>
+    /// <param name="deltaY">Y offset in micrometers.</param>
+    public void TranslateBy(double deltaX, double deltaY)
+    {
+        if (Path?.Segments == null) return;
+
+        foreach (var segment in Path.Segments)
+        {
+            segment.StartPoint = (
+                segment.StartPoint.X + deltaX,
+                segment.StartPoint.Y + deltaY
+            );
+            segment.EndPoint = (
+                segment.EndPoint.X + deltaX,
+                segment.EndPoint.Y + deltaY
+            );
+
+            // If it's a bend segment, translate the center point as well
+            if (segment is BendSegment bend)
+            {
+                bend.Center = (
+                    bend.Center.X + deltaX,
+                    bend.Center.Y + deltaY
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a clone of this frozen path with a new ID.
+    /// </summary>
+    public object Clone()
+    {
+        var clonedPath = new RoutedPath
+        {
+            IsBlockedFallback = Path.IsBlockedFallback,
+            IsInvalidGeometry = Path.IsInvalidGeometry
+        };
+
+        // Deep clone all segments
+        foreach (var segment in Path.Segments)
+        {
+            if (segment is BendSegment bend)
+            {
+                clonedPath.Segments.Add(new BendSegment(
+                    bend.Center.X,
+                    bend.Center.Y,
+                    bend.RadiusMicrometers,
+                    bend.StartAngleDegrees,
+                    bend.SweepAngleDegrees
+                ));
+            }
+            else if (segment is StraightSegment straight)
+            {
+                clonedPath.Segments.Add(new StraightSegment(
+                    straight.StartPoint.X,
+                    straight.StartPoint.Y,
+                    straight.EndPoint.X,
+                    straight.EndPoint.Y,
+                    straight.StartAngleDegrees
+                ));
+            }
+        }
+
+        return new FrozenWaveguidePath
+        {
+            Path = clonedPath,
+            PathId = Guid.NewGuid(),
+            // StartPin and EndPin references must be updated after cloning by the ComponentGroup
+        };
+    }
+}

--- a/Connect-A-Pic-Core/Components/Core/GroupPin.cs
+++ b/Connect-A-Pic-Core/Components/Core/GroupPin.cs
@@ -1,0 +1,54 @@
+namespace CAP_Core.Components.Core;
+
+/// <summary>
+/// External pin exposed by a ComponentGroup.
+/// Maps to an internal component's pin, allowing external waveguide connections to the group.
+/// </summary>
+public class GroupPin : ICloneable
+{
+    /// <summary>
+    /// External name of this group pin (visible to outside connections).
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Reference to the internal component's physical pin that this group pin exposes.
+    /// </summary>
+    public PhysicalPin InternalPin { get; set; }
+
+    /// <summary>
+    /// X position relative to the group's origin (micrometers).
+    /// </summary>
+    public double RelativeX { get; set; }
+
+    /// <summary>
+    /// Y position relative to the group's origin (micrometers).
+    /// </summary>
+    public double RelativeY { get; set; }
+
+    /// <summary>
+    /// Pin angle in degrees (0° = east, 90° = north, etc.).
+    /// </summary>
+    public double AngleDegrees { get; set; }
+
+    /// <summary>
+    /// Unique identifier for this group pin.
+    /// </summary>
+    public Guid PinId { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Creates a clone of this GroupPin with a new ID.
+    /// </summary>
+    public object Clone()
+    {
+        return new GroupPin
+        {
+            Name = Name,
+            RelativeX = RelativeX,
+            RelativeY = RelativeY,
+            AngleDegrees = AngleDegrees,
+            PinId = Guid.NewGuid(),
+            // InternalPin reference must be updated after cloning by the ComponentGroup
+        };
+    }
+}

--- a/UnitTests/Commands/GroupingWorkflowTests.cs
+++ b/UnitTests/Commands/GroupingWorkflowTests.cs
@@ -1,0 +1,320 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.FormulaReading;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Commands;
+
+/// <summary>
+/// Integration tests for ComponentGroup creation and ungrouping workflow.
+/// Tests the full MVVM stack: Core → Commands → ViewModel.
+/// </summary>
+public class GroupingWorkflowTests
+{
+    [Fact]
+    public void CreateGroup_From2Components_CreatesGroupWithCorrectChildren()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateTestComponent("Comp1", 100, 100);
+        var comp2 = CreateTestComponent("Comp2", 200, 100);
+
+        var vm1 = canvas.AddComponent(comp1, "Template1");
+        var vm2 = canvas.AddComponent(comp2, "Template2");
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Act - Create group
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - Individual components removed, group added
+        canvas.Components.Count.ShouldBe(1);
+        var groupVm = canvas.Components[0];
+        groupVm.Component.ShouldBeOfType<ComponentGroup>();
+
+        var group = (ComponentGroup)groupVm.Component;
+        group.ChildComponents.Count.ShouldBe(2);
+        group.ChildComponents.ShouldContain(comp1);
+        group.ChildComponents.ShouldContain(comp2);
+    }
+
+    [Fact]
+    public async Task CreateGroup_WithInternalConnection_FreezesPath()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins("Comp1", 100, 100);
+        var comp2 = CreateComponentWithPins("Comp2", 200, 100);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        // Connect the components
+        var pin1 = comp1.PhysicalPins[0];
+        var pin2 = comp2.PhysicalPins[0];
+        canvas.ConnectPins(pin1, pin2);
+
+        // Wait for routing to complete
+        await canvas.RecalculateRoutesAsync();
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Act - Create group
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - Group has frozen internal path
+        canvas.Components.Count.ShouldBe(1);
+        var group = (ComponentGroup)canvas.Components[0].Component;
+        group.InternalPaths.Count.ShouldBe(1);
+
+        var frozenPath = group.InternalPaths[0];
+        frozenPath.StartPin.ShouldBe(pin1);
+        frozenPath.EndPin.ShouldBe(pin2);
+        frozenPath.Path.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void CreateGroup_ThenUndo_RestoresOriginalComponents()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateTestComponent("Comp1", 100, 100);
+        var comp2 = CreateTestComponent("Comp2", 200, 100);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+
+        // Act - Create group then undo
+        cmd.Execute();
+        canvas.Components.Count.ShouldBe(1);
+
+        cmd.Undo();
+
+        // Assert - Individual components restored
+        canvas.Components.Count.ShouldBe(2);
+        canvas.Components[0].Component.Identifier.ShouldContain("Comp");
+        canvas.Components[1].Component.Identifier.ShouldContain("Comp");
+    }
+
+    [Fact]
+    public void UngroupCommand_RestoresIndividualComponents()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateTestComponent("Comp1", 100, 100);
+        var comp2 = CreateTestComponent("Comp2", 200, 100);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Create group
+        var createCmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        createCmd.Execute();
+
+        var group = (ComponentGroup)canvas.Components[0].Component;
+
+        // Act - Ungroup
+        var ungroupCmd = new UngroupCommand(canvas, group);
+        ungroupCmd.Execute();
+
+        // Assert - Individual components restored
+        canvas.Components.Count.ShouldBe(2);
+        canvas.Components.ShouldContain(c => c.Component == comp1);
+        canvas.Components.ShouldContain(c => c.Component == comp2);
+    }
+
+    [Fact]
+    public void UngroupCommand_ThenUndo_RecreatesGroup()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateTestComponent("Comp1", 100, 100);
+        var comp2 = CreateTestComponent("Comp2", 200, 100);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Create group
+        var createCmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        createCmd.Execute();
+        var group = (ComponentGroup)canvas.Components[0].Component;
+
+        // Ungroup
+        var ungroupCmd = new UngroupCommand(canvas, group);
+        ungroupCmd.Execute();
+        canvas.Components.Count.ShouldBe(2);
+
+        // Act - Undo ungroup
+        ungroupCmd.Undo();
+
+        // Assert - Group recreated
+        canvas.Components.Count.ShouldBe(1);
+        canvas.Components[0].Component.ShouldBeOfType<ComponentGroup>();
+        var restoredGroup = (ComponentGroup)canvas.Components[0].Component;
+        restoredGroup.ChildComponents.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void CreateGroup_WithExternalConnection_CreatesGroupPin()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins("Comp1", 100, 100);
+        var comp2 = CreateComponentWithPins("Comp2", 200, 100);
+        var comp3 = CreateComponentWithPins("Comp3", 300, 100);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+        var vm3 = canvas.AddComponent(comp3);
+
+        // Connect comp2 to comp3 (comp3 is outside the group)
+        var pin2 = comp2.PhysicalPins[0];
+        var pin3 = comp3.PhysicalPins[0];
+        canvas.ConnectPins(pin2, pin3);
+
+        // Select only comp1 and comp2 for grouping
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Act - Create group
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - Group has external pin
+        canvas.Components.Count.ShouldBe(2); // Group + Comp3
+        var group = canvas.Components
+            .Where(c => c.Component is ComponentGroup)
+            .Select(c => (ComponentGroup)c.Component)
+            .First();
+
+        group.ExternalPins.Count.ShouldBe(1);
+        group.ExternalPins[0].InternalPin.ShouldBe(pin2);
+    }
+
+    [Fact]
+    public void CreateGroup_WithLockedComponent_DoesNothing()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateTestComponent("Comp1", 100, 100);
+        var comp2 = CreateTestComponent("Comp2", 200, 100);
+        comp1.IsLocked = true; // Lock one component
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Act - Try to create group
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - No group created, individual components remain
+        canvas.Components.Count.ShouldBe(2);
+        canvas.Components.ShouldNotContain(c => c.Component is ComponentGroup);
+    }
+
+    [Fact]
+    public void CreateGroup_LessThan2Components_DoesNothing()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateTestComponent("Comp1", 100, 100);
+        var vm1 = canvas.AddComponent(comp1);
+
+        canvas.Selection.AddToSelection(vm1);
+
+        // Act - Try to create group with only 1 component
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - No group created
+        canvas.Components.Count.ShouldBe(1);
+        canvas.Components[0].Component.ShouldNotBeOfType<ComponentGroup>();
+    }
+
+    /// <summary>
+    /// Helper to create a simple test component.
+    /// </summary>
+    private Component CreateTestComponent(string identifier, double x, double y)
+    {
+        var sMatrix = new SMatrix(new List<Guid>(), new List<(Guid sliderID, double value)>());
+        var component = new Component(
+            new Dictionary<int, SMatrix> { { 1550, sMatrix } },
+            new List<Slider>(),
+            "test",
+            "",
+            new Part[1, 1] { { new Part() } },
+            -1,
+            identifier,
+            new DiscreteRotation(),
+            new List<PhysicalPin>()
+        )
+        {
+            PhysicalX = x,
+            PhysicalY = y,
+            WidthMicrometers = 50,
+            HeightMicrometers = 30
+        };
+        return component;
+    }
+
+    /// <summary>
+    /// Helper to create a component with physical pins for connection testing.
+    /// </summary>
+    private Component CreateComponentWithPins(string identifier, double x, double y)
+    {
+        var sMatrix = new SMatrix(new List<Guid>(), new List<(Guid sliderID, double value)>());
+        var pins = new List<PhysicalPin>
+        {
+            new PhysicalPin
+            {
+                Name = "Pin1",
+                OffsetXMicrometers = 0,
+                OffsetYMicrometers = 15,
+                AngleDegrees = 0
+            }
+        };
+
+        var component = new Component(
+            new Dictionary<int, SMatrix> { { 1550, sMatrix } },
+            new List<Slider>(),
+            "test",
+            "",
+            new Part[1, 1] { { new Part() } },
+            -1,
+            identifier,
+            new DiscreteRotation(),
+            pins
+        )
+        {
+            PhysicalX = x,
+            PhysicalY = y,
+            WidthMicrometers = 50,
+            HeightMicrometers = 30
+        };
+
+        return component;
+    }
+}


### PR DESCRIPTION
Automated implementation for #112

⚠️ **Stacked PR** - This PR is based on #129. Merge that PR first, then this one will automatically update to target `main`.

Perfect! The build succeeded with 0 errors. Let me create a summary of what was implemented:

## Summary

I have successfully implemented issue #112: **Add Create Group and Ungroup Commands (MVVM)**.

### Implementation Details

#### ✅ **1. Core ComponentGroup Classes (Restored from #111)**
- **ComponentGroup.cs** - Main group class with hierarchical component management
- **FrozenWaveguidePath.cs** - Frozen waveguide paths that move with the group
- **GroupPin.cs** - External pins for group connections
- Added `ParentGroup` property to `Component` class

#### ✅ **2. Command Classes (CAP.Avalonia/Commands/)**
- **CreateGroupCommand.cs** (235 lines)
  - Groups selected components (minimum 2 required)
  - Identifies internal vs external connections
  - Creates frozen waveguide paths for internal connections
  - Creates GroupPins for external connections
  - Full undo/redo support
  - Prevents grouping of locked components

- **UngroupCommand.cs** (117 lines)
  - Explodes ComponentGroup back to individual components
  - Restores waveguide connections from frozen paths
  - Full undo/redo support

#### ✅ **3. ViewModel Integration (MainViewModel.cs)**
- **CreateGroupCommand** with CanExecute binding (requires 2+ selected components)
- **UngroupCommand** with CanExecute binding (requires 1 selected ComponentGroup)
- Proper status messages and selection handling

#### ✅ **4. UI Integration (MainWindow.axaml)**
- **Group Button** with icon and "Create Group (Ctrl+G)" tooltip
- **Ungroup Button** with icon and "Ungroup (Ctrl+Shift+G)" tooltip
- Buttons automatically enable/disable based on selection state

#### ✅ **5. Integration Tests (GroupingWorkflowTests.cs, 319 lines)**
All 8 tests passing:
- ✅ Create group from 2 components
- ✅ Create group with internal connection freezes path
- ✅ Create group then undo restores original components
- ✅ Ungroup command restores individual components
- ✅ Ungroup then undo recreates group
- ✅ Create group with external connection creates GroupPin
- ✅ Create group with locked component does nothing
- ✅ Create group with less than 2 components does nothing

### Vertical Slice Compliance ✅

All required layers implemented:
1. ✅ **Core logic** - ComponentGroup, FrozenWaveguidePath, GroupPin
2. ✅ **Commands** - CreateGroupCommand, UngroupCommand with Execute/Undo
3. ✅ **ViewModel** - RelayCommands in MainViewModel with CanExecute
4. ✅ **View/AXAML** - UI buttons in MainWindow toolbar
5. ✅ **Unit tests** - 8 integration tests covering all scenarios
6. ✅ **Build verification** - 0 errors, all tests pass

### Build & Test Status

- **Build**: ✅ Succeeded (0 errors, warnings only)
- **Grouping Tests**: ✅ 8/8 passing
- **Full Test Suite**: ✅ 615/618 passing (3 pre-existing failures unrelated to this change)

The implementation is complete and follows all MVVM patterns, CLAUDE.md guidelines, and vertical slice requirements. The feature is ready for testing in the UI!


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 25,350
- **Estimated cost:** $0.3791 USD

---
*Generated by autonomous agent using Claude Code.*