### PR TITLE
Agent: Bug: Group Pins Not Visible/Accessible Outside Edit Mode

### DIFF
--- a/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
@@ -15,7 +15,7 @@ public partial class DesignCanvasViewModel : ObservableObject
 {
     public ObservableCollection<ComponentViewModel> Components { get; } = new();
     public ObservableCollection<WaveguideConnectionViewModel> Connections { get; } = new();
-    public ObservableCollection<PinViewModel> AllPins { get; } = new();
+    public ObservableCollection<IPinViewModel> AllPins { get; } = new();
 
     public WaveguideConnectionManager ConnectionManager { get; } = new();
 
@@ -106,7 +106,7 @@ public partial class DesignCanvasViewModel : ObservableObject
     /// The currently highlighted pin (when mouse is near in Connect mode).
     /// </summary>
     [ObservableProperty]
-    private PinViewModel? _highlightedPin;
+    private IPinViewModel? _highlightedPin;
 
     /// <summary>
     /// Distance threshold for pin highlighting (in micrometers).
@@ -606,6 +606,16 @@ public partial class DesignCanvasViewModel : ObservableObject
             AllPins.Add(new PinViewModel(pin, vm));
         }
 
+        // For ComponentGroups, also add GroupPinViewModels for external pins
+        // This enables pin highlighting and connection creation for group pins
+        if (component is ComponentGroup group)
+        {
+            foreach (var groupPin in group.ExternalPins)
+            {
+                AllPins.Add(new GroupPinViewModel(groupPin, group, vm));
+            }
+        }
+
         return vm;
     }
 
@@ -616,7 +626,7 @@ public partial class DesignCanvasViewModel : ObservableObject
 
         ConnectionManager.RemoveConnectionsForComponent(component.Component);
 
-        // Remove pin ViewModels for this component
+        // Remove pin ViewModels for this component (including GroupPin ViewModels)
         var pinsToRemove = AllPins.Where(p => p.ParentComponentViewModel == component).ToList();
         foreach (var pin in pinsToRemove)
         {
@@ -721,7 +731,7 @@ public partial class DesignCanvasViewModel : ObservableObject
     /// <param name="y">Mouse Y position in micrometers</param>
     /// <param name="excludePin">Optional pin to exclude (e.g., the connection start pin)</param>
     /// <returns>The nearest pin if within highlight distance, otherwise null</returns>
-    public PinViewModel? UpdatePinHighlight(double x, double y, PhysicalPin? excludePin = null)
+    public IPinViewModel? UpdatePinHighlight(double x, double y, PhysicalPin? excludePin = null)
     {
         // Clear previous highlight
         if (HighlightedPin != null)
@@ -731,7 +741,7 @@ public partial class DesignCanvasViewModel : ObservableObject
         }
 
         // Find nearest pin
-        PinViewModel? nearest = null;
+        IPinViewModel? nearest = null;
         double nearestDistance = double.MaxValue;
 
         foreach (var pinVm in AllPins)
@@ -743,7 +753,9 @@ public partial class DesignCanvasViewModel : ObservableObject
                 if (pinVm.Pin.ParentComponent == excludePin.ParentComponent) continue;
             }
 
-            var (pinX, pinY) = pinVm.Pin.GetAbsolutePosition();
+            // Use ViewModel's X and Y properties (correct for both PhysicalPins and GroupPins)
+            double pinX = pinVm.X;
+            double pinY = pinVm.Y;
             double dist = Math.Sqrt(Math.Pow(x - pinX, 2) + Math.Pow(y - pinY, 2));
 
             if (dist < nearestDistance && dist <= PinHighlightDistance)
@@ -1096,7 +1108,7 @@ public partial class WaveguideConnectionViewModel : ObservableObject
 /// <summary>
 /// ViewModel for a physical pin with highlighting support.
 /// </summary>
-public partial class PinViewModel : ObservableObject
+public partial class PinViewModel : ObservableObject, IPinViewModel
 {
     public PhysicalPin Pin { get; }
     public ComponentViewModel ParentComponentViewModel { get; }

--- a/CAP.Avalonia/ViewModels/Canvas/GroupPinViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/GroupPinViewModel.cs
@@ -1,0 +1,90 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.ViewModels.Canvas;
+
+/// <summary>
+/// ViewModel for a ComponentGroup external pin (GroupPin).
+/// Provides correct position calculation for pins on group boundaries.
+/// </summary>
+public partial class GroupPinViewModel : ObservableObject, IPinViewModel
+{
+    public GroupPin GroupPin { get; }
+    public ComponentGroup ParentGroup { get; }
+    public ComponentViewModel ParentComponentViewModel { get; }
+
+    [ObservableProperty]
+    private bool _isHighlighted;
+
+    /// <summary>
+    /// Scale factor for visual size (1.0 = normal, 1.5 = highlighted).
+    /// </summary>
+    [ObservableProperty]
+    private double _scale = 1.0;
+
+    /// <summary>
+    /// The underlying PhysicalPin (InternalPin) that this GroupPin exposes.
+    /// Used for connection creation.
+    /// </summary>
+    public PhysicalPin Pin => GroupPin.InternalPin;
+
+    /// <summary>
+    /// Absolute X position of the GroupPin on the group boundary.
+    /// </summary>
+    public double X
+    {
+        get
+        {
+            var (x, _) = GroupPinOccupancyChecker.GetAbsolutePosition(GroupPin, ParentGroup);
+            return x;
+        }
+    }
+
+    /// <summary>
+    /// Absolute Y position of the GroupPin on the group boundary.
+    /// </summary>
+    public double Y
+    {
+        get
+        {
+            var (_, y) = GroupPinOccupancyChecker.GetAbsolutePosition(GroupPin, ParentGroup);
+            return y;
+        }
+    }
+
+    /// <summary>
+    /// Angle of the GroupPin in degrees (0° = east, 90° = north, etc.).
+    /// </summary>
+    public double Angle => GroupPinOccupancyChecker.GetAbsoluteAngle(GroupPin);
+
+    /// <summary>
+    /// Display name of the GroupPin.
+    /// </summary>
+    public string Name => GroupPin.Name;
+
+    /// <summary>
+    /// Whether this pin already has a connection.
+    /// </summary>
+    public bool HasConnection { get; set; }
+
+    public GroupPinViewModel(GroupPin groupPin, ComponentGroup parentGroup, ComponentViewModel parentVm)
+    {
+        GroupPin = groupPin;
+        ParentGroup = parentGroup;
+        ParentComponentViewModel = parentVm;
+    }
+
+    public void SetHighlighted(bool highlighted)
+    {
+        IsHighlighted = highlighted;
+        Scale = highlighted ? 1.5 : 1.0;
+    }
+
+    public void NotifyPositionChanged()
+    {
+        OnPropertyChanged(nameof(X));
+        OnPropertyChanged(nameof(Y));
+        OnPropertyChanged(nameof(Angle));
+    }
+}

--- a/CAP.Avalonia/ViewModels/Canvas/IPinViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/IPinViewModel.cs
@@ -1,0 +1,66 @@
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.ViewModels.Canvas;
+
+/// <summary>
+/// Interface for pin view models (regular pins and group pins).
+/// Provides common properties and methods for pin highlighting and interaction.
+/// </summary>
+public interface IPinViewModel
+{
+    /// <summary>
+    /// The underlying PhysicalPin that this ViewModel represents.
+    /// For GroupPins, this is the InternalPin.
+    /// </summary>
+    PhysicalPin Pin { get; }
+
+    /// <summary>
+    /// The parent component ViewModel.
+    /// </summary>
+    ComponentViewModel ParentComponentViewModel { get; }
+
+    /// <summary>
+    /// Absolute X position of the pin in micrometers.
+    /// </summary>
+    double X { get; }
+
+    /// <summary>
+    /// Absolute Y position of the pin in micrometers.
+    /// </summary>
+    double Y { get; }
+
+    /// <summary>
+    /// Pin angle in degrees (0° = east, 90° = north, etc.).
+    /// </summary>
+    double Angle { get; }
+
+    /// <summary>
+    /// Display name of the pin.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Whether this pin is currently highlighted (mouse is near).
+    /// </summary>
+    bool IsHighlighted { get; set; }
+
+    /// <summary>
+    /// Visual scale factor (1.0 = normal, 1.5 = highlighted).
+    /// </summary>
+    double Scale { get; set; }
+
+    /// <summary>
+    /// Whether this pin already has a connection.
+    /// </summary>
+    bool HasConnection { get; set; }
+
+    /// <summary>
+    /// Sets the highlighted state and updates visual scale.
+    /// </summary>
+    void SetHighlighted(bool highlighted);
+
+    /// <summary>
+    /// Notifies that the pin position has changed (triggers property change events).
+    /// </summary>
+    void NotifyPositionChanged();
+}

--- a/UnitTests/ViewModels/GroupPinViewModelTests.cs
+++ b/UnitTests/ViewModels/GroupPinViewModelTests.cs
@@ -1,0 +1,343 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>
+/// Unit tests for GroupPinViewModel.
+/// Tests that GroupPins are correctly added to AllPins and support highlighting.
+/// </summary>
+public class GroupPinViewModelTests
+{
+    /// <summary>
+    /// Tests that adding a ComponentGroup to the canvas adds its GroupPins to AllPins.
+    /// </summary>
+    [Fact]
+    public void AddComponent_WithComponentGroup_AddsGroupPinsToAllPins()
+    {
+        // Arrange
+        var vm = new DesignCanvasViewModel();
+        var group = CreateGroupWithPins();
+
+        // Act
+        vm.AddComponent(group);
+
+        // Assert
+        // ComponentGroup has no PhysicalPins on the group itself, only ExternalPins
+        vm.AllPins.Count.ShouldBe(1); // 1 group pin
+
+        // Verify the group pin is included
+        var groupPinVm = vm.AllPins.OfType<GroupPinViewModel>().FirstOrDefault();
+        groupPinVm.ShouldNotBeNull();
+        groupPinVm.Name.ShouldBe("external_east");
+    }
+
+    /// <summary>
+    /// Tests that GroupPinViewModel calculates correct absolute positions.
+    /// </summary>
+    [Fact]
+    public void GroupPinViewModel_CalculatesCorrectAbsolutePosition()
+    {
+        // Arrange
+        var group = new ComponentGroup("TestGroup");
+        group.PhysicalX = 100;
+        group.PhysicalY = 200;
+
+        var child = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        group.AddChild(child);
+
+        var groupPin = new GroupPin
+        {
+            Name = "test_pin",
+            InternalPin = child.PhysicalPins.First(),
+            RelativeX = 50,
+            RelativeY = 75,
+            AngleDegrees = 0
+        };
+        group.AddExternalPin(groupPin);
+
+        var componentVm = new ComponentViewModel(group);
+        var pinVm = new GroupPinViewModel(groupPin, group, componentVm);
+
+        // Act & Assert
+        pinVm.X.ShouldBe(150.0); // 100 + 50
+        pinVm.Y.ShouldBe(275.0); // 200 + 75
+    }
+
+    /// <summary>
+    /// Tests that UpdatePinHighlight correctly highlights GroupPins.
+    /// </summary>
+    [Fact]
+    public void UpdatePinHighlight_WithGroupPin_HighlightsCorrectly()
+    {
+        // Arrange
+        var vm = new DesignCanvasViewModel();
+        var group = CreateGroupWithPins();
+        vm.AddComponent(group);
+
+        // Pin position: group at (100, 100), pin at relative (50, 0) = absolute (150, 100)
+        double testX = 150;
+        double testY = 100;
+
+        // Act
+        var highlightedPin = vm.UpdatePinHighlight(testX, testY);
+
+        // Assert
+        highlightedPin.ShouldNotBeNull();
+        highlightedPin.ShouldBeOfType<GroupPinViewModel>();
+        highlightedPin.IsHighlighted.ShouldBeTrue();
+        highlightedPin.Name.ShouldBe("external_east");
+    }
+
+    /// <summary>
+    /// Tests that UpdatePinHighlight selects the nearest pin (GroupPin vs PhysicalPin).
+    /// </summary>
+    [Fact]
+    public void UpdatePinHighlight_SelectsNearestPin()
+    {
+        // Arrange
+        var vm = new DesignCanvasViewModel();
+
+        // Add a regular component
+        var regularComp = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        regularComp.PhysicalX = 200;
+        regularComp.PhysicalY = 100;
+        vm.AddComponent(regularComp);
+
+        // Add a group with a pin
+        var group = CreateGroupWithPins();
+        vm.AddComponent(group);
+
+        // Test point closer to the GroupPin (150, 100) than to the regular component (200, 100)
+        double testX = 155;
+        double testY = 100;
+
+        // Act
+        var highlightedPin = vm.UpdatePinHighlight(testX, testY);
+
+        // Assert
+        highlightedPin.ShouldNotBeNull();
+        highlightedPin.ShouldBeOfType<GroupPinViewModel>();
+        highlightedPin.Name.ShouldBe("external_east");
+    }
+
+    /// <summary>
+    /// Tests that removing a ComponentGroup also removes its GroupPins from AllPins.
+    /// </summary>
+    [Fact]
+    public void RemoveComponent_WithComponentGroup_RemovesGroupPinsFromAllPins()
+    {
+        // Arrange
+        var vm = new DesignCanvasViewModel();
+        var group = CreateGroupWithPins();
+        var componentVm = vm.AddComponent(group);
+
+        // Verify pins were added
+        vm.AllPins.Count.ShouldBe(1); // 1 group pin
+
+        // Act
+        vm.RemoveComponent(componentVm);
+
+        // Assert
+        vm.AllPins.Count.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// Tests that GroupPinViewModel provides the correct InternalPin for connections.
+    /// </summary>
+    [Fact]
+    public void GroupPinViewModel_ExposesCorrectInternalPin()
+    {
+        // Arrange
+        var group = new ComponentGroup("TestGroup");
+        var child = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        group.AddChild(child);
+
+        var internalPin = child.PhysicalPins.First();
+        var groupPin = new GroupPin
+        {
+            Name = "external",
+            InternalPin = internalPin,
+            RelativeX = 50,
+            RelativeY = 0,
+            AngleDegrees = 0
+        };
+        group.AddExternalPin(groupPin);
+
+        var componentVm = new ComponentViewModel(group);
+        var pinVm = new GroupPinViewModel(groupPin, group, componentVm);
+
+        // Act & Assert
+        pinVm.Pin.ShouldBe(internalPin);
+    }
+
+    /// <summary>
+    /// Tests that GroupPinViewModel implements IPinViewModel interface correctly.
+    /// </summary>
+    [Fact]
+    public void GroupPinViewModel_ImplementsIPinViewModelInterface()
+    {
+        // Arrange
+        var group = new ComponentGroup("TestGroup");
+        group.PhysicalX = 100;
+        group.PhysicalY = 100;
+
+        var child = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        group.AddChild(child);
+
+        var groupPin = new GroupPin
+        {
+            Name = "external",
+            InternalPin = child.PhysicalPins.First(),
+            RelativeX = 50,
+            RelativeY = 0,
+            AngleDegrees = 45
+        };
+        group.AddExternalPin(groupPin);
+
+        var componentVm = new ComponentViewModel(group);
+
+        // Act
+        IPinViewModel pinVm = new GroupPinViewModel(groupPin, group, componentVm);
+
+        // Assert
+        pinVm.X.ShouldBe(150.0);
+        pinVm.Y.ShouldBe(100.0);
+        pinVm.Angle.ShouldBe(45.0);
+        pinVm.Name.ShouldBe("external");
+        pinVm.Pin.ShouldBe(child.PhysicalPins.First());
+    }
+
+    /// <summary>
+    /// Tests that SetHighlighted updates IsHighlighted and Scale properties.
+    /// </summary>
+    [Fact]
+    public void SetHighlighted_UpdatesPropertiesCorrectly()
+    {
+        // Arrange
+        var group = CreateGroupWithPins();
+        var groupPin = group.ExternalPins.First();
+        var componentVm = new ComponentViewModel(group);
+        var pinVm = new GroupPinViewModel(groupPin, group, componentVm);
+
+        // Act
+        pinVm.SetHighlighted(true);
+
+        // Assert
+        pinVm.IsHighlighted.ShouldBeTrue();
+        pinVm.Scale.ShouldBe(1.5);
+
+        // Act
+        pinVm.SetHighlighted(false);
+
+        // Assert
+        pinVm.IsHighlighted.ShouldBeFalse();
+        pinVm.Scale.ShouldBe(1.0);
+    }
+
+    /// <summary>
+    /// Tests that a ComponentGroup with multiple external pins adds all to AllPins.
+    /// </summary>
+    [Fact]
+    public void AddComponent_WithMultipleGroupPins_AddsAllToAllPins()
+    {
+        // Arrange
+        var vm = new DesignCanvasViewModel();
+        var group = CreateGroupWithMultiplePins();
+
+        // Act
+        vm.AddComponent(group);
+
+        // Assert
+        // ComponentGroup has no PhysicalPins on the group itself, only 3 GroupPins
+        vm.AllPins.Count.ShouldBe(3);
+
+        var groupPinVms = vm.AllPins.OfType<GroupPinViewModel>().ToList();
+        groupPinVms.Count.ShouldBe(3);
+
+        groupPinVms.ShouldContain(p => p.Name == "external_east");
+        groupPinVms.ShouldContain(p => p.Name == "external_west");
+        groupPinVms.ShouldContain(p => p.Name == "external_north");
+    }
+
+    /// <summary>
+    /// Creates a ComponentGroup with a single external pin for testing.
+    /// </summary>
+    private ComponentGroup CreateGroupWithPins()
+    {
+        var group = new ComponentGroup("TestGroup");
+        group.PhysicalX = 100;
+        group.PhysicalY = 100;
+
+        var child = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        group.AddChild(child);
+
+        var groupPin = new GroupPin
+        {
+            Name = "external_east",
+            InternalPin = child.PhysicalPins.First(),
+            RelativeX = 50,
+            RelativeY = 0,
+            AngleDegrees = 0
+        };
+        group.AddExternalPin(groupPin);
+
+        return group;
+    }
+
+    /// <summary>
+    /// Creates a ComponentGroup with multiple external pins for testing.
+    /// </summary>
+    private ComponentGroup CreateGroupWithMultiplePins()
+    {
+        var group = new ComponentGroup("TestGroup");
+        group.PhysicalX = 100;
+        group.PhysicalY = 100;
+
+        // Add child components
+        var child1 = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        var child2 = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        child2.PhysicalX = 50;
+        var child3 = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        child3.PhysicalX = 100;
+        group.AddChild(child1);
+        group.AddChild(child2);
+        group.AddChild(child3);
+
+        // Add external pins
+        var pin1 = new GroupPin
+        {
+            Name = "external_east",
+            InternalPin = child1.PhysicalPins.First(),
+            RelativeX = 50,
+            RelativeY = 0,
+            AngleDegrees = 0
+        };
+
+        var pin2 = new GroupPin
+        {
+            Name = "external_west",
+            InternalPin = child2.PhysicalPins.First(),
+            RelativeX = -50,
+            RelativeY = 0,
+            AngleDegrees = 180
+        };
+
+        var pin3 = new GroupPin
+        {
+            Name = "external_north",
+            InternalPin = child3.PhysicalPins.First(),
+            RelativeX = 0,
+            RelativeY = -50,
+            AngleDegrees = 90
+        };
+
+        group.AddExternalPin(pin1);
+        group.AddExternalPin(pin2);
+        group.AddExternalPin(pin3);
+
+        return group;
+    }
+}


### PR DESCRIPTION
Automated implementation for #216

⚠️ **Stacked PR** - This PR is based on #222. Merge that PR first, then this one will automatically update to target `main`.

Excellent! All the existing GroupPin rendering tests still pass. Now let's create a summary of what we implemented:

## Summary

I've successfully fixed bug #216: "Group Pins Not Visible/Accessible Outside Edit Mode". Here's what was implemented:

### Root Cause
GroupPins (external pins on ComponentGroups) were rendered correctly but not included in the `AllPins` collection, making them unable to be highlighted or interacted with for connection creation.

### Solution: Complete Vertical Slice

**1. Core Logic** (New Architecture):
- Created `IPinViewModel` interface (`CAP.Avalonia/ViewModels/Canvas/IPinViewModel.cs`) for polymorphic pin handling
- Created `GroupPinViewModel` class (`CAP.Avalonia/ViewModels/Canvas/GroupPinViewModel.cs`) that:
  - Calculates correct absolute positions using `GroupPinOccupancyChecker.GetAbsolutePosition()` 
  - Exposes the InternalPin for connection creation
  - Implements highlighting and visual feedback

**2. ViewModel Updates** (`CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs`):
- Updated `PinViewModel` to implement `IPinViewModel`
- Changed `AllPins` collection type from `ObservableCollection<PinViewModel>` to `ObservableCollection<IPinViewModel>`
- Modified `AddComponent()` to add `GroupPinViewModel` instances for ComponentGroup ExternalPins
- Updated `UpdatePinHighlight()` to use ViewModel's `X` and `Y` properties (works correctly for both types)

**3. View**: No changes needed - existing rendering code in `ComponentGroupRenderer.cs` already worked correctly

**4. Tests** (`UnitTests/ViewModels/GroupPinViewModelTests.cs`):
- 9 comprehensive unit tests covering:
  - GroupPin addition to AllPins collection
  - Correct absolute position calculation
  - Pin highlighting functionality
  - Nearest pin selection
  - Component removal cleanup
  - Multiple GroupPins support
  - Interface implementation verification

### Acceptance Criteria Met
- ✅ GroupPins visible when group is selected (already rendered)
- ✅ GroupPins selectable for connection creation (now in AllPins, can be highlighted)
- ✅ Pin positions calculated correctly on group bounds (GroupPinViewModel uses GroupPinOccupancyChecker)
- ✅ Pin direction indicators shown (already rendered by ComponentGroupRenderer)
- ✅ Works for groups with 1-10+ external pins (tested with 3 pins)
- ✅ Pin tooltips show correct names (existing rendering code)

### Test Results
- **New tests**: 9/9 passing
- **Existing GroupPin tests**: 6/6 passing  
- **Build**: Success with only warnings (code analysis suggestions)
- **No regressions** in GroupPin functionality

The implementation follows SOLID principles with proper interface abstraction, maintains the existing architecture patterns, and provides a complete vertical slice that's immediately testable in the UI.


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 18,283
- **Estimated cost:** $0.2731 USD

---
*Generated by autonomous agent using Claude Code.*