### PR TITLE
Agent: Bug: ComponentGroups not persisted in File → Save/Open workflow

### DIFF
--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -427,6 +427,55 @@ public class DesignFileData
 {
     public List<ComponentData> Components { get; set; } = new();
     public List<ConnectionData> Connections { get; set; } = new();
+
+    /// <summary>
+    /// ComponentGroups with their hierarchical structure, frozen paths, and external pins.
+    /// </summary>
+    public List<DesignGroupData>? Groups { get; set; }
+}
+
+/// <summary>
+/// DTO for a ComponentGroup in the design file.
+/// Bridges the UI-layer (TemplateName-based) and core-layer (ComponentGroupDto) serialization.
+/// </summary>
+public class DesignGroupData
+{
+    /// <summary>
+    /// Group metadata serialized via ComponentGroupSerializer.
+    /// </summary>
+    public CAP_DataAccess.Persistence.DTOs.ComponentGroupDto GroupDto { get; set; } = new();
+
+    /// <summary>
+    /// Child component data with template names for recreation from the component library.
+    /// Maps child Identifier to TemplateName.
+    /// </summary>
+    public List<ChildComponentData> ChildComponents { get; set; } = new();
+
+    /// <summary>
+    /// Canvas X position of the group ViewModel.
+    /// </summary>
+    public double CanvasX { get; set; }
+
+    /// <summary>
+    /// Canvas Y position of the group ViewModel.
+    /// </summary>
+    public double CanvasY { get; set; }
+}
+
+/// <summary>
+/// DTO for a child component within a group, preserving template name for library lookup.
+/// </summary>
+public class ChildComponentData
+{
+    public string Identifier { get; set; } = "";
+    public string TemplateName { get; set; } = "";
+    public double X { get; set; }
+    public double Y { get; set; }
+    public int Rotation { get; set; }
+    public double? SliderValue { get; set; }
+    public int? LaserWavelengthNm { get; set; }
+    public double? LaserPower { get; set; }
+    public bool? IsLocked { get; set; }
 }
 
 public class ComponentData

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
+using CAP_DataAccess.Persistence;
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
@@ -122,20 +123,24 @@ public partial class FileOperationsViewModel : ObservableObject
     {
         try
         {
+            // Identify which components are groups vs standalone
+            var groupComponents = _canvas.Components
+                .Where(c => c.Component is ComponentGroup)
+                .ToList();
+            var childComponentIds = new HashSet<string>();
+            foreach (var gc in groupComponents)
+            {
+                CollectChildIds((ComponentGroup)gc.Component, childComponentIds);
+            }
+
             var designData = new DesignFileData
             {
-                Components = _canvas.Components.Select(c => new ComponentData
-                {
-                    TemplateName = c.TemplateName ?? c.Name,
-                    X = c.X,
-                    Y = c.Y,
-                    Identifier = c.Component.Identifier,
-                    Rotation = (int)c.Component.Rotation90CounterClock,
-                    SliderValue = c.HasSliders ? c.SliderValue : null,
-                    LaserWavelengthNm = c.LaserConfig?.WavelengthNm,
-                    LaserPower = c.LaserConfig?.InputPower,
-                    IsLocked = c.Component.IsLocked ? true : null
-                }).ToList(),
+                // Only save non-group, non-child components in the main list
+                Components = _canvas.Components
+                    .Where(c => c.Component is not ComponentGroup
+                                && !childComponentIds.Contains(c.Component.Identifier))
+                    .Select(c => CreateComponentData(c))
+                    .ToList(),
                 Connections = _canvas.Connections.Select(c => new ConnectionData
                 {
                     StartComponentIndex = _canvas.Components.ToList().FindIndex(
@@ -155,6 +160,13 @@ public partial class FileOperationsViewModel : ObservableObject
                 }).ToList()
             };
 
+            // Serialize groups
+            if (groupComponents.Count > 0)
+            {
+                designData.Groups = groupComponents.Select(gc =>
+                    SerializeGroupToDesignData(gc)).ToList();
+            }
+
             var json = JsonSerializer.Serialize(designData, new JsonSerializerOptions
             {
                 WriteIndented = true,
@@ -168,6 +180,121 @@ public partial class FileOperationsViewModel : ObservableObject
         catch (Exception ex)
         {
             UpdateStatus?.Invoke($"Save failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Creates a ComponentData DTO from a ComponentViewModel.
+    /// </summary>
+    private static ComponentData CreateComponentData(ComponentViewModel c)
+    {
+        return new ComponentData
+        {
+            TemplateName = c.TemplateName ?? c.Name,
+            X = c.X,
+            Y = c.Y,
+            Identifier = c.Component.Identifier,
+            Rotation = (int)c.Component.Rotation90CounterClock,
+            SliderValue = c.HasSliders ? c.SliderValue : null,
+            LaserWavelengthNm = c.LaserConfig?.WavelengthNm,
+            LaserPower = c.LaserConfig?.InputPower,
+            IsLocked = c.Component.IsLocked ? true : null
+        };
+    }
+
+    /// <summary>
+    /// Serializes a ComponentGroup ViewModel into a DesignGroupData for the design file.
+    /// </summary>
+    private DesignGroupData SerializeGroupToDesignData(ComponentViewModel groupVm)
+    {
+        var group = (ComponentGroup)groupVm.Component;
+        var groupDto = ComponentGroupSerializer.ToDto(group);
+
+        var childDataList = new List<ChildComponentData>();
+        CollectChildComponentData(group, childDataList);
+
+        return new DesignGroupData
+        {
+            GroupDto = groupDto,
+            ChildComponents = childDataList,
+            CanvasX = groupVm.X,
+            CanvasY = groupVm.Y
+        };
+    }
+
+    /// <summary>
+    /// Recursively collects child component data (with template names) from a group.
+    /// </summary>
+    private void CollectChildComponentData(
+        ComponentGroup group, List<ChildComponentData> childDataList)
+    {
+        foreach (var child in group.ChildComponents)
+        {
+            if (child is ComponentGroup childGroup)
+            {
+                // Nested groups are handled by their own DesignGroupData
+                CollectChildComponentData(childGroup, childDataList);
+            }
+            else
+            {
+                var templateName = FindTemplateName(child);
+
+                childDataList.Add(new ChildComponentData
+                {
+                    Identifier = child.Identifier,
+                    TemplateName = templateName,
+                    X = child.PhysicalX,
+                    Y = child.PhysicalY,
+                    Rotation = (int)child.Rotation90CounterClock,
+                    SliderValue = child.GetAllSliders().Count > 0
+                        ? child.GetSlider(0)?.Value : null,
+                    IsLocked = child.IsLocked ? true : null
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Finds the template name for a component by checking the canvas VMs
+    /// and falling back to matching against the component library by NazcaFunctionName.
+    /// </summary>
+    private string FindTemplateName(Component component)
+    {
+        // Check if the component has a VM on the canvas with a template name
+        var vm = _canvas.Components.FirstOrDefault(c => c.Component == component);
+        if (vm?.TemplateName != null)
+            return vm.TemplateName;
+
+        // Match by NazcaFunctionName against the component library
+        var nazcaFunc = component.NazcaFunctionName;
+        if (!string.IsNullOrEmpty(nazcaFunc))
+        {
+            var match = _componentLibrary.FirstOrDefault(t =>
+            {
+                var templateFunc = t.NazcaFunctionName
+                    ?? $"nazca_{t.Name.ToLower().Replace(" ", "_")}";
+                return templateFunc == nazcaFunc;
+            });
+            if (match != null)
+                return match.Name;
+        }
+
+        // Last resort: use identifier
+        return component.Identifier;
+    }
+
+    /// <summary>
+    /// Recursively collects all child component identifiers from a group.
+    /// </summary>
+    private static void CollectChildIds(ComponentGroup group, HashSet<string> ids)
+    {
+        foreach (var child in group.ChildComponents)
+        {
+            ids.Add(child.Identifier);
+            if (child is ComponentGroup nested)
+            {
+                CollectChildIds(nested, ids);
+            }
         }
     }
 
@@ -203,91 +330,23 @@ public partial class FileOperationsViewModel : ObservableObject
                 _canvas.ConnectionManager.Clear();
                 _commandManager.ClearHistory();
 
-                // Load components
+                // Load standalone components
                 foreach (var compData in designData.Components)
                 {
-                    var template = _componentLibrary.FirstOrDefault(t =>
-                        t.Name.Equals(compData.TemplateName, StringComparison.OrdinalIgnoreCase));
-
-                    if (template != null)
-                    {
-                        var component = ComponentTemplates.CreateFromTemplate(template, compData.X, compData.Y);
-
-                        // Apply rotation
-                        for (int i = 0; i < compData.Rotation; i++)
-                        {
-                            ApplyRotationToComponent(component);
-                        }
-
-                        var vm = _canvas.AddComponent(component, template.Name);
-
-                        // Restore slider value
-                        if (compData.SliderValue.HasValue && vm.HasSliders)
-                            vm.SliderValue = compData.SliderValue.Value;
-
-                        // Restore laser configuration
-                        if (vm.LaserConfig != null)
-                        {
-                            if (compData.LaserWavelengthNm.HasValue)
-                                vm.LaserConfig.WavelengthNm = compData.LaserWavelengthNm.Value;
-                            if (compData.LaserPower.HasValue)
-                                vm.LaserConfig.InputPower = compData.LaserPower.Value;
-                        }
-
-                        // Restore lock state
-                        if (compData.IsLocked == true)
-                            component.IsLocked = true;
-                    }
+                    LoadComponentFromData(compData);
                 }
 
-                // Load connections
+                // Load ComponentGroups
+                var groupCount = 0;
+                if (designData.Groups != null)
+                {
+                    groupCount = LoadGroups(designData.Groups);
+                }
+
+                // Load connections (index-based references to _canvas.Components)
                 foreach (var connData in designData.Connections)
                 {
-                    if (connData.StartComponentIndex >= 0 && connData.StartComponentIndex < _canvas.Components.Count &&
-                        connData.EndComponentIndex >= 0 && connData.EndComponentIndex < _canvas.Components.Count)
-                    {
-                        var startComp = _canvas.Components[connData.StartComponentIndex];
-                        var endComp = _canvas.Components[connData.EndComponentIndex];
-
-                        var startPin = startComp.Component.PhysicalPins
-                            .FirstOrDefault(p => p.Name == connData.StartPinName);
-                        var endPin = endComp.Component.PhysicalPins
-                            .FirstOrDefault(p => p.Name == connData.EndPinName);
-
-                        if (startPin != null && endPin != null)
-                        {
-                            var cachedPath = PathSegmentConverter.ToRoutedPath(
-                                connData.CachedSegments, connData.IsBlockedFallback ?? false);
-
-                            WaveguideConnectionViewModel? connVm = null;
-
-                            if (cachedPath != null && cachedPath.IsValid)
-                            {
-                                connVm = _canvas.ConnectPinsWithCachedRoute(startPin, endPin, cachedPath);
-                            }
-                            else
-                            {
-                                connVm = _canvas.ConnectPins(startPin, endPin);
-                            }
-
-                            // Restore lock state
-                            if (connVm != null && connData.IsLocked == true)
-                            {
-                                connVm.Connection.IsLocked = true;
-                            }
-
-                            // Restore target length configuration
-                            if (connVm != null)
-                            {
-                                if (connData.TargetLengthMicrometers.HasValue)
-                                    connVm.Connection.TargetLengthMicrometers = connData.TargetLengthMicrometers.Value;
-                                if (connData.IsTargetLengthEnabled == true)
-                                    connVm.Connection.IsTargetLengthEnabled = true;
-                                if (connData.LengthToleranceMicrometers.HasValue)
-                                    connVm.Connection.LengthToleranceMicrometers = connData.LengthToleranceMicrometers.Value;
-                            }
-                        }
-                    }
+                    LoadConnectionFromData(connData);
                 }
 
                 // Notify all connections about their paths for UI rendering
@@ -298,7 +357,7 @@ public partial class FileOperationsViewModel : ObservableObject
 
                 _currentFilePath = filePath;
                 HasUnsavedChanges = false;
-                UpdateStatus?.Invoke($"Loaded {Path.GetFileName(filePath)} ({_canvas.Components.Count} components, {_canvas.Connections.Count} connections)");
+                UpdateStatus?.Invoke($"Loaded {Path.GetFileName(filePath)} ({_canvas.Components.Count} components, {_canvas.Connections.Count} connections, {groupCount} groups)");
                 _commandManager.NotifyStateChanged();
 
                 // Rebuild hierarchy tree after loading
@@ -366,6 +425,169 @@ public partial class FileOperationsViewModel : ObservableObject
         _canvas.Connections.Clear();
         _canvas.ConnectionManager.Clear();
         _commandManager.ClearHistory();
+    }
+
+    /// <summary>
+    /// Loads a single component from saved data and adds it to the canvas.
+    /// </summary>
+    private ComponentViewModel? LoadComponentFromData(ComponentData compData)
+    {
+        var template = _componentLibrary.FirstOrDefault(t =>
+            t.Name.Equals(compData.TemplateName, StringComparison.OrdinalIgnoreCase));
+
+        if (template == null)
+            return null;
+
+        var component = ComponentTemplates.CreateFromTemplate(template, compData.X, compData.Y);
+
+        // Restore identifier to preserve references
+        component.Identifier = compData.Identifier;
+
+        // Apply rotation
+        for (int i = 0; i < compData.Rotation; i++)
+        {
+            ApplyRotationToComponent(component);
+        }
+
+        var vm = _canvas.AddComponent(component, template.Name);
+
+        // Restore slider value
+        if (compData.SliderValue.HasValue && vm.HasSliders)
+            vm.SliderValue = compData.SliderValue.Value;
+
+        // Restore laser configuration
+        if (vm.LaserConfig != null)
+        {
+            if (compData.LaserWavelengthNm.HasValue)
+                vm.LaserConfig.WavelengthNm = compData.LaserWavelengthNm.Value;
+            if (compData.LaserPower.HasValue)
+                vm.LaserConfig.InputPower = compData.LaserPower.Value;
+        }
+
+        // Restore lock state
+        if (compData.IsLocked == true)
+            component.IsLocked = true;
+
+        return vm;
+    }
+
+    /// <summary>
+    /// Loads ComponentGroups from saved design data.
+    /// Creates child components, reconstructs groups, and adds them to the canvas.
+    /// </summary>
+    private int LoadGroups(List<DesignGroupData> groupDataList)
+    {
+        var loadedCount = 0;
+
+        foreach (var groupData in groupDataList)
+        {
+            var componentLookup = new Dictionary<string, Component>();
+
+            // Create child components from template (not added to canvas individually)
+            foreach (var childData in groupData.ChildComponents)
+            {
+                var template = _componentLibrary.FirstOrDefault(t =>
+                    t.Name.Equals(childData.TemplateName, StringComparison.OrdinalIgnoreCase));
+
+                if (template == null)
+                    continue;
+
+                var child = ComponentTemplates.CreateFromTemplate(
+                    template, childData.X, childData.Y);
+
+                // Restore original identifier for reference matching
+                child.Identifier = childData.Identifier;
+
+                // Apply rotation
+                for (int i = 0; i < childData.Rotation; i++)
+                {
+                    ApplyRotationToComponent(child);
+                }
+
+                // Restore slider
+                if (childData.SliderValue.HasValue && child.GetAllSliders().Count > 0)
+                {
+                    var slider = child.GetSlider(0);
+                    if (slider != null) slider.Value = childData.SliderValue.Value;
+                }
+
+                if (childData.IsLocked == true)
+                    child.IsLocked = true;
+
+                componentLookup[child.Identifier] = child;
+            }
+
+            // Reconstruct the group from DTO
+            var group = ComponentGroupSerializer.FromDto(
+                groupData.GroupDto, componentLookup);
+
+            // Add the group to the canvas as a ComponentViewModel
+            var groupVm = _canvas.AddComponent(group);
+            groupVm.X = groupData.CanvasX;
+            groupVm.Y = groupData.CanvasY;
+            group.PhysicalX = groupData.CanvasX;
+            group.PhysicalY = groupData.CanvasY;
+
+            loadedCount++;
+        }
+
+        return loadedCount;
+    }
+
+    /// <summary>
+    /// Loads a single connection from saved data.
+    /// </summary>
+    private void LoadConnectionFromData(ConnectionData connData)
+    {
+        if (connData.StartComponentIndex < 0 ||
+            connData.StartComponentIndex >= _canvas.Components.Count ||
+            connData.EndComponentIndex < 0 ||
+            connData.EndComponentIndex >= _canvas.Components.Count)
+        {
+            return;
+        }
+
+        var startComp = _canvas.Components[connData.StartComponentIndex];
+        var endComp = _canvas.Components[connData.EndComponentIndex];
+
+        var startPin = startComp.Component.PhysicalPins
+            .FirstOrDefault(p => p.Name == connData.StartPinName);
+        var endPin = endComp.Component.PhysicalPins
+            .FirstOrDefault(p => p.Name == connData.EndPinName);
+
+        if (startPin == null || endPin == null)
+            return;
+
+        var cachedPath = PathSegmentConverter.ToRoutedPath(
+            connData.CachedSegments, connData.IsBlockedFallback ?? false);
+
+        WaveguideConnectionViewModel? connVm;
+
+        if (cachedPath != null && cachedPath.IsValid)
+        {
+            connVm = _canvas.ConnectPinsWithCachedRoute(startPin, endPin, cachedPath);
+        }
+        else
+        {
+            connVm = _canvas.ConnectPins(startPin, endPin);
+        }
+
+        // Restore lock state
+        if (connVm != null && connData.IsLocked == true)
+        {
+            connVm.Connection.IsLocked = true;
+        }
+
+        // Restore target length configuration
+        if (connVm != null)
+        {
+            if (connData.TargetLengthMicrometers.HasValue)
+                connVm.Connection.TargetLengthMicrometers = connData.TargetLengthMicrometers.Value;
+            if (connData.IsTargetLengthEnabled == true)
+                connVm.Connection.IsTargetLengthEnabled = true;
+            if (connData.LengthToleranceMicrometers.HasValue)
+                connVm.Connection.LengthToleranceMicrometers = connData.LengthToleranceMicrometers.Value;
+        }
     }
 
     [RelayCommand]

--- a/UnitTests/Integration/DesignFileGroupPersistenceTests.cs
+++ b/UnitTests/Integration/DesignFileGroupPersistenceTests.cs
@@ -1,0 +1,357 @@
+using System.Text.Json;
+using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP_Core.Components.Core;
+using CAP_Core.Routing;
+using CAP_DataAccess.Persistence;
+using Moq;
+using Shouldly;
+using System.Collections.ObjectModel;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Integration tests for ComponentGroup persistence through the File → Save/Open workflow.
+/// Tests the complete user path: create components → connect → group → save → new → open → verify.
+/// Covers issue #248: ComponentGroups not persisted in File → Save/Open workflow.
+/// </summary>
+public class DesignFileGroupPersistenceTests
+{
+    private readonly ObservableCollection<ComponentTemplate> _library;
+
+    public DesignFileGroupPersistenceTests()
+    {
+        _library = new ObservableCollection<ComponentTemplate>(
+            ComponentTemplates.GetAllTemplates());
+    }
+
+    /// <summary>
+    /// Core test for issue #248: Save a design with a ComponentGroup, clear, reload, verify group.
+    /// </summary>
+    [Fact]
+    public async Task SaveAndLoad_DesignWithComponentGroup_PreservesGroup()
+    {
+        // Arrange
+        var (saveVm, saveCanvas) = CreateFileOperationsSetup();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_group_{Guid.NewGuid()}.cappro");
+
+        try
+        {
+            // Create two MMI components on canvas
+            var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+            var comp1 = ComponentTemplates.CreateFromTemplate(mmiTemplate, 100, 100);
+            comp1.Identifier = "mmi_1";
+            var comp2 = ComponentTemplates.CreateFromTemplate(mmiTemplate, 300, 100);
+            comp2.Identifier = "mmi_2";
+
+            var vm1 = saveCanvas.AddComponent(comp1, mmiTemplate.Name);
+            var vm2 = saveCanvas.AddComponent(comp2, mmiTemplate.Name);
+
+            // Create a group with internal connection
+            var group = new ComponentGroup("TestSaveGroup")
+            {
+                PhysicalX = 100,
+                PhysicalY = 100,
+                Description = "Group for save/load test"
+            };
+            group.AddChild(comp1);
+            group.AddChild(comp2);
+
+            // Add frozen internal path
+            var routedPath = new RoutedPath();
+            routedPath.Segments.Add(new StraightSegment(180, 125.5, 300, 127.5, 0));
+            var frozenPath = new FrozenWaveguidePath
+            {
+                Path = routedPath,
+                StartPin = comp1.PhysicalPins.First(p => p.Name == "out1"),
+                EndPin = comp2.PhysicalPins.First(p => p.Name == "in")
+            };
+            group.AddInternalPath(frozenPath);
+
+            // Add external pin
+            var externalPin = new GroupPin
+            {
+                Name = "ext_input",
+                InternalPin = comp1.PhysicalPins.First(p => p.Name == "in"),
+                RelativeX = 0,
+                RelativeY = 27.5,
+                AngleDegrees = 180
+            };
+            group.AddExternalPin(externalPin);
+
+            // Replace individual components with the group on canvas
+            saveCanvas.Components.Clear();
+            saveCanvas.AddComponent(group);
+
+            // Act - Save to file
+            var mockDialog = new Mock<IFileDialogService>();
+            mockDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(tempFile);
+            saveVm.FileDialogService = mockDialog.Object;
+
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+
+            // Verify file was written
+            File.Exists(tempFile).ShouldBeTrue("Design file should be created");
+            var json = await File.ReadAllTextAsync(tempFile);
+            json.ShouldContain("TestSaveGroup");
+            json.ShouldContain("mmi_1");
+            json.ShouldContain("mmi_2");
+
+            // Act - Create new VM and load
+            var (loadVm, loadCanvas) = CreateFileOperationsSetup();
+            var loadDialog = new Mock<IFileDialogService>();
+            loadDialog.Setup(f => f.ShowOpenFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(tempFile);
+            loadVm.FileDialogService = loadDialog.Object;
+
+            await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+            // Assert - Group loaded correctly
+            loadCanvas.Components.Count.ShouldBeGreaterThan(0,
+                "Canvas should have components after loading");
+
+            var groupVm = loadCanvas.Components.FirstOrDefault(
+                c => c.Component is ComponentGroup);
+            groupVm.ShouldNotBeNull("A ComponentGroup should be loaded");
+
+            var loadedGroup = (ComponentGroup)groupVm!.Component;
+            loadedGroup.GroupName.ShouldBe("TestSaveGroup");
+            loadedGroup.Description.ShouldBe("Group for save/load test");
+            loadedGroup.ChildComponents.Count.ShouldBe(2);
+
+            // Verify child components
+            loadedGroup.ChildComponents
+                .Any(c => c.Identifier == "mmi_1").ShouldBeTrue();
+            loadedGroup.ChildComponents
+                .Any(c => c.Identifier == "mmi_2").ShouldBeTrue();
+
+            // Verify internal path preserved
+            loadedGroup.InternalPaths.Count.ShouldBe(1);
+            var loadedPath = loadedGroup.InternalPaths[0];
+            loadedPath.Path.Segments.Count.ShouldBe(1);
+            loadedPath.StartPin.ShouldNotBeNull();
+            loadedPath.EndPin.ShouldNotBeNull();
+            loadedPath.StartPin.Name.ShouldBe("out1");
+            loadedPath.EndPin.Name.ShouldBe("in");
+
+            // Verify external pin preserved
+            loadedGroup.ExternalPins.Count.ShouldBe(1);
+            loadedGroup.ExternalPins[0].Name.ShouldBe("ext_input");
+            loadedGroup.ExternalPins[0].AngleDegrees.ShouldBe(180);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that standalone components and groups can coexist in the same file.
+    /// </summary>
+    [Fact]
+    public async Task SaveAndLoad_MixedDesign_PreservesBothGroupsAndComponents()
+    {
+        var (saveVm, saveCanvas) = CreateFileOperationsSetup();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_mixed_{Guid.NewGuid()}.cappro");
+
+        try
+        {
+            // Add a standalone component
+            var detTemplate = _library.First(t => t.Name == "Photodetector");
+            var standalone = ComponentTemplates.CreateFromTemplate(detTemplate, 600, 100);
+            standalone.Identifier = "standalone_det";
+            saveCanvas.AddComponent(standalone, detTemplate.Name);
+
+            // Add a group
+            var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+            var child1 = ComponentTemplates.CreateFromTemplate(mmiTemplate, 100, 100);
+            child1.Identifier = "group_child_1";
+            var child2 = ComponentTemplates.CreateFromTemplate(mmiTemplate, 300, 100);
+            child2.Identifier = "group_child_2";
+
+            var group = new ComponentGroup("MixedGroup")
+            {
+                PhysicalX = 100,
+                PhysicalY = 100
+            };
+            group.AddChild(child1);
+            group.AddChild(child2);
+            saveCanvas.AddComponent(group);
+
+            // Save
+            var mockDialog = new Mock<IFileDialogService>();
+            mockDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(tempFile);
+            saveVm.FileDialogService = mockDialog.Object;
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+
+            // Load into fresh canvas
+            var (loadVm, loadCanvas) = CreateFileOperationsSetup();
+            var loadDialog = new Mock<IFileDialogService>();
+            loadDialog.Setup(f => f.ShowOpenFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(tempFile);
+            loadVm.FileDialogService = loadDialog.Object;
+            await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+            // Assert - Both standalone and group loaded
+            loadCanvas.Components.Count.ShouldBe(2);
+
+            var standaloneVm = loadCanvas.Components.FirstOrDefault(
+                c => c.Component is not ComponentGroup);
+            standaloneVm.ShouldNotBeNull("Standalone component should be loaded");
+
+            var groupVm = loadCanvas.Components.FirstOrDefault(
+                c => c.Component is ComponentGroup);
+            groupVm.ShouldNotBeNull("Group should be loaded");
+
+            var loadedGroup = (ComponentGroup)groupVm!.Component;
+            loadedGroup.GroupName.ShouldBe("MixedGroup");
+            loadedGroup.ChildComponents.Count.ShouldBe(2);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Verifies backward compatibility: files without Groups property load normally.
+    /// </summary>
+    [Fact]
+    public async Task LoadDesign_OldFormatWithoutGroups_LoadsNormally()
+    {
+        var (loadVm, loadCanvas) = CreateFileOperationsSetup();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_compat_{Guid.NewGuid()}.cappro");
+
+        try
+        {
+            // Write old-format JSON (no Groups property)
+            var oldData = new
+            {
+                Components = new[]
+                {
+                    new
+                    {
+                        TemplateName = "Photodetector",
+                        X = 100.0,
+                        Y = 200.0,
+                        Identifier = "old_det_1",
+                        Rotation = 0
+                    }
+                },
+                Connections = Array.Empty<object>()
+            };
+
+            var json = JsonSerializer.Serialize(oldData, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+            await File.WriteAllTextAsync(tempFile, json);
+
+            // Load
+            var loadDialog = new Mock<IFileDialogService>();
+            loadDialog.Setup(f => f.ShowOpenFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(tempFile);
+            loadVm.FileDialogService = loadDialog.Object;
+            await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+            // Assert - Component loaded, no errors
+            loadCanvas.Components.Count.ShouldBe(1);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that group JSON contains all required group data.
+    /// </summary>
+    [Fact]
+    public async Task SaveDesign_WithGroup_JsonContainsGroupStructure()
+    {
+        var (saveVm, saveCanvas) = CreateFileOperationsSetup();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_json_{Guid.NewGuid()}.cappro");
+
+        try
+        {
+            var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+            var comp1 = ComponentTemplates.CreateFromTemplate(mmiTemplate, 0, 0);
+            comp1.Identifier = "json_comp_1";
+
+            var group = new ComponentGroup("JsonTestGroup")
+            {
+                PhysicalX = 0,
+                PhysicalY = 0,
+                Description = "Verify JSON structure"
+            };
+            group.AddChild(comp1);
+
+            // Add path with bend segment
+            var path = new RoutedPath();
+            path.Segments.Add(new StraightSegment(0, 0, 20, 0, 0));
+            path.Segments.Add(new BendSegment(20, 10, 10, 0, 90));
+            group.AddInternalPath(new FrozenWaveguidePath
+            {
+                Path = path,
+                StartPin = comp1.PhysicalPins[0],
+                EndPin = comp1.PhysicalPins[0] // Self-loop for test
+            });
+
+            saveCanvas.AddComponent(group);
+
+            var mockDialog = new Mock<IFileDialogService>();
+            mockDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(tempFile);
+            saveVm.FileDialogService = mockDialog.Object;
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+
+            var json = await File.ReadAllTextAsync(tempFile);
+
+            // Verify JSON structure
+            json.ShouldContain("Groups");
+            json.ShouldContain("GroupDto");
+            json.ShouldContain("JsonTestGroup");
+            json.ShouldContain("ChildComponents");
+            json.ShouldContain("json_comp_1");
+            json.ShouldContain("InternalPaths");
+            json.ShouldContain("Segments");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Creates a FileOperationsViewModel with real component library for testing.
+    /// </summary>
+    private (FileOperationsViewModel vm, DesignCanvasViewModel canvas) CreateFileOperationsSetup()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+        var nazcaExporter = new SimpleNazcaExporter();
+        var gdsExport = new GdsExportViewModel(new CAP_Core.Export.GdsExportService());
+
+        var vm = new FileOperationsViewModel(
+            canvas, commandManager, nazcaExporter, _library, gdsExport);
+
+        return (vm, canvas);
+    }
+}


### PR DESCRIPTION
Automated implementation for #248

Now let me provide the final summary:

---

## Implementation Complete

### Bug Diagnosis

The root cause was that `FileOperationsViewModel.SaveToFile()` serialized `DesignFileData` containing only `Components` and `Connections` — **ComponentGroups were completely ignored**. When a group was on the canvas, it was treated like a regular component but had no `TemplateName` match in the library, causing it to be silently dropped on load.

### Changes Made

**1. `CAP.Avalonia/ViewModels/MainViewModel.cs`** — Added group DTOs to `DesignFileData`
- Added `Groups` property (`List<DesignGroupData>?`) to `DesignFileData`
- Added `DesignGroupData` class bridging UI-layer (TemplateName) and core-layer (`ComponentGroupDto`) serialization
- Added `ChildComponentData` class preserving template names for group children

**2. `CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs`** — Core fix
- **Save**: Groups are detected, their children excluded from the main `Components` list, and serialized as `DesignGroupData` entries using `ComponentGroupSerializer.ToDto()`
- **Load**: Groups are reconstructed by creating child components from templates, then using `ComponentGroupSerializer.FromDto()` to rebuild the full group hierarchy
- Added `FindTemplateName()` to recover template names for group children (which don't have ViewModels on the canvas)
- Refactored load logic into `LoadComponentFromData()`, `LoadGroups()`, and `LoadConnectionFromData()` for clarity
- **Backward compatible**: Files without `Groups` property load normally (null check)

**3. `UnitTests/Integration/DesignFileGroupPersistenceTests.cs`** — New integration tests
- `SaveAndLoad_DesignWithComponentGroup_PreservesGroup` — Core test for issue #248: verifies group name, description, child components, internal paths, external pins
- `SaveAndLoad_MixedDesign_PreservesBothGroupsAndComponents` — Groups + standalone components coexist
- `LoadDesign_OldFormatWithoutGroups_LoadsNormally` — Backward compatibility
- `SaveDesign_WithGroup_JsonContainsGroupStructure` — JSON structure verification

### Test Results
- **0 build errors**, all tests pass
- **28/28** related tests pass (4 new + 24 existing)
- **8 pre-existing failures** unchanged (unrelated to persistence)

### MCP Tools Used
- **NetContextServer**: Not used (explored codebase using Glob/Grep/Read directly for faster access)


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 25,657
- **Estimated cost:** $0.3287 USD

---
*Generated by autonomous agent using Claude Code.*