### PR TITLE
Agent: Feature: Rename components in Hierarchy Panel

### DIFF
--- a/CAP.Avalonia/Commands/RenameComponentCommand.cs
+++ b/CAP.Avalonia/Commands/RenameComponentCommand.cs
@@ -1,0 +1,59 @@
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.Commands;
+
+/// <summary>
+/// Command to rename a component or group in the Hierarchy Panel.
+/// For regular components, updates <see cref="Component.HumanReadableName"/>.
+/// For groups, updates <see cref="ComponentGroup.GroupName"/>.
+/// Supports undo/redo.
+/// </summary>
+public class RenameComponentCommand : IUndoableCommand
+{
+    private readonly Component _component;
+    private readonly string _newName;
+    private readonly string? _oldHumanReadableName;
+    private readonly string _oldGroupName;
+    private readonly bool _isGroup;
+
+    /// <inheritdoc/>
+    public string Description => $"Rename to '{_newName}'";
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="RenameComponentCommand"/>.
+    /// </summary>
+    /// <param name="component">The component or group to rename.</param>
+    /// <param name="newName">The new display name to apply.</param>
+    public RenameComponentCommand(Component component, string newName)
+    {
+        _component = component ?? throw new ArgumentNullException(nameof(component));
+        _newName = newName ?? throw new ArgumentNullException(nameof(newName));
+        _isGroup = component is ComponentGroup;
+
+        if (_isGroup && component is ComponentGroup group)
+            _oldGroupName = group.GroupName;
+        else
+        {
+            _oldGroupName = string.Empty;
+            _oldHumanReadableName = component.HumanReadableName;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Execute()
+    {
+        if (_isGroup && _component is ComponentGroup group)
+            group.GroupName = _newName;
+        else
+            _component.HumanReadableName = _newName;
+    }
+
+    /// <inheritdoc/>
+    public void Undo()
+    {
+        if (_isGroup && _component is ComponentGroup group)
+            group.GroupName = _oldGroupName;
+        else
+            _component.HumanReadableName = _oldHumanReadableName;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Hierarchy/HierarchyNodeViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Hierarchy/HierarchyNodeViewModel.cs
@@ -46,6 +46,24 @@ public partial class HierarchyNodeViewModel : ObservableObject
     private bool _isInEditMode;
 
     /// <summary>
+    /// Whether this node is in inline rename mode (showing a TextBox for editing).
+    /// </summary>
+    [ObservableProperty]
+    private bool _isRenaming;
+
+    /// <summary>
+    /// The name being edited during inline rename mode.
+    /// </summary>
+    [ObservableProperty]
+    private string _editName = string.Empty;
+
+    /// <summary>
+    /// Callback invoked when the user confirms a rename with the new name.
+    /// Set by <see cref="HierarchyPanelViewModel"/> during node creation.
+    /// </summary>
+    public Action<HierarchyNodeViewModel, string>? RenameConfirmed { get; set; }
+
+    /// <summary>
     /// Whether this component is a group (has children).
     /// </summary>
     public bool IsGroup => Component is ComponentGroup;
@@ -116,6 +134,47 @@ public partial class HierarchyNodeViewModel : ObservableObject
         {
             RefreshDisplayName();
         }
+    }
+
+    /// <summary>
+    /// Enters inline rename mode, pre-filling <see cref="EditName"/> with the current display name.
+    /// </summary>
+    [RelayCommand]
+    private void StartRename()
+    {
+        EditName = Component is ComponentGroup group
+            ? group.GroupName
+            : (Component.HumanReadableName ?? Component.Identifier);
+        IsRenaming = true;
+    }
+
+    /// <summary>
+    /// Confirms the rename, applying the new name via <see cref="RenameConfirmed"/>.
+    /// Exits rename mode. Does nothing if the edit name is empty.
+    /// </summary>
+    [RelayCommand]
+    private void ConfirmRename()
+    {
+        if (!IsRenaming) return;
+
+        var trimmed = EditName?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            CancelRenameCommand.Execute(null);
+            return;
+        }
+
+        IsRenaming = false;
+        RenameConfirmed?.Invoke(this, trimmed);
+    }
+
+    /// <summary>
+    /// Cancels inline rename mode without applying any changes.
+    /// </summary>
+    [RelayCommand]
+    private void CancelRename()
+    {
+        IsRenaming = false;
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Hierarchy/HierarchyPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Hierarchy/HierarchyPanelViewModel.cs
@@ -33,6 +33,12 @@ public partial class HierarchyPanelViewModel : ObservableObject
     /// </summary>
     public Func<(double width, double height)>? GetViewportSize { get; set; }
 
+    /// <summary>
+    /// Callback to handle component rename, typically wired to the undo-aware command manager.
+    /// When null, the rename is applied directly without undo support.
+    /// </summary>
+    public Action<Component, string>? RenameComponent { get; set; }
+
     public HierarchyPanelViewModel(DesignCanvasViewModel canvas)
     {
         _canvas = canvas ?? throw new ArgumentNullException(nameof(canvas));
@@ -71,7 +77,8 @@ public partial class HierarchyPanelViewModel : ObservableObject
         {
             ComponentViewModel = componentVm,
             FocusRequested = FocusOnComponent,
-            SelectionRequested = SelectComponent
+            SelectionRequested = SelectComponent,
+            RenameConfirmed = (n, newName) => ApplyRename(n.Component, newName)
         };
 
         // If this is a group, recursively add its children
@@ -274,5 +281,30 @@ public partial class HierarchyPanelViewModel : ObservableObject
     {
         var node = FindNodeByComponent(component);
         node?.RefreshDisplayName();
+    }
+
+    /// <summary>
+    /// Applies a rename to the given component, using the <see cref="RenameComponent"/> callback
+    /// when set (for undo support), or falling back to a direct rename.
+    /// Always refreshes the node display afterward.
+    /// </summary>
+    private void ApplyRename(Component component, string newName)
+    {
+        if (RenameComponent != null)
+        {
+            RenameComponent(component, newName);
+        }
+        else
+        {
+            // Direct rename (no undo support) — used in tests and when no CommandManager is wired
+            if (component is ComponentGroup group)
+                group.GroupName = newName;
+            else
+                component.HumanReadableName = newName;
+        }
+
+        // Refresh display for regular components (groups auto-refresh via PropertyChanged)
+        if (component is not ComponentGroup)
+            RefreshNode(component);
     }
 }

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -203,6 +203,14 @@ public partial class MainViewModel : ObservableObject
             HierarchyPanel.SyncSelectionFromCanvas(comp);
         };
 
+        // Wire rename from hierarchy panel through undo-aware command manager
+        HierarchyPanel.RenameComponent = (component, newName) =>
+        {
+            var cmd = new Commands.RenameComponentCommand(component, newName);
+            CommandManager.ExecuteCommand(cmd);
+            HierarchyPanel.RefreshNode(component);
+        };
+
         CanvasInteraction.ClearLeftPanelGroupSelection = () =>
         {
             LeftPanel.SelectedGroupTemplate = null;

--- a/CAP.Avalonia/Views/HierarchyPanel.axaml
+++ b/CAP.Avalonia/Views/HierarchyPanel.axaml
@@ -54,13 +54,29 @@
                                            FontSize="14"
                                            VerticalAlignment="Center"/>
 
-                                <!-- Component Name -->
+                                <!-- Component Name (view/edit toggle) -->
                                 <StackPanel Orientation="Vertical" Spacing="2">
+
+                                    <!-- Normal display mode -->
                                     <TextBlock Text="{Binding DisplayName}"
+                                               IsVisible="{Binding !IsRenaming}"
                                                FontWeight="Medium"
                                                FontSize="12"
                                                Foreground="White"
                                                VerticalAlignment="Center"/>
+
+                                    <!-- Inline rename mode: TextBox -->
+                                    <TextBox Text="{Binding EditName, Mode=TwoWay}"
+                                             IsVisible="{Binding IsRenaming}"
+                                             FontSize="12"
+                                             Padding="2,1"
+                                             Background="#3c3c3c"
+                                             Foreground="White"
+                                             BorderBrush="#007acc"
+                                             BorderThickness="1"
+                                             MinWidth="80"
+                                             KeyDown="RenameTextBox_KeyDown"
+                                             LostFocus="RenameTextBox_LostFocus"/>
 
                                     <TextBlock Text="{Binding TypeLabel}"
                                                FontSize="10"

--- a/CAP.Avalonia/Views/HierarchyPanel.axaml.cs
+++ b/CAP.Avalonia/Views/HierarchyPanel.axaml.cs
@@ -1,13 +1,15 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using CAP.Avalonia.ViewModels.Hierarchy;
 
 namespace CAP.Avalonia.Views;
 
 /// <summary>
 /// Code-behind for HierarchyPanel view.
-/// Handles pointer events for tree node selection.
+/// Handles pointer events for tree node selection and inline rename.
 /// </summary>
 public partial class HierarchyPanel : UserControl
 {
@@ -17,15 +19,65 @@ public partial class HierarchyPanel : UserControl
     }
 
     /// <summary>
-    /// Handles pointer press on a tree node to trigger selection.
+    /// Handles pointer press on a tree node.
+    /// Single click selects the component; double-click starts inline rename.
     /// </summary>
     private void TreeNode_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (sender is Border border && border.DataContext is HierarchyNodeViewModel node)
+        if (sender is not Border border || border.DataContext is not HierarchyNodeViewModel node)
+            return;
+
+        if (e.ClickCount == 2)
         {
-            // Select the component on the canvas
+            node.StartRenameCommand.Execute(null);
+
+            // Defer focus so the TextBox is visible before we focus it
+            Dispatcher.UIThread.Post(() =>
+            {
+                var textBox = border.FindDescendantOfType<TextBox>();
+                if (textBox?.IsVisible == true)
+                {
+                    textBox.Focus();
+                    textBox.SelectAll();
+                }
+            });
+        }
+        else
+        {
             node.SelectCommand.Execute(null);
+        }
+
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// Handles Enter (confirm) and Escape (cancel) keys in the rename TextBox.
+    /// </summary>
+    private void RenameTextBox_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (sender is not TextBox tb || tb.DataContext is not HierarchyNodeViewModel node)
+            return;
+
+        if (e.Key == Key.Return || e.Key == Key.Enter)
+        {
+            node.ConfirmRenameCommand.Execute(null);
             e.Handled = true;
+        }
+        else if (e.Key == Key.Escape)
+        {
+            node.CancelRenameCommand.Execute(null);
+            e.Handled = true;
+        }
+    }
+
+    /// <summary>
+    /// Confirms the rename when the TextBox loses focus (e.g., user clicks elsewhere).
+    /// </summary>
+    private void RenameTextBox_LostFocus(object? sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb && tb.DataContext is HierarchyNodeViewModel node && node.IsRenaming)
+        {
+            node.ConfirmRenameCommand.Execute(null);
         }
     }
 }

--- a/UnitTests/ViewModels/HierarchyRenameTests.cs
+++ b/UnitTests/ViewModels/HierarchyRenameTests.cs
@@ -1,0 +1,304 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Hierarchy;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests.Helpers;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>
+/// Tests for inline rename feature in the Hierarchy Panel (issue #278).
+/// Covers HierarchyNodeViewModel rename state, HierarchyPanelViewModel wiring,
+/// and RenameComponentCommand undo/redo.
+/// </summary>
+public class HierarchyRenameTests
+{
+    // ─── HierarchyNodeViewModel rename state ─────────────────────────────────
+
+    [Fact]
+    public void StartRename_SetsIsRenamingTrue()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+
+        node.StartRenameCommand.Execute(null);
+
+        node.IsRenaming.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StartRename_PreFillsEditNameWithCurrentDisplayName()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+
+        node.StartRenameCommand.Execute(null);
+
+        node.EditName.ShouldBe(comp.Identifier);
+    }
+
+    [Fact]
+    public void StartRename_WithHumanReadableName_PreFillsHumanReadableName()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        comp.HumanReadableName = "InputCoupler";
+        var node = new HierarchyNodeViewModel(comp);
+
+        node.StartRenameCommand.Execute(null);
+
+        node.EditName.ShouldBe("InputCoupler");
+    }
+
+    [Fact]
+    public void StartRename_ForGroup_PreFillsGroupName()
+    {
+        var group = new ComponentGroup("MyGroup");
+        var node = new HierarchyNodeViewModel(group);
+
+        node.StartRenameCommand.Execute(null);
+
+        node.EditName.ShouldBe("MyGroup");
+    }
+
+    [Fact]
+    public void CancelRename_SetsIsRenamingFalse()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+        node.StartRenameCommand.Execute(null);
+
+        node.CancelRenameCommand.Execute(null);
+
+        node.IsRenaming.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CancelRename_DoesNotCallRenameConfirmed()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+        bool callbackFired = false;
+        node.RenameConfirmed = (_, _) => callbackFired = true;
+
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "SomeName";
+        node.CancelRenameCommand.Execute(null);
+
+        callbackFired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ConfirmRename_WithValidName_CallsRenameConfirmed()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+        string? receivedName = null;
+        node.RenameConfirmed = (_, name) => receivedName = name;
+
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "OutputCoupler";
+        node.ConfirmRenameCommand.Execute(null);
+
+        receivedName.ShouldBe("OutputCoupler");
+    }
+
+    [Fact]
+    public void ConfirmRename_TrimsWhitespace()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+        string? receivedName = null;
+        node.RenameConfirmed = (_, name) => receivedName = name;
+
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "  MyComponent  ";
+        node.ConfirmRenameCommand.Execute(null);
+
+        receivedName.ShouldBe("MyComponent");
+    }
+
+    [Fact]
+    public void ConfirmRename_SetsIsRenamingFalse()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+        node.RenameConfirmed = (_, _) => { };
+
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "ValidName";
+        node.ConfirmRenameCommand.Execute(null);
+
+        node.IsRenaming.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ConfirmRename_WithEmptyName_DoesNotCallRenameConfirmed()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var node = new HierarchyNodeViewModel(comp);
+        bool callbackFired = false;
+        node.RenameConfirmed = (_, _) => callbackFired = true;
+
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "   ";
+        node.ConfirmRenameCommand.Execute(null);
+
+        callbackFired.ShouldBeFalse();
+        node.IsRenaming.ShouldBeFalse();
+    }
+
+    // ─── HierarchyPanelViewModel integration ─────────────────────────────────
+
+    [Fact]
+    public void HierarchyPanel_ConfirmRename_UpdatesComponentHumanReadableName()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var hierarchy = new HierarchyPanelViewModel(canvas);
+
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        canvas.AddComponent(comp, "Waveguide");
+        hierarchy.RebuildTree();
+
+        var node = hierarchy.RootNodes[0];
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "InputCoupler";
+        node.ConfirmRenameCommand.Execute(null);
+
+        comp.HumanReadableName.ShouldBe("InputCoupler");
+    }
+
+    [Fact]
+    public void HierarchyPanel_ConfirmRename_RefreshesDisplayName()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var hierarchy = new HierarchyPanelViewModel(canvas);
+
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        canvas.AddComponent(comp, "Waveguide");
+        hierarchy.RebuildTree();
+
+        var node = hierarchy.RootNodes[0];
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "OutputWG";
+        node.ConfirmRenameCommand.Execute(null);
+
+        node.DisplayName.ShouldBe("OutputWG");
+    }
+
+    [Fact]
+    public void HierarchyPanel_ConfirmGroupRename_UpdatesGroupName()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var hierarchy = new HierarchyPanelViewModel(canvas);
+
+        var group = new ComponentGroup("OriginalName");
+        canvas.AddComponent(group, "Group");
+        hierarchy.RebuildTree();
+
+        var node = hierarchy.RootNodes[0];
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "RenamedGroup";
+        node.ConfirmRenameCommand.Execute(null);
+
+        group.GroupName.ShouldBe("RenamedGroup");
+    }
+
+    [Fact]
+    public void HierarchyPanel_RenameComponentCallback_IsInvoked()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var hierarchy = new HierarchyPanelViewModel(canvas);
+
+        Component? renamedComponent = null;
+        string? renamedTo = null;
+        hierarchy.RenameComponent = (comp, name) =>
+        {
+            renamedComponent = comp;
+            renamedTo = name;
+        };
+
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        canvas.AddComponent(comp, "Waveguide");
+        hierarchy.RebuildTree();
+
+        var node = hierarchy.RootNodes[0];
+        node.StartRenameCommand.Execute(null);
+        node.EditName = "CustomName";
+        node.ConfirmRenameCommand.Execute(null);
+
+        renamedComponent.ShouldBe(comp);
+        renamedTo.ShouldBe("CustomName");
+    }
+
+    // ─── RenameComponentCommand undo/redo ─────────────────────────────────────
+
+    [Fact]
+    public void RenameComponentCommand_Execute_SetsHumanReadableName()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var cmd = new RenameComponentCommand(comp, "NewName");
+
+        cmd.Execute();
+
+        comp.HumanReadableName.ShouldBe("NewName");
+    }
+
+    [Fact]
+    public void RenameComponentCommand_Undo_RestoresHumanReadableName()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        comp.HumanReadableName = "OriginalName";
+        var cmd = new RenameComponentCommand(comp, "NewName");
+
+        cmd.Execute();
+        cmd.Undo();
+
+        comp.HumanReadableName.ShouldBe("OriginalName");
+    }
+
+    [Fact]
+    public void RenameComponentCommand_Undo_RestoresNullHumanReadableName()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        // HumanReadableName starts as null
+        var cmd = new RenameComponentCommand(comp, "NewName");
+
+        cmd.Execute();
+        cmd.Undo();
+
+        comp.HumanReadableName.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RenameComponentCommand_ForGroup_Execute_SetsGroupName()
+    {
+        var group = new ComponentGroup("OldName");
+        var cmd = new RenameComponentCommand(group, "NewGroupName");
+
+        cmd.Execute();
+
+        group.GroupName.ShouldBe("NewGroupName");
+    }
+
+    [Fact]
+    public void RenameComponentCommand_ForGroup_Undo_RestoresGroupName()
+    {
+        var group = new ComponentGroup("OldName");
+        var cmd = new RenameComponentCommand(group, "NewGroupName");
+
+        cmd.Execute();
+        cmd.Undo();
+
+        group.GroupName.ShouldBe("OldName");
+    }
+
+    [Fact]
+    public void RenameComponentCommand_Description_ContainsNewName()
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        var cmd = new RenameComponentCommand(comp, "SpecialName");
+
+        cmd.Description.ShouldContain("SpecialName");
+    }
+}


### PR DESCRIPTION
Automated implementation for #278

Implementation complete. Here's a summary of what was done:

## Changes

### New file: `CAP.Avalonia/Commands/RenameComponentCommand.cs`
Implements `IUndoableCommand` for renaming — sets `HumanReadableName` for regular components, `GroupName` for groups. Full undo support.

### `HierarchyNodeViewModel.cs`
Added:
- `IsRenaming`, `EditName` observable properties
- `RenameConfirmed` callback action
- `StartRenameCommand` — pre-fills `EditName` with current name, sets `IsRenaming = true`
- `ConfirmRenameCommand` — validates, fires callback, exits rename mode
- `CancelRenameCommand` — exits rename mode without changes

### `HierarchyPanelViewModel.cs`
Added:
- `RenameComponent` callback (wired by `MainViewModel` for undo support, falls back to direct rename)
- `ApplyRename` — fires callback or renames directly, then refreshes node display
- Wires `RenameConfirmed` on all nodes in `CreateNodeRecursive`

### `MainViewModel.cs`
Wires `HierarchyPanel.RenameComponent` → `RenameComponentCommand` via `CommandManager` (undo/redo support).

### `HierarchyPanel.axaml`
Added a `TextBox` (bound to `EditName`) that appears when `IsRenaming` is true, alongside the existing `TextBlock`.

### `HierarchyPanel.axaml.cs`
- Double-click (ClickCount == 2) starts rename and auto-focuses the TextBox
- Enter/Return confirms; Escape cancels
- Lost focus auto-confirms

### `UnitTests/ViewModels/HierarchyRenameTests.cs`
20 tests covering all scenarios — all pass.

**MCP Tools used:** None (used native grep/glob/read tools).


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 28,087
- **Estimated cost:** $0.4207 USD

---
*Generated by autonomous agent using Claude Code.*