### PR TITLE
Agent: Enhancement: Add undo/redo support for entering/exiting group edit mode

### DIFF
--- a/CAP.Avalonia/Commands/EnterGroupEditModeCommand.cs
+++ b/CAP.Avalonia/Commands/EnterGroupEditModeCommand.cs
@@ -1,0 +1,40 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.Commands;
+
+/// <summary>
+/// Undoable command for entering ComponentGroup edit mode.
+/// Allows undo to exit edit mode and redo to re-enter it.
+/// </summary>
+public class EnterGroupEditModeCommand : IUndoableCommand
+{
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly ComponentGroup _group;
+
+    /// <summary>
+    /// Creates a command to enter edit mode for the specified group.
+    /// </summary>
+    /// <param name="canvas">The canvas view model managing edit mode state.</param>
+    /// <param name="group">The group to enter edit mode for.</param>
+    public EnterGroupEditModeCommand(DesignCanvasViewModel canvas, ComponentGroup group)
+    {
+        _canvas = canvas ?? throw new ArgumentNullException(nameof(canvas));
+        _group = group ?? throw new ArgumentNullException(nameof(group));
+    }
+
+    /// <inheritdoc />
+    public string Description => $"Enter group edit mode: {_group.GroupName}";
+
+    /// <inheritdoc />
+    public void Execute()
+    {
+        _canvas.EnterGroupEditMode(_group);
+    }
+
+    /// <inheritdoc />
+    public void Undo()
+    {
+        _canvas.ExitGroupEditMode();
+    }
+}

--- a/CAP.Avalonia/Commands/ExitGroupEditModeCommand.cs
+++ b/CAP.Avalonia/Commands/ExitGroupEditModeCommand.cs
@@ -1,0 +1,40 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.Commands;
+
+/// <summary>
+/// Undoable command for exiting ComponentGroup edit mode.
+/// Allows undo to re-enter edit mode and redo to exit again.
+/// </summary>
+public class ExitGroupEditModeCommand : IUndoableCommand
+{
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly ComponentGroup _group;
+
+    /// <summary>
+    /// Creates a command to exit the current group edit mode.
+    /// </summary>
+    /// <param name="canvas">The canvas view model managing edit mode state.</param>
+    /// <param name="group">The group being exited (captured for undo re-entry).</param>
+    public ExitGroupEditModeCommand(DesignCanvasViewModel canvas, ComponentGroup group)
+    {
+        _canvas = canvas ?? throw new ArgumentNullException(nameof(canvas));
+        _group = group ?? throw new ArgumentNullException(nameof(group));
+    }
+
+    /// <inheritdoc />
+    public string Description => $"Exit group edit mode: {_group.GroupName}";
+
+    /// <inheritdoc />
+    public void Execute()
+    {
+        _canvas.ExitGroupEditMode();
+    }
+
+    /// <inheritdoc />
+    public void Undo()
+    {
+        _canvas.EnterGroupEditMode(_group);
+    }
+}

--- a/CAP.Avalonia/Controls/DesignCanvas.KeyboardHandling.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.KeyboardHandling.cs
@@ -1,4 +1,5 @@
 using Avalonia.Input;
+using CAP.Avalonia.Commands;
 using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Canvas;
 
@@ -179,10 +180,18 @@ public partial class DesignCanvas
     {
         var canvasVm = ViewModel;
 
-        // First priority: Exit group edit mode if active
+        // First priority: Exit group edit mode if active (via command for undo/redo)
         if (canvasVm != null && canvasVm.IsInGroupEditMode)
         {
-            canvasVm.ExitGroupEditMode();
+            if (mainVm?.CommandManager != null && canvasVm.CurrentEditGroup != null)
+            {
+                var cmd = new ExitGroupEditModeCommand(canvasVm, canvasVm.CurrentEditGroup);
+                mainVm.CommandManager.ExecuteCommand(cmd);
+            }
+            else
+            {
+                canvasVm.ExitGroupEditMode();
+            }
             if (mainVm != null)
                 mainVm.StatusText = "Exited group edit mode";
         }

--- a/CAP.Avalonia/Controls/DesignCanvas.MouseHandling.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.MouseHandling.cs
@@ -155,8 +155,16 @@ public partial class DesignCanvas
             if (DetectDoubleClick(_interactionState.DraggingComponent) &&
                 _interactionState.DraggingComponent.Component is ComponentGroup clickedGroup)
             {
-                // Enter group edit mode instead of dragging
-                vm.EnterGroupEditMode(clickedGroup);
+                // Enter group edit mode via command for undo/redo support
+                if (mainVm?.CommandManager != null)
+                {
+                    var cmd = new EnterGroupEditModeCommand(vm, clickedGroup);
+                    mainVm.CommandManager.ExecuteCommand(cmd);
+                }
+                else
+                {
+                    vm.EnterGroupEditMode(clickedGroup);
+                }
                 mainVm?.HierarchyPanel?.RebuildTree();
                 _interactionState.DraggingComponent = null;
                 InvalidateVisual();
@@ -170,7 +178,16 @@ public partial class DesignCanvas
             // Check for double-click on background in edit mode
             if (vm.IsInGroupEditMode && DetectDoubleClick(null))
             {
-                vm.ExitGroupEditMode();
+                // Exit group edit mode via command for undo/redo support
+                if (mainVm?.CommandManager != null && vm.CurrentEditGroup != null)
+                {
+                    var cmd = new ExitGroupEditModeCommand(vm, vm.CurrentEditGroup);
+                    mainVm.CommandManager.ExecuteCommand(cmd);
+                }
+                else
+                {
+                    vm.ExitGroupEditMode();
+                }
                 mainVm?.HierarchyPanel?.RebuildTree();
                 InvalidateVisual();
                 return;

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -163,10 +163,19 @@ public partial class MainWindow : Window
                 mainVm.DeleteSelectedCommand.Execute(null);
                 break;
             case Key.Escape:
-                // First priority: Exit group edit mode if active
+                // First priority: Exit group edit mode if active (via command for undo/redo)
                 if (mainVm.Canvas.IsInGroupEditMode)
                 {
-                    mainVm.Canvas.ExitGroupEditMode();
+                    if (mainVm.Canvas.CurrentEditGroup != null)
+                    {
+                        var exitCmd = new Commands.ExitGroupEditModeCommand(
+                            mainVm.Canvas, mainVm.Canvas.CurrentEditGroup);
+                        mainVm.CommandManager.ExecuteCommand(exitCmd);
+                    }
+                    else
+                    {
+                        mainVm.Canvas.ExitGroupEditMode();
+                    }
                     mainVm.StatusText = "Exited group edit mode";
                 }
                 else

--- a/UnitTests/Commands/GroupEditModeCommandTests.cs
+++ b/UnitTests/Commands/GroupEditModeCommandTests.cs
@@ -1,0 +1,296 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests.Helpers;
+
+namespace UnitTests.Commands;
+
+/// <summary>
+/// Tests for EnterGroupEditModeCommand and ExitGroupEditModeCommand
+/// verifying undo/redo integration with group edit mode.
+/// </summary>
+public class GroupEditModeCommandTests
+{
+    [Fact]
+    public void EnterCommand_Execute_EntersGroupEditMode()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+        var cmd = new EnterGroupEditModeCommand(canvas, group);
+
+        // Act
+        cmd.Execute();
+
+        // Assert
+        canvas.CurrentEditGroup.ShouldBe(group);
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EnterCommand_Undo_ExitsGroupEditMode()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+        var cmd = new EnterGroupEditModeCommand(canvas, group);
+        cmd.Execute();
+
+        // Act
+        cmd.Undo();
+
+        // Assert
+        canvas.CurrentEditGroup.ShouldBeNull();
+        canvas.IsInGroupEditMode.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EnterCommand_Description_ContainsGroupName()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = new ComponentGroup("MyGroupName");
+        var cmd = new EnterGroupEditModeCommand(canvas, group);
+
+        // Assert
+        cmd.Description.ShouldContain("MyGroupName");
+        cmd.Description.ShouldContain("Enter group edit mode");
+    }
+
+    [Fact]
+    public void ExitCommand_Execute_ExitsGroupEditMode()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+        canvas.EnterGroupEditMode(group);
+        var cmd = new ExitGroupEditModeCommand(canvas, group);
+
+        // Act
+        cmd.Execute();
+
+        // Assert
+        canvas.CurrentEditGroup.ShouldBeNull();
+        canvas.IsInGroupEditMode.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ExitCommand_Undo_ReEntersGroupEditMode()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+        canvas.EnterGroupEditMode(group);
+        var cmd = new ExitGroupEditModeCommand(canvas, group);
+        cmd.Execute();
+
+        // Act
+        cmd.Undo();
+
+        // Assert
+        canvas.CurrentEditGroup.ShouldBe(group);
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ExitCommand_Description_ContainsGroupName()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = new ComponentGroup("MyGroupName");
+        var cmd = new ExitGroupEditModeCommand(canvas, group);
+
+        // Assert
+        cmd.Description.ShouldContain("MyGroupName");
+        cmd.Description.ShouldContain("Exit group edit mode");
+    }
+
+    [Fact]
+    public void EnterCommand_ViaCommandManager_CanUndo()
+    {
+        // Arrange
+        var commandManager = new CommandManager();
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+
+        // Act
+        var cmd = new EnterGroupEditModeCommand(canvas, group);
+        commandManager.ExecuteCommand(cmd);
+
+        // Assert
+        commandManager.CanUndo.ShouldBeTrue();
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EnterCommand_UndoViaCommandManager_ExitsEditMode()
+    {
+        // Arrange
+        var commandManager = new CommandManager();
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+        commandManager.ExecuteCommand(new EnterGroupEditModeCommand(canvas, group));
+
+        // Act
+        commandManager.Undo();
+
+        // Assert
+        canvas.IsInGroupEditMode.ShouldBeFalse();
+        canvas.CurrentEditGroup.ShouldBeNull();
+    }
+
+    [Fact]
+    public void EnterCommand_RedoViaCommandManager_ReEntersEditMode()
+    {
+        // Arrange
+        var commandManager = new CommandManager();
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+        commandManager.ExecuteCommand(new EnterGroupEditModeCommand(canvas, group));
+        commandManager.Undo();
+
+        // Act
+        commandManager.Redo();
+
+        // Assert
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+        canvas.CurrentEditGroup.ShouldBe(group);
+    }
+
+    [Fact]
+    public void ExitCommand_ViaCommandManager_UndoReEnters()
+    {
+        // Arrange
+        var commandManager = new CommandManager();
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+        commandManager.ExecuteCommand(new EnterGroupEditModeCommand(canvas, group));
+        commandManager.ExecuteCommand(new ExitGroupEditModeCommand(canvas, group));
+
+        // Act
+        commandManager.Undo();
+
+        // Assert — undo of exit should re-enter
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+        canvas.CurrentEditGroup.ShouldBe(group);
+    }
+
+    [Fact]
+    public void EnterThenExit_UndoChain_WorksCorrectly()
+    {
+        // Arrange
+        var commandManager = new CommandManager();
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        canvas.AddComponent(group);
+
+        // Enter edit mode
+        commandManager.ExecuteCommand(new EnterGroupEditModeCommand(canvas, group));
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+
+        // Exit edit mode
+        commandManager.ExecuteCommand(new ExitGroupEditModeCommand(canvas, group));
+        canvas.IsInGroupEditMode.ShouldBeFalse();
+
+        // Act — Undo exit (should re-enter)
+        commandManager.Undo();
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+        canvas.CurrentEditGroup.ShouldBe(group);
+
+        // Act — Undo enter (should exit)
+        commandManager.Undo();
+        canvas.IsInGroupEditMode.ShouldBeFalse();
+        canvas.CurrentEditGroup.ShouldBeNull();
+
+        // Assert — both undone
+        commandManager.UndoCount.ShouldBe(0);
+        commandManager.RedoCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public void NestedGroups_EnterTwice_UndoTwice_ExitsBoth()
+    {
+        // Arrange
+        var commandManager = new CommandManager();
+        var canvas = new DesignCanvasViewModel();
+        var outerGroup = TestComponentFactory.CreateComponentGroup("Outer");
+        var innerGroup = new ComponentGroup("Inner");
+        outerGroup.AddChild(innerGroup);
+        canvas.AddComponent(outerGroup);
+
+        // Enter outer group
+        commandManager.ExecuteCommand(new EnterGroupEditModeCommand(canvas, outerGroup));
+        canvas.CurrentEditGroup.ShouldBe(outerGroup);
+
+        // Enter inner group
+        commandManager.ExecuteCommand(new EnterGroupEditModeCommand(canvas, innerGroup));
+        canvas.CurrentEditGroup.ShouldBe(innerGroup);
+
+        // Act — Undo inner enter (exits inner, returns to outer)
+        commandManager.Undo();
+        canvas.CurrentEditGroup.ShouldBe(outerGroup);
+        canvas.IsInGroupEditMode.ShouldBeTrue();
+
+        // Act — Undo outer enter (exits outer, returns to root)
+        commandManager.Undo();
+        canvas.CurrentEditGroup.ShouldBeNull();
+        canvas.IsInGroupEditMode.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CommandHistory_PreservesGroupContext()
+    {
+        // Arrange
+        var commandManager = new CommandManager();
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("SpecificGroup", addChildren: true);
+        canvas.AddComponent(group);
+
+        // Act
+        commandManager.ExecuteCommand(new EnterGroupEditModeCommand(canvas, group));
+
+        // Assert — description should identify the group
+        commandManager.UndoDescription.ShouldContain("SpecificGroup");
+    }
+
+    [Fact]
+    public void EnterCommand_NullCanvas_ThrowsArgumentNullException()
+    {
+        // Assert
+        Should.Throw<ArgumentNullException>(() =>
+            new EnterGroupEditModeCommand(null!, new ComponentGroup("Test")));
+    }
+
+    [Fact]
+    public void EnterCommand_NullGroup_ThrowsArgumentNullException()
+    {
+        // Assert
+        Should.Throw<ArgumentNullException>(() =>
+            new EnterGroupEditModeCommand(new DesignCanvasViewModel(), null!));
+    }
+
+    [Fact]
+    public void ExitCommand_NullCanvas_ThrowsArgumentNullException()
+    {
+        // Assert
+        Should.Throw<ArgumentNullException>(() =>
+            new ExitGroupEditModeCommand(null!, new ComponentGroup("Test")));
+    }
+
+    [Fact]
+    public void ExitCommand_NullGroup_ThrowsArgumentNullException()
+    {
+        // Assert
+        Should.Throw<ArgumentNullException>(() =>
+            new ExitGroupEditModeCommand(new DesignCanvasViewModel(), null!));
+    }
+}


### PR DESCRIPTION
Automated implementation for #244

Implementation is complete. Here's a summary:

## Changes Made

### New Files
- **`CAP.Avalonia/Commands/EnterGroupEditModeCommand.cs`** — `IUndoableCommand` that calls `EnterGroupEditMode()` on execute and `ExitGroupEditMode()` on undo
- **`CAP.Avalonia/Commands/ExitGroupEditModeCommand.cs`** — `IUndoableCommand` that calls `ExitGroupEditMode()` on execute and `EnterGroupEditMode()` on undo (captures the group reference for re-entry)
- **`UnitTests/Commands/GroupEditModeCommandTests.cs`** — 17 tests covering all acceptance criteria

### Modified Files
- **`DesignCanvas.MouseHandling.cs`** — Double-click to enter/exit group edit mode now routes through `CommandManager.ExecuteCommand()`
- **`DesignCanvas.KeyboardHandling.cs`** — ESC to exit group edit mode now routes through `CommandManager.ExecuteCommand()`
- **`MainWindow.axaml.cs`** — ESC handler also routes through `CommandManager`

### Acceptance Criteria Coverage
| Criterion | Status |
|---|---|
| Entering group edit mode is undoable | ✅ |
| Exiting group edit mode is undoable | ✅ |
| Undo/redo integrates seamlessly | ✅ |
| Integration tests cover all scenarios | ✅ (17 tests) |
| Nested group editing works with undo/redo | ✅ |
| Command descriptions identify the group | ✅ |

### Test Results
- **17/17 new tests pass**
- **0 regressions** — all pre-existing failures were verified as pre-existing

### MCP Tools Used
- **NetContextServer**: Not used — standard Glob/Grep/Read tools were sufficient for this focused feature


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 18,078
- **Estimated cost:** $0.2180 USD

---
*Generated by autonomous agent using Claude Code.*