### PR TITLE
Agent: Bug: ComponentGroup external pins are not created for unoccupied internal pins

### DIFF
--- a/CAP.Avalonia/Commands/CreateGroupCommand.cs
+++ b/CAP.Avalonia/Commands/CreateGroupCommand.cs
@@ -156,25 +156,35 @@ public class CreateGroupCommand : IUndoableCommand
             }
         }
 
-        // 6. Create GroupPins for external connections
-        foreach (var conn in _externalConnections)
-        {
-            PhysicalPin internalPin;
-            if (componentSet.Contains(conn.StartPin.ParentComponent))
-                internalPin = conn.StartPin;
-            else
-                internalPin = conn.EndPin;
+        // 6. Create GroupPins for ALL unoccupied pins
+        var occupiedPins = new HashSet<PhysicalPin>();
 
-            var (pinX, pinY) = internalPin.GetAbsolutePosition();
-            var groupPin = new GroupPin
+        // Mark pins that are occupied by internal connections
+        foreach (var conn in _internalConnections)
+        {
+            occupiedPins.Add(conn.StartPin);
+            occupiedPins.Add(conn.EndPin);
+        }
+
+        // Expose all unoccupied pins as external pins
+        foreach (var comp in _components)
+        {
+            foreach (var pin in comp.PhysicalPins)
             {
-                Name = $"{internalPin.ParentComponent.Identifier}_{internalPin.Name}",
-                InternalPin = internalPin,
-                RelativeX = pinX - _createdGroup.PhysicalX,
-                RelativeY = pinY - _createdGroup.PhysicalY,
-                AngleDegrees = internalPin.GetAbsoluteAngle()
-            };
-            _createdGroup.AddExternalPin(groupPin);
+                if (!occupiedPins.Contains(pin))
+                {
+                    var (pinX, pinY) = pin.GetAbsolutePosition();
+                    var groupPin = new GroupPin
+                    {
+                        Name = $"{pin.ParentComponent.Identifier}_{pin.Name}",
+                        InternalPin = pin,
+                        RelativeX = pinX - _createdGroup.PhysicalX,
+                        RelativeY = pinY - _createdGroup.PhysicalY,
+                        AngleDegrees = pin.GetAbsoluteAngle()
+                    };
+                    _createdGroup.AddExternalPin(groupPin);
+                }
+            }
         }
 
         try

--- a/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
@@ -773,6 +773,15 @@ public partial class DesignCanvasViewModel : ObservableObject
             AllPins.Add(new PinViewModel(pin, vm));
         }
 
+        // For ComponentGroups, also add external pins
+        if (component is ComponentGroup group)
+        {
+            foreach (var groupPin in group.ExternalPins)
+            {
+                AllPins.Add(new PinViewModel(groupPin.InternalPin, vm));
+            }
+        }
+
         return vm;
     }
 

--- a/UnitTests/Commands/GroupExternalPinTests.cs
+++ b/UnitTests/Commands/GroupExternalPinTests.cs
@@ -1,0 +1,170 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.FormulaReading;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Commands;
+
+/// <summary>
+/// Tests for ComponentGroup external pin creation logic.
+/// Verifies that ALL unoccupied pins are exposed as external pins,
+/// not just pins with existing external connections.
+/// </summary>
+public class GroupExternalPinTests
+{
+    [Fact]
+    public void CreateGroup_WithUnoccupiedPins_ShouldExposeExternalPins()
+    {
+        // Arrange - Create 2 components with 2 pins each, connect 1 internal, 2 unoccupied
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins("Comp1", 100, 100, pinCount: 2);
+        var comp2 = CreateComponentWithPins("Comp2", 200, 100, pinCount: 2);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        // Connect comp1.Pin1 to comp2.Pin1 (internal connection)
+        var pin1 = comp1.PhysicalPins[0];
+        var pin2 = comp2.PhysicalPins[0];
+        canvas.ConnectPins(pin1, pin2);
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Act - Create group
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - Should have 2 external pins (comp1.Pin2 and comp2.Pin2 are unoccupied)
+        var group = (ComponentGroup)canvas.Components.First().Component;
+        group.ExternalPins.Count.ShouldBe(2);
+
+        // Verify the external pins are the correct unoccupied pins
+        var externalPinNames = group.ExternalPins.Select(p => p.InternalPin.Name).ToList();
+        externalPinNames.ShouldContain("Pin2");
+
+        // Verify pins are visible in UI (AllPins collection)
+        var groupVm = canvas.Components.First();
+        var groupPinsInAllPins = canvas.AllPins.Where(p => p.ParentComponentViewModel == groupVm).ToList();
+        groupPinsInAllPins.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void CreateGroup_WithInternalConnection_ShouldOnlyExposeUnoccupiedPins()
+    {
+        // Arrange - 2 components with 1 pin each, connected internally
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins("Comp1", 100, 100, pinCount: 1);
+        var comp2 = CreateComponentWithPins("Comp2", 200, 100, pinCount: 1);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        // Connect them internally
+        var pin1 = comp1.PhysicalPins[0];
+        var pin2 = comp2.PhysicalPins[0];
+        canvas.ConnectPins(pin1, pin2);
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Act - Create group
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - Should have 0 external pins (both pins are occupied by internal connection)
+        var group = (ComponentGroup)canvas.Components.First().Component;
+        group.ExternalPins.Count.ShouldBe(0);
+
+        // No pins should be visible in UI
+        var groupVm = canvas.Components.First();
+        var groupPinsInAllPins = canvas.AllPins.Where(p => p.ParentComponentViewModel == groupVm).ToList();
+        groupPinsInAllPins.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CreateGroup_WithNoConnections_AllPinsShouldBeExternal()
+    {
+        // Arrange - Create 2 components with 2 pins each (4 total pins), no connections
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins("Comp1", 100, 100, pinCount: 2);
+        var comp2 = CreateComponentWithPins("Comp2", 200, 100, pinCount: 2);
+
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        canvas.Selection.AddToSelection(vm1);
+        canvas.Selection.AddToSelection(vm2);
+
+        // Act - Create group (no connections)
+        var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
+        cmd.Execute();
+
+        // Assert - Should have 4 external pins (all pins are unoccupied)
+        var group = (ComponentGroup)canvas.Components.First().Component;
+        group.ExternalPins.Count.ShouldBe(4);
+
+        // Verify all 4 internal pins are represented
+        var internalPins = new HashSet<PhysicalPin>();
+        foreach (var groupPin in group.ExternalPins)
+        {
+            internalPins.Add(groupPin.InternalPin);
+        }
+
+        internalPins.Count.ShouldBe(4);
+        internalPins.ShouldContain(comp1.PhysicalPins[0]);
+        internalPins.ShouldContain(comp1.PhysicalPins[1]);
+        internalPins.ShouldContain(comp2.PhysicalPins[0]);
+        internalPins.ShouldContain(comp2.PhysicalPins[1]);
+
+        // Verify all pins are visible in UI
+        var groupVm = canvas.Components.First();
+        var groupPinsInAllPins = canvas.AllPins.Where(p => p.ParentComponentViewModel == groupVm).ToList();
+        groupPinsInAllPins.Count.ShouldBe(4);
+    }
+
+    /// <summary>
+    /// Helper to create a component with specified number of physical pins.
+    /// </summary>
+    private Component CreateComponentWithPins(string identifier, double x, double y, int pinCount)
+    {
+        var sMatrix = new SMatrix(new List<Guid>(), new List<(Guid sliderID, double value)>());
+        var pins = new List<PhysicalPin>();
+
+        for (int i = 0; i < pinCount; i++)
+        {
+            pins.Add(new PhysicalPin
+            {
+                Name = $"Pin{i + 1}",
+                OffsetXMicrometers = i * 25.0,
+                OffsetYMicrometers = 15,
+                AngleDegrees = 0
+            });
+        }
+
+        var component = new Component(
+            new Dictionary<int, SMatrix> { { 1550, sMatrix } },
+            new List<Slider>(),
+            "test",
+            "",
+            new Part[1, 1] { { new Part() } },
+            -1,
+            identifier,
+            new DiscreteRotation(),
+            pins
+        )
+        {
+            PhysicalX = x,
+            PhysicalY = y,
+            WidthMicrometers = 50,
+            HeightMicrometers = 30
+        };
+
+        return component;
+    }
+}

--- a/UnitTests/Commands/GroupingWorkflowTests.cs
+++ b/UnitTests/Commands/GroupingWorkflowTests.cs
@@ -200,15 +200,18 @@ public class GroupingWorkflowTests
         var cmd = new CreateGroupCommand(canvas, canvas.Selection.SelectedComponents.ToList());
         cmd.Execute();
 
-        // Assert - Group has external pin
+        // Assert - Group has external pins for all unoccupied pins
         canvas.Components.Count.ShouldBe(2); // Group + Comp3
         var group = canvas.Components
             .Where(c => c.Component is ComponentGroup)
             .Select(c => (ComponentGroup)c.Component)
             .First();
 
-        group.ExternalPins.Count.ShouldBe(1);
-        group.ExternalPins[0].InternalPin.ShouldBe(pin2);
+        // Both comp1's pin (unoccupied) and comp2's pin (external connection) should be exposed
+        group.ExternalPins.Count.ShouldBe(2);
+        var pin1 = comp1.PhysicalPins[0];
+        group.ExternalPins.ShouldContain(gp => gp.InternalPin == pin1);
+        group.ExternalPins.ShouldContain(gp => gp.InternalPin == pin2);
     }
 
     [Fact]


### PR DESCRIPTION
Automated implementation for #256

Perfect! All tasks completed successfully. Now let me write a comprehensive summary of the implementation:

## ✅ Implementation Complete!

I've successfully fixed issue #256: **Bug: ComponentGroup external pins are not created for unoccupied internal pins**.

### Summary

The bug was that when creating a ComponentGroup, external pins were only created for pins that already had external connections. This meant grouping isolated components resulted in groups with no external pins, making it impossible to connect anything to the group later.

### Changes Made

#### 1. **Core Fix: CreateGroupCommand.cs** (lines 159-178)
Changed the external pin creation logic from only processing existing external connections to exposing **ALL unoccupied pins**:

```csharp
// BEFORE: Only created pins for existing external connections
foreach (var conn in _externalConnections) { ... }

// AFTER: Create pins for ALL unoccupied pins
var occupiedPins = new HashSet<PhysicalPin>();
foreach (var conn in _internalConnections) {
    occupiedPins.Add(conn.StartPin);
    occupiedPins.Add(conn.EndPin);
}
foreach (var comp in _components) {
    foreach (var pin in comp.PhysicalPins) {
        if (!occupiedPins.Contains(pin)) {
            // Create GroupPin for this unoccupied pin
        }
    }
}
```

#### 2. **UI Fix: DesignCanvasViewModel.cs** (lines 776-782)
Added GroupPin visibility support in `AddComponent()` method:

```csharp
// For ComponentGroups, also add external pins
if (component is ComponentGroup group) {
    foreach (var groupPin in group.ExternalPins) {
        AllPins.Add(new PinViewModel(groupPin.InternalPin, vm));
    }
}
```

#### 3. **New Test File: GroupExternalPinTests.cs**
Created comprehensive tests covering:
- Groups with partially unoccupied pins (2 external pins expected)
- Groups with all pins occupied internally (0 external pins expected)
- Groups with no connections (all 4 pins should be external)

#### 4. **Updated Existing Test: GroupingWorkflowTests.cs** (line 210)
Updated `CreateGroup_WithExternalConnection_CreatesGroupPin` to reflect the new correct behavior:
- **Before**: Expected 1 external pin (only the one with external connection)
- **After**: Expected 2 external pins (both the unoccupied pin AND the externally connected pin)

### Test Results

✅ **All new tests pass** (3/3):
- `CreateGroup_WithUnoccupiedPins_ShouldExposeExternalPins`
- `CreateGroup_WithInternalConnection_ShouldOnlyExposeUnoccupiedPins`
- `CreateGroup_WithNoConnections_AllPinsShouldBeExternal`

✅ **Updated test passes**:
- `CreateGroup_WithExternalConnection_CreatesGroupPin`

✅ **No regressions introduced**:
- Test suite: **1070 passed, 8 failed** (8 failures are pre-existing, documented in MEMORY.md)
- Build: **Success** (151 warnings, 0 errors - warnings are pre-existing)

### Verification

The fix ensures:
1. **All unoccupied pins are exposed** as external pins when creating a group
2. **Pins occupied by internal connections** are NOT exposed
3. **External pins are visible in the UI** (AllPins collection)
4. **User can now connect to grouped isolated components**

### Files Modified
- `CAP.Avalonia/Commands/CreateGroupCommand.cs` - Core pin exposure logic
- `CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs` - UI pin visibility
- `UnitTests/Commands/GroupExternalPinTests.cs` - New comprehensive tests (NEW FILE)
- `UnitTests/Commands/GroupingWorkflowTests.cs` - Updated test expectations

### MCP Tools Used
None - This was a straightforward bug fix with clear requirements and test cases provided in the issue description.


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 10,179
- **Estimated cost:** $0.1516 USD

---
*Generated by autonomous agent using Claude Code.*