### PR TITLE
Agent: Feature: Error Console with copy functionality

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -29,6 +29,7 @@ public partial class App : Application
         services.AddSingleton<IDataAccessor, FileDataAccessor>();
         services.AddSingleton<CAP_Core.Components.Creation.GroupLibraryManager>();
         services.AddSingleton<GdsExportService>();
+        services.AddSingleton<CAP_Core.ErrorConsoleService>();
 
         // Register application services
         services.AddSingleton<SimulationService>();

--- a/CAP.Avalonia/ViewModels/Diagnostics/ErrorConsoleViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/ErrorConsoleViewModel.cs
@@ -1,0 +1,154 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CAP_Contracts.Logger;
+using CAP_Core;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Diagnostics;
+
+/// <summary>
+/// Display-ready wrapper for a <see cref="Log"/> entry, mapping level to color and formatted text.
+/// </summary>
+public class LogDisplayEntry
+{
+    /// <summary>Formatted one-line display text.</summary>
+    public string Text { get; }
+
+    /// <summary>Avalonia color string based on log level.</summary>
+    public string Color { get; }
+
+    /// <summary>Original log level (used for count aggregation).</summary>
+    public LogLevel Level { get; }
+
+    /// <summary>Initializes a display entry from a raw <see cref="Log"/>.</summary>
+    public LogDisplayEntry(Log log)
+    {
+        Level = log.Level;
+        Text = $"[{log.TimeStamp:HH:mm:ss}] [{log.Level.ToString().ToUpper()}] {log.Message}";
+        Color = log.Level switch
+        {
+            LogLevel.Error or LogLevel.Fatal => "#FF6B6B",
+            LogLevel.Warn => "#FFD93D",
+            _ => "#A0A0A0"
+        };
+    }
+}
+
+/// <summary>
+/// ViewModel for the collapsible error console bottom panel.
+/// Wraps <see cref="ErrorConsoleService"/> to expose entries as UI-ready display items
+/// and provides toggle, clear, and copy commands.
+/// </summary>
+public partial class ErrorConsoleViewModel : ObservableObject
+{
+    private readonly ErrorConsoleService _service;
+    private readonly ObservableCollection<LogDisplayEntry> _displayEntries = new();
+
+    /// <summary>
+    /// UI-ready display entries derived from the underlying log service.
+    /// </summary>
+    public ReadOnlyObservableCollection<LogDisplayEntry> DisplayEntries { get; }
+
+    /// <summary>
+    /// Clipboard copy callback. Injected by the View code-behind because
+    /// clipboard access in Avalonia requires a TopLevel reference.
+    /// </summary>
+    public Func<string, Task>? CopyToClipboard { get; set; }
+
+    /// <summary>Whether the console content area is visible (expanded).</summary>
+    [ObservableProperty]
+    private bool _isVisible;
+
+    /// <summary>Number of Error/Fatal entries.</summary>
+    [ObservableProperty]
+    private int _errorCount;
+
+    /// <summary>Number of Warning entries.</summary>
+    [ObservableProperty]
+    private int _warningCount;
+
+    /// <summary>Whether there are any error entries.</summary>
+    public bool HasErrors => ErrorCount > 0;
+
+    /// <summary>Whether there are any warning entries.</summary>
+    public bool HasWarnings => WarningCount > 0;
+
+    /// <summary>Total number of displayed entries.</summary>
+    public int EntryCount => _displayEntries.Count;
+
+    /// <summary>
+    /// Initializes a new <see cref="ErrorConsoleViewModel"/> bound to the given service.
+    /// </summary>
+    /// <param name="service">The singleton error console service.</param>
+    public ErrorConsoleViewModel(ErrorConsoleService service)
+    {
+        _service = service;
+        DisplayEntries = new ReadOnlyObservableCollection<LogDisplayEntry>(_displayEntries);
+        _service.EntryAdded += OnEntryAdded;
+    }
+
+    private void OnEntryAdded(object? sender, Log entry)
+    {
+        _displayEntries.Add(new LogDisplayEntry(entry));
+        RefreshCounts();
+
+        // Auto-expand for errors to draw user attention
+        if (entry.Level >= LogLevel.Error)
+            IsVisible = true;
+    }
+
+    private void RefreshCounts()
+    {
+        ErrorCount = _displayEntries.Count(e => e.Level >= LogLevel.Error);
+        WarningCount = _displayEntries.Count(e => e.Level == LogLevel.Warn);
+        OnPropertyChanged(nameof(HasErrors));
+        OnPropertyChanged(nameof(HasWarnings));
+        OnPropertyChanged(nameof(EntryCount));
+    }
+
+    /// <summary>
+    /// Convenience method to log a message directly via the underlying service.
+    /// </summary>
+    /// <param name="message">Message to log.</param>
+    /// <param name="level">Severity level.</param>
+    /// <param name="ex">Optional exception for additional context.</param>
+    public void Log(string message, LogLevel level = LogLevel.Error, Exception? ex = null)
+    {
+        var fullMessage = ex != null ? $"{message}\n{ex}" : message;
+        _service.Log(level, fullMessage);
+    }
+
+    /// <summary>Toggles the console content area open or closed.</summary>
+    [RelayCommand]
+    private void Toggle() => IsVisible = !IsVisible;
+
+    /// <summary>Clears all log entries from the console.</summary>
+    [RelayCommand]
+    private void Clear()
+    {
+        _service.Clear();
+        _displayEntries.Clear();
+        ErrorCount = 0;
+        WarningCount = 0;
+        OnPropertyChanged(nameof(HasErrors));
+        OnPropertyChanged(nameof(HasWarnings));
+        OnPropertyChanged(nameof(EntryCount));
+    }
+
+    /// <summary>Copies all current log entries as plain text to the system clipboard.</summary>
+    [RelayCommand]
+    private async Task CopyAll()
+    {
+        if (CopyToClipboard == null || _displayEntries.Count == 0)
+            return;
+
+        var sb = new StringBuilder();
+        foreach (var entry in _displayEntries)
+            sb.AppendLine(entry.Text);
+
+        await CopyToClipboard(sb.ToString());
+    }
+}

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CAP_Core.Components.Core;
+using CAP_Core;
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP_DataAccess.Components.ComponentDraftMapper;
@@ -78,6 +79,11 @@ public partial class MainViewModel : ObservableObject
     public HierarchyPanelViewModel HierarchyPanel => LeftPanel.HierarchyPanel;
     public ComponentLibraryViewModel GroupLibrary => LeftPanel.ComponentLibrary;
 
+    /// <summary>
+    /// ViewModel for the error console panel (collapsible, bottom of window).
+    /// </summary>
+    public ErrorConsoleViewModel ErrorConsole => BottomPanel.ErrorConsole;
+
     // Backward-compatible library properties
     public ObservableCollection<ComponentTemplate> ComponentLibrary => LeftPanel.AllTemplates;
     public ObservableCollection<ComponentTemplate> FilteredComponentLibrary => LeftPanel.FilteredTemplates;
@@ -148,7 +154,8 @@ public partial class MainViewModel : ObservableObject
         CAP_Core.Components.Creation.GroupLibraryManager groupLibraryManager,
         Services.GroupPreviewGenerator previewGenerator,
         Services.IInputDialogService inputDialogService,
-        CAP_Core.Export.GdsExportService gdsExportService)
+        CAP_Core.Export.GdsExportService gdsExportService,
+        ErrorConsoleService errorConsoleService)
     {
         Simulation = simulationService;
         CommandManager = commandManager;
@@ -164,7 +171,7 @@ public partial class MainViewModel : ObservableObject
         FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, LeftPanel.AllTemplates, gdsExportVm);
         ViewportControl = new ViewportControlViewModel(_canvas);
         RightPanel = new RightPanelViewModel(_canvas, preferencesService);
-        BottomPanel = new BottomPanelViewModel(_canvas, CommandManager);
+        BottomPanel = new BottomPanelViewModel(_canvas, CommandManager, errorConsoleService);
 
         // Wire up status callbacks
         CanvasInteraction.UpdateStatus = UpdateStatusText;
@@ -506,6 +513,8 @@ public partial class MainViewModel : ObservableObject
         catch (Exception ex)
         {
             StatusText = $"Simulation error: {ex.Message}";
+            ErrorConsole.Log($"Simulation failed: {ex.Message}", CAP_Contracts.Logger.LogLevel.Error, ex);
+
         }
         finally
         {

--- a/CAP.Avalonia/ViewModels/Panels/BottomPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/BottomPanelViewModel.cs
@@ -1,14 +1,16 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CAP.Avalonia.ViewModels.Analysis;
 using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.Commands;
+using CAP_Core;
 
 namespace CAP.Avalonia.ViewModels.Panels;
 
 /// <summary>
 /// ViewModel for the bottom panel.
-/// Contains waveguide length configuration, element locking, and status text.
+/// Contains waveguide length configuration, element locking, status text, and error console.
 /// Max 250 lines per CLAUDE.md guideline.
 /// </summary>
 public partial class BottomPanelViewModel : ObservableObject
@@ -23,13 +25,22 @@ public partial class BottomPanelViewModel : ObservableObject
     /// </summary>
     public ElementLockViewModel ElementLock { get; }
 
+    /// <summary>
+    /// ViewModel for the collapsible error console panel.
+    /// </summary>
+    public ErrorConsoleViewModel ErrorConsole { get; }
+
     [ObservableProperty]
     private string _statusText = "Ready";
 
-    public BottomPanelViewModel(DesignCanvasViewModel canvas, CommandManager commandManager)
+    /// <summary>
+    /// Initializes the bottom panel with canvas, command manager, and error console service.
+    /// </summary>
+    public BottomPanelViewModel(DesignCanvasViewModel canvas, CommandManager commandManager, ErrorConsoleService errorConsoleService)
     {
         WaveguideLength = new WaveguideLengthViewModel();
         ElementLock = new ElementLockViewModel();
+        ErrorConsole = new ErrorConsoleViewModel(errorConsoleService);
 
         // Configure ViewModels that need dependencies
         ElementLock.Configure(canvas, commandManager);

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:CAP.Avalonia.ViewModels"
         xmlns:vmLib="using:CAP.Avalonia.ViewModels.Library"
+        xmlns:diagnostics="using:CAP.Avalonia.ViewModels.Diagnostics"
         xmlns:creation="using:CAP_Core.Components.Creation"
         xmlns:controls="using:CAP.Avalonia.Controls"
         xmlns:views="using:CAP.Avalonia.Views"
@@ -14,6 +15,7 @@
     <Window.KeyBindings>
         <KeyBinding Gesture="Ctrl+G" Command="{Binding CreateGroupCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+G" Command="{Binding UngroupCommand}" />
+        <KeyBinding Gesture="F12" Command="{Binding ErrorConsole.ToggleCommand}" />
     </Window.KeyBindings>
 
     <DockPanel>
@@ -112,8 +114,80 @@
                 <TextBlock Text="{Binding StatusText}"
                            VerticalAlignment="Center" Margin="10,0" Foreground="LightGray"/>
                 <TextBlock VerticalAlignment="Center" Margin="20,0,0,0" Foreground="Gray">
-                    <Run Text="S=Select  C=Connect  D=Delete  R=Rotate  G=Grid Snap  F=Fit  L=Simulate  P=Toggle Overlay  Del=Remove  Ctrl+G=Group  Ctrl+Shift+G=Ungroup  Ctrl+L=Lock/Unlock  Ctrl+Z/Y=Undo/Redo  Ctrl+C/V=Copy/Paste"/>
+                    <Run Text="S=Select  C=Connect  D=Delete  R=Rotate  G=Grid Snap  F=Fit  L=Simulate  P=Toggle Overlay  Del=Remove  Ctrl+G=Group  Ctrl+Shift+G=Ungroup  Ctrl+L=Lock/Unlock  Ctrl+Z/Y=Undo/Redo  Ctrl+C/V=Copy/Paste  F12=Error Console"/>
                 </TextBlock>
+            </StackPanel>
+        </Border>
+
+        <!-- Error Console Panel (collapsible, above status bar, toggled via F12) -->
+        <Border DockPanel.Dock="Bottom" Background="#161616" BorderThickness="0,1,0,0" BorderBrush="#3d3d3d">
+            <StackPanel>
+                <!-- Header bar: always visible, click to toggle -->
+                <DockPanel Height="26" Background="#252526">
+                    <!-- Action buttons on the right -->
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="4,0">
+                        <Button Content="📋"
+                                Command="{Binding ErrorConsole.CopyAllCommand}"
+                                Width="28" Height="20" Margin="2,0" Padding="0"
+                                Background="#3d3d3d" Foreground="LightGray"
+                                FontSize="11"
+                                ToolTip.Tip="Copy all entries to clipboard"/>
+                        <Button Content="✕"
+                                Command="{Binding ErrorConsole.ClearCommand}"
+                                Width="24" Height="20" Margin="2,0" Padding="0"
+                                Background="#3d3d3d" Foreground="LightGray"
+                                FontSize="11"
+                                ToolTip.Tip="Clear console"/>
+                    </StackPanel>
+                    <!-- Toggle button fills remaining space -->
+                    <Button Command="{Binding ErrorConsole.ToggleCommand}"
+                            Background="Transparent"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Left"
+                            Height="26" Padding="8,0"
+                            ToolTip.Tip="Toggle error console (F12)">
+                        <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                            <TextBlock Text="▶" Foreground="Gray" FontSize="9" VerticalAlignment="Center"
+                                       IsVisible="{Binding ErrorConsole.IsVisible, Converter={x:Static BoolConverters.Not}}"/>
+                            <TextBlock Text="▼" Foreground="Gray" FontSize="9" VerticalAlignment="Center"
+                                       IsVisible="{Binding ErrorConsole.IsVisible}"/>
+                            <TextBlock Text="Error Console" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                            <!-- Error badge -->
+                            <Border Background="#5d2020" CornerRadius="8" Padding="5,1"
+                                    IsVisible="{Binding ErrorConsole.HasErrors}">
+                                <TextBlock Text="{Binding ErrorConsole.ErrorCount}"
+                                           Foreground="#FF6B6B" FontSize="10" VerticalAlignment="Center"/>
+                            </Border>
+                            <!-- Warning badge -->
+                            <Border Background="#5d4510" CornerRadius="8" Padding="5,1"
+                                    IsVisible="{Binding ErrorConsole.HasWarnings}">
+                                <TextBlock Text="{Binding ErrorConsole.WarningCount}"
+                                           Foreground="#FFD93D" FontSize="10" VerticalAlignment="Center"/>
+                            </Border>
+                        </StackPanel>
+                    </Button>
+                </DockPanel>
+
+                <!-- Content area: only shown when IsVisible is true -->
+                <Border IsVisible="{Binding ErrorConsole.IsVisible}" Height="180" Background="#161616">
+                    <ListBox x:Name="ErrorConsoleListBox"
+                             ItemsSource="{Binding ErrorConsole.DisplayEntries}"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="diagnostics:LogDisplayEntry">
+                                <TextBlock Text="{Binding Text}"
+                                           Foreground="{Binding Color}"
+                                           FontFamily="Consolas, Courier New, monospace"
+                                           FontSize="11"
+                                           Padding="4,1"
+                                           TextWrapping="NoWrap"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Border>
             </StackPanel>
         </Border>
 

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -46,6 +46,29 @@ public partial class MainWindow : Window
                     }
                 };
 
+                // Wire up clipboard for ErrorConsole
+                vm.ErrorConsole.CopyToClipboard = async (text) =>
+                {
+                    var clipboard = Clipboard;
+                    if (clipboard != null)
+                    {
+                        await clipboard.SetTextAsync(text);
+                    }
+                };
+
+                // Wire up auto-scroll: scroll to the newest entry when entries are added
+                vm.ErrorConsole.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(vm.ErrorConsole.EntryCount) && ErrorConsoleListBox != null)
+                    {
+                        var items = ErrorConsoleListBox.ItemsSource;
+                        if (items is System.Collections.IList list && list.Count > 0)
+                        {
+                            ErrorConsoleListBox.ScrollIntoView(list[list.Count - 1]);
+                        }
+                    }
+                };
+
                 // Wire up GridSplitter resize events
                 SetupPanelResizing(vm);
 

--- a/Connect-A-Pic-Core/ErrorConsoleService.cs
+++ b/Connect-A-Pic-Core/ErrorConsoleService.cs
@@ -1,0 +1,68 @@
+using System.Collections.ObjectModel;
+using CAP_Contracts.Logger;
+
+namespace CAP_Core;
+
+/// <summary>
+/// Singleton service that collects application log entries for display in the error console UI.
+/// Retains at most <see cref="MaxEntries"/> entries to prevent unbounded memory growth.
+/// </summary>
+public class ErrorConsoleService
+{
+    /// <summary>Maximum number of retained log entries.</summary>
+    public const int MaxEntries = 100;
+
+    private readonly ObservableCollection<Log> _entries = new();
+
+    /// <summary>All current log entries, oldest first.</summary>
+    public ReadOnlyObservableCollection<Log> Entries { get; }
+
+    /// <summary>Raised whenever a new entry is added.</summary>
+    public event EventHandler<Log>? EntryAdded;
+
+    /// <summary>Initializes a new <see cref="ErrorConsoleService"/>.</summary>
+    public ErrorConsoleService()
+    {
+        Entries = new ReadOnlyObservableCollection<Log>(_entries);
+    }
+
+    /// <summary>Logs an entry at the specified severity level.</summary>
+    /// <param name="level">Severity of the log entry.</param>
+    /// <param name="message">Human-readable message.</param>
+    public void Log(LogLevel level, string message)
+    {
+        if (_entries.Count >= MaxEntries)
+            _entries.RemoveAt(0);
+
+        var entry = new Log
+        {
+            Level = level,
+            Message = message,
+            TimeStamp = DateTime.Now,
+            ClassName = ""
+        };
+
+        _entries.Add(entry);
+        EntryAdded?.Invoke(this, entry);
+    }
+
+    /// <summary>Logs an error message, optionally including exception details.</summary>
+    /// <param name="message">Context message describing where the error occurred.</param>
+    /// <param name="ex">Optional exception to include in the log.</param>
+    public void LogError(string message, Exception? ex = null)
+    {
+        var fullMessage = ex != null ? $"{message}: {ex.Message}" : message;
+        Log(LogLevel.Error, fullMessage);
+    }
+
+    /// <summary>Logs a warning message.</summary>
+    /// <param name="message">Warning description.</param>
+    public void LogWarning(string message) => Log(LogLevel.Warn, message);
+
+    /// <summary>Logs an informational message.</summary>
+    /// <param name="message">Info description.</param>
+    public void LogInfo(string message) => Log(LogLevel.Info, message);
+
+    /// <summary>Removes all log entries from the console.</summary>
+    public void Clear() => _entries.Clear();
+}

--- a/UnitTests/Integration/NewProjectIntegrationTests.cs
+++ b/UnitTests/Integration/NewProjectIntegrationTests.cs
@@ -54,7 +54,8 @@ public class NewProjectIntegrationTests
             _groupLibraryManager,
             _previewGenerator,
             _inputDialogService,
-            _gdsExportService);
+            _gdsExportService,
+            new CAP_Core.ErrorConsoleService());
 
         // Add a component to the canvas
         var component = TestComponentFactory.CreateStraightWaveGuide();
@@ -84,7 +85,8 @@ public class NewProjectIntegrationTests
             _groupLibraryManager,
             _previewGenerator,
             _inputDialogService,
-            _gdsExportService);
+            _gdsExportService,
+            new CAP_Core.ErrorConsoleService());
 
         var mockMessageBox = new Mock<IMessageBoxService>();
         mockMessageBox
@@ -124,7 +126,8 @@ public class NewProjectIntegrationTests
             _groupLibraryManager,
             _previewGenerator,
             _inputDialogService,
-            _gdsExportService);
+            _gdsExportService,
+            new CAP_Core.ErrorConsoleService());
 
         // Add component
         var component = TestComponentFactory.CreateStraightWaveGuide();
@@ -153,7 +156,8 @@ public class NewProjectIntegrationTests
             _groupLibraryManager,
             _previewGenerator,
             _inputDialogService,
-            _gdsExportService);
+            _gdsExportService,
+            new CAP_Core.ErrorConsoleService());
 
         // Add two components with physical pins
         var comp1 = TestComponentFactory.CreateStraightWaveGuide();
@@ -195,7 +199,8 @@ public class NewProjectIntegrationTests
             _groupLibraryManager,
             _previewGenerator,
             _inputDialogService,
-            _gdsExportService);
+            _gdsExportService,
+            new CAP_Core.ErrorConsoleService());
 
         // Create a group with some components
         var comp1 = TestComponentFactory.CreateStraightWaveGuide();
@@ -242,7 +247,8 @@ public class NewProjectIntegrationTests
             _groupLibraryManager,
             _previewGenerator,
             _inputDialogService,
-            _gdsExportService);
+            _gdsExportService,
+            new CAP_Core.ErrorConsoleService());
 
         // Create nested groups
         var comp = TestComponentFactory.CreateStraightWaveGuide();

--- a/UnitTests/ViewModels/ErrorConsoleViewModelTests.cs
+++ b/UnitTests/ViewModels/ErrorConsoleViewModelTests.cs
@@ -1,0 +1,230 @@
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP_Contracts.Logger;
+using CAP_Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>
+/// Unit and integration tests for <see cref="ErrorConsoleViewModel"/> and <see cref="ErrorConsoleService"/>.
+/// </summary>
+public class ErrorConsoleViewModelTests
+{
+    // ─── ErrorConsoleService unit tests ───────────────────────────────────────
+
+    [Fact]
+    public void Log_AddsEntryToEntries()
+    {
+        var service = new ErrorConsoleService();
+
+        service.Log(LogLevel.Error, "test error");
+
+        service.Entries.Count.ShouldBe(1);
+        service.Entries[0].Message.ShouldBe("test error");
+        service.Entries[0].Level.ShouldBe(LogLevel.Error);
+    }
+
+    [Fact]
+    public void Log_CappsAtMaxEntries()
+    {
+        var service = new ErrorConsoleService();
+
+        for (int i = 0; i < ErrorConsoleService.MaxEntries + 10; i++)
+            service.Log(LogLevel.Info, $"msg {i}");
+
+        service.Entries.Count.ShouldBe(ErrorConsoleService.MaxEntries);
+    }
+
+    [Fact]
+    public void Log_OldestEntryDroppedWhenAtCapacity()
+    {
+        var service = new ErrorConsoleService();
+
+        for (int i = 0; i < ErrorConsoleService.MaxEntries; i++)
+            service.Log(LogLevel.Info, $"msg {i}");
+
+        service.Log(LogLevel.Error, "newest");
+
+        service.Entries.Count.ShouldBe(ErrorConsoleService.MaxEntries);
+        service.Entries[^1].Message.ShouldBe("newest");
+        service.Entries[0].Message.ShouldBe("msg 1"); // "msg 0" was dropped
+    }
+
+    [Fact]
+    public void Clear_RemovesAllEntries()
+    {
+        var service = new ErrorConsoleService();
+        service.Log(LogLevel.Error, "err1");
+        service.Log(LogLevel.Warn, "warn1");
+
+        service.Clear();
+
+        service.Entries.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void LogError_IncludesExceptionMessage()
+    {
+        var service = new ErrorConsoleService();
+        var ex = new InvalidOperationException("boom");
+
+        service.LogError("context", ex);
+
+        service.Entries[0].Message.ShouldContain("context");
+        service.Entries[0].Message.ShouldContain("boom");
+    }
+
+    [Fact]
+    public void EntryAdded_EventFiredOnLog()
+    {
+        var service = new ErrorConsoleService();
+        Log? received = null;
+        service.EntryAdded += (_, entry) => received = entry;
+
+        service.Log(LogLevel.Warn, "hello");
+
+        received.ShouldNotBeNull();
+        received!.Value.Message.ShouldBe("hello");
+    }
+
+    // ─── ErrorConsoleViewModel integration tests ──────────────────────────────
+
+    [Fact]
+    public void ViewModel_DisplaysEntryWhenServiceLogs()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+
+        service.Log(LogLevel.Error, "test error");
+
+        vm.DisplayEntries.Count.ShouldBe(1);
+        vm.DisplayEntries[0].Text.ShouldContain("test error");
+        vm.DisplayEntries[0].Text.ShouldContain("ERROR");
+    }
+
+    [Fact]
+    public void ViewModel_ErrorCountUpdatedOnLog()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+
+        service.Log(LogLevel.Error, "e1");
+        service.Log(LogLevel.Fatal, "e2");
+        service.Log(LogLevel.Warn, "w1");
+
+        vm.ErrorCount.ShouldBe(2);
+        vm.WarningCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ViewModel_HasErrorsAndHasWarnings_ReflectCounts()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+
+        vm.HasErrors.ShouldBeFalse();
+        vm.HasWarnings.ShouldBeFalse();
+
+        service.Log(LogLevel.Error, "err");
+        vm.HasErrors.ShouldBeTrue();
+        vm.HasWarnings.ShouldBeFalse();
+
+        service.Log(LogLevel.Warn, "warn");
+        vm.HasWarnings.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ViewModel_AutoExpandsOnError()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+        vm.IsVisible.ShouldBeFalse();
+
+        service.Log(LogLevel.Error, "auto expand me");
+
+        vm.IsVisible.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ViewModel_DoesNotAutoExpandOnInfo()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+
+        service.Log(LogLevel.Info, "just info");
+
+        vm.IsVisible.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ViewModel_ClearCommand_RemovesDisplayEntries()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+        service.Log(LogLevel.Error, "err");
+        service.Log(LogLevel.Warn, "warn");
+
+        vm.ClearCommand.Execute(null);
+
+        vm.DisplayEntries.Count.ShouldBe(0);
+        vm.ErrorCount.ShouldBe(0);
+        vm.WarningCount.ShouldBe(0);
+        vm.EntryCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ViewModel_ToggleCommand_FlipsIsVisible()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+
+        vm.IsVisible.ShouldBeFalse();
+        vm.ToggleCommand.Execute(null);
+        vm.IsVisible.ShouldBeTrue();
+        vm.ToggleCommand.Execute(null);
+        vm.IsVisible.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ViewModel_CopyAll_InvokesClipboardCallback()
+    {
+        var service = new ErrorConsoleService();
+        var vm = new ErrorConsoleViewModel(service);
+        service.Log(LogLevel.Error, "err1");
+        service.Log(LogLevel.Warn, "warn1");
+
+        string? copiedText = null;
+        vm.CopyToClipboard = text => { copiedText = text; return Task.CompletedTask; };
+
+        await vm.CopyAllCommand.ExecuteAsync(null);
+
+        copiedText.ShouldNotBeNullOrEmpty();
+        copiedText!.ShouldContain("err1");
+        copiedText.ShouldContain("warn1");
+    }
+
+    [Fact]
+    public void LogDisplayEntry_ErrorColor_IsRed()
+    {
+        var log = new Log { Level = LogLevel.Error, Message = "x", TimeStamp = DateTime.Now, ClassName = "" };
+        var entry = new LogDisplayEntry(log);
+        entry.Color.ShouldBe("#FF6B6B");
+    }
+
+    [Fact]
+    public void LogDisplayEntry_WarnColor_IsYellow()
+    {
+        var log = new Log { Level = LogLevel.Warn, Message = "x", TimeStamp = DateTime.Now, ClassName = "" };
+        var entry = new LogDisplayEntry(log);
+        entry.Color.ShouldBe("#FFD93D");
+    }
+
+    [Fact]
+    public void LogDisplayEntry_InfoColor_IsGray()
+    {
+        var log = new Log { Level = LogLevel.Info, Message = "x", TimeStamp = DateTime.Now, ClassName = "" };
+        var entry = new LogDisplayEntry(log);
+        entry.Color.ShouldBe("#A0A0A0");
+    }
+}

--- a/UnitTests/ViewModels/UndoRedoIntegrationTests.cs
+++ b/UnitTests/ViewModels/UndoRedoIntegrationTests.cs
@@ -264,7 +264,8 @@ public class UndoRedoIntegrationTests
             groupLibraryManager,
             previewGenerator,
             inputDialogService,
-            gdsExportService
+            gdsExportService,
+            new CAP_Core.ErrorConsoleService()
         );
     }
 }

--- a/UnitTests/ViewModels/ZoomToFitDebugTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitDebugTests.cs
@@ -22,7 +22,8 @@ public class ZoomToFitDebugTests
             new CAP_Core.Components.Creation.GroupLibraryManager(),
             new GroupPreviewGenerator(),
             new InputDialogService(),
-            new GdsExportService());
+            new GdsExportService(),
+            new CAP_Core.ErrorConsoleService());
 
         // Add component
         var comp = TestComponentFactory.CreateStraightWaveGuide();

--- a/UnitTests/ViewModels/ZoomToFitGroupsTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitGroupsTests.cs
@@ -16,7 +16,7 @@ namespace UnitTests.ViewModels;
 public class ZoomToFitGroupsTests
 {
     private static MainViewModel CreateViewModel() =>
-        new(new SimulationService(), new SimpleNazcaExporter(), new PdkLoader(), new CommandManager(), new UserPreferencesService(), new CAP_Core.Components.Creation.GroupLibraryManager(), new GroupPreviewGenerator(), new InputDialogService(), new GdsExportService());
+        new(new SimulationService(), new SimpleNazcaExporter(), new PdkLoader(), new CommandManager(), new UserPreferencesService(), new CAP_Core.Components.Creation.GroupLibraryManager(), new GroupPreviewGenerator(), new InputDialogService(), new GdsExportService(), new CAP_Core.ErrorConsoleService());
 
     /// <summary>
     /// Regression test: Verifies that zoom-to-fit correctly includes components

--- a/UnitTests/ViewModels/ZoomToFitTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitTests.cs
@@ -14,7 +14,7 @@ namespace UnitTests.ViewModels;
 public class ZoomToFitTests
 {
     private static MainViewModel CreateViewModel() =>
-        new(new SimulationService(), new SimpleNazcaExporter(), new PdkLoader(), new CommandManager(), new UserPreferencesService(), new CAP_Core.Components.Creation.GroupLibraryManager(), new GroupPreviewGenerator(), new InputDialogService(), new GdsExportService());
+        new(new SimulationService(), new SimpleNazcaExporter(), new PdkLoader(), new CommandManager(), new UserPreferencesService(), new CAP_Core.Components.Creation.GroupLibraryManager(), new GroupPreviewGenerator(), new InputDialogService(), new GdsExportService(), new CAP_Core.ErrorConsoleService());
 
     [Fact]
     public void ZoomToFit_EmptyCanvas_DoesNotChangeZoom()


### PR DESCRIPTION
Automated implementation for #283

Implementation complete. Here's a summary:

---

## Implementation Summary — Issue #283: Error Console with Copy Functionality

### Files Created

| File | Purpose |
|------|---------|
| `Connect-A-Pic-Core/ErrorConsoleService.cs` | Singleton service storing up to 100 `Log` entries (reuses existing `CAP_Contracts.Logger` types), with `LogError`/`LogWarning`/`LogInfo` helpers |
| `CAP.Avalonia/ViewModels/Diagnostics/ErrorConsoleViewModel.cs` | ViewModel with `Toggle`, `Clear`, `CopyAll` commands; auto-expands on errors; exposes color-coded `LogDisplayEntry` items |
| `UnitTests/ViewModels/ErrorConsoleViewModelTests.cs` | 17 unit + integration tests covering all behavior |

### Files Modified

| File | Change |
|------|--------|
| `BottomPanelViewModel.cs` | Added `ErrorConsoleViewModel ErrorConsole` property; injected `ErrorConsoleService` |
| `MainViewModel.cs` | Added `ErrorConsoleService` DI parameter; `ErrorConsole` backward-compat property; wires simulation errors to the console |
| `App.axaml.cs` | Registered `ErrorConsoleService` as singleton |
| `MainWindow.axaml` | Added `F12` keybinding; added collapsible bottom panel with header badges, error list, copy & clear buttons |
| `MainWindow.axaml.cs` | Wired clipboard callback + auto-scroll on new entries |
| 5 test files | Added `new ErrorConsoleService()` to `MainViewModel` constructor calls |

### Features Delivered
- **Collapsible panel** — toggled via F12 or by clicking the header
- **Color-coded entries** — red for errors/fatal, yellow for warnings, gray for info
- **Timestamps** on every entry
- **Error/warning badge counts** in the header (always visible)
- **Auto-expands** when an error is logged
- **Copy to Clipboard** — copies all entries as plain text
- **Clear** button
- **Max 100 entries** (oldest dropped)
- **Auto-scroll** to newest entry
- Simulation errors are automatically forwarded to the console

**MCP Tools used:** None — used direct file search (Glob/Grep/Read) and the semantic search tool was not needed since the codebase was navigated efficiently with direct patterns.


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 37,418
- **Estimated cost:** $0.5605 USD

---
*Generated by autonomous agent using Claude Code.*