### PR TITLE
Agent: Add ErrorConsole logging to all exception handlers in ViewModels

### DIFF
--- a/CAP.Avalonia/ViewModels/Analysis/CompressLayoutViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/CompressLayoutViewModel.cs
@@ -1,3 +1,4 @@
+using CAP_Core;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CAP_Core.Analysis;
@@ -28,8 +29,16 @@ public partial class CompressLayoutViewModel : ObservableObject
     [ObservableProperty]
     private int _maxIterations = 100;
 
+    private readonly ErrorConsoleService? _errorConsole;
     private DesignCanvasViewModel? _canvas;
     private readonly LayoutCompressor _compressor = new();
+
+    /// <summary>Initializes a new instance of <see cref="CompressLayoutViewModel"/>.</summary>
+    /// <param name="errorConsole">Optional service for error logging.</param>
+    public CompressLayoutViewModel(ErrorConsoleService? errorConsole = null)
+    {
+        _errorConsole = errorConsole;
+    }
 
     /// <summary>
     /// Configures the compressor for the given canvas.
@@ -129,6 +138,7 @@ public partial class CompressLayoutViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Layout compression failed: {ex.Message}", ex);
             StatusText = $"Compression failed: {ex.Message}";
             ResultText = "";
         }

--- a/CAP.Avalonia/ViewModels/Analysis/ParameterSweepViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/ParameterSweepViewModel.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using System.Text;
+using CAP_Core;
 using CAP_Core.Analysis;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
@@ -38,9 +39,17 @@ public partial class ParameterSweepViewModel : ObservableObject
     [ObservableProperty]
     private string _statusText = "";
 
+    private readonly ErrorConsoleService? _errorConsole;
     private DesignCanvasViewModel? _canvas;
     private ComponentViewModel? _targetComponent;
     private SweepResult? _lastResult;
+
+    /// <summary>Initializes a new instance of <see cref="ParameterSweepViewModel"/>.</summary>
+    /// <param name="errorConsole">Optional service for error logging.</param>
+    public ParameterSweepViewModel(ErrorConsoleService? errorConsole = null)
+    {
+        _errorConsole = errorConsole;
+    }
 
     /// <summary>
     /// File dialog service for CSV export. Set by MainViewModel.
@@ -120,8 +129,9 @@ public partial class ParameterSweepViewModel : ObservableObject
             ResultText = FormatResultsTable(_lastResult, pinNameMap);
             StatusText = $"Sweep complete: {dataPoints.Count} points";
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            _errorConsole?.LogError($"Parameter sweep failed: {ex.Message}", ex);
             StatusText = $"Sweep failed: {ex.Message}";
         }
         finally
@@ -160,6 +170,7 @@ public partial class ParameterSweepViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Failed to export sweep results: {ex.Message}", ex);
             StatusText = $"Export failed: {ex.Message}";
         }
     }

--- a/CAP.Avalonia/ViewModels/Diagnostics/ExportValidationViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/ExportValidationViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using CAP_Core;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CAP.Avalonia.Services;
@@ -40,11 +41,15 @@ public partial class ExportValidationViewModel : ObservableObject
 
     private readonly SimpleNazcaExporter _exporter;
     private readonly ExportValidator _validator;
+    private readonly ErrorConsoleService? _errorConsole;
 
-    public ExportValidationViewModel()
+    /// <summary>Initializes a new instance of <see cref="ExportValidationViewModel"/>.</summary>
+    /// <param name="errorConsole">Optional service for error logging.</param>
+    public ExportValidationViewModel(ErrorConsoleService? errorConsole = null)
     {
         _exporter = new SimpleNazcaExporter();
         _validator = new ExportValidator();
+        _errorConsole = errorConsole;
     }
 
     /// <summary>
@@ -79,6 +84,7 @@ public partial class ExportValidationViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Export validation failed: {ex.Message}", ex);
             ValidationStatus = $"Validation failed: {ex.Message}";
             HasResults = false;
         }

--- a/CAP.Avalonia/ViewModels/Diagnostics/RoutingDiagnosticsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/RoutingDiagnosticsViewModel.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using CAP_Core;
 using CAP_Core.Routing;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -13,6 +14,14 @@ namespace CAP.Avalonia.ViewModels.Diagnostics;
 /// </summary>
 public partial class RoutingDiagnosticsViewModel : ObservableObject
 {
+    private readonly ErrorConsoleService? _errorConsole;
+
+    /// <summary>Initializes a new instance of <see cref="RoutingDiagnosticsViewModel"/>.</summary>
+    /// <param name="errorConsole">Optional service for error logging.</param>
+    public RoutingDiagnosticsViewModel(ErrorConsoleService? errorConsole = null)
+    {
+        _errorConsole = errorConsole;
+    }
     [ObservableProperty]
     private bool _isAnalyzing;
 
@@ -123,6 +132,7 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Routing diagnostics failed: {ex.Message}", ex);
             StatusText = $"Analysis failed: {ex.Message}";
         }
         finally
@@ -177,6 +187,7 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Failed to export routing paths: {ex.Message}", ex);
             StatusText = $"Export failed: {ex.Message}";
         }
     }
@@ -225,6 +236,7 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Failed to copy routing paths to clipboard: {ex.Message}", ex);
             StatusText = $"Copy failed: {ex.Message}";
         }
     }

--- a/CAP.Avalonia/ViewModels/Diagnostics/SMatrixPerformanceViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/SMatrixPerformanceViewModel.cs
@@ -1,3 +1,4 @@
+using CAP_Core;
 using CAP_Core.LightCalculation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -11,6 +12,14 @@ namespace CAP.Avalonia.ViewModels.Diagnostics;
 public partial class SMatrixPerformanceViewModel : ObservableObject
 {
     private readonly SMatrixStatisticsAnalyzer _analyzer = new();
+    private readonly ErrorConsoleService? _errorConsole;
+
+    /// <summary>Initializes a new instance of <see cref="SMatrixPerformanceViewModel"/>.</summary>
+    /// <param name="errorConsole">Optional service for error logging.</param>
+    public SMatrixPerformanceViewModel(ErrorConsoleService? errorConsole = null)
+    {
+        _errorConsole = errorConsole;
+    }
 
     [ObservableProperty]
     private string _matrixSizeText = "-";
@@ -70,6 +79,7 @@ public partial class SMatrixPerformanceViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"S-Matrix analysis failed: {ex.Message}", ex);
             StatusText = $"Analysis failed: {ex.Message}";
             ResetStatistics();
         }

--- a/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
@@ -1,3 +1,4 @@
+using CAP_Core;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CAP_Core.Export;
@@ -57,10 +58,16 @@ public partial class GdsExportViewModel : ObservableObject
     /// </summary>
     public Action<string?>? OnPythonPathChanged { get; set; }
 
-    public GdsExportViewModel(GdsExportService exportService)
+    private readonly ErrorConsoleService? _errorConsole;
+
+    /// <summary>Initializes a new instance of <see cref="GdsExportViewModel"/>.</summary>
+    /// <param name="exportService">GDS export service.</param>
+    /// <param name="errorConsole">Optional service for error logging.</param>
+    public GdsExportViewModel(GdsExportService exportService, ErrorConsoleService? errorConsole = null)
     {
         _exportService = exportService;
         _discoveryService = new PythonDiscoveryService();
+        _errorConsole = errorConsole;
     }
 
     /// <summary>
@@ -170,6 +177,7 @@ public partial class GdsExportViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Python discovery failed: {ex.Message}", ex);
             PythonStatus = $"✗ Search failed: {ex.Message}";
         }
         finally

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -163,14 +163,14 @@ public partial class MainViewModel : ObservableObject
         _canvas.SimulationRequested = async () => await ExecuteSimulation();
 
         // Initialize Panel ViewModels (order matters due to dependencies)
-        LeftPanel = new LeftPanelViewModel(_canvas, groupLibraryManager, pdkLoader, preferencesService);
+        LeftPanel = new LeftPanelViewModel(_canvas, groupLibraryManager, pdkLoader, preferencesService, errorConsoleService);
         CanvasInteraction = new CanvasInteractionViewModel(_canvas, commandManager, LeftPanel.ComponentLibrary, previewGenerator, inputDialogService);
-        var gdsExportVm = new ViewModels.Export.GdsExportViewModel(gdsExportService);
+        var gdsExportVm = new ViewModels.Export.GdsExportViewModel(gdsExportService, errorConsoleService);
         gdsExportVm.Initialize(preferencesService.GetCustomPythonPath());
         gdsExportVm.OnPythonPathChanged = path => preferencesService.SetCustomPythonPath(path);
-        FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, LeftPanel.AllTemplates, gdsExportVm);
+        FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, LeftPanel.AllTemplates, gdsExportVm, errorConsoleService);
         ViewportControl = new ViewportControlViewModel(_canvas);
-        RightPanel = new RightPanelViewModel(_canvas, preferencesService);
+        RightPanel = new RightPanelViewModel(_canvas, preferencesService, errorConsoleService);
         BottomPanel = new BottomPanelViewModel(_canvas, CommandManager, errorConsoleService);
 
         // Wire up status callbacks
@@ -288,6 +288,7 @@ public partial class MainViewModel : ObservableObject
                 catch (Exception ex)
                 {
                     StatusText = $"Failed to load template '{template.Name}': {ex.Message}";
+                    ErrorConsole.Log($"Failed to load template '{template.Name}': {ex.Message}", CAP_Contracts.Logger.LogLevel.Error, ex);
                     return;
                 }
 

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Text.Json;
+using CAP_Core;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CAP_Core.Components;
@@ -25,6 +26,7 @@ public partial class FileOperationsViewModel : ObservableObject
     private readonly CommandManager _commandManager;
     private readonly SimpleNazcaExporter _nazcaExporter;
     private readonly ObservableCollection<ComponentTemplate> _componentLibrary;
+    private readonly ErrorConsoleService? _errorConsole;
 
     private string? _currentFilePath;
 
@@ -61,18 +63,21 @@ public partial class FileOperationsViewModel : ObservableObject
     /// </summary>
     public IMessageBoxService? MessageBoxService { get; set; }
 
+    /// <summary>Initializes a new instance of <see cref="FileOperationsViewModel"/>.</summary>
     public FileOperationsViewModel(
         DesignCanvasViewModel canvas,
         CommandManager commandManager,
         SimpleNazcaExporter nazcaExporter,
         ObservableCollection<ComponentTemplate> componentLibrary,
-        GdsExportViewModel gdsExport)
+        GdsExportViewModel gdsExport,
+        ErrorConsoleService? errorConsole = null)
     {
         _canvas = canvas;
         _commandManager = commandManager;
         _nazcaExporter = nazcaExporter;
         _componentLibrary = componentLibrary;
         GdsExport = gdsExport;
+        _errorConsole = errorConsole;
 
         // Track changes to mark project as unsaved
         _canvas.Components.CollectionChanged += (s, e) => HasUnsavedChanges = true;
@@ -186,6 +191,7 @@ public partial class FileOperationsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Failed to save design: {ex.Message}", ex);
             UpdateStatus?.Invoke($"Save failed: {ex.Message}");
         }
     }
@@ -481,6 +487,7 @@ public partial class FileOperationsViewModel : ObservableObject
             }
             catch (Exception ex)
             {
+                _errorConsole?.LogError($"Failed to load design: {ex.Message}", ex);
                 UpdateStatus?.Invoke($"Load failed: {ex.Message}");
             }
         }
@@ -855,6 +862,7 @@ public partial class FileOperationsViewModel : ObservableObject
             }
             catch (Exception ex)
             {
+                _errorConsole?.LogError($"Failed to export Nazca design: {ex.Message}", ex);
                 UpdateStatus?.Invoke($"Export failed: {ex.Message}");
             }
         }

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using CAP_Core;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Avalonia.Controls;
@@ -25,6 +26,7 @@ public partial class LeftPanelViewModel : ObservableObject
     private readonly DesignCanvasViewModel _canvas;
     private readonly PdkLoader _pdkLoader;
     private readonly UserPreferencesService _preferencesService;
+    private readonly ErrorConsoleService? _errorConsole;
 
     /// <summary>
     /// ViewModel for the hierarchy panel showing component tree structure.
@@ -100,15 +102,18 @@ public partial class LeftPanelViewModel : ObservableObject
     /// </summary>
     public Action<GroupTemplate>? OnGroupTemplateSelected { get; set; }
 
+    /// <summary>Initializes a new instance of <see cref="LeftPanelViewModel"/>.</summary>
     public LeftPanelViewModel(
         DesignCanvasViewModel canvas,
         GroupLibraryManager libraryManager,
         PdkLoader pdkLoader,
-        UserPreferencesService preferencesService)
+        UserPreferencesService preferencesService,
+        ErrorConsoleService? errorConsole = null)
     {
         _canvas = canvas;
         _pdkLoader = pdkLoader;
         _preferencesService = preferencesService;
+        _errorConsole = errorConsole;
 
         HierarchyPanel = new HierarchyPanelViewModel(canvas);
         PdkManager = new PdkManagerViewModel();
@@ -189,9 +194,9 @@ public partial class LeftPanelViewModel : ObservableObject
 
                 PdkManager.RegisterPdk(pdk.Name, pdkFile, true, componentCount);
             }
-            catch
+            catch (Exception ex)
             {
-                // Skip malformed PDK files silently at startup
+                _errorConsole?.LogWarning($"Skipped malformed PDK file '{Path.GetFileName(pdkFile)}': {ex.Message}");
             }
         }
     }
@@ -299,6 +304,7 @@ public partial class LeftPanelViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Failed to load PDK: {ex.Message}", ex);
             UpdateStatus?.Invoke($"Failed to load PDK: {ex.Message}");
         }
     }

--- a/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
@@ -1,3 +1,4 @@
+using CAP_Core;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Avalonia.Controls;
 using CAP.Avalonia.ViewModels.Analysis;
@@ -82,18 +83,19 @@ public partial class RightPanelViewModel : ObservableObject
     /// </summary>
     public GroupSMatrixViewModel GroupSMatrix { get; }
 
-    public RightPanelViewModel(DesignCanvasViewModel canvas, UserPreferencesService preferencesService)
+    /// <summary>Initializes a new instance of <see cref="RightPanelViewModel"/>.</summary>
+    public RightPanelViewModel(DesignCanvasViewModel canvas, UserPreferencesService preferencesService, ErrorConsoleService? errorConsole = null)
     {
         _preferencesService = preferencesService;
 
-        Sweep = new ParameterSweepViewModel();
-        RoutingDiagnostics = new RoutingDiagnosticsViewModel();
+        Sweep = new ParameterSweepViewModel(errorConsole);
+        RoutingDiagnostics = new RoutingDiagnosticsViewModel(errorConsole);
         DesignValidation = new DesignValidationViewModel();
         DimensionDiagnostics = new ComponentDimensionDiagnosticsViewModel(canvas);
         DimensionValidator = new ComponentDimensionViewModel();
-        ExportValidation = new ExportValidationViewModel();
-        SMatrixPerformance = new SMatrixPerformanceViewModel();
-        CompressLayout = new CompressLayoutViewModel();
+        ExportValidation = new ExportValidationViewModel(errorConsole);
+        SMatrixPerformance = new SMatrixPerformanceViewModel(errorConsole);
+        CompressLayout = new CompressLayoutViewModel(errorConsole);
         GroupSMatrix = new GroupSMatrixViewModel();
 
         // Configure ViewModels that need canvas reference

--- a/CAP.Avalonia/ViewModels/ProjectPersistenceViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ProjectPersistenceViewModel.cs
@@ -1,3 +1,4 @@
+using CAP_Core;
 using CAP.Avalonia.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -12,6 +13,7 @@ public partial class ProjectPersistenceViewModel : ObservableObject
 {
     private readonly ProjectPersistenceService _persistenceService;
     private readonly IFileDialogService? _fileDialogService;
+    private readonly ErrorConsoleService? _errorConsole;
 
     [ObservableProperty]
     private string _currentFilePath = "";
@@ -19,12 +21,15 @@ public partial class ProjectPersistenceViewModel : ObservableObject
     [ObservableProperty]
     private string _statusMessage = "";
 
+    /// <summary>Initializes a new instance of <see cref="ProjectPersistenceViewModel"/>.</summary>
     public ProjectPersistenceViewModel(
         ProjectPersistenceService persistenceService,
-        IFileDialogService? fileDialogService = null)
+        IFileDialogService? fileDialogService = null,
+        ErrorConsoleService? errorConsole = null)
     {
         _persistenceService = persistenceService;
         _fileDialogService = fileDialogService;
+        _errorConsole = errorConsole;
     }
 
     /// <summary>
@@ -115,6 +120,7 @@ public partial class ProjectPersistenceViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Failed to save project: {ex.Message}", ex);
             StatusMessage = $"Error saving project: {ex.Message}";
         }
     }
@@ -134,6 +140,7 @@ public partial class ProjectPersistenceViewModel : ObservableObject
         }
         catch (Exception ex)
         {
+            _errorConsole?.LogError($"Failed to load project: {ex.Message}", ex);
             StatusMessage = $"Error loading project: {ex.Message}";
         }
     }


### PR DESCRIPTION
Automated implementation for #294

All 18 catch blocks (17 + the pre-existing simulation one) now log to ErrorConsole. The implementation is complete.

**Summary:**

All 17 exception catch blocks in ViewModels now log to ErrorConsole:

| ViewModel | Catch Blocks | Approach |
|-----------|-------------|----------|
| `LeftPanelViewModel` | 2 | `LogWarning` (malformed PDK at startup), `LogError` (PDK load) |
| `FileOperationsViewModel` | 3 | `LogError` for save/load/export |
| `MainViewModel` | 2 | Already had simulation logging; added template load logging via `ErrorConsole.Log()` |
| `SMatrixPerformanceViewModel` | 1 | `LogError` |
| `RoutingDiagnosticsViewModel` | 3 | `LogError` for analysis/export/clipboard |
| `ExportValidationViewModel` | 1 | `LogError` |
| `ProjectPersistenceViewModel` | 2 | `LogError` for save/load |
| `ParameterSweepViewModel` | 2 | `LogError` (with `OperationCanceledException` guard on sweep) |
| `CompressLayoutViewModel` | 1 | `LogError` |
| `GdsExportViewModel` | 1 | `LogError` |

**Design choices:**
- Used optional nullable `ErrorConsoleService? errorConsole = null` parameters everywhere — zero test files needed changes
- `ErrorConsoleService` is propagated through: `MainViewModel` → `RightPanelViewModel` → child VMs
- `MainViewModel` uses `ErrorConsole.Log(...)` (via `ErrorConsoleViewModel`) for consistency with the existing simulation error logging pattern

MCP Tools used: None (used direct file reads and grep searches).


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 23,447
- **Estimated cost:** $0.3510 USD

---
*Generated by autonomous agent using Claude Code.*