### PR TITLE
Agent: Bug: Copy/Paste group doesn't copy child components

### DIFF
--- a/Connect-A-Pic-Core/Components/Core/Component.cs
+++ b/Connect-A-Pic-Core/Components/Core/Component.cs
@@ -274,7 +274,7 @@ public class Component : ICloneable
 
         return pinIdMapping;
     }
-    public object Clone()
+    public virtual object Clone()
     {
         var clonedParts = CloneParts();
         var clonedSliderMap = CloneSliders();

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -347,6 +347,16 @@ public class ComponentGroup : Component
     }
 
     /// <summary>
+    /// Overrides Component.Clone() to perform a deep copy of the ComponentGroup.
+    /// This ensures that copy/paste operations correctly clone child components and internal paths.
+    /// </summary>
+    /// <returns>A new ComponentGroup instance with cloned children and paths.</returns>
+    public override object Clone()
+    {
+        return DeepCopy();
+    }
+
+    /// <summary>
     /// Creates a deep copy of this ComponentGroup with new unique identifiers for all components.
     /// Used for instantiating group templates from the library.
     /// </summary>

--- a/UnitTests/Commands/CopyPasteWorkflowTests.cs
+++ b/UnitTests/Commands/CopyPasteWorkflowTests.cs
@@ -245,6 +245,135 @@ public class CopyPasteWorkflowTests
             "Should create 2 new components from 2 paste operations");
     }
 
+    /// <summary>
+    /// Verifies that copying and pasting a ComponentGroup preserves all child components.
+    /// This is the integration test for issue #164.
+    /// </summary>
+    [Fact]
+    public void Paste_ComponentGroup_CopiesAllChildComponents()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        // Create a group with 2 child components
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        group.PhysicalX = 200;
+        group.PhysicalY = 200;
+
+        var groupVm = canvas.AddComponent(group);
+
+        int initialComponentCount = canvas.Components.Count;
+        int childCount = group.ChildComponents.Count;
+
+        // Copy the group
+        canvas.Clipboard.Copy(
+            new[] { groupVm },
+            canvas.Connections);
+
+        // Paste the group
+        var cmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        cmd.Execute();
+
+        cmd.Result.ShouldNotBeNull("Paste should succeed");
+        cmd.Result.Components.Count.ShouldBe(1, "Should paste exactly one component (the group)");
+
+        var pastedGroupVm = cmd.Result.Components[0];
+        pastedGroupVm.Component.ShouldBeOfType<ComponentGroup>("Pasted component should be a ComponentGroup");
+
+        var pastedGroup = (ComponentGroup)pastedGroupVm.Component;
+
+        // Verify child components were copied
+        pastedGroup.ChildComponents.Count.ShouldBe(childCount,
+            "Pasted group should have same number of children as original");
+
+        // Verify children are different instances
+        foreach (var pastedChild in pastedGroup.ChildComponents)
+        {
+            pastedChild.ShouldNotBeNull("Child component should not be null");
+            group.ChildComponents.ShouldNotContain(pastedChild,
+                "Pasted child should be a new instance, not a reference to original");
+        }
+
+        // Verify children have correct parent references
+        foreach (var pastedChild in pastedGroup.ChildComponents)
+        {
+            pastedChild.ParentGroup.ShouldBe(pastedGroup,
+                "Pasted child should reference the pasted group as parent");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that pasting a group with internal connections preserves those connections.
+    /// Note: This test verifies the structure is preserved, even though the internal paths
+    /// list may be empty for groups created from TestComponentFactory.
+    /// </summary>
+    [Fact]
+    public void Paste_ComponentGroupWithInternalPaths_PreservesGroupStructure()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        // Create a simple group (internal paths would require more complex setup
+        // with properly initialized components having matching logical/physical pins)
+        var group = TestComponentFactory.CreateComponentGroup("ConnectedGroup", addChildren: true);
+        group.PhysicalX = 100;
+        group.PhysicalY = 100;
+
+        int childCount = group.ChildComponents.Count;
+        var groupVm = canvas.AddComponent(group);
+
+        // Copy and paste
+        canvas.Clipboard.Copy(new[] { groupVm }, canvas.Connections);
+        var cmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        cmd.Execute();
+
+        var pastedGroup = (ComponentGroup)cmd.Result.Components[0].Component;
+
+        // Verify the group structure is preserved
+        pastedGroup.ChildComponents.Count.ShouldBe(childCount,
+            "Pasted group should have all children");
+
+        // Verify children are independent copies
+        foreach (var pastedChild in pastedGroup.ChildComponents)
+        {
+            group.ChildComponents.ShouldNotContain(pastedChild,
+                "Pasted children should be new instances");
+            pastedChild.ParentGroup.ShouldBe(pastedGroup,
+                "Pasted children should reference the pasted group");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that pasting a nested group (group within group) works correctly.
+    /// </summary>
+    [Fact]
+    public void Paste_NestedComponentGroup_CopiesAllLevels()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        var outerGroup = TestComponentFactory.CreateComponentGroup("OuterGroup", addChildren: false);
+        var innerGroup = TestComponentFactory.CreateComponentGroup("InnerGroup", addChildren: true);
+        outerGroup.AddChild(innerGroup);
+        outerGroup.PhysicalX = 300;
+        outerGroup.PhysicalY = 300;
+
+        var groupVm = canvas.AddComponent(outerGroup);
+
+        // Copy and paste
+        canvas.Clipboard.Copy(new[] { groupVm }, canvas.Connections);
+        var cmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        cmd.Execute();
+
+        var pastedOuter = (ComponentGroup)cmd.Result.Components[0].Component;
+
+        pastedOuter.ChildComponents.Count.ShouldBe(1, "Outer group should have one child");
+        var pastedInner = pastedOuter.ChildComponents[0] as ComponentGroup;
+
+        pastedInner.ShouldNotBeNull("Child should be a ComponentGroup");
+        pastedInner.ChildComponents.Count.ShouldBe(2,
+            "Inner group should have its 2 child components");
+        pastedInner.ParentGroup.ShouldBe(pastedOuter,
+            "Inner group should reference outer group as parent");
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/UnitTests/Components/ComponentGroupCloningTests.cs
+++ b/UnitTests/Components/ComponentGroupCloningTests.cs
@@ -1,0 +1,299 @@
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Unit tests for ComponentGroup deep cloning functionality.
+/// Verifies that Clone() properly copies child components, internal paths, and external pins.
+/// </summary>
+public class ComponentGroupCloningTests
+{
+    /// <summary>
+    /// Verifies that cloning an empty group creates a new instance with no children.
+    /// </summary>
+    [Fact]
+    public void Clone_EmptyGroup_CreatesNewInstance()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("EmptyGroup", addChildren: false);
+
+        var cloned = (ComponentGroup)original.Clone();
+
+        cloned.ShouldNotBeNull("Cloned group should not be null");
+        cloned.ShouldNotBeSameAs(original, "Cloned group should be a different instance");
+        cloned.GroupName.ShouldBe("EmptyGroup", "Group name should be copied");
+        cloned.ChildComponents.Count.ShouldBe(0, "Cloned empty group should have no children");
+    }
+
+    /// <summary>
+    /// Verifies that cloning a group with children creates deep copies of all children.
+    /// </summary>
+    [Fact]
+    public void Clone_GroupWithChildren_CreatesDeepCopyOfChildren()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("ParentGroup", addChildren: true);
+
+        var cloned = (ComponentGroup)original.Clone();
+
+        cloned.ShouldNotBeNull("Cloned group should not be null");
+        cloned.ShouldNotBeSameAs(original, "Cloned group should be a different instance");
+        cloned.ChildComponents.Count.ShouldBe(original.ChildComponents.Count,
+            "Cloned group should have same number of children");
+
+        // Verify children are cloned (not the same instances)
+        for (int i = 0; i < original.ChildComponents.Count; i++)
+        {
+            var originalChild = original.ChildComponents[i];
+            var clonedChild = cloned.ChildComponents[i];
+
+            clonedChild.ShouldNotBeSameAs(originalChild,
+                $"Child {i} should be a different instance");
+            clonedChild.Identifier.ShouldNotBe(originalChild.Identifier,
+                $"Child {i} should have a different identifier");
+            clonedChild.PhysicalX.ShouldBe(originalChild.PhysicalX,
+                $"Child {i} X position should be preserved");
+            clonedChild.PhysicalY.ShouldBe(originalChild.PhysicalY,
+                $"Child {i} Y position should be preserved");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that cloned children have their ParentGroup reference set correctly.
+    /// </summary>
+    [Fact]
+    public void Clone_GroupWithChildren_SetsParentGroupReferences()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("ParentGroup", addChildren: true);
+
+        var cloned = (ComponentGroup)original.Clone();
+
+        foreach (var child in cloned.ChildComponents)
+        {
+            child.ParentGroup.ShouldBe(cloned,
+                "Cloned child should reference the cloned parent group");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that cloning a group with internal paths creates deep copies of those paths.
+    /// </summary>
+    [Fact]
+    public void Clone_GroupWithInternalPaths_CreatesDeepCopyOfPaths()
+    {
+        var group = new ComponentGroup("ConnectedGroup")
+        {
+            PhysicalX = 0,
+            PhysicalY = 0
+        };
+
+        // Create components with physical pins using ComponentWithPins helper
+        var child1 = CreateComponentWithPins("Child1", 100, 100);
+        var child2 = CreateComponentWithPins("Child2", 400, 100);
+
+        group.AddChild(child1);
+        group.AddChild(child2);
+
+        // Create a frozen path between children
+        var routedPath = new RoutedPath();
+        routedPath.Segments.Add(new StraightSegment(
+            child1.PhysicalX + 250,
+            child1.PhysicalY + 125,
+            child2.PhysicalX,
+            child2.PhysicalY + 125,
+            0));
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            StartPin = child1.PhysicalPins[0],
+            EndPin = child2.PhysicalPins[0],
+            Path = routedPath
+        };
+        group.AddInternalPath(frozenPath);
+
+        var cloned = (ComponentGroup)group.Clone();
+
+        cloned.InternalPaths.Count.ShouldBe(1, "Cloned group should have one internal path");
+        var clonedPath = cloned.InternalPaths[0];
+
+        clonedPath.ShouldNotBeSameAs(frozenPath, "Cloned path should be a different instance");
+        clonedPath.Path.ShouldNotBeSameAs(frozenPath.Path,
+            "Cloned path's RoutedPath should be a different instance");
+
+        // Verify the cloned path references the cloned components
+        clonedPath.StartPin.ParentComponent.ShouldBe(cloned.ChildComponents[0],
+            "Cloned path should reference cloned child components");
+        clonedPath.EndPin.ParentComponent.ShouldBe(cloned.ChildComponents[1],
+            "Cloned path should reference cloned child components");
+    }
+
+    /// <summary>
+    /// Helper to create a component with physical pins for testing.
+    /// </summary>
+    private static Component CreateComponentWithPins(string identifier, double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>
+        {
+            new("out", 0, MatterType.Light, RectSide.Right)
+        });
+
+        var physicalPins = new List<PhysicalPin>
+        {
+            new()
+            {
+                Name = "out",
+                OffsetXMicrometers = 250,
+                OffsetYMicrometers = 125,
+                AngleDegrees = 0
+            }
+        };
+
+        var component = new Component(
+            new Dictionary<int, SMatrix>(),
+            new List<Slider>(),
+            "test_component",
+            "",
+            parts,
+            0,
+            identifier,
+            DiscreteRotation.R0,
+            physicalPins);
+
+        component.WidthMicrometers = 250;
+        component.HeightMicrometers = 250;
+        component.PhysicalX = x;
+        component.PhysicalY = y;
+
+        return component;
+    }
+
+    /// <summary>
+    /// Verifies that cloning a group with external pins creates deep copies of those pins.
+    /// </summary>
+    [Fact]
+    public void Clone_GroupWithExternalPins_CreatesDeepCopyOfPins()
+    {
+        var group = new ComponentGroup("GroupWithPins")
+        {
+            PhysicalX = 0,
+            PhysicalY = 0
+        };
+
+        var child1 = CreateComponentWithPins("Child1", 100, 100);
+        group.AddChild(child1);
+
+        // Add an external pin
+        var externalPin = new GroupPin
+        {
+            Name = "group_input",
+            InternalPin = child1.PhysicalPins[0],
+            RelativeX = 0,
+            RelativeY = 125,
+            AngleDegrees = 180
+        };
+        group.AddExternalPin(externalPin);
+
+        var cloned = (ComponentGroup)group.Clone();
+
+        cloned.ExternalPins.Count.ShouldBe(1, "Cloned group should have one external pin");
+        var clonedPin = cloned.ExternalPins[0];
+
+        clonedPin.ShouldNotBeSameAs(externalPin, "Cloned pin should be a different instance");
+        clonedPin.Name.ShouldBe("group_input", "Pin name should be preserved");
+        clonedPin.RelativeX.ShouldBe(0, "Pin relative X should be preserved");
+        clonedPin.RelativeY.ShouldBe(125, "Pin relative Y should be preserved");
+
+        // Verify the cloned pin references the cloned component
+        clonedPin.InternalPin.ParentComponent.ShouldBe(cloned.ChildComponents[0],
+            "Cloned external pin should reference cloned child component");
+    }
+
+    /// <summary>
+    /// Verifies that cloning a nested group (group within group) works correctly.
+    /// </summary>
+    [Fact]
+    public void Clone_NestedGroup_CreatesDeepCopyRecursively()
+    {
+        var outerGroup = TestComponentFactory.CreateComponentGroup("OuterGroup", addChildren: false);
+        var innerGroup = TestComponentFactory.CreateComponentGroup("InnerGroup", addChildren: true);
+
+        outerGroup.AddChild(innerGroup);
+
+        var clonedOuter = (ComponentGroup)outerGroup.Clone();
+
+        clonedOuter.ChildComponents.Count.ShouldBe(1, "Outer group should have one child");
+        var clonedInner = clonedOuter.ChildComponents[0] as ComponentGroup;
+
+        clonedInner.ShouldNotBeNull("Child should be a ComponentGroup");
+        clonedInner.ShouldNotBeSameAs(innerGroup, "Inner group should be cloned");
+        clonedInner.ChildComponents.Count.ShouldBe(2,
+            "Inner group should have its children cloned");
+
+        // Verify parent references
+        clonedInner.ParentGroup.ShouldBe(clonedOuter,
+            "Cloned inner group should reference cloned outer group");
+    }
+
+    /// <summary>
+    /// Verifies that cloning preserves group physical properties (position, size, rotation).
+    /// </summary>
+    [Fact]
+    public void Clone_PreservesPhysicalProperties()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("PhysicalGroup", addChildren: true);
+        original.PhysicalX = 500;
+        original.PhysicalY = 300;
+
+        var cloned = (ComponentGroup)original.Clone();
+
+        cloned.PhysicalX.ShouldBe(500, "X position should be preserved");
+        cloned.PhysicalY.ShouldBe(300, "Y position should be preserved");
+        cloned.WidthMicrometers.ShouldBe(original.WidthMicrometers, "Width should be preserved");
+        cloned.HeightMicrometers.ShouldBe(original.HeightMicrometers, "Height should be preserved");
+        cloned.Rotation90CounterClock.ShouldBe(original.Rotation90CounterClock,
+            "Rotation should be preserved");
+    }
+
+    /// <summary>
+    /// Verifies that cloning creates new unique identifiers for the group.
+    /// </summary>
+    [Fact]
+    public void Clone_CreatesNewIdentifier()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("UniqueGroup", addChildren: false);
+        var originalId = original.Identifier;
+
+        var cloned = (ComponentGroup)original.Clone();
+
+        cloned.Identifier.ShouldNotBe(originalId,
+            "Cloned group should have a different identifier");
+    }
+
+    /// <summary>
+    /// Verifies that multiple clones are independent (modifying one doesn't affect others).
+    /// </summary>
+    [Fact]
+    public void Clone_MultipleTimes_CreatesIndependentCopies()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("OriginalGroup", addChildren: true);
+
+        var clone1 = (ComponentGroup)original.Clone();
+        var clone2 = (ComponentGroup)original.Clone();
+
+        clone1.ShouldNotBeSameAs(clone2, "Each clone should be a different instance");
+        clone1.Identifier.ShouldNotBe(clone2.Identifier,
+            "Each clone should have a unique identifier");
+
+        // Modify clone1
+        clone1.PhysicalX = 999;
+
+        // Verify clone2 is unaffected
+        clone2.PhysicalX.ShouldBe(original.PhysicalX,
+            "Modifying one clone should not affect another");
+    }
+}


### PR DESCRIPTION
Automated implementation for #164

⚠️ **Stacked PR** - This PR is based on #175. Merge that PR first, then this one will automatically update to target `main`.

Perfect! Let me create a summary of the implementation:

## Summary

I've successfully fixed issue #164 (Bug: Copy/Paste group doesn't copy child components). The fix implements a complete vertical slice with all required layers:

### Changes Made

#### 1. **Core Logic** (`Connect-A-Pic-Core/Components/Core/`)
- Made `Component.Clone()` virtual to allow proper polymorphic behavior
- Added `ComponentGroup.Clone()` override that delegates to the existing `DeepCopy()` method
- This ensures that when a ComponentGroup is cloned via the base `Component` reference, it properly deep copies all child components, internal paths, and external pins

#### 2. **Unit Tests** (`UnitTests/Components/ComponentGroupCloningTests.cs`)
Created 9 comprehensive unit tests covering:
- Empty group cloning
- Deep copy of child components
- ParentGroup reference preservation
- Internal frozen path cloning
- External pin cloning
- Nested group cloning (recursive)
- Physical property preservation
- Unique identifier generation
- Multiple independent clones

#### 3. **Integration Tests** (`UnitTests/Commands/CopyPasteWorkflowTests.cs`)
Added 3 integration tests for the complete copy/paste workflow:
- `Paste_ComponentGroup_CopiesAllChildComponents` - Verifies all children are copied
- `Paste_ComponentGroupWithInternalPaths_PreservesGroupStructure` - Verifies group structure integrity
- `Paste_NestedComponentGroup_CopiesAllLevels` - Verifies nested groups work correctly

### Test Results
- **All new tests pass**: 9 unit tests + 3 integration tests = 12/12 passing
- **All existing copy/paste tests pass**: 11/11 passing
- **Total test suite**: 788 passing, 24 skipped
- **Note**: 3 pre-existing failures in unrelated tests (GridPersistence and ManhattanRouting) that also fail on the main branch

### How It Works

The fix addresses the root cause: when `ComponentClipboard.Paste()` calls `component.Clone()` on a `ComponentGroup` instance that's stored as a `Component` reference, it now correctly invokes the overridden `Clone()` method instead of the base implementation. This triggers `DeepCopy()` which:

1. Creates a new ComponentGroup with a unique identifier
2. Recursively clones all child components (including nested groups)
3. Clones all internal frozen waveguide paths with updated pin references
4. Clones all external pins with proper component references
5. Preserves all physical properties (position, size, rotation)

### Manual Testing Instructions

1. Create a group from 2-3 connected components (Ctrl+G)
2. Select the group
3. Copy with Ctrl+C
4. Paste with Ctrl+V
5. **Expected**: The pasted group contains all child components, is fully editable (double-click), and internal connections are preserved
6. **Verify**: The pasted group is independent (moving it doesn't affect the original)

The implementation follows all CLAUDE.md guidelines:
- Complete vertical slice (Core + Tests)
- Clean, focused changes
- Comprehensive test coverage
- No backwards compatibility hacks needed
- Build and tests pass successfully


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 18,001
- **Estimated cost:** $0.2687 USD

---
*Generated by autonomous agent using Claude Code.*