### PR TITLE
Fix #286: Guid-based component identity to fix copied-group save/load bug

### DIFF
--- a/CAP-DataAccess/Persistence/ComponentGroupSerializer.cs
+++ b/CAP-DataAccess/Persistence/ComponentGroupSerializer.cs
@@ -25,18 +25,21 @@ public static class ComponentGroupSerializer
             GroupName = group.GroupName,
             Description = group.Description,
             Identifier = group.Identifier,
+            IdGuid = group.Id.ToString(),
             GridX = group.GridXMainTile,
             GridY = group.GridYMainTile,
             PhysicalX = group.PhysicalX,
             PhysicalY = group.PhysicalY,
             Rotation90CounterClock = (int)group.Rotation90CounterClock,
-            ParentGroupId = group.ParentGroup?.Identifier
+            ParentGroupId = group.ParentGroup?.Identifier,
+            ParentGroupIdGuid = group.ParentGroup?.Id.ToString()
         };
 
-        // Add child component IDs
+        // Add child component IDs (both name and Guid for forward/backward compat)
         foreach (var child in group.ChildComponents)
         {
             dto.ChildComponentIds.Add(child.Identifier);
+            dto.ChildComponentGuids.Add(child.Id.ToString());
         }
 
         // Serialize frozen paths
@@ -56,9 +59,10 @@ public static class ComponentGroupSerializer
 
     /// <summary>
     /// Reconstructs a ComponentGroup from a DTO after all individual components are loaded.
+    /// Uses name-based lookup (backward-compatible path for old files and grid persistence).
     /// </summary>
     /// <param name="dto">The DTO containing group data.</param>
-    /// <param name="componentLookup">Dictionary mapping component IDs to Component instances.</param>
+    /// <param name="componentLookup">Dictionary mapping component names to Component instances.</param>
     /// <returns>Reconstructed ComponentGroup.</returns>
     public static ComponentGroup FromDto(
         ComponentGroupDto dto,
@@ -69,6 +73,38 @@ public static class ComponentGroupSerializer
         if (componentLookup == null)
             throw new ArgumentNullException(nameof(componentLookup));
 
+        return FromDtoCore(dto, guidLookup: null, nameLookup: componentLookup);
+    }
+
+    /// <summary>
+    /// Reconstructs a ComponentGroup from a DTO using Guid-based lookup.
+    /// Falls back to name-based lookup for old files that predate Guid fields.
+    /// </summary>
+    /// <param name="dto">The DTO containing group data.</param>
+    /// <param name="guidLookup">Dictionary mapping saved component Guids to Component instances.</param>
+    /// <param name="nameFallback">Optional name-based fallback for old files.</param>
+    /// <returns>Reconstructed ComponentGroup.</returns>
+    public static ComponentGroup FromDto(
+        ComponentGroupDto dto,
+        Dictionary<Guid, Component> guidLookup,
+        Dictionary<string, Component>? nameFallback = null)
+    {
+        if (dto == null)
+            throw new ArgumentNullException(nameof(dto));
+        if (guidLookup == null)
+            throw new ArgumentNullException(nameof(guidLookup));
+
+        return FromDtoCore(dto, guidLookup, nameFallback);
+    }
+
+    /// <summary>
+    /// Core reconstruction logic shared by both FromDto overloads.
+    /// </summary>
+    private static ComponentGroup FromDtoCore(
+        ComponentGroupDto dto,
+        Dictionary<Guid, Component>? guidLookup,
+        Dictionary<string, Component>? nameLookup)
+    {
         // Create the group
         var group = new ComponentGroup(dto.GroupName)
         {
@@ -79,35 +115,69 @@ public static class ComponentGroupSerializer
             Rotation90CounterClock = (DiscreteRotation)dto.Rotation90CounterClock
         };
 
-        // Add child components
-        foreach (var childId in dto.ChildComponentIds)
+        // Add child components - prefer Guid lookup, fall back to name lookup
+        var useGuids = guidLookup != null && dto.ChildComponentGuids.Count == dto.ChildComponentIds.Count
+                       && dto.ChildComponentGuids.Count > 0;
+
+        for (int i = 0; i < dto.ChildComponentIds.Count; i++)
         {
-            if (componentLookup.TryGetValue(childId, out var childComponent))
+            var childId = dto.ChildComponentIds[i];
+            Component? childComponent = null;
+
+            if (useGuids && Guid.TryParse(dto.ChildComponentGuids[i], out var childGuid))
             {
-                group.AddChild(childComponent);
+                guidLookup!.TryGetValue(childGuid, out childComponent);
             }
-            else
+
+            if (childComponent == null && nameLookup != null)
+            {
+                nameLookup.TryGetValue(childId, out childComponent);
+            }
+
+            if (childComponent == null)
             {
                 throw new InvalidOperationException(
                     $"Child component '{childId}' not found in component lookup.");
             }
+
+            group.AddChild(childComponent);
         }
 
         // Reconstruct frozen paths
         foreach (var pathDto in dto.InternalPaths)
         {
-            var frozenPath = FromFrozenPathDto(pathDto, componentLookup);
+            var frozenPath = FromFrozenPathDto(pathDto, guidLookup, nameLookup);
             group.AddInternalPath(frozenPath);
         }
 
         // Reconstruct external pins
         foreach (var pinDto in dto.ExternalPins)
         {
-            var groupPin = FromGroupPinDto(pinDto, componentLookup);
+            var groupPin = FromGroupPinDto(pinDto, guidLookup, nameLookup);
             group.AddExternalPin(groupPin);
         }
 
         return group;
+    }
+
+    /// <summary>
+    /// Resolves a component from Guid or name lookup with fallback logic.
+    /// </summary>
+    private static Component ResolveComponent(
+        string? guidStr,
+        string nameId,
+        Dictionary<Guid, Component>? guidLookup,
+        Dictionary<string, Component>? nameLookup)
+    {
+        if (guidStr != null && guidLookup != null && Guid.TryParse(guidStr, out var guid))
+        {
+            if (guidLookup.TryGetValue(guid, out var byGuid)) return byGuid;
+        }
+
+        if (nameLookup != null && nameLookup.TryGetValue(nameId, out var byName)) return byName;
+
+        throw new InvalidOperationException(
+            $"Component '{nameId}' (Guid: {guidStr ?? "none"}) not found in lookup.");
     }
 
     /// <summary>
@@ -119,8 +189,10 @@ public static class ComponentGroupSerializer
         {
             PathId = frozenPath.PathId.ToString(),
             StartComponentId = frozenPath.StartPin.ParentComponent.Identifier,
+            StartComponentGuid = frozenPath.StartPin.ParentComponent.Id.ToString(),
             StartPinName = frozenPath.StartPin.Name,
             EndComponentId = frozenPath.EndPin.ParentComponent.Identifier,
+            EndComponentGuid = frozenPath.EndPin.ParentComponent.Id.ToString(),
             EndPinName = frozenPath.EndPin.Name,
             IsBlockedFallback = frozenPath.Path.IsBlockedFallback,
             IsInvalidGeometry = frozenPath.Path.IsInvalidGeometry
@@ -136,24 +208,23 @@ public static class ComponentGroupSerializer
     }
 
     /// <summary>
-    /// Reconstructs a FrozenWaveguidePath from a DTO.
+    /// Reconstructs a FrozenWaveguidePath from a DTO (name-based, backward-compat).
     /// </summary>
     private static FrozenWaveguidePath FromFrozenPathDto(
         FrozenPathDto dto,
         Dictionary<string, Component> componentLookup)
-    {
-        // Find start and end pins
-        if (!componentLookup.TryGetValue(dto.StartComponentId, out var startComp))
-        {
-            throw new InvalidOperationException(
-                $"Start component '{dto.StartComponentId}' not found.");
-        }
+        => FromFrozenPathDto(dto, null, componentLookup);
 
-        if (!componentLookup.TryGetValue(dto.EndComponentId, out var endComp))
-        {
-            throw new InvalidOperationException(
-                $"End component '{dto.EndComponentId}' not found.");
-        }
+    /// <summary>
+    /// Reconstructs a FrozenWaveguidePath from a DTO with dual-lookup support.
+    /// </summary>
+    private static FrozenWaveguidePath FromFrozenPathDto(
+        FrozenPathDto dto,
+        Dictionary<Guid, Component>? guidLookup,
+        Dictionary<string, Component>? nameLookup)
+    {
+        var startComp = ResolveComponent(dto.StartComponentGuid, dto.StartComponentId, guidLookup, nameLookup);
+        var endComp = ResolveComponent(dto.EndComponentGuid, dto.EndComponentId, guidLookup, nameLookup);
 
         var startPin = startComp.PhysicalPins.FirstOrDefault(p => p.Name == dto.StartPinName);
         var endPin = endComp.PhysicalPins.FirstOrDefault(p => p.Name == dto.EndPinName);
@@ -257,6 +328,7 @@ public static class ComponentGroupSerializer
             PinId = pin.PinId.ToString(),
             Name = pin.Name,
             InternalComponentId = pin.InternalPin.ParentComponent.Identifier,
+            InternalComponentGuid = pin.InternalPin.ParentComponent.Id.ToString(),
             InternalPinName = pin.InternalPin.Name,
             RelativeX = pin.RelativeX,
             RelativeY = pin.RelativeY,
@@ -265,17 +337,23 @@ public static class ComponentGroupSerializer
     }
 
     /// <summary>
-    /// Reconstructs a GroupPin from a DTO.
+    /// Reconstructs a GroupPin from a DTO (name-based, backward-compat).
     /// </summary>
     private static GroupPin FromGroupPinDto(
         GroupPinDto dto,
         Dictionary<string, Component> componentLookup)
+        => FromGroupPinDto(dto, null, componentLookup);
+
+    /// <summary>
+    /// Reconstructs a GroupPin from a DTO with dual-lookup support.
+    /// </summary>
+    private static GroupPin FromGroupPinDto(
+        GroupPinDto dto,
+        Dictionary<Guid, Component>? guidLookup,
+        Dictionary<string, Component>? nameLookup)
     {
-        if (!componentLookup.TryGetValue(dto.InternalComponentId, out var internalComp))
-        {
-            throw new InvalidOperationException(
-                $"Internal component '{dto.InternalComponentId}' not found for group pin.");
-        }
+        var internalComp = ResolveComponent(
+            dto.InternalComponentGuid, dto.InternalComponentId, guidLookup, nameLookup);
 
         var internalPin = internalComp.PhysicalPins.FirstOrDefault(p => p.Name == dto.InternalPinName);
         if (internalPin == null)

--- a/CAP-DataAccess/Persistence/DTOs/ComponentGroupDto.cs
+++ b/CAP-DataAccess/Persistence/DTOs/ComponentGroupDto.cs
@@ -18,9 +18,27 @@ public class ComponentGroupDto
     public string Description { get; set; } = "";
 
     /// <summary>
-    /// Component identifier (inherited from Component base class).
+    /// Component identifier (human-readable name, for backward compat and display).
     /// </summary>
     public string Identifier { get; set; } = "";
+
+    /// <summary>
+    /// Stable unique ID (Guid string) for this group.
+    /// Used as the primary lookup key; falls back to Identifier for old files.
+    /// </summary>
+    public string? IdGuid { get; set; }
+
+    /// <summary>
+    /// Stable unique ID (Guid string) of parent group.
+    /// Falls back to ParentGroupId for old files.
+    /// </summary>
+    public string? ParentGroupIdGuid { get; set; }
+
+    /// <summary>
+    /// Guid-string IDs of child components, parallel to ChildComponentIds.
+    /// Used as the primary lookup key; falls back to ChildComponentIds for old files.
+    /// </summary>
+    public List<string> ChildComponentGuids { get; set; } = new();
 
     /// <summary>
     /// Grid X position of main tile.
@@ -80,9 +98,14 @@ public class FrozenPathDto
     public string PathId { get; set; } = "";
 
     /// <summary>
-    /// Identifier of the start pin's parent component.
+    /// Identifier of the start pin's parent component (human-readable, for old files).
     /// </summary>
     public string StartComponentId { get; set; } = "";
+
+    /// <summary>
+    /// Guid string of the start pin's parent component. Primary lookup key.
+    /// </summary>
+    public string? StartComponentGuid { get; set; }
 
     /// <summary>
     /// Name of the start pin on the start component.
@@ -90,9 +113,14 @@ public class FrozenPathDto
     public string StartPinName { get; set; } = "";
 
     /// <summary>
-    /// Identifier of the end pin's parent component.
+    /// Identifier of the end pin's parent component (human-readable, for old files).
     /// </summary>
     public string EndComponentId { get; set; } = "";
+
+    /// <summary>
+    /// Guid string of the end pin's parent component. Primary lookup key.
+    /// </summary>
+    public string? EndComponentGuid { get; set; }
 
     /// <summary>
     /// Name of the end pin on the end component.
@@ -192,9 +220,14 @@ public class GroupPinDto
     public string Name { get; set; } = "";
 
     /// <summary>
-    /// Identifier of the internal component that owns this pin.
+    /// Identifier of the internal component that owns this pin (human-readable, for old files).
     /// </summary>
     public string InternalComponentId { get; set; } = "";
+
+    /// <summary>
+    /// Guid string of the internal component. Primary lookup key.
+    /// </summary>
+    public string? InternalComponentGuid { get; set; }
 
     /// <summary>
     /// Name of the internal pin on the internal component.

--- a/CAP.Avalonia/Selection/ComponentClipboard.cs
+++ b/CAP.Avalonia/Selection/ComponentClipboard.cs
@@ -83,10 +83,16 @@ public class ComponentClipboard
         var newComponents = new List<ComponentViewModel>();
         var clonedComps = new List<Component>();
 
-        // Get existing component names for unique name generation
+        // Get existing component names for unique name generation.
+        // Include child identifiers from all groups so copy names don't collide.
         var existingNames = canvas.Components
             .Select(c => c.Component.Identifier)
             .ToList();
+        foreach (var comp in canvas.Components)
+        {
+            if (comp.Component is ComponentGroup grp)
+                CollectAllChildIdentifiers(grp, existingNames);
+        }
 
         // Calculate offset: either from cursor position or fixed offset
         double offsetX, offsetY;
@@ -197,8 +203,23 @@ public class ComponentClipboard
     }
 
     /// <summary>
-    /// Recursively renames child components within a group to have readable Identifiers and HumanReadableNames.
+    /// Recursively collects all child component identifiers from a group hierarchy.
+    /// Used to ensure pasted copy names don't collide with existing group children.
+    /// </summary>
+    private static void CollectAllChildIdentifiers(ComponentGroup group, List<string> names)
+    {
+        foreach (var child in group.ChildComponents)
+        {
+            names.Add(child.Identifier);
+            if (child is ComponentGroup nested)
+                CollectAllChildIdentifiers(nested, names);
+        }
+    }
+
+    /// <summary>
+    /// Recursively renames child components within a group to have readable Names.
     /// Builds a mapping of old Identifiers to new Component references for ExternalPin updates.
+    /// Note: Each component gets a fresh Id (Guid) automatically via Clone(), so Id collisions are impossible.
     /// </summary>
     private void RenameGroupChildren(ComponentGroup group, List<string> existingNames, Dictionary<string, Component> identifierMap)
     {

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -571,6 +571,13 @@ public class DesignGroupData
 public class ChildComponentData
 {
     public string Identifier { get; set; } = "";
+
+    /// <summary>
+    /// Guid string of the component instance (stable unique ID).
+    /// Used as the primary lookup key during load; falls back to Identifier for old files.
+    /// </summary>
+    public string? ComponentGuid { get; set; }
+
     public string TemplateName { get; set; } = "";
     public double X { get; set; }
     public double Y { get; set; }

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -301,6 +301,7 @@ public partial class FileOperationsViewModel : ObservableObject
             childDataList.Add(new ChildComponentData
             {
                 Identifier = child.Identifier,
+                ComponentGuid = child.Id.ToString(),
                 TemplateName = templateName,
                 X = child.PhysicalX,
                 Y = child.PhysicalY,
@@ -598,16 +599,24 @@ public partial class FileOperationsViewModel : ObservableObject
     /// </summary>
     private int LoadGroups(List<DesignGroupData> groupDataList)
     {
-        // Build a global component lookup that will include both regular components and groups
-        var allComponents = new Dictionary<string, Component>();
+        // Primary lookup: by saved Guid (prevents name-collision bugs when copying groups).
+        // Fallback lookup: by Identifier string (for old files that predate Guid fields).
+        var guidLookup = new Dictionary<Guid, Component>();
+        var nameFallback = new Dictionary<string, Component>();
 
         // First pass: Create all non-group child components
         foreach (var groupData in groupDataList)
         {
             foreach (var childData in groupData.ChildComponents)
             {
-                // Skip if already created (can happen with shared children)
-                if (allComponents.ContainsKey(childData.Identifier))
+                // Determine the lookup key for this child
+                var hasGuid = childData.ComponentGuid != null
+                              && Guid.TryParse(childData.ComponentGuid, out var childGuid);
+
+                // Skip if already created under the same key
+                if (hasGuid && guidLookup.ContainsKey(Guid.Parse(childData.ComponentGuid!)))
+                    continue;
+                if (!hasGuid && nameFallback.ContainsKey(childData.Identifier))
                     continue;
 
                 var template = _componentLibrary.FirstOrDefault(t =>
@@ -619,7 +628,7 @@ public partial class FileOperationsViewModel : ObservableObject
                 var child = ComponentTemplates.CreateFromTemplate(
                     template, childData.X, childData.Y);
 
-                // Restore original identifier for reference matching
+                // Restore human-readable name
                 child.Identifier = childData.Identifier;
 
                 // Restore HumanReadableName
@@ -642,22 +651,29 @@ public partial class FileOperationsViewModel : ObservableObject
                 if (childData.IsLocked == true)
                     child.IsLocked = true;
 
-                allComponents[child.Identifier] = child;
+                // Index by saved Guid (primary) and by name (fallback for old files)
+                if (hasGuid)
+                    guidLookup[Guid.Parse(childData.ComponentGuid!)] = child;
+                nameFallback[child.Identifier] = child;
             }
         }
 
         // Second pass: Reconstruct groups in dependency order (children before parents)
-        // Sort groups by their child component IDs to ensure child groups are loaded first
         var orderedGroups = TopologicalSortGroups(groupDataList);
 
         foreach (var groupData in orderedGroups)
         {
-            // Reconstruct the group from DTO using the global component lookup
+            // Reconstruct the group using Guid-based lookup with name fallback
             var group = ComponentGroupSerializer.FromDto(
-                groupData.GroupDto, allComponents);
+                groupData.GroupDto, guidLookup, nameFallback);
 
-            // Add the reconstructed group to the global lookup
-            allComponents[group.Identifier] = group;
+            // Index the group itself so nested parents can find it
+            if (groupData.GroupDto.IdGuid != null
+                && Guid.TryParse(groupData.GroupDto.IdGuid, out var groupGuid))
+            {
+                guidLookup[groupGuid] = group;
+            }
+            nameFallback[group.Identifier] = group;
 
             // Only add top-level groups (groups without a parent) to the canvas
             if (groupData.GroupDto.ParentGroupId == null)

--- a/Connect-A-Pic-Core/Components/Core/Component.cs
+++ b/Connect-A-Pic-Core/Components/Core/Component.cs
@@ -15,12 +15,30 @@ public class Component : ICloneable
     public int WidthInTiles => Parts.GetLength(0);
     public int HeightInTiles => Parts.GetLength(1);
     public int TypeNumber { get; set; }
-    public string Identifier{ get; set; }
 
     /// <summary>
-    /// Human-readable display name for UI (e.g., "GratingCoupler_1").
-    /// Separate from <see cref="Identifier"/> to preserve persistence stability.
-    /// When null, the UI falls back to displaying <see cref="Identifier"/>.
+    /// Globally unique identifier for this component instance.
+    /// Automatically assigned on construction; each Clone() gets a fresh Guid.
+    /// Used as the stable lookup key in persistence to avoid name-collision bugs.
+    /// </summary>
+    public Guid Id { get; private set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Human-readable name for this component (e.g., "MMI_1x2_1").
+    /// Can be changed freely without affecting lookup-by-Id.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Backward-compatible alias for <see cref="Name"/>.
+    /// Old code can still use Identifier to get/set the Name.
+    /// </summary>
+    public string Identifier { get => Name; set => Name = value; }
+
+    /// <summary>
+    /// Optional human-readable display name for UI (e.g., "MMI 2x2 Coupler 1").
+    /// When null, the UI should fall back to displaying <see cref="Name"/>.
+    /// This allows the PDK display name to be shown in UI while keeping Name as the unique identifier.
     /// </summary>
     public string? HumanReadableName { get; set; }
 
@@ -74,7 +92,7 @@ public class Component : ICloneable
     {
         Parts = parts;
         TypeNumber = typeNumber;
-        Identifier = identifier;
+        Name = identifier;
         _discreteRotation = rotationCounterClock;
         WaveLengthToSMatrixMap = laserWaveLengthToSMatrixMap;
         SliderMap = new();
@@ -319,7 +337,7 @@ public class Component : ICloneable
         // Clone physical pins
         var clonedPhysicalPins = ClonePhysicalPins(clonedPins);
 
-        var clonedComponent = new Component(clonedLaserSMatrixMap, clonedSliderMap.Values.ToList(), NazcaFunctionName, NazcaFunctionParameters, clonedParts, TypeNumber, Identifier, Rotation90CounterClock, clonedPhysicalPins);
+        var clonedComponent = new Component(clonedLaserSMatrixMap, clonedSliderMap.Values.ToList(), NazcaFunctionName, NazcaFunctionParameters, clonedParts, TypeNumber, Name, Rotation90CounterClock, clonedPhysicalPins);
 
         // Copy physical dimensions and position
         clonedComponent.WidthMicrometers = WidthMicrometers;

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -518,8 +518,8 @@ public class ComponentGroup : Component, INotifyPropertyChanged
             Rotation90CounterClock = Rotation90CounterClock
         };
 
-        // Map old component identifiers to new cloned components
-        var componentMap = new Dictionary<string, Component>();
+        // Map old component Ids (Guid) to new cloned components
+        var componentMap = new Dictionary<Guid, Component>();
 
         // Deep copy child components
         foreach (var child in ChildComponents)
@@ -536,20 +536,18 @@ public class ComponentGroup : Component, INotifyPropertyChanged
                 clonedChild = CloneComponent(child);
             }
 
-            // CRITICAL FIX: Give cloned child a new unique Identifier (GUID-based string)
+            // Use child.Id (Guid) as the key for the component map
             // This prevents ID collisions when copying groups and then saving/loading
-            var originalIdentifier = child.Identifier;
-            clonedChild.Identifier = $"{originalIdentifier}_{Guid.NewGuid():N}";
-
-            componentMap[originalIdentifier] = clonedChild;
+            // The cloned child already has a new Id from Clone()
+            componentMap[child.Id] = clonedChild;
             newGroup.AddChild(clonedChild);
         }
 
         // Clone frozen waveguide paths
         foreach (var frozenPath in InternalPaths)
         {
-            var startComp = componentMap[frozenPath.StartPin.ParentComponent.Identifier];
-            var endComp = componentMap[frozenPath.EndPin.ParentComponent.Identifier];
+            var startComp = componentMap[frozenPath.StartPin.ParentComponent.Id];
+            var endComp = componentMap[frozenPath.EndPin.ParentComponent.Id];
 
             var newStartPin = startComp.PhysicalPins.First(p => p.Name == frozenPath.StartPin.Name);
             var newEndPin = endComp.PhysicalPins.First(p => p.Name == frozenPath.EndPin.Name);
@@ -568,7 +566,7 @@ public class ComponentGroup : Component, INotifyPropertyChanged
         // Clone external pins
         foreach (var externalPin in ExternalPins)
         {
-            var internalComp = componentMap[externalPin.InternalPin.ParentComponent.Identifier];
+            var internalComp = componentMap[externalPin.InternalPin.ParentComponent.Id];
             var newInternalPin = internalComp.PhysicalPins.First(p => p.Name == externalPin.InternalPin.Name);
 
             var clonedPin = new GroupPin


### PR DESCRIPTION
## Summary

- **Root cause**: `Component.Identifier` served as both unique ID and display name. Copying a group twice gave children identical `Identifier` strings. On load, the deduplication check (`if (allComponents.ContainsKey(childData.Identifier)) continue`) skipped the second group's children, causing both copied groups to share the same child objects.
- **Fix**: Add `Component.Id` (Guid, auto-generated, immutable) as the stable unique key. Serialization stores Guid alongside the existing string identifier; loading uses Guid as primary lookup with string fallback for old files. Also fixed `ComponentClipboard.Paste()` to include group children in `existingNames` so `GenerateCopyName()` sees them and avoids duplicates on the first paste.
- **Backward compatibility**: Old `.cappro` files without Guid fields continue to load via the name-based fallback path.

## Changes

| File | What changed |
|------|-------------|
| `Component.cs` | Add `Id` (Guid) + `Name`; `Identifier` becomes backward-compat alias for `Name` |
| `ComponentGroup.cs` | `DeepCopy()` keys `componentMap` by `Guid` instead of `string` |
| `ComponentGroupDto.cs` | Add `IdGuid`, `ParentGroupIdGuid`, `ChildComponentGuids`, `StartComponentGuid`, `EndComponentGuid`, `InternalComponentGuid` |
| `ComponentGroupSerializer.cs` | Populate Guid fields on save; Guid-primary / name-fallback lookup on load; new `FromDto()` overload |
| `MainViewModel.cs` | Add `ComponentGuid` to `ChildComponentData` |
| `FileOperationsViewModel.cs` | Store child Guid; build dual-lookup dicts in `LoadGroups()` |
| `ComponentClipboard.cs` | Collect all group-child identifiers before paste to avoid duplicate names |
| `FileOperationsViewModelTests.cs` | Add regression test `CopiedGroup_AfterSaveLoad_ShouldHaveUniqueChildIdsAndBeSelectable` |

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 1187 passed, 8 pre-existing failures (unchanged), 20 skipped
- [x] New regression test `CopiedGroup_AfterSaveLoad_ShouldHaveUniqueChildIdsAndBeSelectable` passes
- [x] Pre-existing failures verified unchanged via `git stash` baseline check

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)