### PR TITLE
Agent: Feature: Right-click context menu for group templates (Delete + Rename)

### DIFF
--- a/CAP.Avalonia/ViewModels/Library/ComponentLibraryViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentLibraryViewModel.cs
@@ -117,6 +117,52 @@ public partial class ComponentLibraryViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Callback to show a rename input dialog. Set by the View layer.
+    /// Takes the current template name, returns new name or null if cancelled.
+    /// </summary>
+    public Func<string, Task<string?>>? ShowRenameDialogAsync { get; set; }
+
+    /// <summary>
+    /// Renames a group template using the ShowRenameDialogAsync callback.
+    /// </summary>
+    /// <param name="template">The template to rename.</param>
+    [RelayCommand]
+    private async Task RenameTemplate(GroupTemplate template)
+    {
+        if (ShowRenameDialogAsync == null)
+            return;
+
+        var newName = await ShowRenameDialogAsync(template.Name);
+        if (string.IsNullOrWhiteSpace(newName) || newName.Trim() == template.Name)
+            return;
+
+        newName = newName.Trim();
+        var group = template.TemplateGroup;
+        if (group == null)
+            return;
+
+        var source = template.Source;
+        var description = template.Description;
+        var preview = template.PreviewThumbnailBase64;
+
+        _libraryManager.RemoveTemplate(template);
+
+        var userItem = UserGroups.FirstOrDefault(vm => vm.Template == template);
+        if (userItem != null)
+            UserGroups.Remove(userItem);
+
+        var pdkItem = PdkGroups.FirstOrDefault(vm => vm.Template == template);
+        if (pdkItem != null)
+            PdkGroups.Remove(pdkItem);
+
+        var newTemplate = _libraryManager.SaveTemplate(group, newName, description, source);
+        if (preview != null)
+            newTemplate.PreviewThumbnailBase64 = preview;
+
+        AddTemplate(newTemplate);
+    }
+
+    /// <summary>
     /// Duplicates a group template with a new name.
     /// </summary>
     /// <param name="template">The template to duplicate.</param>

--- a/CAP.Avalonia/ViewModels/Library/GroupTemplateItemViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Library/GroupTemplateItemViewModel.cs
@@ -41,4 +41,13 @@ public partial class GroupTemplateItemViewModel : ObservableObject
     {
         _parentViewModel.RemoveTemplateCommand.Execute(Template);
     }
+
+    /// <summary>
+    /// Renames this group template via a dialog prompt.
+    /// </summary>
+    [RelayCommand]
+    private void Rename()
+    {
+        _parentViewModel.RenameTemplateCommand.Execute(Template);
+    }
 }

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -173,6 +173,12 @@
                                                 PointerExited="OnGroupItemPointerExited"
                                                 Background="Transparent"
                                                 ClipToBounds="False">
+                                            <Border.ContextMenu>
+                                                <ContextMenu>
+                                                    <MenuItem Header="Rename" Command="{Binding RenameCommand}"/>
+                                                    <MenuItem Header="Delete" Command="{Binding DeleteCommand}"/>
+                                                </ContextMenu>
+                                            </Border.ContextMenu>
                                             <Grid>
                                             <StackPanel Orientation="Horizontal">
                                                 <!-- Preview box with component count and size info -->
@@ -242,6 +248,12 @@
                                                 PointerExited="OnGroupItemPointerExited"
                                                 Background="Transparent"
                                                 ClipToBounds="False">
+                                            <Border.ContextMenu>
+                                                <ContextMenu>
+                                                    <MenuItem Header="Rename" Command="{Binding RenameCommand}"/>
+                                                    <MenuItem Header="Delete" Command="{Binding DeleteCommand}"/>
+                                                </ContextMenu>
+                                            </Border.ContextMenu>
                                             <Grid>
                                             <StackPanel Orientation="Horizontal">
                                                 <!-- Preview box with component count and size info -->

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -26,6 +26,13 @@ public partial class MainWindow : Window
                 vm.RoutingDiagnostics.FileDialogService = vm.FileDialogService;
                 vm.ViewportControl.GetViewportSize = GetActualViewportSize;
 
+                // Wire up rename dialog for group templates
+                vm.GroupLibrary.ShowRenameDialogAsync = async (currentName) =>
+                {
+                    var dialog = new RenameDialog(currentName);
+                    return await dialog.ShowDialog<string?>(this);
+                };
+
                 // Wire up clipboard for RoutingDiagnostics
                 vm.RoutingDiagnostics.CopyToClipboard = async (text) =>
                 {

--- a/CAP.Avalonia/Views/RenameDialog.axaml
+++ b/CAP.Avalonia/Views/RenameDialog.axaml
@@ -1,0 +1,21 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CAP.Avalonia.Views.RenameDialog"
+        Title="Rename Group Template"
+        Width="340" Height="130"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#1e1e1e"
+        Foreground="White">
+    <StackPanel Margin="15" Spacing="8">
+        <TextBlock Text="Enter new name:" Foreground="LightGray"/>
+        <TextBox x:Name="NameTextBox"
+                 Background="#2d2d2d"
+                 Foreground="White"
+                 CaretBrush="White"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="OK" Width="80" Click="OnOkClicked"/>
+            <Button Content="Cancel" Width="80" Click="OnCancelClicked"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/CAP.Avalonia/Views/RenameDialog.axaml.cs
+++ b/CAP.Avalonia/Views/RenameDialog.axaml.cs
@@ -1,0 +1,33 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace CAP.Avalonia.Views;
+
+/// <summary>
+/// Simple dialog window for entering a new name when renaming a group template.
+/// Returns the new name string on confirmation, or null on cancellation.
+/// </summary>
+public partial class RenameDialog : Window
+{
+    /// <summary>
+    /// Initializes the rename dialog with the current name pre-filled.
+    /// </summary>
+    /// <param name="currentName">The current template name to pre-fill in the text box.</param>
+    public RenameDialog(string currentName)
+    {
+        InitializeComponent();
+        NameTextBox.Text = currentName;
+        NameTextBox.SelectAll();
+        Opened += (_, _) => NameTextBox.Focus();
+    }
+
+    private void OnOkClicked(object? sender, RoutedEventArgs e)
+    {
+        Close(NameTextBox.Text?.Trim());
+    }
+
+    private void OnCancelClicked(object? sender, RoutedEventArgs e)
+    {
+        Close(null);
+    }
+}

--- a/UnitTests/ViewModels/ComponentLibraryViewModelTests.cs
+++ b/UnitTests/ViewModels/ComponentLibraryViewModelTests.cs
@@ -248,6 +248,95 @@ public class ComponentLibraryViewModelTests : IDisposable
         _viewModel.StatusText.ShouldBe("1 user group(s), 1 PDK macro(s)");
     }
 
+    [Fact]
+    public async Task RenameTemplate_UpdatesTemplateNameInCollection()
+    {
+        // Arrange - use AddTemplate to avoid stale reference after LoadGroupsCommand reload
+        var group = CreateTestGroup("OriginalGroup", 2);
+        var template = _libraryManager.SaveTemplate(group, "Original Name", "description", "User");
+        template.TemplateGroup = group;
+        _viewModel.AddTemplate(template);
+        _viewModel.UserGroups.Count.ShouldBe(1);
+
+        _viewModel.ShowRenameDialogAsync = _ => Task.FromResult<string?>("New Name");
+
+        // Act
+        await _viewModel.RenameTemplateCommand.ExecuteAsync(template);
+
+        // Assert
+        _viewModel.UserGroups.Count.ShouldBe(1);
+        _viewModel.UserGroups[0].Template.Name.ShouldBe("New Name");
+    }
+
+    [Fact]
+    public async Task RenameTemplate_DoesNothing_WhenDialogCancelled()
+    {
+        // Arrange
+        var group = CreateTestGroup("MyGroup", 1);
+        var template = _libraryManager.SaveTemplate(group, "My Template", null, "User");
+        template.TemplateGroup = group;
+        _viewModel.AddTemplate(template);
+
+        _viewModel.ShowRenameDialogAsync = _ => Task.FromResult<string?>(null);
+
+        // Act
+        await _viewModel.RenameTemplateCommand.ExecuteAsync(template);
+
+        // Assert - name unchanged
+        _viewModel.UserGroups.Count.ShouldBe(1);
+        _viewModel.UserGroups[0].Template.Name.ShouldBe("My Template");
+    }
+
+    [Fact]
+    public async Task RenameTemplate_DoesNothing_WhenNameUnchanged()
+    {
+        // Arrange
+        var group = CreateTestGroup("Group", 1);
+        var template = _libraryManager.SaveTemplate(group, "Same Name", null, "User");
+        template.TemplateGroup = group;
+        _viewModel.AddTemplate(template);
+
+        _viewModel.ShowRenameDialogAsync = _ => Task.FromResult<string?>("Same Name");
+
+        // Act
+        await _viewModel.RenameTemplateCommand.ExecuteAsync(template);
+
+        // Assert - still same name, no duplicate
+        _viewModel.UserGroups.Count.ShouldBe(1);
+        _viewModel.UserGroups[0].Template.Name.ShouldBe("Same Name");
+    }
+
+    [Fact]
+    public async Task RenameTemplate_DoesNothing_WhenNoDialogCallback()
+    {
+        // Arrange
+        var group = CreateTestGroup("Group", 1);
+        var template = _libraryManager.SaveTemplate(group, "Template", null, "User");
+        template.TemplateGroup = group;
+        _viewModel.AddTemplate(template);
+
+        // ShowRenameDialogAsync is null by default
+
+        // Act - should not throw
+        await _viewModel.RenameTemplateCommand.ExecuteAsync(template);
+
+        // Assert - unchanged
+        _viewModel.UserGroups.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RenameCommand_IsAvailableOnGroupTemplateItemViewModel()
+    {
+        // Arrange
+        var group = CreateTestGroup("Group", 1);
+        var template = _libraryManager.SaveTemplate(group, "Test", null, "User");
+        var itemVm = new GroupTemplateItemViewModel(template, _viewModel);
+
+        // Act & Assert
+        itemVm.RenameCommand.ShouldNotBeNull();
+        itemVm.RenameCommand.CanExecute(null).ShouldBeTrue();
+    }
+
     /// <summary>
     /// Creates a test ComponentGroup with the specified number of child components.
     /// </summary>


### PR DESCRIPTION
Automated implementation for #277

Implementation complete. Here's a summary of all changes made:

## Changes Made

### Modified Files

**`GroupTemplateItemViewModel.cs`** — Added `RenameCommand` that delegates to the parent ViewModel's `RenameTemplateCommand`.

**`ComponentLibraryViewModel.cs`** — Added:
- `ShowRenameDialogAsync` property (`Func<string, Task<string?>>`) — callback set by the View layer to show the dialog
- `RenameTemplateCommand` — async command that prompts for a new name, then removes the old template and saves with the new name (preserving source, description, and preview thumbnail)

**`MainWindow.axaml`** — Added `ContextMenu` with **Rename** and **Delete** menu items to both User Groups and PDK Groups `DataTemplate` borders.

**`MainWindow.axaml.cs`** — Wired up `ShowRenameDialogAsync` in the `Loaded` event to show the `RenameDialog` window.

**`ComponentLibraryViewModelTests.cs`** — Added 5 new tests covering: successful rename, cancel behaviour, same-name no-op, missing dialog callback no-op, and `RenameCommand` availability on `GroupTemplateItemViewModel`.

### New Files

**`CAP.Avalonia/Views/RenameDialog.axaml`** + **`.axaml.cs`** — Minimal dark-themed Avalonia dialog with a pre-filled TextBox and OK/Cancel buttons. Returns the trimmed name or `null` on cancellation.

---

**MCP Tools used:** None (direct file reads + grep were sufficient for this focused feature).


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 21,918
- **Estimated cost:** $0.3283 USD

---
*Generated by autonomous agent using Claude Code.*