### PR TITLE
Agent: ComponentGroup simulation: Light propagation fails (outputPower = 0)

### DIFF
--- a/Connect-A-Pic-Core/LightCalculation/ComponentGroupSMatrixBuilder.cs
+++ b/Connect-A-Pic-Core/LightCalculation/ComponentGroupSMatrixBuilder.cs
@@ -236,9 +236,10 @@ public class ComponentGroupSMatrixBuilder
             var endInFlow = frozenPath.EndPin.LogicalPin.IDInFlow;
             var endOutFlow = frozenPath.EndPin.LogicalPin.IDOutFlow;
 
-            // Connect start → end and end → start
-            connections[(startInFlow, endOutFlow)] = Complex.One;
-            connections[(endInFlow, startOutFlow)] = Complex.One;
+            // Forward: light flows from StartPin OutFlow to EndPin InFlow
+            connections[(startOutFlow, endInFlow)] = Complex.One;
+            // Reverse: light flows from EndPin OutFlow to StartPin InFlow (bidirectional)
+            connections[(endOutFlow, startInFlow)] = Complex.One;
         }
 
         if (connections.Count == 0)
@@ -251,15 +252,30 @@ public class ComponentGroupSMatrixBuilder
     }
 
     /// <summary>
-    /// Extracts a sub-matrix containing only the specified external pins.
-    /// This reduces the full system matrix to just the group's external interface.
+    /// Extracts an effective sub-matrix for the specified external pins by running
+    /// the internal system matrix through enough propagation steps to capture all
+    /// multi-hop paths (e.g. comp1 → internal connection → comp2).
     /// </summary>
     private SMatrix ExtractExternalPinMatrix(SMatrix systemMatrix, List<Guid> externalPinIds)
     {
+        // Compute the effective transfer: A + A^2 + ... + A^n
+        // This captures all multi-hop paths through the group's internal components.
+        // Single-hop read (A only) misses paths that go through intermediate pins.
+        int maxSteps = systemMatrix.PinReference.Count * 2;
+        var A = systemMatrix.SMat;
+        var runningPower = A;
+        var effectiveA = A.Clone();
+
+        for (int i = 1; i < maxSteps; i++)
+        {
+            runningPower = A * runningPower;
+            effectiveA += runningPower;
+        }
+
         var externalMatrix = new SMatrix(externalPinIds, new());
         var transfers = new Dictionary<(Guid, Guid), Complex>();
 
-        // Extract only the rows/columns for external pins
+        // Extract the effective transfers for external pins only
         foreach (var pinIn in externalPinIds)
         {
             foreach (var pinOut in externalPinIds)
@@ -270,7 +286,7 @@ public class ComponentGroupSMatrixBuilder
                 if (systemMatrix.PinReference.TryGetValue(pinIn, out int idxIn) &&
                     systemMatrix.PinReference.TryGetValue(pinOut, out int idxOut))
                 {
-                    var value = systemMatrix.SMat[idxOut, idxIn];
+                    var value = effectiveA[idxOut, idxIn];
                     if (value != Complex.Zero)
                     {
                         transfers[(pinIn, pinOut)] = value;

--- a/UnitTests/Simulation/ComponentGroupSimulationTests.cs
+++ b/UnitTests/Simulation/ComponentGroupSimulationTests.cs
@@ -112,7 +112,9 @@ public class ComponentGroupSimulationTests
             0,
             new System.Numerics.Complex(1.0, 0),
             true);
-        portManager.AddLightSource(externalInput, sourcePhysicalPin.LogicalPin.IDInFlow);
+        // Light enters from the left side of the source and propagates forward (leftIn → rightOut)
+        var sourceLeftLogicalPin = source.Parts[0, 0].GetPinAt(CAP_Core.Tiles.RectSide.Left);
+        portManager.AddLightSource(externalInput, sourceLeftLogicalPin.IDInFlow);
 
         var gridManager = GridManager.CreateForSimulation(
             tileManager, connectionManager, portManager);


### PR DESCRIPTION
Automated implementation for #289

All 1267 tests pass (1247 passing, 20 skipped — same as before). Let me summarize the three bugs found and fixed:

---

## Summary

**Root Cause**: Three bugs in `ComponentGroupSMatrixBuilder.cs` and the test itself:

### Bug 1 — Swapped IDInFlow/IDOutFlow in `BuildInternalConnectionMatrix`
**File**: `Connect-A-Pic-Core/LightCalculation/ComponentGroupSMatrixBuilder.cs:239-240`

The internal waveguide connections had `IDInFlow` and `IDOutFlow` reversed. A connection between two pins should transfer: `(startPin.IDOutFlow → endPin.IDInFlow)` (light exits one pin and enters the next), but the code had `(startPin.IDInFlow, endPin.IDOutFlow)` — matching nothing in the propagation chain.

### Bug 2 — Single-hop extraction in `ExtractExternalPinMatrix`
**File**: `Connect-A-Pic-Core/LightCalculation/ComponentGroupSMatrixBuilder.cs:257-284`

The extracted group S-matrix read only **direct** (single-step) entries from the internal system matrix. But a chain of 2 components requires 3 hops (comp1 → connection → comp2). The fix computes the effective power series `A + A² + ... + Aⁿ` to capture all multi-hop paths before extracting the external-pin sub-matrix.

### Bug 3 — Wrong external input pin in the test
**File**: `UnitTests/Simulation/ComponentGroupSimulationTests.cs:115`

The test injected light at `sourcePhysicalPin.LogicalPin.IDInFlow` (the source's RIGHT pin's inflow). The straight-waveguide S-matrix routes `rightIn → leftOut` (backward), which dead-ends. The fix attaches the external input to the source's LEFT pin (`source.Parts[0,0].GetPinAt(Left).IDInFlow`), so light propagates forward: `leftIn → rightOut → (connection) → groupIn → (group S-matrix) → groupOut`.

---

**MCP Tools used**: None — all investigation done via direct file reads and grep.


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 48,767
- **Estimated cost:** $0.7312 USD

---
*Generated by autonomous agent using Claude Code.*