### PR TITLE
Agent: Bug: After ungroup, A* routing not recalculated and connections break

### DIFF
--- a/CAP.Avalonia/Commands/UngroupCommand.cs
+++ b/CAP.Avalonia/Commands/UngroupCommand.cs
@@ -51,21 +51,16 @@ public class UngroupCommand : IUndoableCommand
             }
 
             // 2. Convert frozen paths back to WaveguideConnections
+            // IMPORTANT: Do NOT use cached routes - they're from before group movement!
+            // The group may have been moved, rotated, or edited since grouping.
+            // We must recalculate routes to reflect current component positions.
             _restoredConnections.Clear();
             foreach (var frozenPath in _group.InternalPaths)
             {
-                // Create a new connection with the frozen path as its route
-                var connection = new WaveguideConnection
-                {
-                    StartPin = frozenPath.StartPin,
-                    EndPin = frozenPath.EndPin
-                };
-
-                // Add the connection with the cached route
-                _canvas.ConnectionManager.AddConnectionWithCachedRoute(
+                // Add connection without route - will be recalculated below
+                var connection = _canvas.ConnectionManager.AddConnectionDeferred(
                     frozenPath.StartPin,
-                    frozenPath.EndPin,
-                    frozenPath.Path
+                    frozenPath.EndPin
                 );
 
                 var connVm = new WaveguideConnectionViewModel(connection);

--- a/UnitTests/Commands/GroupingWorkflowTests.cs
+++ b/UnitTests/Commands/GroupingWorkflowTests.cs
@@ -310,6 +310,79 @@ public class GroupingWorkflowTests
         canvas.Components.ShouldNotContain(c => c.Component is ComponentGroup);
     }
 
+    [Fact]
+    public async Task UngroupCommand_AfterGroupMoved_RecalculatesRoutes()
+    {
+        // Arrange - Create components with connection
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins("Comp1", 100, 100);
+        var comp2 = CreateComponentWithPins("Comp2", 200, 100);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        // Connect the components
+        var pin1 = comp1.PhysicalPins[0];
+        var pin2 = comp2.PhysicalPins[0];
+        canvas.ConnectPins(pin1, pin2);
+
+        // Wait for routing to complete
+        await canvas.RecalculateRoutesAsync();
+
+        // Verify connection has valid route
+        var originalConnection = canvas.ConnectionManager.Connections[0];
+        originalConnection.IsPathValid.ShouldBeTrue();
+        var originalStartX = originalConnection.RoutedPath?.Segments[0].StartPoint.X ?? 0;
+        var originalEndX = originalConnection.RoutedPath?.Segments[^1].EndPoint.X ?? 0;
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Create group
+        var createCmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        createCmd.Execute();
+
+        var group = (ComponentGroup)canvas.Components[0].Component;
+
+        // Act - Move the group to a new position
+        group.MoveGroup(500, 500); // Move significantly
+
+        // Ungroup - this should trigger route recalculation
+        var ungroupCmd = new UngroupCommand(canvas, group);
+        ungroupCmd.Execute();
+
+        // Wait for routing to complete
+        await canvas.RecalculateRoutesAsync();
+
+        // Assert - Routes should be recalculated for new positions
+        canvas.Components.Count.ShouldBe(2);
+        canvas.Connections.Count.ShouldBe(1);
+
+        var restoredConnection = canvas.ConnectionManager.Connections[0];
+        restoredConnection.IsPathValid.ShouldBeTrue();
+
+        // Verify route endpoints match current component positions
+        var (startX, startY) = pin1.GetAbsolutePosition();
+        var (endX, endY) = pin2.GetAbsolutePosition();
+
+        var routedPath = restoredConnection.RoutedPath;
+        routedPath.ShouldNotBeNull();
+        routedPath.Segments.Count.ShouldBeGreaterThan(0);
+
+        var firstSegment = routedPath.Segments[0];
+        var lastSegment = routedPath.Segments[^1];
+
+        // Route should start and end at current pin positions (within tolerance)
+        Math.Abs(firstSegment.StartPoint.X - startX).ShouldBeLessThan(1.0);
+        Math.Abs(firstSegment.StartPoint.Y - startY).ShouldBeLessThan(1.0);
+        Math.Abs(lastSegment.EndPoint.X - endX).ShouldBeLessThan(1.0);
+        Math.Abs(lastSegment.EndPoint.Y - endY).ShouldBeLessThan(1.0);
+
+        // Route coordinates should be different from original (group was moved)
+        Math.Abs(firstSegment.StartPoint.X - originalStartX).ShouldBeGreaterThan(100);
+        Math.Abs(lastSegment.EndPoint.X - originalEndX).ShouldBeGreaterThan(100);
+    }
+
     /// <summary>
     /// Helper to create a simple test component.
     /// </summary>


### PR DESCRIPTION
Automated implementation for #143

⚠️ **Stacked PR** - This PR is based on #156. Merge that PR first, then this one will automatically update to target `main`.

Perfect! Now let me create a summary document of what was implemented:

## Summary

I successfully implemented a fix for issue #143: **Bug: After ungroup, A* routing not recalculated and connections break**.

### Root Cause Analysis

The bug occurred because when ungrouping a `ComponentGroup`:
1. The frozen waveguide paths were restored using **cached routes** from when the group was first created
2. If the group was moved, rotated, or edited after creation, these cached routes would be at incorrect positions
3. The `AddConnectionWithCachedRoute` method preserved these outdated cached paths
4. While `RecalculateRoutesAsync()` was called, the incremental routing logic would detect endpoint mismatches and invalidate the routes, but the visual update might not happen immediately

### Implementation

**Changed File: `CAP.Avalonia/Commands/UngroupCommand.cs`**

Replaced the `AddConnectionWithCachedRoute` call with `AddConnectionDeferred`:

```csharp
// OLD CODE (lines 53-74):
foreach (var frozenPath in _group.InternalPaths)
{
    var connection = new WaveguideConnection
    {
        StartPin = frozenPath.StartPin,
        EndPin = frozenPath.EndPin
    };
    _canvas.ConnectionManager.AddConnectionWithCachedRoute(
        frozenPath.StartPin,
        frozenPath.EndPin,
        frozenPath.Path  // <- PROBLEM: outdated cached route!
    );
    // ...
}

// NEW CODE:
foreach (var frozenPath in _group.InternalPaths)
{
    // Add connection without route - will be recalculated
    var connection = _canvas.ConnectionManager.AddConnectionDeferred(
        frozenPath.StartPin,
        frozenPath.EndPin
    );
    // ...
}
```

The `AddConnectionDeferred` method adds connections without routes, and the subsequent `RecalculateRoutesAsync()` call (line 85) properly recalculates all routes using A* pathfinding with current component positions.

### Test Coverage

**Added Test: `UnitTests/Commands/GroupingWorkflowTests.cs`**

New test case: `UngroupCommand_AfterGroupMoved_RecalculatesRoutes`

This test:
1. Creates 2 components with a connection
2. Groups them
3. Moves the group significantly (500 µm in X and Y)
4. Ungroups
5. Verifies that routes are recalculated to match current pin positions
6. Confirms that route coordinates are different from original positions

### Verification

All tests passing:
- ✅ All 11 `GroupingWorkflowTests` pass (including new test)
- ✅ All 5 `Ungroup*` tests pass
- ✅ All 7 `ComponentGroupMovement` tests pass
- ✅ Build succeeds with no new warnings or errors

**Pre-existing test failures** (unrelated to this fix):
- 6 tests were already failing before my changes (GridPersistence, LeftPanelWidth, ManhattanRouting, AsyncRouting)

### User Impact

**Before fix:**
- Ungrouping a moved/rotated group → broken waveguide connections
- Connections drawn at wrong positions
- Manual re-routing required

**After fix:**
- Ungrouping any group → automatic A* route recalculation
- Waveguides correctly connect components at current positions
- Proper obstacle avoidance
- Immediate visual update

The fix ensures that ungrouping always triggers proper A* routing recalculation, regardless of whether the group was moved, rotated, or edited after creation.


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 6,611
- **Estimated cost:** $0.0978 USD

---
*Generated by autonomous agent using Claude Code.*