### PR TITLE
Agent: Refactor WaveguideRouter from static singleton to Dependency Injection

### DIFF
--- a/CAP.Avalonia/Commands/RotateComponentCommand.cs
+++ b/CAP.Avalonia/Commands/RotateComponentCommand.cs
@@ -1,7 +1,6 @@
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
-using CAP_Core.Components.Connections;
 
 namespace CAP.Avalonia.Commands;
 
@@ -107,8 +106,7 @@ public class RotateComponentCommand : IUndoableCommand
         _component.NotifyDimensionsChanged();
 
         // Update obstacle in pathfinding grid
-        var router = WaveguideConnection.SharedRouter;
-        router.UpdateComponentObstacle(comp);
+        _canvas.Router.UpdateComponentObstacle(comp);
 
         // Recalculate paths asynchronously (pin angles change with rotation)
         _ = _canvas.RecalculateRoutesAsync();

--- a/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
@@ -13,11 +13,29 @@ namespace CAP.Avalonia.ViewModels.Canvas;
 
 public partial class DesignCanvasViewModel : ObservableObject
 {
+    private readonly WaveguideRouter _router;
+
     public ObservableCollection<ComponentViewModel> Components { get; } = new();
     public ObservableCollection<WaveguideConnectionViewModel> Connections { get; } = new();
     public ObservableCollection<PinViewModel> AllPins { get; } = new();
 
-    public WaveguideConnectionManager ConnectionManager { get; } = new();
+    public WaveguideConnectionManager ConnectionManager { get; }
+
+    /// <summary>
+    /// Initializes a new instance with a fresh <see cref="WaveguideRouter"/>.
+    /// </summary>
+    public DesignCanvasViewModel() : this(new WaveguideRouter()) { }
+
+    /// <summary>
+    /// Initializes a new instance with an injected <see cref="WaveguideRouter"/>.
+    /// </summary>
+    /// <param name="router">The waveguide router for A* pathfinding and obstacle management.</param>
+    public DesignCanvasViewModel(WaveguideRouter router)
+    {
+        _router = router;
+        ConnectionManager = new WaveguideConnectionManager(router);
+        InitializeAStarRouting();
+    }
 
     /// <summary>
     /// Manages multi-component selection state.
@@ -114,9 +132,9 @@ public partial class DesignCanvasViewModel : ObservableObject
     public double PinHighlightDistance { get; set; } = 15.0;
 
     /// <summary>
-    /// Gets the shared waveguide router for A* pathfinding configuration.
+    /// Gets the waveguide router for A* pathfinding configuration.
     /// </summary>
-    public WaveguideRouter Router => WaveguideConnection.SharedRouter;
+    public WaveguideRouter Router => _router;
 
     /// <summary>
     /// Whether A* pathfinding with obstacle avoidance is enabled.
@@ -220,12 +238,6 @@ public partial class DesignCanvasViewModel : ObservableObject
 
     [ObservableProperty]
     private double _panY;
-
-    public DesignCanvasViewModel()
-    {
-        // Initialize A* pathfinding by default
-        InitializeAStarRouting();
-    }
 
     /// <summary>
     /// Enters edit mode for a ComponentGroup (Unity-style sub-canvas approach).

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -106,12 +106,6 @@ namespace CAP_Core.Components.Connections
         /// </summary>
         public double TotalLossDb { get; private set; }
 
-        /// <summary>
-        /// Shared router instance for all connections.
-        /// Public to allow initialization of A* pathfinding grid.
-        /// </summary>
-        public static WaveguideRouter SharedRouter { get; } = new();
-
         // Nazca-Export
         public string ExportToNazca()
         {
@@ -141,7 +135,8 @@ namespace CAP_Core.Components.Connections
         /// Recalculates the transmission coefficient based on current pin positions and loss parameters.
         /// Should be called whenever connected components are moved.
         /// </summary>
-        public void RecalculateTransmission()
+        /// <param name="router">The waveguide router to use for path calculation.</param>
+        public void RecalculateTransmission(WaveguideRouter router)
         {
             if (StartPin == null || EndPin == null)
             {
@@ -152,10 +147,10 @@ namespace CAP_Core.Components.Connections
             }
 
             // Update router settings
-            SharedRouter.MinBendRadiusMicrometers = BendRadiusMicrometers;
+            router.MinBendRadiusMicrometers = BendRadiusMicrometers;
 
             // Route the connection
-            RoutedPath = SharedRouter.Route(StartPin, EndPin);
+            RoutedPath = router.Route(StartPin, EndPin);
 
             // Calculate total loss from actual path
             double propagationLoss = (PathLengthMicrometers / 10000.0) * PropagationLossDbPerCm; // µm to cm

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
@@ -6,6 +6,17 @@ namespace CAP_Core.Components.Connections;
 
 public class WaveguideConnectionManager
 {
+    private readonly WaveguideRouter _router;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="WaveguideConnectionManager"/> with the given router.
+    /// </summary>
+    /// <param name="router">The waveguide router used for path calculation and obstacle management.</param>
+    public WaveguideConnectionManager(WaveguideRouter router)
+    {
+        _router = router;
+    }
+
     public List<WaveguideConnection> Connections { get; } = new();
 
     /// <summary>
@@ -71,7 +82,7 @@ public class WaveguideConnectionManager
         Connections.Add(connection);
 
         // Register cached route as obstacle for future routing
-        var router = WaveguideConnection.SharedRouter;
+        var router = _router;
         if (UseSequentialRouting && router.PathfindingGrid != null &&
             connection.IsPathValid && connection.RoutedPath != null)
         {
@@ -125,7 +136,7 @@ public class WaveguideConnectionManager
     /// </summary>
     public void RemoveConnectionsForComponent(Component component)
     {
-        var router = WaveguideConnection.SharedRouter;
+        var router = _router;
         var connectionsToRemove = Connections
             .Where(c => c.StartPin.ParentComponent == component ||
                         c.EndPin.ParentComponent == component)
@@ -148,7 +159,7 @@ public class WaveguideConnectionManager
     public void RemoveConnection(WaveguideConnection connection)
     {
         // Remove waveguide obstacle from pathfinding grid
-        var router = WaveguideConnection.SharedRouter;
+        var router = _router;
         if (router.PathfindingGrid != null)
         {
             router.PathfindingGrid.RemoveWaveguideObstacle(connection.Id);
@@ -169,7 +180,7 @@ public class WaveguideConnectionManager
     /// </summary>
     public void RemoveConnectionDeferred(WaveguideConnection connection)
     {
-        var router = WaveguideConnection.SharedRouter;
+        var router = _router;
         if (router.PathfindingGrid != null)
         {
             router.PathfindingGrid.RemoveWaveguideObstacle(connection.Id);
@@ -206,7 +217,7 @@ public class WaveguideConnectionManager
         Action? progressCallback = null,
         CancellationToken cancellationToken = default)
     {
-        var router = WaveguideConnection.SharedRouter;
+        var router = _router;
 
         if (UseSequentialRouting && router.PathfindingGrid != null)
         {
@@ -257,7 +268,7 @@ public class WaveguideConnectionManager
             foreach (var connection in Connections)
             {
                 if (cancellationToken.IsCancellationRequested) return;
-                connection.RecalculateTransmission();
+                connection.RecalculateTransmission(_router);
                 progressCallback?.Invoke();
             }
         }
@@ -321,7 +332,7 @@ public class WaveguideConnectionManager
             if (cancellationToken.IsCancellationRequested)
                 return (false, failedCount);
 
-            connection.RecalculateTransmission();
+            connection.RecalculateTransmission(_router);
             progressCallback?.Invoke();
 
             // Register ALL paths with valid geometry as obstacles, including blocked fallbacks.
@@ -404,7 +415,7 @@ public class WaveguideConnectionManager
             if (cancellationToken.IsCancellationRequested)
                 return (false, failedCount);
 
-            connection.RecalculateTransmission();
+            connection.RecalculateTransmission(_router);
             progressCallback?.Invoke();
 
             // Register ANY path with valid geometry as an obstacle, including blocked fallbacks.
@@ -525,7 +536,7 @@ public class WaveguideConnectionManager
     /// </summary>
     public void RecalculateTransmissionsForComponent(Component component)
     {
-        var router = WaveguideConnection.SharedRouter;
+        var router = _router;
 
         if (UseSequentialRouting && router.PathfindingGrid != null)
         {
@@ -541,7 +552,7 @@ public class WaveguideConnectionManager
                 if (connection.StartPin.ParentComponent == component ||
                     connection.EndPin.ParentComponent == component)
                 {
-                    connection.RecalculateTransmission();
+                    connection.RecalculateTransmission(_router);
                 }
             }
         }

--- a/Connect-A-Pic-Core/Grid/GridManager.cs
+++ b/Connect-A-Pic-Core/Grid/GridManager.cs
@@ -1,6 +1,7 @@
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
 using CAP_Core.Tiles;
 using System.ComponentModel;
 using Component = CAP_Core.Components.Core.Component;
@@ -58,7 +59,7 @@ namespace CAP_Core.Grid
             ComponentRotator = new ComponentRotator(TileManager,ComponentMover);
             ComponentRelationshipManager = new ComponentRelationshipManager(TileManager);
             LightManager = new LightManager();
-            WaveguideConnections = new WaveguideConnectionManager();
+            WaveguideConnections = new WaveguideConnectionManager(new WaveguideRouter());
         }
 
     }

--- a/UnitTests/Components/WaveguideLengthTests.cs
+++ b/UnitTests/Components/WaveguideLengthTests.cs
@@ -1,5 +1,6 @@
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
 using Shouldly;
 using Xunit;
 
@@ -56,7 +57,7 @@ public class WaveguideLengthTests
     public void LengthDifference_CalculatesCorrectly()
     {
         var connection = CreateTestConnection();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
         var targetLength = actualLength + 50.0;
@@ -83,7 +84,7 @@ public class WaveguideLengthTests
     public void IsLengthMatched_ReturnsTrueWhenWithinTolerance()
     {
         var connection = CreateTestConnection();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
 
@@ -98,7 +99,7 @@ public class WaveguideLengthTests
     public void IsLengthMatched_ReturnsFalseWhenOutsideTolerance()
     {
         var connection = CreateTestConnection();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
 
@@ -113,7 +114,7 @@ public class WaveguideLengthTests
     public void IsLengthMatched_RespectsCustomTolerance()
     {
         var connection = CreateTestConnection();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
 
@@ -128,7 +129,7 @@ public class WaveguideLengthTests
     public void LengthDifference_PositiveWhenActualIsLonger()
     {
         var connection = CreateTestConnection();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
         var targetLength = actualLength - 10.0;
@@ -146,7 +147,7 @@ public class WaveguideLengthTests
     public void LengthDifference_NegativeWhenActualIsShorter()
     {
         var connection = CreateTestConnection();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
         var targetLength = actualLength + 15.0;

--- a/UnitTests/Persistence/RouteSegmentCacheTests.cs
+++ b/UnitTests/Persistence/RouteSegmentCacheTests.cs
@@ -150,7 +150,7 @@ public class RouteSegmentCacheTests
             PropagationLossDbPerCm = 2.0,
             BendLossDbPer90Deg = 0.1
         };
-        conn1.RecalculateTransmission();
+        conn1.RecalculateTransmission(new WaveguideRouter());
         var routedPath = conn1.RoutedPath;
 
         if (routedPath == null) return; // Router may not find path without grid
@@ -251,15 +251,14 @@ public class RouteSegmentCacheTests
     [Fact]
     public void AddConnectionWithCachedRoute_RegistersObstacle()
     {
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        router.InitializePathfindingGrid(-50, -50, 200, 100,
+            new[] { CreateTestComponent(0, 0), CreateTestComponent(100, 0) });
+        var manager = new WaveguideConnectionManager(router);
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(100, 0);
         var startPin = CreateOutputPin(startComp);
         var endPin = CreateInputPin(endComp);
-
-        var router = WaveguideConnection.SharedRouter;
-        router.InitializePathfindingGrid(-50, -50, 200, 100,
-            new[] { startComp, endComp });
 
         var cachedPath = new RoutedPath();
         cachedPath.Segments.Add(new StraightSegment(50, 25, 100, 25, 0));

--- a/UnitTests/Routing/AsyncRoutingTests.cs
+++ b/UnitTests/Routing/AsyncRoutingTests.cs
@@ -3,6 +3,7 @@ using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.FormulaReading;
 using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
 using CAP_Core.Tiles;
 using Shouldly;
 using Xunit;
@@ -17,13 +18,13 @@ public class AsyncRoutingTests
     [Fact]
     public async Task RecalculateAllTransmissionsAsync_CompletesSuccessfully()
     {
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        var manager = new WaveguideConnectionManager(router);
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
         var startPin = CreateOutputPin(startComp);
         var endPin = CreateInputPin(endComp);
 
-        var router = WaveguideConnection.SharedRouter;
         router.InitializePathfindingGrid(-50, -50, 300, 100,
             new[] { startComp, endComp });
 
@@ -38,7 +39,7 @@ public class AsyncRoutingTests
     [Fact]
     public async Task RecalculateAllTransmissionsAsync_Cancellation_ReturnsFalse()
     {
-        var manager = new WaveguideConnectionManager();
+        var manager = new WaveguideConnectionManager(new WaveguideRouter());
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
         var startPin = CreateOutputPin(startComp);
@@ -56,7 +57,7 @@ public class AsyncRoutingTests
     [Fact]
     public void AddConnectionDeferred_DoesNotRoute()
     {
-        var manager = new WaveguideConnectionManager();
+        var manager = new WaveguideConnectionManager(new WaveguideRouter());
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
         var startPin = CreateOutputPin(startComp);
@@ -74,7 +75,7 @@ public class AsyncRoutingTests
     [Fact]
     public void RemoveConnectionDeferred_DoesNotRecalculate()
     {
-        var manager = new WaveguideConnectionManager();
+        var manager = new WaveguideConnectionManager(new WaveguideRouter());
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
 
@@ -98,7 +99,7 @@ public class AsyncRoutingTests
     [Fact]
     public void RemoveConnectionsForComponent_Deferred_RemovesCorrectConnections()
     {
-        var manager = new WaveguideConnectionManager();
+        var manager = new WaveguideConnectionManager(new WaveguideRouter());
         var compA = CreateTestComponent(0, 0);
         var compB = CreateTestComponent(200, 0);
         var compC = CreateTestComponent(400, 0);
@@ -116,13 +117,13 @@ public class AsyncRoutingTests
     [Fact]
     public async Task RecalculateAllTransmissionsAsync_AfterDeferred_RoutesSuccessfully()
     {
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        var manager = new WaveguideConnectionManager(router);
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
         var startPin = CreateOutputPin(startComp);
         var endPin = CreateInputPin(endComp);
 
-        var router = WaveguideConnection.SharedRouter;
         router.InitializePathfindingGrid(-50, -50, 300, 100,
             new[] { startComp, endComp });
 
@@ -144,13 +145,13 @@ public class AsyncRoutingTests
     {
         // Simulates the crash scenario: multiple overlapping routing operations
         // Previously caused InvalidOperationException on Dictionary concurrent access
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        var manager = new WaveguideConnectionManager(router);
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
         var startPin = CreateOutputPin(startComp);
         var endPin = CreateInputPin(endComp);
 
-        var router = WaveguideConnection.SharedRouter;
         router.InitializePathfindingGrid(-50, -50, 300, 100,
             new[] { startComp, endComp });
 
@@ -173,13 +174,13 @@ public class AsyncRoutingTests
     public async Task CancelAndRestart_DoesNotThrowConcurrencyException()
     {
         // Simulates the exact user scenario: start routing, cancel, restart immediately
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        var manager = new WaveguideConnectionManager(router);
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
         var startPin = CreateOutputPin(startComp);
         var endPin = CreateInputPin(endComp);
 
-        var router = WaveguideConnection.SharedRouter;
         router.InitializePathfindingGrid(-50, -50, 300, 100,
             new[] { startComp, endComp });
 
@@ -204,11 +205,11 @@ public class AsyncRoutingTests
     public async Task RapidCancelRestart_StressTest()
     {
         // Stress test: rapidly cancel and restart routing 10 times
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        var manager = new WaveguideConnectionManager(router);
         var startComp = CreateTestComponent(0, 0);
         var endComp = CreateTestComponent(200, 0);
 
-        var router = WaveguideConnection.SharedRouter;
         router.InitializePathfindingGrid(-50, -50, 300, 100,
             new[] { startComp, endComp });
 
@@ -236,14 +237,13 @@ public class AsyncRoutingTests
     public void IncrementalRouting_PreservesValidRoutes()
     {
         // Setup: two connections, both routed successfully
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        var manager = new WaveguideConnectionManager(router);
         var compA = CreateTestComponent(0, 0);
         var compB = CreateTestComponent(200, 0);
         var compC = CreateTestComponent(0, 100);
         var compD = CreateTestComponent(200, 100);
 
-        var router = WaveguideConnection.SharedRouter;
-        // Reset router to known state (other tests may have changed settings)
         router.MinBendRadiusMicrometers = 10.0;
         router.AStarCellSize = 2.0;
         router.CostCalculator.MinStraightRunCells = 20;
@@ -279,14 +279,13 @@ public class AsyncRoutingTests
     public void IncrementalRouting_ReroutesOnlyAffectedConnections()
     {
         // Setup: two connections routed successfully
-        var manager = new WaveguideConnectionManager();
+        var router = new WaveguideRouter();
+        var manager = new WaveguideConnectionManager(router);
         var compA = CreateTestComponent(0, 0);
         var compB = CreateTestComponent(200, 0);
         var compC = CreateTestComponent(0, 100);
         var compD = CreateTestComponent(200, 100);
 
-        var router = WaveguideConnection.SharedRouter;
-        // Reset router to known state (other tests may have changed settings)
         router.MinBendRadiusMicrometers = 10.0;
         router.AStarCellSize = 2.0;
         router.CostCalculator.MinStraightRunCells = 20;

--- a/UnitTests/Routing/GroupEditModeRoutingTests.cs
+++ b/UnitTests/Routing/GroupEditModeRoutingTests.cs
@@ -170,7 +170,7 @@ public class GroupEditModeRoutingTests
 
         canvas.EnterGroupEditMode(group);
 
-        WaveguideConnection.SharedRouter.PathfindingGrid.ShouldNotBeNull(
+        canvas.Router.PathfindingGrid.ShouldNotBeNull(
             "Pathfinding grid should be initialized after entering group edit mode");
     }
 

--- a/UnitTests/Routing/HierarchicalPathfinderTests.cs
+++ b/UnitTests/Routing/HierarchicalPathfinderTests.cs
@@ -246,7 +246,7 @@ public class HierarchicalPathfinderTests
     [Fact]
     public void WaveguideRouter_BuildHierarchicalGraph_IntegratesCorrectly()
     {
-        var router = WaveguideConnection.SharedRouter;
+        var router = new WaveguideRouter();
         var comp1 = CreateTestComponent(0, 0);
         var comp2 = CreateTestComponent(200, 0);
 

--- a/UnitTests/Routing/ManhattanRoutingIntegrationTests.cs
+++ b/UnitTests/Routing/ManhattanRoutingIntegrationTests.cs
@@ -3,6 +3,7 @@ using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.FormulaReading;
 using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
 using CAP_Core.Tiles;
 using Shouldly;
 using Xunit;
@@ -13,19 +14,8 @@ namespace UnitTests.Routing;
 /// Integration tests for Manhattan router obstacle registration and collision detection.
 /// Tests fix for issue #87: Manhattan router waveguides not registered in PathfindingGrid.
 /// </summary>
-public class ManhattanRoutingIntegrationTests : IDisposable
+public class ManhattanRoutingIntegrationTests
 {
-    /// <summary>
-    /// Cleanup after each test to prevent shared state pollution.
-    /// The SharedRouter is static, so we need to clean it up between tests.
-    /// </summary>
-    public void Dispose()
-    {
-        // Clear the shared router's pathfinding grid to prevent test interference
-        var router = WaveguideConnection.SharedRouter;
-        router.ClearPathfindingGrid();
-    }
-
     [Fact]
     public void ManhattanFallbackPath_RegisteredAsObstacle_BlocksSubsequentAStar()
     {
@@ -33,14 +23,12 @@ public class ManhattanRoutingIntegrationTests : IDisposable
         // 1. Create a Manhattan fallback connection
         // 2. Create a second A* connection that should avoid the first
 
-        var manager = new WaveguideConnectionManager
+        var router = new WaveguideRouter { MinBendRadiusMicrometers = 10.0 };
+        var manager = new WaveguideConnectionManager(router)
         {
             UseSequentialRouting = true,
             WaveguideWidthMicrometers = 4.0
         };
-
-        var router = WaveguideConnection.SharedRouter;
-        router.MinBendRadiusMicrometers = 10.0;
 
         // Components positioned so first connection uses Manhattan fallback
         var comp1 = CreateTestComponent(0, 0);
@@ -87,14 +75,12 @@ public class ManhattanRoutingIntegrationTests : IDisposable
     {
         // Arrange - Test that sequential routing registers all paths (A* or Manhattan)
 
-        var manager = new WaveguideConnectionManager
+        var router = new WaveguideRouter { MinBendRadiusMicrometers = 10.0 };
+        var manager = new WaveguideConnectionManager(router)
         {
             UseSequentialRouting = true,
             WaveguideWidthMicrometers = 4.0
         };
-
-        var router = WaveguideConnection.SharedRouter;
-        router.MinBendRadiusMicrometers = 10.0;
 
         var comp1 = CreateTestComponent(0, 0);
         var comp2 = CreateTestComponent(200, 0);
@@ -132,14 +118,12 @@ public class ManhattanRoutingIntegrationTests : IDisposable
     {
         // Arrange - A* connection first, then Manhattan that crosses it
 
-        var manager = new WaveguideConnectionManager
+        var router = new WaveguideRouter { MinBendRadiusMicrometers = 10.0 };
+        var manager = new WaveguideConnectionManager(router)
         {
             UseSequentialRouting = true,
             WaveguideWidthMicrometers = 4.0
         };
-
-        var router = WaveguideConnection.SharedRouter;
-        router.MinBendRadiusMicrometers = 10.0;
 
         var comp1 = CreateTestComponent(0, 50);
         var comp2 = CreateTestComponent(200, 50);
@@ -176,14 +160,12 @@ public class ManhattanRoutingIntegrationTests : IDisposable
     {
         // Arrange - Test that removing a Manhattan path clears its obstacles
 
-        var manager = new WaveguideConnectionManager
+        var router = new WaveguideRouter { MinBendRadiusMicrometers = 10.0 };
+        var manager = new WaveguideConnectionManager(router)
         {
             UseSequentialRouting = true,
             WaveguideWidthMicrometers = 4.0
         };
-
-        var router = WaveguideConnection.SharedRouter;
-        router.MinBendRadiusMicrometers = 10.0;
 
         var comp1 = CreateTestComponent(0, 0);
         var comp2 = CreateTestComponent(200, 100);

--- a/UnitTests/Routing/RoutingEdgeCaseTests.cs
+++ b/UnitTests/Routing/RoutingEdgeCaseTests.cs
@@ -284,38 +284,29 @@ public class RoutingEdgeCaseTests
         var comp1 = CreateTestComponent(0, 0);
         var comp2 = CreateTestComponent(150, 0);
 
-        // Configure the shared static router (reset to known state after test)
-        var router = WaveguideConnection.SharedRouter;
-        router.MinBendRadiusMicrometers = BendRadius;
-        router.MinWaveguideSpacingMicrometers = 2.0;
+        var router = new WaveguideRouter
+        {
+            MinBendRadiusMicrometers = BendRadius,
+            MinWaveguideSpacingMicrometers = 2.0
+        };
         router.InitializePathfindingGrid(-50, -50, 300, 150, new[] { comp1, comp2 });
 
-        try
-        {
-            var pin1Start = CreatePin(comp1, 50, 15, 0);
-            var pin1End = CreatePin(comp2, 0, 15, 180);
-            var pin2Start = CreatePin(comp1, 50, 35, 0);
-            var pin2End = CreatePin(comp2, 0, 35, 180);
+        var pin1Start = CreatePin(comp1, 50, 15, 0);
+        var pin1End = CreatePin(comp2, 0, 15, 180);
+        var pin2Start = CreatePin(comp1, 50, 35, 0);
+        var pin2End = CreatePin(comp2, 0, 35, 180);
 
-            var connManager = new WaveguideConnectionManager { UseSequentialRouting = true };
-            var conn1 = connManager.AddConnection(pin1Start, pin1End);
-            var conn2 = connManager.AddConnection(pin2Start, pin2End);
+        var connManager = new WaveguideConnectionManager(router) { UseSequentialRouting = true };
+        var conn1 = connManager.AddConnection(pin1Start, pin1End);
+        var conn2 = connManager.AddConnection(pin2Start, pin2End);
 
-            conn1.RoutedPath.ShouldNotBeNull("Connection 1 should have a route");
-            conn2.RoutedPath.ShouldNotBeNull("Connection 2 should have a route");
-            conn1.RoutedPath.IsValid.ShouldBeTrue("Connection 1 path should be valid");
-            conn2.RoutedPath.IsValid.ShouldBeTrue("Connection 2 path should be valid");
+        conn1.RoutedPath.ShouldNotBeNull("Connection 1 should have a route");
+        conn2.RoutedPath.ShouldNotBeNull("Connection 2 should have a route");
+        conn1.RoutedPath.IsValid.ShouldBeTrue("Connection 1 path should be valid");
+        conn2.RoutedPath.IsValid.ShouldBeTrue("Connection 2 path should be valid");
 
-            DumpPath(conn1.RoutedPath, pin1Start, pin1End, "conn1");
-            DumpPath(conn2.RoutedPath, pin2Start, pin2End, "conn2");
-        }
-        finally
-        {
-            // Reset shared router to avoid interfering with other tests
-            router.MinBendRadiusMicrometers = 10.0;
-            router.MinWaveguideSpacingMicrometers = 2.0;
-            router.InitializePathfindingGrid(-100, -100, 400, 250, Array.Empty<Component>());
-        }
+        DumpPath(conn1.RoutedPath, pin1Start, pin1End, "conn1");
+        DumpPath(conn2.RoutedPath, pin2Start, pin2End, "conn2");
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/UnitTests/Routing/WaveguideConnectionTests.cs
+++ b/UnitTests/Routing/WaveguideConnectionTests.cs
@@ -3,6 +3,7 @@ using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.FormulaReading;
 using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
 using CAP_Core.Tiles;
 using Shouldly;
 using System.Numerics;
@@ -46,7 +47,7 @@ public class WaveguideConnectionTests
         };
 
         // Act
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         // Assert
         connection.RoutedPath.ShouldNotBeNull();
@@ -85,8 +86,9 @@ public class WaveguideConnectionTests
         };
 
         // Act
-        shortConnection.RecalculateTransmission();
-        longConnection.RecalculateTransmission();
+        var router = new WaveguideRouter();
+        shortConnection.RecalculateTransmission(router);
+        longConnection.RecalculateTransmission(router);
 
         // Assert
         longConnection.TotalLossDb.ShouldBeGreaterThan(shortConnection.TotalLossDb);
@@ -128,7 +130,7 @@ public class WaveguideConnectionTests
         };
 
         // Act
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         // Assert
         connection.BendCount.ShouldBeGreaterThan(0);
@@ -148,7 +150,7 @@ public class WaveguideConnectionTests
         };
 
         // Act
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         // Assert
         connection.RoutedPath.ShouldBeNull();
@@ -170,7 +172,7 @@ public class WaveguideConnectionTests
         };
 
         // Act
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         // Assert
         connection.TransmissionCoefficient.Imaginary.ShouldBe(0);

--- a/UnitTests/Simulation/ComponentGroupSimulationTests.cs
+++ b/UnitTests/Simulation/ComponentGroupSimulationTests.cs
@@ -92,7 +92,7 @@ public class ComponentGroupSimulationTests
         tileManager.AddComponent(source);
         tileManager.AddComponent(group);
 
-        var connectionManager = new WaveguideConnectionManager();
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
         var routedPath = new RoutedPath();
         routedPath.Segments.Add(new StraightSegment(-10, 0.5, 0, 0.5, 0));
 
@@ -159,7 +159,7 @@ public class ComponentGroupSimulationTests
         var tileManager = new ComponentListTileManager();
         tileManager.AddComponent(group);
 
-        var connectionManager = new WaveguideConnectionManager();
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
         var portManager = new PhysicalExternalPortManager();
 
         var gridManager = GridManager.CreateForSimulation(
@@ -199,7 +199,7 @@ public class ComponentGroupSimulationTests
         var tileManager = new ComponentListTileManager();
         tileManager.AddComponent(group);
 
-        var connectionManager = new WaveguideConnectionManager();
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
         var portManager = new PhysicalExternalPortManager();
 
         var gridManager = GridManager.CreateForSimulation(
@@ -257,7 +257,7 @@ public class ComponentGroupSimulationTests
         var tileManager = new ComponentListTileManager();
         tileManager.AddComponent(outerGroup);
 
-        var connectionManager = new WaveguideConnectionManager();
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
         var portManager = new PhysicalExternalPortManager();
 
         var gridManager = GridManager.CreateForSimulation(

--- a/UnitTests/Simulation/IntegrationCircuitBuilder.cs
+++ b/UnitTests/Simulation/IntegrationCircuitBuilder.cs
@@ -6,6 +6,7 @@ using CAP_Core.Components.ComponentHelpers;
 using CAP_Core.ExternalPorts;
 using CAP_Core.Grid;
 using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
 using CAP_Core.Tiles;
 
 namespace UnitTests.Simulation;
@@ -47,7 +48,7 @@ public static class IntegrationCircuitBuilder
             tileManager.AddComponent(c);
         }
 
-        var connectionManager = new WaveguideConnectionManager();
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
         AddConnection(connectionManager, gcInput.Pins["waveguide"], splitter.Pins["in1"]);
         AddConnection(connectionManager, splitter.Pins["out1"], dcTop.Pins["in1"]);
         AddConnection(connectionManager, splitter.Pins["out2"], dcBottom.Pins["in1"]);

--- a/UnitTests/Simulation/SimulationPropagationTests.cs
+++ b/UnitTests/Simulation/SimulationPropagationTests.cs
@@ -6,6 +6,7 @@ using CAP_Core.Components.ComponentHelpers;
 using CAP_Core.ExternalPorts;
 using CAP_Core.Grid;
 using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
 using CAP_Core.Tiles;
 using Shouldly;
 using Xunit;
@@ -94,7 +95,7 @@ public class SimulationPropagationTests
         tileManager.AddComponent(gc);
         tileManager.AddComponent(dc);
 
-        var connectionManager = new WaveguideConnectionManager();
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
         connectionManager.AddExistingConnection(connection);
 
         var portManager = new PhysicalExternalPortManager();
@@ -224,7 +225,7 @@ public class SimulationPropagationTests
         tileManager.AddComponent(gc);
         tileManager.AddComponent(dc);
 
-        var connectionManager = new WaveguideConnectionManager();
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
         connectionManager.AddExistingConnection(connection);
 
         var portManager = new PhysicalExternalPortManager();

--- a/UnitTests/ViewModels/WaveguideLengthIntegrationTests.cs
+++ b/UnitTests/ViewModels/WaveguideLengthIntegrationTests.cs
@@ -1,6 +1,7 @@
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
 using Shouldly;
 using Xunit;
 
@@ -63,7 +64,7 @@ public class WaveguideLengthIntegrationTests
     public void ViewModel_SetTargetToCurrentCommand_SetsCorrectValue()
     {
         var (connection, connVm) = CreateTestConnectionAndViewModel();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var vm = new WaveguideLengthViewModel
         {
@@ -83,7 +84,7 @@ public class WaveguideLengthIntegrationTests
     public void ViewModel_UpdatesLengthStatus_WithMatchedLength()
     {
         var (connection, connVm) = CreateTestConnectionAndViewModel();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
         connection.TargetLengthMicrometers = actualLength + 0.5;
@@ -104,7 +105,7 @@ public class WaveguideLengthIntegrationTests
     public void ViewModel_UpdatesLengthStatus_WithTooShortPath()
     {
         var (connection, connVm) = CreateTestConnectionAndViewModel();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
         connection.TargetLengthMicrometers = actualLength + 10.0;
@@ -125,7 +126,7 @@ public class WaveguideLengthIntegrationTests
     public void ViewModel_UpdatesLengthStatus_WithTooLongPath()
     {
         var (connection, connVm) = CreateTestConnectionAndViewModel();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         var actualLength = connection.PathLengthMicrometers;
         connection.TargetLengthMicrometers = actualLength - 10.0;
@@ -146,7 +147,7 @@ public class WaveguideLengthIntegrationTests
     public void ViewModel_ShowsCurrentLengthWhenTargetDisabled()
     {
         var (connection, connVm) = CreateTestConnectionAndViewModel();
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
         connection.IsTargetLengthEnabled = false;
 
         var vm = new WaveguideLengthViewModel
@@ -201,7 +202,7 @@ public class WaveguideLengthIntegrationTests
         connection.TargetLengthMicrometers = 400.0;
         connection.IsTargetLengthEnabled = true;
         connection.LengthToleranceMicrometers = 2.0;
-        connection.RecalculateTransmission();
+        connection.RecalculateTransmission(new WaveguideRouter());
 
         connVm.IsTargetLengthEnabled.ShouldBeTrue();
         connVm.TargetLengthMicrometers.ShouldBe(400.0);


### PR DESCRIPTION
Automated implementation for #288

Implementation complete. Here's a summary of all changes made:

## Changes Summary

### Production Code (5 files)

**`WaveguideConnection.cs`**
- Removed static `SharedRouter` property
- Changed `RecalculateTransmission()` to accept `WaveguideRouter router` parameter

**`WaveguideConnectionManager.cs`**
- Added `WaveguideRouter` constructor injection (`_router` field)
- Replaced all 5 `WaveguideConnection.SharedRouter` usages with `_router`
- Updated all `connection.RecalculateTransmission()` calls to pass `_router`

**`DesignCanvasViewModel.cs`**
- Added `private readonly WaveguideRouter _router` field
- Added `DesignCanvasViewModel(WaveguideRouter router)` constructor — initializes `_router`, `ConnectionManager`, and calls `InitializeAStarRouting()`
- Default `DesignCanvasViewModel()` delegates to `: this(new WaveguideRouter())`
- Changed `Router => WaveguideConnection.SharedRouter` to `Router => _router`

**`RotateComponentCommand.cs`**
- Changed `WaveguideConnection.SharedRouter` → `_canvas.Router`
- Removed unused `using CAP_Core.Components.Connections`

**`GridManager.cs`**
- Updated `GridManager(int width, int height)` to pass `new WaveguideRouter()` to `WaveguideConnectionManager`

### Test Files (11 files updated)
All tests now create their own `WaveguideRouter` instances — no shared mutable state between tests. `ManhattanRoutingIntegrationTests` no longer needs `IDisposable` since there's nothing to clean up.

### Build & Tests
- Build: ✅ 0 errors
- Tests: 1200 passed, 1 failed (pre-existing `ComponentGroup_WithComputedSMatrix_SimulatesSuccessfully` — confirmed failing before this PR)

---

MCP Tools used: None (semantic search not needed — the issue description provided exact file locations)


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 36,797
- **Estimated cost:** $0.5507 USD

---
*Generated by autonomous agent using Claude Code.*