### PR TITLE
Agent: Bug: 'Neu' button in group edit mode doesn't exit edit mode properly

### DIFF
--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -375,6 +375,7 @@ public partial class FileOperationsViewModel : ObservableObject
 
     /// <summary>
     /// Creates a new empty project, prompting to save if there are unsaved changes.
+    /// Exits group edit mode if active before clearing the canvas.
     /// </summary>
     [RelayCommand]
     private async Task NewProject()
@@ -403,6 +404,12 @@ public partial class FileOperationsViewModel : ObservableObject
                 return;
             }
             // DontSave: continue to clear
+        }
+
+        // Exit group edit mode if active
+        if (_canvas.IsInGroupEditMode)
+        {
+            _canvas.ExitToRoot();
         }
 
         // Clear the canvas

--- a/UnitTests/Integration/NewProjectIntegrationTests.cs
+++ b/UnitTests/Integration/NewProjectIntegrationTests.cs
@@ -182,4 +182,95 @@ public class NewProjectIntegrationTests
         // Verify connections are cleared
         mainVm.Canvas.Connections.Count.ShouldBe(0);
     }
+
+    [Fact]
+    public async Task NewProject_ExitsGroupEditMode()
+    {
+        var mainVm = new MainViewModel(
+            _simulationService,
+            _nazcaExporter,
+            _pdkLoader,
+            _commandManager,
+            _preferencesService,
+            _groupLibraryManager,
+            _previewGenerator,
+            _inputDialogService,
+            _gdsExportService);
+
+        // Create a group with some components
+        var comp1 = TestComponentFactory.CreateStraightWaveGuide();
+        var comp2 = TestComponentFactory.CreateStraightWaveGuide();
+        comp1.PhysicalX = 0;
+        comp1.PhysicalY = 0;
+        comp2.PhysicalX = 100;
+        comp2.PhysicalY = 0;
+
+        var group = new ComponentGroup("TestGroup");
+        group.AddChild(comp1);
+        group.AddChild(comp2);
+
+        mainVm.Canvas.AddComponent(group);
+
+        // Enter group edit mode
+        mainVm.Canvas.EnterGroupEditMode(group);
+        mainVm.Canvas.IsInGroupEditMode.ShouldBeTrue();
+
+        // Mark as saved
+        mainVm.FileOperations.HasUnsavedChanges = false;
+
+        // Execute NewProject
+        await mainVm.NewProjectCommand.ExecuteAsync(null);
+
+        // Verify group edit mode is exited
+        mainVm.Canvas.IsInGroupEditMode.ShouldBeFalse();
+        mainVm.Canvas.CurrentEditGroup.ShouldBeNull();
+
+        // Verify canvas is cleared
+        mainVm.Canvas.Components.Count.ShouldBe(0);
+        mainVm.Canvas.Connections.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task NewProject_ExitsNestedGroupEditMode()
+    {
+        var mainVm = new MainViewModel(
+            _simulationService,
+            _nazcaExporter,
+            _pdkLoader,
+            _commandManager,
+            _preferencesService,
+            _groupLibraryManager,
+            _previewGenerator,
+            _inputDialogService,
+            _gdsExportService);
+
+        // Create nested groups
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var childGroup = new ComponentGroup("ChildGroup");
+        childGroup.AddChild(comp);
+
+        var parentGroup = new ComponentGroup("ParentGroup");
+        parentGroup.AddChild(childGroup);
+
+        mainVm.Canvas.AddComponent(parentGroup);
+
+        // Enter nested group edit mode
+        mainVm.Canvas.EnterGroupEditMode(parentGroup);
+        mainVm.Canvas.EnterGroupEditMode(childGroup);
+        mainVm.Canvas.IsInGroupEditMode.ShouldBeTrue();
+
+        // Mark as saved
+        mainVm.FileOperations.HasUnsavedChanges = false;
+
+        // Execute NewProject
+        await mainVm.NewProjectCommand.ExecuteAsync(null);
+
+        // Verify all group edit modes are exited
+        mainVm.Canvas.IsInGroupEditMode.ShouldBeFalse();
+        mainVm.Canvas.CurrentEditGroup.ShouldBeNull();
+        mainVm.Canvas.BreadcrumbPath.Count.ShouldBe(0);
+
+        // Verify canvas is cleared
+        mainVm.Canvas.Components.Count.ShouldBe(0);
+    }
 }


### PR DESCRIPTION
Automated implementation for #252

Excellent! Now let me create a summary document of the implementation:

## Implementation Summary

I've successfully fixed issue #252 where the "Neu" (New) button in the top menu bar was not properly exiting group edit mode before clearing the canvas.

### Root Cause
The `NewProject` command in `FileOperationsViewModel` was directly clearing the canvas without checking if the user was in group edit mode. This left the application in an inconsistent state where:
- Group edit mode remained active (`IsInGroupEditMode = true`)
- The canvas was empty but still showed as being "inside" a group
- User had to press ESC again to exit the ghost edit mode

### Solution
Modified the `NewProject` method in `FileOperationsViewModel.cs` to:
1. Check if group edit mode is active using `_canvas.IsInGroupEditMode`
2. Call `_canvas.ExitToRoot()` to exit all group edit modes (including nested ones)
3. Then proceed with clearing the canvas as normal

The fix uses `ExitToRoot()` instead of `ExitGroupEditMode()` to ensure that even nested group edit sessions are properly exited, returning the user to the root canvas level.

### Changes Made

**1. Core Logic (`FileOperationsViewModel.cs`)**
- Added group edit mode exit logic before canvas clearing
- Updated XML documentation to reflect the new behavior
- Only 7 lines added - minimal, focused change

**2. Unit Tests (`NewProjectIntegrationTests.cs`)**
- Added `NewProject_ExitsGroupEditMode()` test - verifies single-level group edit mode exit
- Added `NewProject_ExitsNestedGroupEditMode()` test - verifies nested group edit mode exit
- Both tests verify complete cleanup: `IsInGroupEditMode = false`, `CurrentEditGroup = null`, `BreadcrumbPath` cleared

### Test Results
✅ All new tests pass (6/6 NewProject tests passing)
✅ Full test suite: 1069 passing, 8 failing (pre-existing failures documented in MEMORY.md)
✅ Build succeeds with no new warnings

### Verification
The fix ensures that:
- ✅ The "Neu" button exits group edit mode before clearing
- ✅ Nested group edit modes are properly exited
- ✅ Canvas returns to root level after new project
- ✅ All state is properly cleared (no ghost components or edit mode)
- ✅ Existing functionality is preserved (save prompts, etc.)

### MCP Tools Used
No MCP tools were used for this implementation. Standard file reading, editing, and testing tools were sufficient for this focused bug fix.


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 9,998
- **Estimated cost:** $0.1074 USD

---
*Generated by autonomous agent using Claude Code.*