### PR TITLE
Agent: Bug: Saved Groups cannot be placed on canvas

### DIFF
--- a/Connect-A-Pic-Core/Components/Creation/GroupLibraryManager.cs
+++ b/Connect-A-Pic-Core/Components/Creation/GroupLibraryManager.cs
@@ -92,8 +92,9 @@ public class GroupLibraryManager
         var fileName = $"{safeName}_{DateTime.Now:yyyyMMdd_HHmmss}.json";
         var filePath = Path.Combine(targetFolder, fileName);
 
-        // Create file data structure (minimal metadata only)
-        // Actual serialization will be handled by the persistence layer
+        // Serialize full group data so it can be reconstructed when loaded from disk
+        var groupDataJson = GroupTemplateSerializer.Serialize(group);
+
         var fileData = new GroupLibraryFileData
         {
             Name = name,
@@ -102,7 +103,8 @@ public class GroupLibraryManager
             CreatedAt = DateTime.Now,
             ComponentCount = group.ChildComponents.Count,
             WidthMicrometers = group.WidthMicrometers,
-            HeightMicrometers = group.HeightMicrometers
+            HeightMicrometers = group.HeightMicrometers,
+            GroupData = groupDataJson
         };
 
         var json = JsonSerializer.Serialize(fileData, new JsonSerializerOptions
@@ -217,6 +219,13 @@ public class GroupLibraryManager
                 if (fileData == null)
                     continue;
 
+                // Deserialize the full group data if available
+                ComponentGroup? templateGroup = null;
+                if (!string.IsNullOrWhiteSpace(fileData.GroupData))
+                {
+                    templateGroup = GroupTemplateSerializer.Deserialize(fileData.GroupData);
+                }
+
                 var template = new GroupTemplate
                 {
                     Name = fileData.Name,
@@ -228,8 +237,8 @@ public class GroupLibraryManager
                     HeightMicrometers = fileData.HeightMicrometers,
                     Source = source,
                     CreatedAt = fileData.CreatedAt,
-                    PreviewThumbnailBase64 = fileData.PreviewThumbnailBase64
-                    // Note: TemplateGroup is loaded on-demand when needed
+                    PreviewThumbnailBase64 = fileData.PreviewThumbnailBase64,
+                    TemplateGroup = templateGroup
                 };
 
                 _templates.Add(template);
@@ -253,7 +262,7 @@ public class GroupLibraryManager
 
 /// <summary>
 /// JSON file structure for saved group templates.
-/// Stores metadata only - the actual ComponentGroup is stored in TemplateGroup property.
+/// Stores metadata and the full serialized ComponentGroup data for reconstruction.
 /// </summary>
 public class GroupLibraryFileData
 {
@@ -265,4 +274,10 @@ public class GroupLibraryFileData
     public double WidthMicrometers { get; set; }
     public double HeightMicrometers { get; set; }
     public string? PreviewThumbnailBase64 { get; set; }
+
+    /// <summary>
+    /// Serialized ComponentGroup data (JSON string from GroupTemplateSerializer).
+    /// Contains all child components, frozen paths, and external pins.
+    /// </summary>
+    public string? GroupData { get; set; }
 }

--- a/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
+++ b/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
@@ -1,0 +1,463 @@
+using System.Text.Json;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+
+namespace CAP_Core.Components.Creation;
+
+/// <summary>
+/// Self-contained serializer for ComponentGroup templates.
+/// Unlike ComponentGroupSerializer in CAP-DataAccess which uses external component references,
+/// this serializer embeds all child component data inline for independent storage and retrieval.
+/// </summary>
+public static class GroupTemplateSerializer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    /// <summary>
+    /// Serializes a ComponentGroup to a self-contained JSON string.
+    /// All child components, frozen paths, and external pins are embedded inline.
+    /// </summary>
+    public static string Serialize(ComponentGroup group)
+    {
+        if (group == null)
+            throw new ArgumentNullException(nameof(group));
+
+        var dto = ToDto(group);
+        return JsonSerializer.Serialize(dto, JsonOptions);
+    }
+
+    /// <summary>
+    /// Deserializes a ComponentGroup from a self-contained JSON string.
+    /// </summary>
+    public static ComponentGroup? Deserialize(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        var dto = JsonSerializer.Deserialize<GroupTemplateDto>(json, JsonOptions);
+        return dto == null ? null : FromDto(dto);
+    }
+
+    /// <summary>
+    /// Converts a ComponentGroup to a self-contained DTO.
+    /// </summary>
+    private static GroupTemplateDto ToDto(ComponentGroup group)
+    {
+        var dto = new GroupTemplateDto
+        {
+            GroupName = group.GroupName,
+            Description = group.Description,
+            Identifier = group.Identifier,
+            PhysicalX = group.PhysicalX,
+            PhysicalY = group.PhysicalY,
+            WidthMicrometers = group.WidthMicrometers,
+            HeightMicrometers = group.HeightMicrometers,
+            Rotation = (int)group.Rotation90CounterClock
+        };
+
+        // Serialize child components inline
+        foreach (var child in group.ChildComponents)
+        {
+            if (child is ComponentGroup childGroup)
+            {
+                dto.Children.Add(new ChildComponentDto
+                {
+                    IsGroup = true,
+                    NestedGroup = ToDto(childGroup)
+                });
+            }
+            else
+            {
+                dto.Children.Add(SerializeComponent(child));
+            }
+        }
+
+        // Serialize frozen paths (reference children by index)
+        foreach (var path in group.InternalPaths)
+        {
+            dto.InternalPaths.Add(SerializeFrozenPath(path, group.ChildComponents));
+        }
+
+        // Serialize external pins (reference children by index)
+        foreach (var pin in group.ExternalPins)
+        {
+            dto.ExternalPins.Add(SerializeGroupPin(pin, group.ChildComponents));
+        }
+
+        return dto;
+    }
+
+    /// <summary>
+    /// Reconstructs a ComponentGroup from a self-contained DTO.
+    /// </summary>
+    private static ComponentGroup FromDto(GroupTemplateDto dto)
+    {
+        var group = new ComponentGroup(dto.GroupName)
+        {
+            Description = dto.Description,
+            Identifier = dto.Identifier,
+            PhysicalX = dto.PhysicalX,
+            PhysicalY = dto.PhysicalY,
+            WidthMicrometers = dto.WidthMicrometers,
+            HeightMicrometers = dto.HeightMicrometers
+        };
+
+        // Deserialize child components
+        foreach (var childDto in dto.Children)
+        {
+            Component child;
+            if (childDto.IsGroup && childDto.NestedGroup != null)
+            {
+                child = FromDto(childDto.NestedGroup);
+            }
+            else
+            {
+                child = DeserializeComponent(childDto);
+            }
+            group.AddChild(child);
+        }
+
+        // Deserialize frozen paths
+        foreach (var pathDto in dto.InternalPaths)
+        {
+            var frozenPath = DeserializeFrozenPath(pathDto, group.ChildComponents);
+            if (frozenPath != null)
+            {
+                group.AddInternalPath(frozenPath);
+            }
+        }
+
+        // Deserialize external pins
+        foreach (var pinDto in dto.ExternalPins)
+        {
+            var groupPin = DeserializeGroupPin(pinDto, group.ChildComponents);
+            if (groupPin != null)
+            {
+                group.AddExternalPin(groupPin);
+            }
+        }
+
+        return group;
+    }
+
+    /// <summary>
+    /// Serializes a regular Component to a DTO with all data inline.
+    /// </summary>
+    private static ChildComponentDto SerializeComponent(Component comp)
+    {
+        var pins = comp.PhysicalPins.Select(p => new PinDto
+        {
+            Name = p.Name,
+            OffsetX = p.OffsetXMicrometers,
+            OffsetY = p.OffsetYMicrometers,
+            AngleDegrees = p.AngleDegrees
+        }).ToList();
+
+        return new ChildComponentDto
+        {
+            IsGroup = false,
+            Identifier = comp.Identifier,
+            NazcaFunctionName = comp.NazcaFunctionName,
+            NazcaFunctionParameters = comp.NazcaFunctionParameters,
+            NazcaModuleName = comp.NazcaModuleName,
+            TypeNumber = comp.TypeNumber,
+            PhysicalX = comp.PhysicalX,
+            PhysicalY = comp.PhysicalY,
+            WidthMicrometers = comp.WidthMicrometers,
+            HeightMicrometers = comp.HeightMicrometers,
+            Rotation = (int)comp.Rotation90CounterClock,
+            Pins = pins
+        };
+    }
+
+    /// <summary>
+    /// Deserializes a regular Component from a DTO.
+    /// </summary>
+    private static Component DeserializeComponent(ChildComponentDto dto)
+    {
+        var physicalPins = dto.Pins.Select(p => new PhysicalPin
+        {
+            Name = p.Name,
+            OffsetXMicrometers = p.OffsetX,
+            OffsetYMicrometers = p.OffsetY,
+            AngleDegrees = p.AngleDegrees
+        }).ToList();
+
+        return new Component(
+            new Dictionary<int, SMatrix>(),
+            new List<Slider>(),
+            dto.NazcaFunctionName ?? "",
+            dto.NazcaFunctionParameters ?? "",
+            new Part[1, 1] { { new Part() } },
+            dto.TypeNumber,
+            dto.Identifier ?? $"comp_{Guid.NewGuid():N}",
+            (DiscreteRotation)dto.Rotation,
+            physicalPins)
+        {
+            PhysicalX = dto.PhysicalX,
+            PhysicalY = dto.PhysicalY,
+            WidthMicrometers = dto.WidthMicrometers,
+            HeightMicrometers = dto.HeightMicrometers,
+            NazcaModuleName = dto.NazcaModuleName
+        };
+    }
+
+    /// <summary>
+    /// Serializes a frozen path, referencing child components by index.
+    /// </summary>
+    private static FrozenPathDto SerializeFrozenPath(
+        FrozenWaveguidePath path,
+        List<Component> children)
+    {
+        int startIdx = children.IndexOf(path.StartPin.ParentComponent);
+        int endIdx = children.IndexOf(path.EndPin.ParentComponent);
+
+        var segments = path.Path.Segments.Select(seg =>
+        {
+            if (seg is BendSegment bend)
+            {
+                return new SegmentDto
+                {
+                    Type = "arc",
+                    StartX = bend.StartPoint.X,
+                    StartY = bend.StartPoint.Y,
+                    EndX = bend.EndPoint.X,
+                    EndY = bend.EndPoint.Y,
+                    StartAngleDegrees = bend.StartAngleDegrees,
+                    CenterX = bend.Center.X,
+                    CenterY = bend.Center.Y,
+                    RadiusMicrometers = bend.RadiusMicrometers,
+                    SweepAngleDegrees = bend.SweepAngleDegrees
+                };
+            }
+
+            return new SegmentDto
+            {
+                Type = "straight",
+                StartX = seg.StartPoint.X,
+                StartY = seg.StartPoint.Y,
+                EndX = seg.EndPoint.X,
+                EndY = seg.EndPoint.Y,
+                StartAngleDegrees = seg.StartAngleDegrees
+            };
+        }).ToList();
+
+        return new FrozenPathDto
+        {
+            StartChildIndex = startIdx,
+            StartPinName = path.StartPin.Name,
+            EndChildIndex = endIdx,
+            EndPinName = path.EndPin.Name,
+            IsBlockedFallback = path.Path.IsBlockedFallback,
+            IsInvalidGeometry = path.Path.IsInvalidGeometry,
+            Segments = segments
+        };
+    }
+
+    /// <summary>
+    /// Deserializes a frozen path, resolving child references by index.
+    /// </summary>
+    private static FrozenWaveguidePath? DeserializeFrozenPath(
+        FrozenPathDto dto,
+        List<Component> children)
+    {
+        if (dto.StartChildIndex < 0 || dto.StartChildIndex >= children.Count)
+            return null;
+        if (dto.EndChildIndex < 0 || dto.EndChildIndex >= children.Count)
+            return null;
+
+        var startComp = children[dto.StartChildIndex];
+        var endComp = children[dto.EndChildIndex];
+
+        var startPin = startComp.PhysicalPins.FirstOrDefault(p => p.Name == dto.StartPinName);
+        var endPin = endComp.PhysicalPins.FirstOrDefault(p => p.Name == dto.EndPinName);
+
+        if (startPin == null || endPin == null)
+            return null;
+
+        var routedPath = new RoutedPath
+        {
+            IsBlockedFallback = dto.IsBlockedFallback,
+            IsInvalidGeometry = dto.IsInvalidGeometry
+        };
+
+        foreach (var seg in dto.Segments)
+        {
+            if (seg.Type == "arc")
+            {
+                routedPath.Segments.Add(new BendSegment(
+                    seg.CenterX, seg.CenterY,
+                    seg.RadiusMicrometers,
+                    seg.StartAngleDegrees,
+                    seg.SweepAngleDegrees));
+            }
+            else
+            {
+                routedPath.Segments.Add(new StraightSegment(
+                    seg.StartX, seg.StartY,
+                    seg.EndX, seg.EndY,
+                    seg.StartAngleDegrees));
+            }
+        }
+
+        return new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            Path = routedPath,
+            StartPin = startPin,
+            EndPin = endPin
+        };
+    }
+
+    /// <summary>
+    /// Serializes a group pin, referencing internal component by child index.
+    /// </summary>
+    private static ExternalPinDto SerializeGroupPin(
+        GroupPin pin,
+        List<Component> children)
+    {
+        int childIdx = children.IndexOf(pin.InternalPin.ParentComponent);
+
+        return new ExternalPinDto
+        {
+            Name = pin.Name,
+            ChildIndex = childIdx,
+            InternalPinName = pin.InternalPin.Name,
+            RelativeX = pin.RelativeX,
+            RelativeY = pin.RelativeY,
+            AngleDegrees = pin.AngleDegrees
+        };
+    }
+
+    /// <summary>
+    /// Deserializes a group pin, resolving internal component by child index.
+    /// </summary>
+    private static GroupPin? DeserializeGroupPin(
+        ExternalPinDto dto,
+        List<Component> children)
+    {
+        if (dto.ChildIndex < 0 || dto.ChildIndex >= children.Count)
+            return null;
+
+        var internalComp = children[dto.ChildIndex];
+        var internalPin = internalComp.PhysicalPins.FirstOrDefault(
+            p => p.Name == dto.InternalPinName);
+
+        if (internalPin == null)
+            return null;
+
+        return new GroupPin
+        {
+            PinId = Guid.NewGuid(),
+            Name = dto.Name,
+            InternalPin = internalPin,
+            RelativeX = dto.RelativeX,
+            RelativeY = dto.RelativeY,
+            AngleDegrees = dto.AngleDegrees
+        };
+    }
+}
+
+#region DTOs for self-contained group template serialization
+
+/// <summary>
+/// Self-contained DTO for a ComponentGroup template.
+/// All data needed for reconstruction is embedded inline.
+/// </summary>
+public class GroupTemplateDto
+{
+    public string GroupName { get; set; } = "";
+    public string Description { get; set; } = "";
+    public string Identifier { get; set; } = "";
+    public double PhysicalX { get; set; }
+    public double PhysicalY { get; set; }
+    public double WidthMicrometers { get; set; }
+    public double HeightMicrometers { get; set; }
+    public int Rotation { get; set; }
+    public List<ChildComponentDto> Children { get; set; } = new();
+    public List<FrozenPathDto> InternalPaths { get; set; } = new();
+    public List<ExternalPinDto> ExternalPins { get; set; } = new();
+}
+
+/// <summary>
+/// DTO for a child component (regular or nested group).
+/// </summary>
+public class ChildComponentDto
+{
+    public bool IsGroup { get; set; }
+    public string? Identifier { get; set; }
+    public string? NazcaFunctionName { get; set; }
+    public string? NazcaFunctionParameters { get; set; }
+    public string? NazcaModuleName { get; set; }
+    public int TypeNumber { get; set; }
+    public double PhysicalX { get; set; }
+    public double PhysicalY { get; set; }
+    public double WidthMicrometers { get; set; }
+    public double HeightMicrometers { get; set; }
+    public int Rotation { get; set; }
+    public List<PinDto> Pins { get; set; } = new();
+    public GroupTemplateDto? NestedGroup { get; set; }
+}
+
+/// <summary>
+/// DTO for a physical pin on a child component.
+/// </summary>
+public class PinDto
+{
+    public string Name { get; set; } = "";
+    public double OffsetX { get; set; }
+    public double OffsetY { get; set; }
+    public double AngleDegrees { get; set; }
+}
+
+/// <summary>
+/// DTO for a frozen waveguide path within the group.
+/// References child components by index in the Children list.
+/// </summary>
+public class FrozenPathDto
+{
+    public int StartChildIndex { get; set; }
+    public string StartPinName { get; set; } = "";
+    public int EndChildIndex { get; set; }
+    public string EndPinName { get; set; } = "";
+    public bool IsBlockedFallback { get; set; }
+    public bool IsInvalidGeometry { get; set; }
+    public List<SegmentDto> Segments { get; set; } = new();
+}
+
+/// <summary>
+/// DTO for a path segment (straight or arc).
+/// </summary>
+public class SegmentDto
+{
+    public string Type { get; set; } = "straight";
+    public double StartX { get; set; }
+    public double StartY { get; set; }
+    public double EndX { get; set; }
+    public double EndY { get; set; }
+    public double StartAngleDegrees { get; set; }
+    public double CenterX { get; set; }
+    public double CenterY { get; set; }
+    public double RadiusMicrometers { get; set; }
+    public double SweepAngleDegrees { get; set; }
+}
+
+/// <summary>
+/// DTO for an external pin exposed by the group.
+/// References internal component by index in the Children list.
+/// </summary>
+public class ExternalPinDto
+{
+    public string Name { get; set; } = "";
+    public int ChildIndex { get; set; }
+    public string InternalPinName { get; set; } = "";
+    public double RelativeX { get; set; }
+    public double RelativeY { get; set; }
+    public double AngleDegrees { get; set; }
+}
+
+#endregion

--- a/UnitTests/Integration/GroupTemplatePersistenceTests.cs
+++ b/UnitTests/Integration/GroupTemplatePersistenceTests.cs
@@ -1,0 +1,417 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Integration tests for the complete save → load → place workflow.
+/// Verifies that group templates survive disk persistence and can be placed on canvas
+/// after being loaded from disk (the root cause of issue #243).
+/// </summary>
+public class GroupTemplatePersistenceTests : IDisposable
+{
+    private readonly string _testLibraryPath;
+
+    public GroupTemplatePersistenceTests()
+    {
+        _testLibraryPath = Path.Combine(
+            Path.GetTempPath(),
+            $"GroupPersistenceTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testLibraryPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testLibraryPath))
+        {
+            Directory.Delete(_testLibraryPath, true);
+        }
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_TemplateGroupIsNotNull()
+    {
+        // Arrange - Save a group template
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroup("TestGroup", 2);
+        saveManager.SaveTemplate(group, "My Template");
+
+        // Act - Load from disk with a new manager instance (simulates app restart)
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+
+        // Assert
+        loadManager.Templates.Count.ShouldBe(1);
+        var loaded = loadManager.Templates[0];
+        loaded.Name.ShouldBe("My Template");
+        loaded.TemplateGroup.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_PreservesChildComponents()
+    {
+        // Arrange
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroup("TestGroup", 3);
+        saveManager.SaveTemplate(group, "3-Component Group");
+
+        // Act
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+
+        // Assert
+        var loaded = loadManager.Templates[0].TemplateGroup!;
+        loaded.ChildComponents.Count.ShouldBe(3);
+        loaded.GroupName.ShouldBe("TestGroup");
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_PreservesChildPositions()
+    {
+        // Arrange
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroup("PositionTest", 2);
+        group.ChildComponents[0].PhysicalX = 100;
+        group.ChildComponents[0].PhysicalY = 200;
+        group.ChildComponents[1].PhysicalX = 300;
+        group.ChildComponents[1].PhysicalY = 400;
+        saveManager.SaveTemplate(group, "Position Test");
+
+        // Act
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+
+        // Assert
+        var loaded = loadManager.Templates[0].TemplateGroup!;
+        loaded.ChildComponents[0].PhysicalX.ShouldBe(100);
+        loaded.ChildComponents[0].PhysicalY.ShouldBe(200);
+        loaded.ChildComponents[1].PhysicalX.ShouldBe(300);
+        loaded.ChildComponents[1].PhysicalY.ShouldBe(400);
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_PreservesChildPins()
+    {
+        // Arrange
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroup("PinTest", 2);
+        saveManager.SaveTemplate(group, "Pin Test");
+
+        // Act
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+
+        // Assert
+        var loaded = loadManager.Templates[0].TemplateGroup!;
+        foreach (var child in loaded.ChildComponents)
+        {
+            child.PhysicalPins.Count.ShouldBe(2);
+            child.PhysicalPins[0].Name.ShouldBe("a0");
+            child.PhysicalPins[1].Name.ShouldBe("b0");
+        }
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_PreservesInternalPaths()
+    {
+        // Arrange
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroupWithConnection("PathTest");
+        saveManager.SaveTemplate(group, "Path Test");
+
+        // Act
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+
+        // Assert
+        var loaded = loadManager.Templates[0].TemplateGroup!;
+        loaded.InternalPaths.Count.ShouldBe(1);
+
+        var path = loaded.InternalPaths[0];
+        path.StartPin.ShouldNotBeNull();
+        path.EndPin.ShouldNotBeNull();
+        path.StartPin.ParentComponent.ShouldBe(loaded.ChildComponents[0]);
+        path.EndPin.ParentComponent.ShouldBe(loaded.ChildComponents[1]);
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_PreservesExternalPins()
+    {
+        // Arrange
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroupWithExternalPins("PinGroup");
+        saveManager.SaveTemplate(group, "External Pin Test");
+
+        // Act
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+
+        // Assert
+        var loaded = loadManager.Templates[0].TemplateGroup!;
+        loaded.ExternalPins.Count.ShouldBe(1);
+
+        var extPin = loaded.ExternalPins[0];
+        extPin.Name.ShouldBe("ext_a0");
+        extPin.InternalPin.ShouldNotBeNull();
+        extPin.InternalPin.ParentComponent.ShouldBe(loaded.ChildComponents[0]);
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_CanInstantiateTemplate()
+    {
+        // Arrange
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroup("InstTest", 2);
+        saveManager.SaveTemplate(group, "Instantiate Test");
+
+        // Act
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+        var loaded = loadManager.Templates[0];
+        var instance = loadManager.InstantiateTemplate(loaded, 500, 500);
+
+        // Assert
+        instance.ShouldNotBeNull();
+        instance.PhysicalX.ShouldBe(500);
+        instance.PhysicalY.ShouldBe(500);
+        instance.ChildComponents.Count.ShouldBe(2);
+        instance.Identifier.ShouldNotBe(loaded.TemplateGroup!.Identifier);
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_CanPlaceOnCanvas()
+    {
+        // Arrange - Save a template
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroup("PlaceTest", 2);
+        saveManager.SaveTemplate(group, "Place Test");
+
+        // Act - Load with new manager and try to place
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+        var template = loadManager.Templates[0];
+
+        var canvas = new DesignCanvasViewModel();
+        var cmd = PlaceGroupTemplateCommand.TryCreate(
+            canvas, loadManager, template, 500, 500);
+
+        // Assert - Command should succeed (not null)
+        cmd.ShouldNotBeNull();
+        cmd!.Execute();
+
+        canvas.Components.Count.ShouldBe(1);
+        var placedGroup = (ComponentGroup)canvas.Components[0].Component;
+        placedGroup.ChildComponents.Count.ShouldBe(2);
+        placedGroup.IsPrefab.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FullWorkflow_CreateGroupSavePlaceFromDisk()
+    {
+        // Step 1: Create components and group on canvas
+        var canvas1 = new DesignCanvasViewModel();
+        var comp1 = CreateTestComponentWithTwoPins("comp1", 0, 0);
+        var comp2 = CreateTestComponentWithTwoPins("comp2", 100, 0);
+        var vm1 = canvas1.AddComponent(comp1);
+        var vm2 = canvas1.AddComponent(comp2);
+
+        var createCmd = new CreateGroupCommand(
+            canvas1, new List<ComponentViewModel> { vm1, vm2 });
+        createCmd.Execute();
+
+        var createdGroup = (ComponentGroup)canvas1.Components
+            .First(c => c.Component is ComponentGroup).Component;
+
+        // Step 2: Save as prefab to library
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var libraryVm = new ComponentLibraryViewModel(saveManager);
+        var saveCmd = new SaveGroupAsPrefabCommand(
+            libraryVm,
+            new GroupPreviewGenerator(),
+            createdGroup,
+            "My Prefab");
+        saveCmd.Execute();
+
+        // Step 3: Simulate app restart - load from disk with new manager
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+        var loadedTemplate = loadManager.Templates[0];
+
+        // Step 4: Place loaded template on a new canvas
+        var canvas2 = new DesignCanvasViewModel();
+        var placeCmd = PlaceGroupTemplateCommand.TryCreate(
+            canvas2, loadManager, loadedTemplate, 500, 500);
+
+        // Assert: full workflow succeeds
+        placeCmd.ShouldNotBeNull();
+        placeCmd!.Execute();
+
+        canvas2.Components.Count.ShouldBe(1);
+        var placedGroup = (ComponentGroup)canvas2.Components[0].Component;
+        placedGroup.ChildComponents.Count.ShouldBe(2);
+        placedGroup.IsPrefab.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SaveTemplate_ThenLoadFromDisk_PreservesPathGeometry()
+    {
+        // Arrange
+        var saveManager = new GroupLibraryManager(_testLibraryPath);
+        var group = CreateTestGroupWithStraightPath("GeomTest");
+        saveManager.SaveTemplate(group, "Geometry Test");
+
+        // Act
+        var loadManager = new GroupLibraryManager(_testLibraryPath);
+        loadManager.LoadTemplates();
+
+        // Assert
+        var loaded = loadManager.Templates[0].TemplateGroup!;
+        loaded.InternalPaths.Count.ShouldBe(1);
+
+        var path = loaded.InternalPaths[0];
+        path.Path.Segments.Count.ShouldBe(1);
+
+        var segment = path.Path.Segments[0].ShouldBeOfType<StraightSegment>();
+        segment.StartPoint.X.ShouldBe(50, tolerance: 0.01);
+        segment.StartPoint.Y.ShouldBe(0, tolerance: 0.01);
+        segment.EndPoint.X.ShouldBe(100, tolerance: 0.01);
+        segment.EndPoint.Y.ShouldBe(0, tolerance: 0.01);
+    }
+
+    /// <summary>
+    /// Creates a ComponentGroup with the specified number of children, each with 2 pins.
+    /// </summary>
+    private ComponentGroup CreateTestGroup(string name, int childCount)
+    {
+        var group = new ComponentGroup(name)
+        {
+            PhysicalX = 0,
+            PhysicalY = 0
+        };
+
+        for (int i = 0; i < childCount; i++)
+        {
+            var child = CreateTestComponentWithTwoPins(
+                $"comp_{i}_{Guid.NewGuid():N}",
+                i * 100, 0);
+            group.AddChild(child);
+        }
+
+        return group;
+    }
+
+    /// <summary>
+    /// Creates a group with two children connected by a frozen path (no segments).
+    /// </summary>
+    private ComponentGroup CreateTestGroupWithConnection(string name)
+    {
+        var group = CreateTestGroup(name, 2);
+        var comp1 = group.ChildComponents[0];
+        var comp2 = group.ChildComponents[1];
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            StartPin = comp1.PhysicalPins[1], // b0
+            EndPin = comp2.PhysicalPins[0],   // a0
+            Path = new RoutedPath()
+        };
+
+        group.AddInternalPath(frozenPath);
+        return group;
+    }
+
+    /// <summary>
+    /// Creates a group with two children connected by a frozen path with geometry.
+    /// </summary>
+    private ComponentGroup CreateTestGroupWithStraightPath(string name)
+    {
+        var group = CreateTestGroup(name, 2);
+        var comp1 = group.ChildComponents[0];
+        var comp2 = group.ChildComponents[1];
+
+        var routedPath = new RoutedPath();
+        routedPath.Segments.Add(new StraightSegment(50, 0, 100, 0, 0));
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            StartPin = comp1.PhysicalPins[1], // b0
+            EndPin = comp2.PhysicalPins[0],   // a0
+            Path = routedPath
+        };
+
+        group.AddInternalPath(frozenPath);
+        return group;
+    }
+
+    /// <summary>
+    /// Creates a group with an external pin.
+    /// </summary>
+    private ComponentGroup CreateTestGroupWithExternalPins(string name)
+    {
+        var group = CreateTestGroup(name, 2);
+        var comp1 = group.ChildComponents[0];
+
+        var extPin = new GroupPin
+        {
+            PinId = Guid.NewGuid(),
+            Name = "ext_a0",
+            InternalPin = comp1.PhysicalPins[0], // a0
+            RelativeX = 0,
+            RelativeY = 0,
+            AngleDegrees = 180
+        };
+
+        group.AddExternalPin(extPin);
+        return group;
+    }
+
+    /// <summary>
+    /// Creates a test component with two pins (a0, b0).
+    /// </summary>
+    private Component CreateTestComponentWithTwoPins(
+        string identifier, double x, double y)
+    {
+        return new Component(
+            new Dictionary<int, SMatrix>(),
+            new List<Slider>(),
+            "test_component",
+            "",
+            new Part[1, 1] { { new Part() } },
+            -1,
+            identifier,
+            DiscreteRotation.R0,
+            new List<PhysicalPin>
+            {
+                new PhysicalPin
+                {
+                    Name = "a0",
+                    OffsetXMicrometers = 0,
+                    OffsetYMicrometers = 0,
+                    AngleDegrees = 180
+                },
+                new PhysicalPin
+                {
+                    Name = "b0",
+                    OffsetXMicrometers = 50,
+                    OffsetYMicrometers = 0,
+                    AngleDegrees = 0
+                }
+            })
+        {
+            PhysicalX = x,
+            PhysicalY = y,
+            WidthMicrometers = 50,
+            HeightMicrometers = 30
+        };
+    }
+}

--- a/UnitTests/Integration/GroupTemplateSerializerTests.cs
+++ b/UnitTests/Integration/GroupTemplateSerializerTests.cs
@@ -1,0 +1,273 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Unit tests for GroupTemplateSerializer.
+/// Verifies serialization round-trip preserves all group data.
+/// </summary>
+public class GroupTemplateSerializerTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_EmptyGroup_RoundTrips()
+    {
+        // Arrange
+        var group = new ComponentGroup("EmptyGroup")
+        {
+            Description = "Test description",
+            PhysicalX = 10,
+            PhysicalY = 20
+        };
+
+        // Act
+        var json = GroupTemplateSerializer.Serialize(group);
+        var result = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result!.GroupName.ShouldBe("EmptyGroup");
+        result.Description.ShouldBe("Test description");
+        result.PhysicalX.ShouldBe(10);
+        result.PhysicalY.ShouldBe(20);
+    }
+
+    [Fact]
+    public void SerializeAndDeserialize_WithChildren_PreservesAllData()
+    {
+        // Arrange
+        var group = CreateGroupWithChildren(3);
+
+        // Act
+        var json = GroupTemplateSerializer.Serialize(group);
+        var result = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result!.ChildComponents.Count.ShouldBe(3);
+
+        for (int i = 0; i < 3; i++)
+        {
+            result.ChildComponents[i].PhysicalX.ShouldBe(i * 100);
+            result.ChildComponents[i].PhysicalPins.Count.ShouldBe(2);
+            result.ChildComponents[i].PhysicalPins[0].Name.ShouldBe("a0");
+            result.ChildComponents[i].PhysicalPins[1].Name.ShouldBe("b0");
+        }
+    }
+
+    [Fact]
+    public void SerializeAndDeserialize_WithFrozenPath_PreservesPathAndPinLinks()
+    {
+        // Arrange
+        var group = CreateGroupWithChildren(2);
+        var comp1 = group.ChildComponents[0];
+        var comp2 = group.ChildComponents[1];
+
+        var routedPath = new RoutedPath();
+        routedPath.Segments.Add(new StraightSegment(50, 0, 100, 0, 0));
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            StartPin = comp1.PhysicalPins[1], // b0
+            EndPin = comp2.PhysicalPins[0],   // a0
+            Path = routedPath
+        };
+        group.AddInternalPath(frozenPath);
+
+        // Act
+        var json = GroupTemplateSerializer.Serialize(group);
+        var result = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result!.InternalPaths.Count.ShouldBe(1);
+
+        var loadedPath = result.InternalPaths[0];
+        loadedPath.StartPin.Name.ShouldBe("b0");
+        loadedPath.EndPin.Name.ShouldBe("a0");
+        loadedPath.StartPin.ParentComponent.ShouldBe(result.ChildComponents[0]);
+        loadedPath.EndPin.ParentComponent.ShouldBe(result.ChildComponents[1]);
+
+        loadedPath.Path.Segments.Count.ShouldBe(1);
+        var seg = loadedPath.Path.Segments[0].ShouldBeOfType<StraightSegment>();
+        seg.StartPoint.X.ShouldBe(50, tolerance: 0.01);
+        seg.EndPoint.X.ShouldBe(100, tolerance: 0.01);
+    }
+
+    [Fact]
+    public void SerializeAndDeserialize_WithArcSegment_PreservesGeometry()
+    {
+        // Arrange
+        var group = CreateGroupWithChildren(2);
+        var routedPath = new RoutedPath();
+        routedPath.Segments.Add(new BendSegment(75, 15, 25, 0, 90));
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            StartPin = group.ChildComponents[0].PhysicalPins[1],
+            EndPin = group.ChildComponents[1].PhysicalPins[0],
+            Path = routedPath
+        };
+        group.AddInternalPath(frozenPath);
+
+        // Act
+        var json = GroupTemplateSerializer.Serialize(group);
+        var result = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        var seg = result!.InternalPaths[0].Path.Segments[0]
+            .ShouldBeOfType<BendSegment>();
+        seg.Center.X.ShouldBe(75, tolerance: 0.01);
+        seg.Center.Y.ShouldBe(15, tolerance: 0.01);
+        seg.RadiusMicrometers.ShouldBe(25, tolerance: 0.01);
+        seg.StartAngleDegrees.ShouldBe(0, tolerance: 0.01);
+        seg.SweepAngleDegrees.ShouldBe(90, tolerance: 0.01);
+    }
+
+    [Fact]
+    public void SerializeAndDeserialize_WithExternalPins_PreservesLinks()
+    {
+        // Arrange
+        var group = CreateGroupWithChildren(2);
+        var extPin = new GroupPin
+        {
+            PinId = Guid.NewGuid(),
+            Name = "ext_a0",
+            InternalPin = group.ChildComponents[0].PhysicalPins[0],
+            RelativeX = 0,
+            RelativeY = 0,
+            AngleDegrees = 180
+        };
+        group.AddExternalPin(extPin);
+
+        // Act
+        var json = GroupTemplateSerializer.Serialize(group);
+        var result = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result!.ExternalPins.Count.ShouldBe(1);
+
+        var loadedPin = result.ExternalPins[0];
+        loadedPin.Name.ShouldBe("ext_a0");
+        loadedPin.AngleDegrees.ShouldBe(180);
+        loadedPin.InternalPin.Name.ShouldBe("a0");
+        loadedPin.InternalPin.ParentComponent.ShouldBe(result.ChildComponents[0]);
+    }
+
+    [Fact]
+    public void SerializeAndDeserialize_NestedGroup_PreservesHierarchy()
+    {
+        // Arrange
+        var innerGroup = CreateGroupWithChildren(2);
+        innerGroup.GroupName = "InnerGroup";
+
+        var outerGroup = new ComponentGroup("OuterGroup");
+        outerGroup.AddChild(innerGroup);
+        outerGroup.AddChild(CreateTestComponent("outer_comp", 300, 0));
+
+        // Act
+        var json = GroupTemplateSerializer.Serialize(outerGroup);
+        var result = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result!.ChildComponents.Count.ShouldBe(2);
+
+        var nestedGroup = result.ChildComponents[0].ShouldBeOfType<ComponentGroup>();
+        nestedGroup.GroupName.ShouldBe("InnerGroup");
+        nestedGroup.ChildComponents.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Deserialize_NullOrEmpty_ReturnsNull()
+    {
+        GroupTemplateSerializer.Deserialize(null!).ShouldBeNull();
+        GroupTemplateSerializer.Deserialize("").ShouldBeNull();
+        GroupTemplateSerializer.Deserialize("  ").ShouldBeNull();
+    }
+
+    [Fact]
+    public void DeepCopy_AfterDeserialization_CreatesIndependentCopy()
+    {
+        // Arrange
+        var group = CreateGroupWithChildren(2);
+        var json = GroupTemplateSerializer.Serialize(group);
+        var deserialized = GroupTemplateSerializer.Deserialize(json)!;
+
+        // Act
+        var copy = deserialized.DeepCopy();
+
+        // Assert
+        copy.Identifier.ShouldNotBe(deserialized.Identifier);
+        copy.ChildComponents[0].Identifier.ShouldNotBe(
+            deserialized.ChildComponents[0].Identifier);
+        copy.ChildComponents.Count.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// Creates a group with the specified number of children, each with 2 pins.
+    /// </summary>
+    private ComponentGroup CreateGroupWithChildren(int count)
+    {
+        var group = new ComponentGroup("TestGroup")
+        {
+            PhysicalX = 0,
+            PhysicalY = 0
+        };
+
+        for (int i = 0; i < count; i++)
+        {
+            group.AddChild(CreateTestComponent(
+                $"comp_{i}_{Guid.NewGuid():N}",
+                i * 100, 0));
+        }
+
+        return group;
+    }
+
+    /// <summary>
+    /// Creates a test component with two pins.
+    /// </summary>
+    private Component CreateTestComponent(string id, double x, double y)
+    {
+        return new Component(
+            new Dictionary<int, SMatrix>(),
+            new List<Slider>(),
+            "test_component",
+            "",
+            new Part[1, 1] { { new Part() } },
+            -1,
+            id,
+            DiscreteRotation.R0,
+            new List<PhysicalPin>
+            {
+                new PhysicalPin
+                {
+                    Name = "a0",
+                    OffsetXMicrometers = 0,
+                    OffsetYMicrometers = 0,
+                    AngleDegrees = 180
+                },
+                new PhysicalPin
+                {
+                    Name = "b0",
+                    OffsetXMicrometers = 50,
+                    OffsetYMicrometers = 0,
+                    AngleDegrees = 0
+                }
+            })
+        {
+            PhysicalX = x,
+            PhysicalY = y,
+            WidthMicrometers = 50,
+            HeightMicrometers = 30
+        };
+    }
+}


### PR DESCRIPTION
Automated implementation for #243

Here's a summary of the bug fix and changes:

## Bug Fix Summary: Issue #243 - Saved Groups cannot be placed on canvas

### Root Cause

`GroupLibraryManager.SaveTemplate()` only serialized **metadata** (name, description, component count, dimensions) to disk, not the actual `ComponentGroup` data. When `LoadTemplatesFromFolder()` loaded templates from disk, `TemplateGroup` was always `null`. This caused `PlaceGroupTemplateCommand.TryCreate()` to return `null` at the check `if (template.TemplateGroup == null)`, preventing placement.

Templates only worked within the same session because `TemplateGroup` was set in-memory during `SaveTemplate()`, but the data was lost on app restart.

### Changes Made

**1. New file: `Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs`**
- Self-contained serializer that embeds all child component data inline (unlike `ComponentGroupSerializer` in CAP-DataAccess which uses external references)
- Serializes/deserializes: child components with pins, frozen waveguide paths with full geometry, external pins, and nested groups
- References children by index for path/pin linkage (no external lookup needed)

**2. Modified: `Connect-A-Pic-Core/Components/Creation/GroupLibraryManager.cs`** (21 insertions, 6 deletions)
- `SaveTemplate()`: Now serializes the full `ComponentGroup` via `GroupTemplateSerializer.Serialize()` and stores it in `GroupLibraryFileData.GroupData`
- `LoadTemplatesFromFolder()`: Deserializes the group data and sets `TemplateGroup` on the loaded template
- `GroupLibraryFileData`: Added `GroupData` property for the serialized group JSON

**3. New file: `UnitTests/Integration/GroupTemplatePersistenceTests.cs`** (10 tests)
- Tests the full save-to-disk-then-load-from-disk workflow
- Verifies child components, positions, pins, frozen paths, external pins, and path geometry survive persistence
- Tests the complete create-group → save-as-prefab → restart → load → place workflow

**4. New file: `UnitTests/Integration/GroupTemplateSerializerTests.cs`** (8 tests)
- Tests serialization round-trip for empty groups, children, frozen paths, arc/straight segments, external pins, nested groups
- Tests `DeepCopy()` after deserialization creates independent copies
- Tests null/empty input handling

### Test Results
- **59 group-related tests pass** (41 existing + 18 new)
- **0 regressions** introduced (7 pre-existing failures unrelated to this fix)
- Build succeeds with 0 errors

### MCP Tools used
- NetContextServer: Not used (direct file exploration was sufficient)


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 24,435
- **Estimated cost:** $0.3659 USD

---
*Generated by autonomous agent using Claude Code.*