### PR TITLE
Agent: Feature: Delete button (red X) for saved groups in library

### DIFF
--- a/CAP.Avalonia/Commands/RenameGroupCommand.cs
+++ b/CAP.Avalonia/Commands/RenameGroupCommand.cs
@@ -43,7 +43,7 @@ public class RenameGroupCommand : IUndoableCommand
         // Find existing template for this group
         var libraryManager = _libraryViewModel.GetLibraryManager();
         _existingTemplate = _libraryViewModel.UserGroups
-            .FirstOrDefault(t => t.Name == _oldName);
+            .FirstOrDefault(t => t.Template.Name == _oldName)?.Template;
 
         // Update group properties
         _group.GroupName = _newName;
@@ -56,7 +56,12 @@ public class RenameGroupCommand : IUndoableCommand
         if (_existingTemplate != null)
         {
             libraryManager.RemoveTemplate(_existingTemplate);
-            _libraryViewModel.UserGroups.Remove(_existingTemplate);
+            var itemToRemove = _libraryViewModel.UserGroups
+                .FirstOrDefault(vm => vm.Template == _existingTemplate);
+            if (itemToRemove != null)
+            {
+                _libraryViewModel.UserGroups.Remove(itemToRemove);
+            }
         }
 
         // Save new template with updated name

--- a/CAP.Avalonia/ViewModels/Library/ComponentLibraryViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentLibraryViewModel.cs
@@ -17,14 +17,14 @@ public partial class ComponentLibraryViewModel : ObservableObject
     private string _statusText = "No groups loaded";
 
     /// <summary>
-    /// User-created group templates.
+    /// User-created group templates (wrapped for UI interactions).
     /// </summary>
-    public ObservableCollection<GroupTemplate> UserGroups { get; } = new();
+    public ObservableCollection<GroupTemplateItemViewModel> UserGroups { get; } = new();
 
     /// <summary>
-    /// PDK-provided group templates (macros).
+    /// PDK-provided group templates (macros, wrapped for UI interactions).
     /// </summary>
-    public ObservableCollection<GroupTemplate> PdkGroups { get; } = new();
+    public ObservableCollection<GroupTemplateItemViewModel> PdkGroups { get; } = new();
 
     /// <summary>
     /// Currently selected group template for drag-and-drop.
@@ -55,12 +55,12 @@ public partial class ComponentLibraryViewModel : ObservableObject
 
         foreach (var template in _libraryManager.UserTemplates)
         {
-            UserGroups.Add(template);
+            UserGroups.Add(new GroupTemplateItemViewModel(template, this));
         }
 
         foreach (var template in _libraryManager.PdkTemplates)
         {
-            PdkGroups.Add(template);
+            PdkGroups.Add(new GroupTemplateItemViewModel(template, this));
         }
 
         UpdateStatus();
@@ -72,13 +72,15 @@ public partial class ComponentLibraryViewModel : ObservableObject
     /// <param name="template">The template to add.</param>
     public void AddTemplate(GroupTemplate template)
     {
+        var itemVm = new GroupTemplateItemViewModel(template, this);
+
         if (template.Source == "User")
         {
-            UserGroups.Add(template);
+            UserGroups.Add(itemVm);
         }
         else
         {
-            PdkGroups.Add(template);
+            PdkGroups.Add(itemVm);
         }
 
         UpdateStatus();
@@ -89,12 +91,27 @@ public partial class ComponentLibraryViewModel : ObservableObject
     /// </summary>
     /// <param name="template">The template to remove.</param>
     [RelayCommand]
-    private void RemoveTemplate(GroupTemplate template)
+    public void RemoveTemplate(GroupTemplate template)
     {
         if (_libraryManager.RemoveTemplate(template))
         {
-            UserGroups.Remove(template);
-            PdkGroups.Remove(template);
+            // Remove from wrapped collections by comparing FilePath since objects may differ after reload
+            var userItem = UserGroups.FirstOrDefault(vm =>
+                vm.Template == template ||
+                (vm.Template.FilePath != null && vm.Template.FilePath == template.FilePath));
+            if (userItem != null)
+            {
+                UserGroups.Remove(userItem);
+            }
+
+            var pdkItem = PdkGroups.FirstOrDefault(vm =>
+                vm.Template == template ||
+                (vm.Template.FilePath != null && vm.Template.FilePath == template.FilePath));
+            if (pdkItem != null)
+            {
+                PdkGroups.Remove(pdkItem);
+            }
+
             UpdateStatus();
         }
     }

--- a/CAP.Avalonia/ViewModels/Library/GroupTemplateItemViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Library/GroupTemplateItemViewModel.cs
@@ -1,0 +1,44 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CAP_Core.Components.Creation;
+
+namespace CAP.Avalonia.ViewModels.Library;
+
+/// <summary>
+/// ViewModel wrapper for a GroupTemplate to support UI interactions like hover state and delete button.
+/// </summary>
+public partial class GroupTemplateItemViewModel : ObservableObject
+{
+    private readonly ComponentLibraryViewModel _parentViewModel;
+
+    /// <summary>
+    /// The underlying GroupTemplate being displayed.
+    /// </summary>
+    public GroupTemplate Template { get; }
+
+    /// <summary>
+    /// Whether the mouse is currently hovering over this item (to show delete button).
+    /// </summary>
+    [ObservableProperty]
+    private bool _isHovered;
+
+    /// <summary>
+    /// Initializes a new instance of the GroupTemplateItemViewModel.
+    /// </summary>
+    /// <param name="template">The underlying GroupTemplate.</param>
+    /// <param name="parentViewModel">The parent ComponentLibraryViewModel for delete command.</param>
+    public GroupTemplateItemViewModel(GroupTemplate template, ComponentLibraryViewModel parentViewModel)
+    {
+        Template = template;
+        _parentViewModel = parentViewModel;
+    }
+
+    /// <summary>
+    /// Deletes this group template from the library.
+    /// </summary>
+    [RelayCommand]
+    private void Delete()
+    {
+        _parentViewModel.RemoveTemplateCommand.Execute(Template);
+    }
+}

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -165,37 +165,57 @@
                                      Background="Transparent"
                                      MaxHeight="150">
                                 <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="creation:GroupTemplate">
-                                        <StackPanel Orientation="Horizontal" Margin="3" Cursor="Hand"
-                                                    ToolTip.Tip="{Binding Description}">
-                                            <!-- Preview box with component count and size info -->
-                                            <Border Width="56" Height="36"
-                                                    Background="#1e1e1e"
-                                                    BorderBrush="#3e3e3e"
-                                                    BorderThickness="1"
-                                                    CornerRadius="3"
-                                                    Margin="0,0,6,0">
-                                                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                    <TextBlock Text="{Binding ComponentCount}"
-                                                               FontSize="16" FontWeight="Bold"
-                                                               Foreground="#4CAF50"
-                                                               HorizontalAlignment="Center"/>
-                                                    <TextBlock Text="comp" FontSize="7"
-                                                               Foreground="Gray"
-                                                               HorizontalAlignment="Center"
-                                                               Margin="0,-2,0,0"/>
+                                    <DataTemplate x:DataType="vmLib:GroupTemplateItemViewModel">
+                                        <Grid Margin="3" Cursor="Hand"
+                                              ToolTip.Tip="{Binding Template.Description}"
+                                              PointerEntered="OnGroupItemPointerEntered"
+                                              PointerExited="OnGroupItemPointerExited">
+                                            <StackPanel Orientation="Horizontal">
+                                                <!-- Preview box with component count and size info -->
+                                                <Border Width="56" Height="36"
+                                                        Background="#1e1e1e"
+                                                        BorderBrush="#3e3e3e"
+                                                        BorderThickness="1"
+                                                        CornerRadius="3"
+                                                        Margin="0,0,6,0">
+                                                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding Template.ComponentCount}"
+                                                                   FontSize="16" FontWeight="Bold"
+                                                                   Foreground="#4CAF50"
+                                                                   HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="comp" FontSize="7"
+                                                                   Foreground="Gray"
+                                                                   HorizontalAlignment="Center"
+                                                                   Margin="0,-2,0,0"/>
+                                                    </StackPanel>
+                                                </Border>
+                                                <StackPanel VerticalAlignment="Center">
+                                                    <TextBlock Text="{Binding Template.Name}" FontWeight="SemiBold" FontSize="11" Foreground="White"/>
+                                                    <TextBlock FontSize="9" Foreground="Gray">
+                                                        <Run Text="{Binding Template.WidthMicrometers, StringFormat={}{0:F0}}"/>
+                                                        <Run Text="×"/>
+                                                        <Run Text="{Binding Template.HeightMicrometers, StringFormat={}{0:F0}}"/>
+                                                        <Run Text="μm"/>
+                                                    </TextBlock>
                                                 </StackPanel>
-                                            </Border>
-                                            <StackPanel VerticalAlignment="Center">
-                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="11" Foreground="White"/>
-                                                <TextBlock FontSize="9" Foreground="Gray">
-                                                    <Run Text="{Binding WidthMicrometers, StringFormat={}{0:F0}}"/>
-                                                    <Run Text="×"/>
-                                                    <Run Text="{Binding HeightMicrometers, StringFormat={}{0:F0}}"/>
-                                                    <Run Text="μm"/>
-                                                </TextBlock>
                                             </StackPanel>
-                                        </StackPanel>
+
+                                            <!-- Delete button (visible on hover) -->
+                                            <Button IsVisible="{Binding IsHovered}"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Top"
+                                                    Width="18" Height="18"
+                                                    Padding="0"
+                                                    Margin="0,-3,-3,0"
+                                                    Background="#D32F2F"
+                                                    CornerRadius="9"
+                                                    Command="{Binding DeleteCommand}"
+                                                    ToolTip.Tip="Delete saved group">
+                                                <PathIcon Data="M 4,4 L 10,10 M 4,10 L 10,4"
+                                                          Width="10" Height="10"
+                                                          Foreground="White"/>
+                                            </Button>
+                                        </Grid>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>
@@ -209,37 +229,57 @@
                                      Background="Transparent"
                                      MaxHeight="150">
                                 <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="creation:GroupTemplate">
-                                        <StackPanel Orientation="Horizontal" Margin="3" Cursor="Hand"
-                                                    ToolTip.Tip="{Binding Description}">
-                                            <!-- Preview box with component count and size info -->
-                                            <Border Width="56" Height="36"
-                                                    Background="#1e1e1e"
-                                                    BorderBrush="#3e3e3e"
-                                                    BorderThickness="1"
-                                                    CornerRadius="3"
-                                                    Margin="0,0,6,0">
-                                                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                    <TextBlock Text="{Binding ComponentCount}"
-                                                               FontSize="16" FontWeight="Bold"
-                                                               Foreground="#4CAF50"
-                                                               HorizontalAlignment="Center"/>
-                                                    <TextBlock Text="comp" FontSize="7"
-                                                               Foreground="Gray"
-                                                               HorizontalAlignment="Center"
-                                                               Margin="0,-2,0,0"/>
+                                    <DataTemplate x:DataType="vmLib:GroupTemplateItemViewModel">
+                                        <Grid Margin="3" Cursor="Hand"
+                                              ToolTip.Tip="{Binding Template.Description}"
+                                              PointerEntered="OnGroupItemPointerEntered"
+                                              PointerExited="OnGroupItemPointerExited">
+                                            <StackPanel Orientation="Horizontal">
+                                                <!-- Preview box with component count and size info -->
+                                                <Border Width="56" Height="36"
+                                                        Background="#1e1e1e"
+                                                        BorderBrush="#3e3e3e"
+                                                        BorderThickness="1"
+                                                        CornerRadius="3"
+                                                        Margin="0,0,6,0">
+                                                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding Template.ComponentCount}"
+                                                                   FontSize="16" FontWeight="Bold"
+                                                                   Foreground="#4CAF50"
+                                                                   HorizontalAlignment="Center"/>
+                                                        <TextBlock Text="comp" FontSize="7"
+                                                                   Foreground="Gray"
+                                                                   HorizontalAlignment="Center"
+                                                                   Margin="0,-2,0,0"/>
+                                                    </StackPanel>
+                                                </Border>
+                                                <StackPanel VerticalAlignment="Center">
+                                                    <TextBlock Text="{Binding Template.Name}" FontWeight="SemiBold" FontSize="11" Foreground="White"/>
+                                                    <TextBlock FontSize="9" Foreground="Gray">
+                                                        <Run Text="{Binding Template.WidthMicrometers, StringFormat={}{0:F0}}"/>
+                                                        <Run Text="×"/>
+                                                        <Run Text="{Binding Template.HeightMicrometers, StringFormat={}{0:F0}}"/>
+                                                        <Run Text="μm"/>
+                                                    </TextBlock>
                                                 </StackPanel>
-                                            </Border>
-                                            <StackPanel VerticalAlignment="Center">
-                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="11" Foreground="White"/>
-                                                <TextBlock FontSize="9" Foreground="Gray">
-                                                    <Run Text="{Binding WidthMicrometers, StringFormat={}{0:F0}}"/>
-                                                    <Run Text="×"/>
-                                                    <Run Text="{Binding HeightMicrometers, StringFormat={}{0:F0}}"/>
-                                                    <Run Text="μm"/>
-                                                </TextBlock>
                                             </StackPanel>
-                                        </StackPanel>
+
+                                            <!-- Delete button (visible on hover) -->
+                                            <Button IsVisible="{Binding IsHovered}"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Top"
+                                                    Width="18" Height="18"
+                                                    Padding="0"
+                                                    Margin="0,-3,-3,0"
+                                                    Background="#D32F2F"
+                                                    CornerRadius="9"
+                                                    Command="{Binding DeleteCommand}"
+                                                    ToolTip.Tip="Delete saved group">
+                                                <PathIcon Data="M 4,4 L 10,10 M 4,10 L 10,4"
+                                                          Width="10" Height="10"
+                                                          Foreground="White"/>
+                                            </Button>
+                                        </Grid>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Library;
 using System.ComponentModel;
 using System.Linq;
 
@@ -256,6 +257,28 @@ public partial class MainWindow : Window
         if (DataContext is MainViewModel vm)
         {
             vm.ZoomToFit(DesignCanvasControl.Bounds.Width, DesignCanvasControl.Bounds.Height);
+        }
+    }
+
+    /// <summary>
+    /// Handles pointer entering a group template item (shows delete button).
+    /// </summary>
+    private void OnGroupItemPointerEntered(object? sender, PointerEventArgs e)
+    {
+        if (sender is Grid grid && grid.DataContext is GroupTemplateItemViewModel itemVm)
+        {
+            itemVm.IsHovered = true;
+        }
+    }
+
+    /// <summary>
+    /// Handles pointer leaving a group template item (hides delete button).
+    /// </summary>
+    private void OnGroupItemPointerExited(object? sender, PointerEventArgs e)
+    {
+        if (sender is Grid grid && grid.DataContext is GroupTemplateItemViewModel itemVm)
+        {
+            itemVm.IsHovered = false;
         }
     }
 

--- a/Connect-A-Pic-Core/Components/Creation/GroupLibraryManager.cs
+++ b/Connect-A-Pic-Core/Components/Creation/GroupLibraryManager.cs
@@ -140,15 +140,20 @@ public class GroupLibraryManager
     /// <returns>True if successfully removed.</returns>
     public bool RemoveTemplate(GroupTemplate template)
     {
-        if (!_templates.Contains(template))
+        // Find the template by FilePath since object references may differ after reload
+        var templateToRemove = _templates.FirstOrDefault(t =>
+            t == template ||
+            (t.FilePath != null && t.FilePath == template.FilePath));
+
+        if (templateToRemove == null)
             return false;
 
         // Delete file if it exists
-        if (template.FilePath != null && File.Exists(template.FilePath))
+        if (templateToRemove.FilePath != null && File.Exists(templateToRemove.FilePath))
         {
             try
             {
-                File.Delete(template.FilePath);
+                File.Delete(templateToRemove.FilePath);
             }
             catch
             {
@@ -156,7 +161,7 @@ public class GroupLibraryManager
             }
         }
 
-        return _templates.Remove(template);
+        return _templates.Remove(templateToRemove);
     }
 
     /// <summary>

--- a/UnitTests/Commands/RenameGroupCommandTests.cs
+++ b/UnitTests/Commands/RenameGroupCommandTests.cs
@@ -55,7 +55,7 @@ public class RenameGroupCommandTests : IDisposable
         group.GroupName.ShouldBe("New Name");
         group.Description.ShouldBe("New description");
         _libraryViewModel.UserGroups.Count.ShouldBe(1);
-        _libraryViewModel.UserGroups.First().Name.ShouldBe("New Name");
+        _libraryViewModel.UserGroups.First().Template.Name.ShouldBe("New Name");
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class RenameGroupCommandTests : IDisposable
         group.GroupName.ShouldBe("Original");
         group.Description.ShouldBe("Original desc");
         _libraryViewModel.UserGroups.Count.ShouldBe(1);
-        _libraryViewModel.UserGroups.First().Name.ShouldBe("Original");
+        _libraryViewModel.UserGroups.First().Template.Name.ShouldBe("Original");
     }
 
     [Fact]
@@ -123,8 +123,8 @@ public class RenameGroupCommandTests : IDisposable
         command.Execute();
 
         // Assert
-        _libraryViewModel.UserGroups.ShouldNotContain(t => t.Name == "OldName");
-        _libraryViewModel.UserGroups.ShouldContain(t => t.Name == "NewName");
+        _libraryViewModel.UserGroups.ShouldNotContain(t => t.Template.Name == "OldName");
+        _libraryViewModel.UserGroups.ShouldContain(t => t.Template.Name == "NewName");
     }
 
     [Fact]

--- a/UnitTests/Commands/SaveGroupAsPrefabCommandTests.cs
+++ b/UnitTests/Commands/SaveGroupAsPrefabCommandTests.cs
@@ -77,7 +77,7 @@ public class SaveGroupAsPrefabCommandTests : IDisposable
 
         // Assert
         _libraryViewModel.UserGroups.Count.ShouldBe(initialCount + 1);
-        _libraryViewModel.UserGroups.Last().Name.ShouldBe("My Prefab");
+        _libraryViewModel.UserGroups.Last().Template.Name.ShouldBe("My Prefab");
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class SaveGroupAsPrefabCommandTests : IDisposable
         cmd.Execute();
 
         // Assert
-        var template = _libraryViewModel.UserGroups.Last();
+        var template = _libraryViewModel.UserGroups.Last().Template;
         template.Description.ShouldBe("This is a detailed description");
     }
 

--- a/UnitTests/Components/GroupLibraryManagerTests.cs
+++ b/UnitTests/Components/GroupLibraryManagerTests.cs
@@ -196,6 +196,71 @@ public class GroupLibraryManagerTests : IDisposable
         group.IsPrefab.ShouldBeTrue();
     }
 
+    [Fact]
+    public void RemoveTemplate_WithNonexistentTemplate_ReturnsFalse()
+    {
+        // Arrange
+        var group = CreateTestGroup("TestGroup", 1);
+        var template = new GroupTemplate
+        {
+            Name = "Nonexistent",
+            Source = "User"
+        };
+
+        // Act
+        var removed = _manager.RemoveTemplate(template);
+
+        // Assert
+        removed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RemoveTemplate_WithNullFilePath_SuccessfullyRemovesTemplate()
+    {
+        // Arrange
+        var group = CreateTestGroup("TestGroup", 1);
+        var template = _manager.SaveTemplate(group, "Test Template");
+        template.FilePath = null; // Simulate template without file
+
+        // Act
+        var removed = _manager.RemoveTemplate(template);
+
+        // Assert
+        removed.ShouldBeTrue();
+        _manager.Templates.ShouldNotContain(template);
+    }
+
+    [Fact]
+    public void RemoveTemplate_Multiple_DeletesAllSpecifiedTemplates()
+    {
+        // Arrange
+        var group1 = CreateTestGroup("Group1", 1);
+        var group2 = CreateTestGroup("Group2", 2);
+        var group3 = CreateTestGroup("Group3", 3);
+
+        var template1 = _manager.SaveTemplate(group1, "Template 1");
+        var template2 = _manager.SaveTemplate(group2, "Template 2");
+        var template3 = _manager.SaveTemplate(group3, "Template 3");
+
+        _manager.Templates.Count.ShouldBe(3);
+
+        // Act - Remove template 2
+        var removed = _manager.RemoveTemplate(template2);
+
+        // Assert
+        removed.ShouldBeTrue();
+        _manager.Templates.Count.ShouldBe(2);
+        _manager.Templates.ShouldContain(template1);
+        _manager.Templates.ShouldNotContain(template2);
+        _manager.Templates.ShouldContain(template3);
+
+        // Verify file was deleted
+        if (template2.FilePath != null)
+        {
+            File.Exists(template2.FilePath).ShouldBeFalse();
+        }
+    }
+
     /// <summary>
     /// Creates a test ComponentGroup with the specified number of child components.
     /// </summary>

--- a/UnitTests/ViewModels/ComponentLibraryViewModelTests.cs
+++ b/UnitTests/ViewModels/ComponentLibraryViewModelTests.cs
@@ -1,0 +1,295 @@
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>
+/// Integration tests for ComponentLibraryViewModel.
+/// Tests the interaction between Core (GroupLibraryManager) and ViewModel layers.
+/// </summary>
+public class ComponentLibraryViewModelTests : IDisposable
+{
+    private readonly string _testLibraryPath;
+    private readonly GroupLibraryManager _libraryManager;
+    private readonly ComponentLibraryViewModel _viewModel;
+
+    public ComponentLibraryViewModelTests()
+    {
+        // Create a temporary directory for testing
+        _testLibraryPath = Path.Combine(Path.GetTempPath(), $"ComponentLibraryVmTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testLibraryPath);
+
+        _libraryManager = new GroupLibraryManager(_testLibraryPath);
+        _viewModel = new ComponentLibraryViewModel(_libraryManager);
+    }
+
+    public void Dispose()
+    {
+        // Clean up test directory
+        if (Directory.Exists(_testLibraryPath))
+        {
+            Directory.Delete(_testLibraryPath, true);
+        }
+    }
+
+    [Fact]
+    public void LoadGroups_PopulatesUserGroupsCollection()
+    {
+        // Arrange
+        var group1 = CreateTestGroup("Group1", 2);
+        var group2 = CreateTestGroup("Group2", 3);
+        _libraryManager.SaveTemplate(group1, "User Group 1", null, "User");
+        _libraryManager.SaveTemplate(group2, "User Group 2", null, "User");
+
+        // Act
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        // Assert
+        _viewModel.UserGroups.Count.ShouldBe(2);
+        _viewModel.UserGroups.Select(vm => vm.Template.Name).ShouldContain("User Group 1");
+        _viewModel.UserGroups.Select(vm => vm.Template.Name).ShouldContain("User Group 2");
+    }
+
+    [Fact]
+    public void LoadGroups_PopulatesPdkGroupsCollection()
+    {
+        // Arrange
+        var pdkGroup = CreateTestGroup("PdkGroup", 1);
+        _libraryManager.SaveTemplate(pdkGroup, "PDK Macro 1", null, "PDK");
+
+        // Act
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        // Assert
+        _viewModel.PdkGroups.Count.ShouldBe(1);
+        _viewModel.PdkGroups[0].Template.Name.ShouldBe("PDK Macro 1");
+        _viewModel.PdkGroups[0].Template.Source.ShouldBe("PDK");
+    }
+
+    [Fact]
+    public void RemoveTemplate_RemovesFromUserGroupsCollection()
+    {
+        // Arrange
+        var group = CreateTestGroup("TestGroup", 2);
+        var template = _libraryManager.SaveTemplate(group, "Test Group", null, "User");
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        _viewModel.UserGroups.Count.ShouldBe(1);
+
+        // Act
+        _viewModel.RemoveTemplateCommand.Execute(template);
+
+        // Assert
+        _viewModel.UserGroups.Count.ShouldBe(0);
+        _libraryManager.Templates.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemoveTemplate_RemovesFromPdkGroupsCollection()
+    {
+        // Arrange
+        var group = CreateTestGroup("PdkGroup", 1);
+        var template = _libraryManager.SaveTemplate(group, "PDK Macro", null, "PDK");
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        _viewModel.PdkGroups.Count.ShouldBe(1);
+
+        // Act
+        _viewModel.RemoveTemplateCommand.Execute(template);
+
+        // Assert
+        _viewModel.PdkGroups.Count.ShouldBe(0);
+        _libraryManager.Templates.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemoveTemplate_UpdatesStatusText()
+    {
+        // Arrange
+        var group1 = CreateTestGroup("Group1", 1);
+        var group2 = CreateTestGroup("Group2", 2);
+        var template1 = _libraryManager.SaveTemplate(group1, "Group 1", null, "User");
+        var template2 = _libraryManager.SaveTemplate(group2, "Group 2", null, "User");
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        _viewModel.StatusText.ShouldBe("2 user group(s), 0 PDK macro(s)");
+
+        // Act
+        _viewModel.RemoveTemplateCommand.Execute(template1);
+
+        // Assert
+        _viewModel.StatusText.ShouldBe("1 user group(s), 0 PDK macro(s)");
+    }
+
+    [Fact]
+    public void AddTemplate_AddsToUserGroupsCollection()
+    {
+        // Arrange
+        var group = CreateTestGroup("NewGroup", 3);
+        var template = _libraryManager.SaveTemplate(group, "New Template", "Test description", "User");
+
+        _viewModel.UserGroups.Count.ShouldBe(0);
+
+        // Act
+        _viewModel.AddTemplate(template);
+
+        // Assert
+        _viewModel.UserGroups.Count.ShouldBe(1);
+        _viewModel.UserGroups[0].Template.ShouldBe(template);
+        _viewModel.StatusText.ShouldBe("1 user group(s), 0 PDK macro(s)");
+    }
+
+    [Fact]
+    public void AddTemplate_AddsToPdkGroupsCollection()
+    {
+        // Arrange
+        var group = CreateTestGroup("PdkMacro", 2);
+        var template = _libraryManager.SaveTemplate(group, "PDK Template", "PDK macro", "PDK");
+
+        _viewModel.PdkGroups.Count.ShouldBe(0);
+
+        // Act
+        _viewModel.AddTemplate(template);
+
+        // Assert
+        _viewModel.PdkGroups.Count.ShouldBe(1);
+        _viewModel.PdkGroups[0].Template.ShouldBe(template);
+        _viewModel.StatusText.ShouldBe("0 user group(s), 1 PDK macro(s)");
+    }
+
+    [Fact]
+    public void DuplicateTemplate_CreatesNewTemplateInCollection()
+    {
+        // Arrange
+        var group = CreateTestGroup("Original", 2);
+        var template = _libraryManager.SaveTemplate(group, "Original Template", "Description", "User");
+        template.TemplateGroup = group; // Ensure group is loaded
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        _viewModel.UserGroups.Count.ShouldBe(1);
+
+        // Act
+        _viewModel.DuplicateTemplateCommand.Execute(template);
+
+        // Assert
+        _viewModel.UserGroups.Count.ShouldBe(2);
+        _viewModel.UserGroups[1].Template.Name.ShouldBe("Original Template_Copy");
+    }
+
+    [Fact]
+    public void GroupTemplateItemViewModel_DeleteCommand_CallsParentRemove()
+    {
+        // Arrange
+        var group = CreateTestGroup("TestGroup", 1);
+        var template = _libraryManager.SaveTemplate(group, "Test Template", null, "User");
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        var itemVm = _viewModel.UserGroups[0];
+        _viewModel.UserGroups.Count.ShouldBe(1);
+
+        // Act
+        itemVm.DeleteCommand.Execute(null);
+
+        // Assert
+        _viewModel.UserGroups.Count.ShouldBe(0);
+        _libraryManager.Templates.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GroupTemplateItemViewModel_HoverState_TogglesCorrectly()
+    {
+        // Arrange
+        var group = CreateTestGroup("TestGroup", 1);
+        var template = _libraryManager.SaveTemplate(group, "Test Template", null, "User");
+        var itemVm = new GroupTemplateItemViewModel(template, _viewModel);
+
+        itemVm.IsHovered.ShouldBeFalse();
+
+        // Act - Simulate hover
+        itemVm.IsHovered = true;
+
+        // Assert
+        itemVm.IsHovered.ShouldBeTrue();
+
+        // Act - Simulate hover exit
+        itemVm.IsHovered = false;
+
+        // Assert
+        itemVm.IsHovered.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void StatusText_ReflectsEmptyLibrary()
+    {
+        // Arrange & Act
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        // Assert
+        _viewModel.StatusText.ShouldBe("No saved groups");
+    }
+
+    [Fact]
+    public void StatusText_ReflectsMixedUserAndPdkGroups()
+    {
+        // Arrange
+        var userGroup = CreateTestGroup("UserGroup", 1);
+        var pdkGroup = CreateTestGroup("PdkGroup", 1);
+        _libraryManager.SaveTemplate(userGroup, "User Group", null, "User");
+        _libraryManager.SaveTemplate(pdkGroup, "PDK Macro", null, "PDK");
+
+        // Act
+        _viewModel.LoadGroupsCommand.Execute(null);
+
+        // Assert
+        _viewModel.StatusText.ShouldBe("1 user group(s), 1 PDK macro(s)");
+    }
+
+    /// <summary>
+    /// Creates a test ComponentGroup with the specified number of child components.
+    /// </summary>
+    private ComponentGroup CreateTestGroup(string name, int childCount)
+    {
+        var group = new ComponentGroup(name)
+        {
+            PhysicalX = 0,
+            PhysicalY = 0
+        };
+
+        for (int i = 0; i < childCount; i++)
+        {
+            var child = new Component(
+                new Dictionary<int, CAP_Core.LightCalculation.SMatrix>(),
+                new List<Slider>(),
+                "test_component",
+                "",
+                new Part[1, 1] { { new Part() } },
+                -1,
+                $"comp_{i}_{Guid.NewGuid():N}",
+                DiscreteRotation.R0,
+                new List<PhysicalPin>
+                {
+                    new PhysicalPin
+                    {
+                        Name = "a0",
+                        OffsetXMicrometers = 0,
+                        OffsetYMicrometers = 0,
+                        AngleDegrees = 180
+                    }
+                })
+            {
+                PhysicalX = i * 100,
+                PhysicalY = 0,
+                WidthMicrometers = 50,
+                HeightMicrometers = 30
+            };
+
+            group.AddChild(child);
+        }
+
+        return group;
+    }
+}

--- a/UnitTests/ViewModels/GroupLibraryIntegrationTests.cs
+++ b/UnitTests/ViewModels/GroupLibraryIntegrationTests.cs
@@ -53,7 +53,7 @@ public class GroupLibraryIntegrationTests : IDisposable
 
         // Assert
         _libraryViewModel.UserGroups.Count.ShouldBe(1);
-        var template = _libraryViewModel.UserGroups.First();
+        var template = _libraryViewModel.UserGroups.First().Template;
         template.Name.ShouldBe("My Saved Group");
         template.Description.ShouldBe("A test group with 3 components");
         template.ComponentCount.ShouldBe(3);
@@ -106,14 +106,15 @@ public class GroupLibraryIntegrationTests : IDisposable
         var group = CreateTestGroup("Group to Remove", 1);
         _libraryManager.SaveTemplate(group, "Remove Me");
         _libraryViewModel.LoadGroupsCommand.Execute(null);
-        var template = _libraryViewModel.UserGroups.First();
+        var templateVm = _libraryViewModel.UserGroups.First();
+        var template = templateVm.Template;
         var filePath = template.FilePath;
 
         // Act
         _libraryViewModel.RemoveTemplateCommand.Execute(template);
 
         // Assert
-        _libraryViewModel.UserGroups.ShouldNotContain(template);
+        _libraryViewModel.UserGroups.ShouldNotContain(templateVm);
         if (filePath != null)
         {
             File.Exists(filePath).ShouldBeFalse();
@@ -127,7 +128,8 @@ public class GroupLibraryIntegrationTests : IDisposable
         var group = CreateTestGroup("Original", 2);
         _libraryManager.SaveTemplate(group, "Original Group", "Original description");
         _libraryViewModel.LoadGroupsCommand.Execute(null);
-        var original = _libraryViewModel.UserGroups.First();
+        var originalVm = _libraryViewModel.UserGroups.First();
+        var original = originalVm.Template;
         original.TemplateGroup = group; // Ensure template group is loaded
 
         // Act
@@ -135,9 +137,9 @@ public class GroupLibraryIntegrationTests : IDisposable
 
         // Assert
         _libraryViewModel.UserGroups.Count.ShouldBe(2);
-        var duplicate = _libraryViewModel.UserGroups.FirstOrDefault(t => t.Name.Contains("Copy"));
+        var duplicate = _libraryViewModel.UserGroups.FirstOrDefault(t => t.Template.Name.Contains("Copy"));
         duplicate.ShouldNotBeNull();
-        duplicate!.ComponentCount.ShouldBe(2);
+        duplicate!.Template.ComponentCount.ShouldBe(2);
     }
 
     [Fact]

--- a/UnitTests/ViewModels/GroupPrefabWorkflowTests.cs
+++ b/UnitTests/ViewModels/GroupPrefabWorkflowTests.cs
@@ -98,7 +98,7 @@ public class GroupPrefabWorkflowTests : IDisposable
         // Assert 2 - Now in library and marked as prefab
         _libraryViewModel.UserGroups.Count.ShouldBe(initialLibraryCount + 1);
         group.IsPrefab.ShouldBeTrue();
-        _libraryViewModel.UserGroups.Last().Name.ShouldBe("My Reusable Prefab");
+        _libraryViewModel.UserGroups.Last().Template.Name.ShouldBe("My Reusable Prefab");
     }
 
     [Fact]


### PR DESCRIPTION
Automated implementation for #264

Perfect! The 7 failing tests match the expected pre-existing failures (ComponentGroupSMatrixBuilder, ManhattanRouting, GroupEditMode, ComponentGroupSimulation). Our implementation didn't break any existing tests!

## Summary

✅ **Implementation complete!**

I've successfully implemented Issue #264: Feature: Delete button (red X) for saved groups in library.

### What was implemented:

**1. Core Logic** (Already existed)
- `GroupLibraryManager.RemoveTemplate()` - Fixed to compare templates by FilePath instead of object reference

**2. ViewModel Layer**
- Created `GroupTemplateItemViewModel.cs` - A wrapper class that adds hover state and delete command support
- Updated `ComponentLibraryViewModel.cs` - Changed collections from `GroupTemplate` to `GroupTemplateItemViewModel` and fixed removal logic to handle object reference differences after reload

**3. View/AXAML Layer**
- Updated `MainWindow.axaml` - Added red X delete button that appears on hover for both User Groups and PDK Groups
- Updated `MainWindow.axaml.cs` - Added hover event handlers to toggle `IsHovered` state

**4. Testing**
- Added 3 new unit tests to `GroupLibraryManagerTests.cs` for delete functionality edge cases
- Created `ComponentLibraryViewModelTests.cs` with 12 comprehensive integration tests covering Core→ViewModel interaction
- Fixed existing tests that were affected by the ViewModel wrapper changes

### Key Features:
- ✅ Red X button appears on hover over saved group icons
- ✅ Clicking X removes group from library
- ✅ Group disappears from "Saved Groups" panel immediately
- ✅ File is deleted from disk
- ✅ Status text updates to reflect new count
- ✅ Works for both User Groups and PDK Groups
- ✅ All tests passing (except 7 pre-existing failures)

### Test Results:
- **1086 tests passing** ✅
- **7 pre-existing failures** (documented in MEMORY.md, not related to this PR)
- **0 new failures**

The feature is fully functional and ready for user testing in the UI!


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 23,463
- **Estimated cost:** $0.3509 USD

---
*Generated by autonomous agent using Claude Code.*