### PR TITLE
Agent: Bug: Group copy-paste with undo/redo creates shadow components and wrong positions

### DIFF
--- a/CAP.Avalonia/Commands/CreateGroupCommand.cs
+++ b/CAP.Avalonia/Commands/CreateGroupCommand.cs
@@ -56,14 +56,9 @@ public class CreateGroupCommand : IUndoableCommand
             {
                 _canvas.BeginCommandExecution();
 
-                // Remove child components from canvas
-                var componentsToRemove = _canvas.Components
-                    .Where(cvm => _components.Contains(cvm.Component))
-                    .ToList();
-
-                foreach (var compVm in componentsToRemove)
+                // Remove child components from canvas (use stored VMs for identity)
+                foreach (var compVm in _componentViewModels)
                 {
-                    // Remove pins
                     var pinsToRemove = _canvas.AllPins
                         .Where(p => p.ParentComponentViewModel == compVm)
                         .ToList();
@@ -71,6 +66,7 @@ public class CreateGroupCommand : IUndoableCommand
                     {
                         _canvas.AllPins.Remove(pin);
                     }
+                    _canvas.Router.RemoveComponentObstacle(compVm.Component);
                     _canvas.Components.Remove(compVm);
                 }
 
@@ -81,8 +77,9 @@ public class CreateGroupCommand : IUndoableCommand
                     _canvas.ConnectionManager.RemoveConnectionDeferred(connVm.Connection);
                 }
 
-                // Re-add the SAME group
+                // Re-add the SAME group ViewModel and Router obstacle
                 _canvas.Components.Add(_groupViewModel);
+                _canvas.Router.AddComponentObstacle(_createdGroup);
 
                 // Re-add group pins
                 foreach (var pin in _createdGroup.ExternalPins)
@@ -271,11 +268,15 @@ public class CreateGroupCommand : IUndoableCommand
                 {
                     comp.PhysicalX = pos.x;
                     comp.PhysicalY = pos.y;
+                    // Sync the ViewModel's cached position with the model
+                    compVm.X = pos.x;
+                    compVm.Y = pos.y;
                 }
                 comp.ParentGroup = null;
 
                 // Restore the SAME ViewModel (not create a new one!)
                 _canvas.Components.Add(compVm);
+                _canvas.Router.AddComponentObstacle(comp);
 
                 // Re-add pins to AllPins
                 foreach (var pin in comp.PhysicalPins)

--- a/CAP.Avalonia/Commands/PasteComponentsCommand.cs
+++ b/CAP.Avalonia/Commands/PasteComponentsCommand.cs
@@ -1,11 +1,13 @@
 using CAP.Avalonia.Selection;
 using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
 
 namespace CAP.Avalonia.Commands;
 
 /// <summary>
 /// Command for pasting copied components onto the canvas.
-/// Supports undo by removing all pasted components.
+/// On first Execute, creates new clones via clipboard. On Redo, re-adds
+/// the same component instances to avoid creating shadow/duplicate components.
 /// </summary>
 public class PasteComponentsCommand : IUndoableCommand
 {
@@ -38,6 +40,14 @@ public class PasteComponentsCommand : IUndoableCommand
     /// <inheritdoc />
     public void Execute()
     {
+        // Redo scenario: re-add the SAME components instead of creating new clones
+        if (_result != null)
+        {
+            ReAddPastedComponents();
+            return;
+        }
+
+        // First execution: create new clones via clipboard
         _result = _clipboard.Paste(_canvas, _targetX, _targetY);
     }
 
@@ -53,11 +63,47 @@ public class PasteComponentsCommand : IUndoableCommand
             _canvas.Connections.Remove(conn);
         }
 
-        // Remove pasted components
+        // Remove pasted components (but keep _result so Redo can restore them)
         foreach (var comp in _result.Components)
         {
             _canvas.RemoveComponent(comp);
         }
+    }
+
+    /// <summary>
+    /// Re-adds previously pasted components on Redo, preserving object identity.
+    /// </summary>
+    private void ReAddPastedComponents()
+    {
+        try
+        {
+            _canvas.BeginCommandExecution();
+
+            foreach (var compVm in _result!.Components)
+            {
+                _canvas.Components.Add(compVm);
+                _canvas.Router.AddComponentObstacle(compVm.Component);
+
+                foreach (var pin in compVm.Component.PhysicalPins)
+                {
+                    _canvas.AllPins.Add(new PinViewModel(pin, compVm));
+                }
+            }
+
+            // Re-add connections
+            foreach (var connVm in _result.Connections)
+            {
+                _canvas.ConnectionManager.AddExistingConnection(connVm.Connection);
+                _canvas.Connections.Add(connVm);
+            }
+        }
+        finally
+        {
+            _canvas.EndCommandExecution();
+        }
+
+        _ = _canvas.RecalculateRoutesAsync();
+        _canvas.InvalidateSimulation();
     }
 
     /// <summary>

--- a/CAP.Avalonia/Commands/UngroupCommand.cs
+++ b/CAP.Avalonia/Commands/UngroupCommand.cs
@@ -7,6 +7,7 @@ namespace CAP.Avalonia.Commands;
 /// <summary>
 /// Command to explode a ComponentGroup back to individual components.
 /// Unfreezes internal paths and restores waveguide connections.
+/// Preserves object identity across undo/redo cycles to prevent shadow components.
 /// </summary>
 public class UngroupCommand : IUndoableCommand
 {
@@ -14,10 +15,14 @@ public class UngroupCommand : IUndoableCommand
     private readonly ComponentGroup _group;
     private ComponentViewModel? _groupViewModel;
     private readonly List<ComponentViewModel> _restoredComponentViewModels = new();
-    private readonly List<WaveguideConnection> _restoredConnections = new();
+    private readonly List<WaveguideConnectionViewModel> _restoredConnectionViewModels = new();
     private readonly double _groupX;
     private readonly double _groupY;
+    private bool _hasExecutedOnce;
 
+    /// <summary>
+    /// Creates an ungroup command for the given group.
+    /// </summary>
     public UngroupCommand(DesignCanvasViewModel canvas, ComponentGroup group)
     {
         _canvas = canvas;
@@ -26,11 +31,20 @@ public class UngroupCommand : IUndoableCommand
         _groupY = group.PhysicalY;
     }
 
+    /// <inheritdoc />
     public string Description => $"Ungroup {_group.GroupName}";
 
+    /// <inheritdoc />
     public void Execute()
     {
-        // Find the group's ViewModel
+        // On Redo, reuse stored ViewModels instead of creating new ones
+        if (_hasExecutedOnce)
+        {
+            ReAddRestoredComponents();
+            return;
+        }
+
+        // First execution
         _groupViewModel = _canvas.Components.FirstOrDefault(c => c.Component == _group);
         if (_groupViewModel == null)
             return;
@@ -51,13 +65,9 @@ public class UngroupCommand : IUndoableCommand
             }
 
             // 2. Convert frozen paths back to WaveguideConnections
-            // IMPORTANT: Do NOT use cached routes - they're from before group movement!
-            // The group may have been moved, rotated, or edited since grouping.
-            // We must recalculate routes to reflect current component positions.
-            _restoredConnections.Clear();
+            _restoredConnectionViewModels.Clear();
             foreach (var frozenPath in _group.InternalPaths)
             {
-                // Add connection without route - will be recalculated below
                 var connection = _canvas.ConnectionManager.AddConnectionDeferred(
                     frozenPath.StartPin,
                     frozenPath.EndPin
@@ -65,7 +75,7 @@ public class UngroupCommand : IUndoableCommand
 
                 var connVm = new WaveguideConnectionViewModel(connection);
                 _canvas.Connections.Add(connVm);
-                _restoredConnections.Add(connection);
+                _restoredConnectionViewModels.Add(connVm);
             }
 
             // 3. Remove the group from canvas
@@ -76,11 +86,14 @@ public class UngroupCommand : IUndoableCommand
             _canvas.EndCommandExecution();
         }
 
+        _hasExecutedOnce = true;
+
         // Update routes for the restored connections
         _ = _canvas.RecalculateRoutesAsync();
         _canvas.InvalidateSimulation();
     }
 
+    /// <inheritdoc />
     public void Undo()
     {
         if (_groupViewModel == null)
@@ -91,23 +104,17 @@ public class UngroupCommand : IUndoableCommand
             _canvas.BeginCommandExecution();
 
             // Remove restored connections
-            foreach (var conn in _restoredConnections)
+            foreach (var connVm in _restoredConnectionViewModels)
             {
-                var connVm = _canvas.Connections.FirstOrDefault(c => c.Connection == conn);
-                if (connVm != null)
-                {
-                    _canvas.Connections.Remove(connVm);
-                    _canvas.ConnectionManager.RemoveConnectionDeferred(conn);
-                }
+                _canvas.Connections.Remove(connVm);
+                _canvas.ConnectionManager.RemoveConnectionDeferred(connVm.Connection);
             }
 
             // Remove individual components
             foreach (var compVm in _restoredComponentViewModels)
             {
-                // Set component back as child of group
                 compVm.Component.ParentGroup = _group;
 
-                // Remove pins
                 var pinsToRemove = _canvas.AllPins
                     .Where(p => p.ParentComponentViewModel == compVm)
                     .ToList();
@@ -116,20 +123,72 @@ public class UngroupCommand : IUndoableCommand
                     _canvas.AllPins.Remove(pin);
                 }
 
+                _canvas.Router.RemoveComponentObstacle(compVm.Component);
                 _canvas.Components.Remove(compVm);
             }
 
-            // Re-add the group
+            // Re-add the group using the SAME ViewModel
             _group.PhysicalX = _groupX;
             _group.PhysicalY = _groupY;
-            _groupViewModel = _canvas.AddComponent(_group);
+            _canvas.Components.Add(_groupViewModel);
+            _canvas.Router.AddComponentObstacle(_group);
+
+            foreach (var pin in _group.ExternalPins)
+            {
+                _canvas.AllPins.Add(new PinViewModel(pin.InternalPin, _groupViewModel));
+            }
         }
         finally
         {
             _canvas.EndCommandExecution();
         }
 
-        // Recalculate routes
+        _ = _canvas.RecalculateRoutesAsync();
+        _canvas.InvalidateSimulation();
+    }
+
+    /// <summary>
+    /// Re-adds previously restored child components on Redo, preserving object identity.
+    /// </summary>
+    private void ReAddRestoredComponents()
+    {
+        // Find the group's current ViewModel on canvas
+        _groupViewModel = _canvas.Components.FirstOrDefault(c => c.Component == _group);
+        if (_groupViewModel == null)
+            return;
+
+        try
+        {
+            _canvas.BeginCommandExecution();
+
+            // Re-add the SAME child ViewModels
+            foreach (var childVm in _restoredComponentViewModels)
+            {
+                childVm.Component.ParentGroup = null;
+                _canvas.Components.Add(childVm);
+                _canvas.Router.AddComponentObstacle(childVm.Component);
+
+                foreach (var pin in childVm.Component.PhysicalPins)
+                {
+                    _canvas.AllPins.Add(new PinViewModel(pin, childVm));
+                }
+            }
+
+            // Re-add the SAME connection ViewModels
+            foreach (var connVm in _restoredConnectionViewModels)
+            {
+                _canvas.ConnectionManager.AddExistingConnection(connVm.Connection);
+                _canvas.Connections.Add(connVm);
+            }
+
+            // Remove the group from canvas
+            _canvas.RemoveComponent(_groupViewModel);
+        }
+        finally
+        {
+            _canvas.EndCommandExecution();
+        }
+
         _ = _canvas.RecalculateRoutesAsync();
         _canvas.InvalidateSimulation();
     }

--- a/UnitTests/Commands/GroupCopyPasteUndoRedoTests.cs
+++ b/UnitTests/Commands/GroupCopyPasteUndoRedoTests.cs
@@ -1,0 +1,327 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Commands;
+
+/// <summary>
+/// Tests for issue #251: Group copy-paste with undo/redo creates shadow
+/// components and wrong positions.
+/// Verifies that paste/undo/redo cycles preserve object identity and positions.
+/// </summary>
+public class GroupCopyPasteUndoRedoTests
+{
+    [Fact]
+    public void PasteGroup_UndoRedo_ShouldPreserveSameComponentInstances()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        group.PhysicalX = 100;
+        group.PhysicalY = 100;
+        canvas.AddComponent(group);
+
+        var groupVm = canvas.Components.First();
+        canvas.Clipboard.Copy(new[] { groupVm }, canvas.Connections);
+
+        // Act: Paste
+        var pasteCmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        commandManager.ExecuteCommand(pasteCmd);
+        var pastedComponent = pasteCmd.Result!.Components[0].Component;
+        canvas.Components.Count.ShouldBe(2);
+
+        // Act: Undo paste
+        commandManager.Undo();
+        canvas.Components.Count.ShouldBe(1);
+
+        // Act: Redo paste
+        commandManager.Redo();
+        canvas.Components.Count.ShouldBe(2);
+
+        // Assert: pasted component should be the SAME instance
+        var redoneVm = canvas.Components.FirstOrDefault(c => c.Component == pastedComponent);
+        redoneVm.ShouldNotBeNull("Redo should restore the same component instance");
+    }
+
+    [Fact]
+    public void PasteGroup_UndoRedo_ShouldNotCreateShadowComponents()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        group.PhysicalX = 100;
+        group.PhysicalY = 100;
+        canvas.AddComponent(group);
+
+        var groupVm = canvas.Components.First();
+        canvas.Clipboard.Copy(new[] { groupVm }, canvas.Connections);
+
+        // Act: Paste → Undo → Redo → Undo → Redo (multiple cycles)
+        var pasteCmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        commandManager.ExecuteCommand(pasteCmd);
+        canvas.Components.Count.ShouldBe(2, "After paste: 2 components");
+
+        commandManager.Undo();
+        canvas.Components.Count.ShouldBe(1, "After undo: 1 component");
+
+        commandManager.Redo();
+        canvas.Components.Count.ShouldBe(2, "After first redo: 2 components");
+
+        commandManager.Undo();
+        canvas.Components.Count.ShouldBe(1, "After second undo: 1 component");
+
+        commandManager.Redo();
+        canvas.Components.Count.ShouldBe(2, "After second redo: 2 components (no shadow)");
+    }
+
+    [Fact]
+    public void PasteGroup_MoveGroup_CreateSuperGroup_UndoAll_RedoAll_CorrectState()
+    {
+        // Reproduce the exact scenario from issue #251
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+
+        // Step 1: Create two components
+        var comp1 = TestComponentFactory.CreateBasicComponent();
+        comp1.PhysicalX = 0;
+        comp1.PhysicalY = 0;
+        var vm1 = canvas.AddComponent(comp1);
+
+        var comp2 = TestComponentFactory.CreateBasicComponent();
+        comp2.PhysicalX = 300;
+        comp2.PhysicalY = 0;
+        var vm2 = canvas.AddComponent(comp2);
+
+        // Step 2: Create a group
+        var createGroupCmd = new CreateGroupCommand(
+            canvas, new List<ComponentViewModel> { vm1, vm2 });
+        commandManager.ExecuteCommand(createGroupCmd);
+        canvas.Components.Count.ShouldBe(1, "Should have 1 group");
+
+        var groupVm = canvas.Components.First();
+        var group1 = (ComponentGroup)groupVm.Component;
+
+        // Step 3: Copy the group
+        canvas.Clipboard.Copy(new[] { groupVm }, canvas.Connections);
+
+        // Step 4: Paste the group
+        var pasteCmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        commandManager.ExecuteCommand(pasteCmd);
+        canvas.Components.Count.ShouldBe(2, "Should have 2 groups after paste");
+
+        var pastedGroupVm = pasteCmd.Result!.Components[0];
+        var group2 = (ComponentGroup)pastedGroupVm.Component;
+
+        // Step 5: Move the pasted group
+        double moveEndX = pastedGroupVm.X + 200;
+        double moveEndY = pastedGroupVm.Y + 200;
+        var moveCmd = new MoveComponentCommand(
+            canvas, pastedGroupVm,
+            pastedGroupVm.X, pastedGroupVm.Y,
+            moveEndX, moveEndY);
+        commandManager.ExecuteCommand(moveCmd);
+
+        // Step 6: Create super-group from both groups
+        var updatedGroupVm = canvas.Components.First(c => c.Component == group1);
+        var updatedPastedVm = canvas.Components.First(c => c.Component == group2);
+        var superGroupCmd = new CreateGroupCommand(
+            canvas, new List<ComponentViewModel> { updatedGroupVm, updatedPastedVm });
+        commandManager.ExecuteCommand(superGroupCmd);
+        canvas.Components.Count.ShouldBe(1, "Should have 1 super-group");
+
+        // Step 7: Undo 4 times (super-group, move, paste, group)
+        commandManager.Undo(); // undo super-group
+        canvas.Components.Count.ShouldBe(2, "After undo super-group: 2 groups");
+
+        commandManager.Undo(); // undo move
+        canvas.Components.Count.ShouldBe(2, "After undo move: 2 groups");
+
+        commandManager.Undo(); // undo paste
+        canvas.Components.Count.ShouldBe(1, "After undo paste: 1 group");
+
+        commandManager.Undo(); // undo group creation
+        canvas.Components.Count.ShouldBe(2, "After undo group: 2 components");
+
+        // Step 8: Redo 4 times
+        commandManager.Redo(); // redo group creation
+        canvas.Components.Count.ShouldBe(1, "After redo group: 1 group");
+
+        commandManager.Redo(); // redo paste
+        canvas.Components.Count.ShouldBe(2, "After redo paste: 2 groups");
+
+        commandManager.Redo(); // redo move
+        canvas.Components.Count.ShouldBe(2, "After redo move: 2 groups");
+
+        commandManager.Redo(); // redo super-group
+        canvas.Components.Count.ShouldBe(1, "After redo super-group: 1 super-group");
+    }
+
+    [Fact]
+    public void PasteGroup_UndoRedo_ShouldPreservePositions()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+
+        var group = TestComponentFactory.CreateComponentGroup("TestGroup", addChildren: true);
+        group.PhysicalX = 100;
+        group.PhysicalY = 100;
+        canvas.AddComponent(group);
+
+        var groupVm = canvas.Components.First();
+        canvas.Clipboard.Copy(new[] { groupVm }, canvas.Connections);
+
+        // Act: Paste
+        var pasteCmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        commandManager.ExecuteCommand(pasteCmd);
+        var pastedVm = pasteCmd.Result!.Components[0];
+        double pasteX = pastedVm.X;
+        double pasteY = pastedVm.Y;
+
+        // Act: Undo then Redo
+        commandManager.Undo();
+        commandManager.Redo();
+
+        // Assert: position should be preserved
+        var restoredVm = canvas.Components.First(c => c.Component == pastedVm.Component);
+        restoredVm.X.ShouldBe(pasteX, "X position should be preserved after undo/redo");
+        restoredVm.Y.ShouldBe(pasteY, "Y position should be preserved after undo/redo");
+    }
+
+    [Fact]
+    public void CreateGroup_UndoRedo_ShouldSyncViewModelPositions()
+    {
+        // Tests that VM.X/Y are synced with Component.PhysicalX/Y on undo
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+
+        var comp1 = TestComponentFactory.CreateBasicComponent();
+        comp1.PhysicalX = 50;
+        comp1.PhysicalY = 50;
+        var vm1 = canvas.AddComponent(comp1);
+
+        var comp2 = TestComponentFactory.CreateBasicComponent();
+        comp2.PhysicalX = 350;
+        comp2.PhysicalY = 50;
+        var vm2 = canvas.AddComponent(comp2);
+
+        double originalX1 = vm1.X;
+        double originalY1 = vm1.Y;
+        double originalX2 = vm2.X;
+        double originalY2 = vm2.Y;
+
+        // Create group
+        var createGroupCmd = new CreateGroupCommand(
+            canvas, new List<ComponentViewModel> { vm1, vm2 });
+        commandManager.ExecuteCommand(createGroupCmd);
+
+        // Undo
+        commandManager.Undo();
+
+        // Assert: VM positions should match original positions
+        var restoredVm1 = canvas.Components.First(c => c.Component == comp1);
+        var restoredVm2 = canvas.Components.First(c => c.Component == comp2);
+
+        restoredVm1.X.ShouldBe(originalX1, "VM1.X should match original after undo");
+        restoredVm1.Y.ShouldBe(originalY1, "VM1.Y should match original after undo");
+        restoredVm2.X.ShouldBe(originalX2, "VM2.X should match original after undo");
+        restoredVm2.Y.ShouldBe(originalY2, "VM2.Y should match original after undo");
+
+        // Also verify model is synced
+        restoredVm1.Component.PhysicalX.ShouldBe(restoredVm1.X,
+            "Model PhysicalX should match VM X");
+        restoredVm2.Component.PhysicalX.ShouldBe(restoredVm2.X,
+            "Model PhysicalX should match VM X");
+    }
+
+    [Fact]
+    public void UngroupCommand_UndoRedo_ShouldPreserveViewModelIdentity()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+
+        var comp1 = TestComponentFactory.CreateBasicComponent();
+        comp1.PhysicalX = 0;
+        comp1.PhysicalY = 0;
+        var vm1 = canvas.AddComponent(comp1);
+
+        var comp2 = TestComponentFactory.CreateBasicComponent();
+        comp2.PhysicalX = 300;
+        comp2.PhysicalY = 0;
+        var vm2 = canvas.AddComponent(comp2);
+
+        // Create group
+        var createGroupCmd = new CreateGroupCommand(
+            canvas, new List<ComponentViewModel> { vm1, vm2 });
+        commandManager.ExecuteCommand(createGroupCmd);
+
+        var group = (ComponentGroup)canvas.Components.First().Component;
+
+        // Ungroup
+        var ungroupCmd = new UngroupCommand(canvas, group);
+        commandManager.ExecuteCommand(ungroupCmd);
+        canvas.Components.Count.ShouldBe(2, "After ungroup: 2 components");
+
+        var childVms = canvas.Components.ToList();
+
+        // Undo ungroup
+        commandManager.Undo();
+        canvas.Components.Count.ShouldBe(1, "After undo ungroup: 1 group");
+
+        // Redo ungroup
+        commandManager.Redo();
+        canvas.Components.Count.ShouldBe(2, "After redo ungroup: 2 components");
+
+        // Assert: same child component instances should be restored
+        foreach (var childVm in childVms)
+        {
+            canvas.Components.ShouldContain(c => c.Component == childVm.Component,
+                "Redo should restore the same component instance");
+        }
+    }
+
+    [Fact]
+    public void UngroupCommand_MultipleUndoRedoCycles_NoShadowComponents()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+
+        var comp1 = TestComponentFactory.CreateBasicComponent();
+        comp1.PhysicalX = 0;
+        comp1.PhysicalY = 0;
+        canvas.AddComponent(comp1);
+
+        var comp2 = TestComponentFactory.CreateBasicComponent();
+        comp2.PhysicalX = 300;
+        comp2.PhysicalY = 0;
+        canvas.AddComponent(comp2);
+
+        // Create group
+        var vms = canvas.Components.ToList();
+        var createGroupCmd = new CreateGroupCommand(canvas, vms);
+        commandManager.ExecuteCommand(createGroupCmd);
+        var group = (ComponentGroup)canvas.Components.First().Component;
+
+        // Ungroup
+        var ungroupCmd = new UngroupCommand(canvas, group);
+        commandManager.ExecuteCommand(ungroupCmd);
+
+        // Multiple undo/redo cycles
+        for (int i = 0; i < 3; i++)
+        {
+            commandManager.Undo(); // undo ungroup → 1 group
+            canvas.Components.Count.ShouldBe(1, $"Cycle {i}: After undo ungroup: 1 group");
+
+            commandManager.Redo(); // redo ungroup → 2 components
+            canvas.Components.Count.ShouldBe(2, $"Cycle {i}: After redo ungroup: 2 components");
+        }
+    }
+}


### PR DESCRIPTION
Automated implementation for #251

Let me create a summary of the changes and commit.

## Summary of Changes

### Root Causes Found

The bug had **three root causes** across three command classes:

### 1. `PasteComponentsCommand` — Shadow components on Redo
**Problem:** `Execute()` always called `_clipboard.Paste()`, which creates **new clones** every time. On Redo (when `Execute()` is called again by `CommandManager`), new component instances were created while the old ones became orphaned "shadow" references.

**Fix:** Added a Redo path that checks if `_result` already exists. On Redo, the command re-adds the **same** previously-created `ComponentViewModel` instances instead of creating new clones.

### 2. `UngroupCommand` — Shadow components on Redo, stale group VM on Undo
**Problem:** 
- `Execute()` always created NEW `ComponentViewModel` instances via `canvas.AddComponent(child)` on every call, including Redo.
- `Undo()` created a NEW `_groupViewModel` via `canvas.AddComponent(_group)` instead of reusing the stored one, and lost track of stored connection VMs.

**Fix:** Added `_hasExecutedOnce` flag. On Redo, re-adds the **same** stored child VMs and connection VMs. On Undo, re-adds the **same** group VM directly to the collection instead of creating a new wrapper.

### 3. `CreateGroupCommand` — Wrong positions after Undo, missing Router obstacles
**Problem:**
- When undoing group creation, `comp.PhysicalX` was restored but the ViewModel's cached `X` property was NOT synced, causing position divergence.
- Router obstacles were not managed during Redo/Undo (components removed from canvas without removing obstacles, group re-added without adding obstacle).

**Fix:** 
- Added `compVm.X = pos.x; compVm.Y = pos.y;` sync in Undo.
- Added `Router.AddComponentObstacle`/`RemoveComponentObstacle` calls in both Redo and Undo paths.
- Changed Redo path to use stored `_componentViewModels` list instead of re-querying canvas.

### Files Changed
- `CAP.Avalonia/Commands/PasteComponentsCommand.cs` — Redo path preserving object identity
- `CAP.Avalonia/Commands/UngroupCommand.cs` — Redo/Undo preserving object identity
- `CAP.Avalonia/Commands/CreateGroupCommand.cs` — VM position sync + Router obstacle management
- `UnitTests/Commands/GroupCopyPasteUndoRedoTests.cs` — 7 new tests (NEW FILE)

### Tests
- 7 new tests, all passing
- 0 regressions
- Existing 7 failures are all pre-existing (documented in MEMORY.md)

MCP Tools used: None were available or needed for this fix.


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 23,429
- **Estimated cost:** $0.3099 USD

---
*Generated by autonomous agent using Claude Code.*