### PR TITLE
Agent: Add ComponentGroup support to Nazca/GDS export

### DIFF
--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -51,6 +51,7 @@ public class SimpleNazcaExporter
     /// Generates standalone Nazca cell definitions for PDK components.
     /// Each unique PDK function used in the design gets a stub cell
     /// with correct dimensions and pin positions — no external PDK install needed.
+    /// ComponentGroups are flattened — stubs are generated for all child components.
     /// </summary>
     private static void AppendPdkComponentStubs(StringBuilder sb, DesignCanvasViewModel canvas)
     {
@@ -60,22 +61,34 @@ public class SimpleNazcaExporter
         foreach (var compVm in canvas.Components)
         {
             var comp = compVm.Component;
-            var funcName = comp.NazcaFunctionName;
-            if (string.IsNullOrEmpty(funcName) || !RequiresStub(funcName))
-                continue;
-            if (!generated.Add(funcName))
-                continue; // already generated
-
-            // Check if this is a parametric straight waveguide
-            if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
+            if (comp is ComponentGroup group)
             {
-                AppendParametricStraightStub(sb, funcName, comp, ci);
+                foreach (var child in group.GetAllComponentsRecursive())
+                    AppendComponentStub(sb, child, generated, ci);
             }
             else
             {
-                AppendStandardComponentStub(sb, funcName, comp, ci);
+                AppendComponentStub(sb, comp, generated, ci);
             }
         }
+    }
+
+    /// <summary>
+    /// Generates a PDK stub for a single component if required.
+    /// </summary>
+    private static void AppendComponentStub(
+        StringBuilder sb, Component comp, HashSet<string> generated, CultureInfo ci)
+    {
+        var funcName = comp.NazcaFunctionName;
+        if (string.IsNullOrEmpty(funcName) || !RequiresStub(funcName))
+            return;
+        if (!generated.Add(funcName))
+            return;
+
+        if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
+            AppendParametricStraightStub(sb, funcName, comp, ci);
+        else
+            AppendStandardComponentStub(sb, funcName, comp, ci);
     }
 
     /// <summary>
@@ -185,57 +198,72 @@ public class SimpleNazcaExporter
         foreach (var compVm in canvas.Components)
         {
             var comp = compVm.Component;
-            var varName = $"comp_{compIndex}";
-            componentNames[comp] = varName;
-
-            // Calculate origin offset based on component type:
-            // - PDK components (both real and demo_pdk): use NazcaOriginOffset (rotated if needed)
-            // - Parametric straights: calculate from first pin (rotated)
-            double originOffsetX = 0;
-            double originOffsetY = 0;
-
-            var funcName = comp.NazcaFunctionName;
-            if (!string.IsNullOrEmpty(funcName) && (IsPdkFunction(funcName) || funcName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase)))
+            if (comp is ComponentGroup group)
             {
-                // PDK component (real or demo_pdk): use stored NazcaOriginOffset, accounting for rotation
-                double offsetX = comp.NazcaOriginOffsetX;
-                double offsetY = comp.NazcaOriginOffsetY;
-                double rotRad = comp.RotationDegrees * Math.PI / 180.0;
-
-                originOffsetX = offsetX * Math.Cos(rotRad) - offsetY * Math.Sin(rotRad);
-                originOffsetY = offsetX * Math.Sin(rotRad) + offsetY * Math.Cos(rotRad);
-            }
-            else if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
-            {
-                // Parametric straight: offset by rotated pin position
-                var firstPin = comp.PhysicalPins.FirstOrDefault();
-                if (firstPin != null)
-                {
-                    double pinLocalX = firstPin.OffsetXMicrometers;
-                    double pinLocalY = firstPin.OffsetYMicrometers;
-                    double rotRad = comp.RotationDegrees * Math.PI / 180.0;
-
-                    originOffsetX = pinLocalX * Math.Cos(rotRad) - pinLocalY * Math.Sin(rotRad);
-                    originOffsetY = pinLocalX * Math.Sin(rotRad) + pinLocalY * Math.Cos(rotRad);
-                }
+                // Flatten group: export all child components at their absolute positions
+                foreach (var child in group.GetAllComponentsRecursive())
+                    AppendSingleComponent(sb, child, componentNames, ref compIndex, ci);
             }
             else
             {
-                // Fallback for legacy components: offset by height for Y-flip
-                originOffsetY = comp.HeightMicrometers;
+                AppendSingleComponent(sb, comp, componentNames, ref compIndex, ci);
             }
-
-            var nazcaX = (comp.PhysicalX + originOffsetX).ToString("F2", ci);
-            var nazcaY = NormalizeZero(-(comp.PhysicalY + originOffsetY)).ToString("F2", ci);
-            var rot = NormalizeZero(-comp.RotationDegrees).ToString("F0", ci);
-            var nazcaFunc = GetNazcaFunction(comp);
-
-            sb.AppendLine($"        {varName} = {nazcaFunc}.put({nazcaX}, {nazcaY}, {rot})  # {comp.Identifier}");
-            compIndex++;
         }
 
         sb.AppendLine();
         return componentNames;
+    }
+
+    /// <summary>
+    /// Appends a single component placement to the Nazca script and records its variable name.
+    /// </summary>
+    private static void AppendSingleComponent(
+        StringBuilder sb, Component comp, Dictionary<Component, string> componentNames,
+        ref int compIndex, CultureInfo ci)
+    {
+        var varName = $"comp_{compIndex}";
+        componentNames[comp] = varName;
+
+        var (originOffsetX, originOffsetY) = CalculateOriginOffset(comp);
+
+        var nazcaX = (comp.PhysicalX + originOffsetX).ToString("F2", ci);
+        var nazcaY = NormalizeZero(-(comp.PhysicalY + originOffsetY)).ToString("F2", ci);
+        var rot = NormalizeZero(-comp.RotationDegrees).ToString("F0", ci);
+        var nazcaFunc = GetNazcaFunction(comp);
+
+        sb.AppendLine($"        {varName} = {nazcaFunc}.put({nazcaX}, {nazcaY}, {rot})  # {comp.Identifier}");
+        compIndex++;
+    }
+
+    /// <summary>
+    /// Calculates the Nazca origin offset for a component based on its type.
+    /// </summary>
+    private static (double OffsetX, double OffsetY) CalculateOriginOffset(Component comp)
+    {
+        var funcName = comp.NazcaFunctionName;
+
+        if (!string.IsNullOrEmpty(funcName) && (IsPdkFunction(funcName) || funcName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase)))
+        {
+            double rotRad = comp.RotationDegrees * Math.PI / 180.0;
+            double offsetX = comp.NazcaOriginOffsetX * Math.Cos(rotRad) - comp.NazcaOriginOffsetY * Math.Sin(rotRad);
+            double offsetY = comp.NazcaOriginOffsetX * Math.Sin(rotRad) + comp.NazcaOriginOffsetY * Math.Cos(rotRad);
+            return (offsetX, offsetY);
+        }
+
+        if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
+        {
+            var firstPin = comp.PhysicalPins.FirstOrDefault();
+            if (firstPin != null)
+            {
+                double rotRad = comp.RotationDegrees * Math.PI / 180.0;
+                double offsetX = firstPin.OffsetXMicrometers * Math.Cos(rotRad) - firstPin.OffsetYMicrometers * Math.Sin(rotRad);
+                double offsetY = firstPin.OffsetXMicrometers * Math.Sin(rotRad) + firstPin.OffsetYMicrometers * Math.Cos(rotRad);
+                return (offsetX, offsetY);
+            }
+        }
+
+        // Fallback for legacy components: offset by height for Y-flip
+        return (0, comp.HeightMicrometers);
     }
 
     private static void AppendConnections(
@@ -243,25 +271,49 @@ public class SimpleNazcaExporter
         DesignCanvasViewModel canvas,
         Dictionary<Component, string> componentNames)
     {
-        if (canvas.Connections.Count == 0)
+        var hasFrozenPaths = canvas.Components.Any(vm => vm.Component is ComponentGroup);
+        if (canvas.Connections.Count == 0 && !hasFrozenPaths)
             return;
 
         sb.AppendLine("        # Waveguide Connections");
+
         foreach (var connVm in canvas.Connections)
         {
             var conn = connVm.Connection;
             var segments = conn.GetPathSegments();
 
             if (segments.Count > 0)
-            {
                 AppendSegmentExport(sb, segments);
-            }
             else
-            {
                 AppendFallbackExport(sb, conn, componentNames);
-            }
         }
+
+        // Export frozen waveguide paths from ComponentGroups
+        foreach (var compVm in canvas.Components)
+        {
+            if (compVm.Component is ComponentGroup group)
+                AppendGroupFrozenPaths(sb, group);
+        }
+
         sb.AppendLine();
+    }
+
+    /// <summary>
+    /// Exports all frozen waveguide paths from a ComponentGroup (and nested groups) as Nazca segments.
+    /// </summary>
+    private static void AppendGroupFrozenPaths(StringBuilder sb, ComponentGroup group)
+    {
+        foreach (var frozenPath in group.InternalPaths)
+        {
+            if (frozenPath?.Path?.Segments?.Count > 0)
+                AppendSegmentExport(sb, frozenPath.Path.Segments);
+        }
+
+        foreach (var child in group.ChildComponents)
+        {
+            if (child is ComponentGroup nestedGroup)
+                AppendGroupFrozenPaths(sb, nestedGroup);
+        }
     }
 
     /// <summary>

--- a/UnitTests/Services/SimpleNazcaExporterTests.cs
+++ b/UnitTests/Services/SimpleNazcaExporterTests.cs
@@ -206,6 +206,135 @@ public class SimpleNazcaExporterTests
         return component;
     }
 
+    // ── ComponentGroup export tests ──────────────────────────────────────────
+
+    [Fact]
+    public void Export_ComponentGroupWithTwoChildren_ExportsBothChildren()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = CreateTestGroupWithTwoChildren();
+        canvas.Components.Add(new ComponentViewModel(group));
+
+        var exporter = new SimpleNazcaExporter();
+
+        // Act
+        var result = exporter.Export(canvas);
+
+        // Assert: both children appear as comp_0 and comp_1 placements
+        result.ShouldContain("comp_0 =");
+        result.ShouldContain("comp_1 =");
+        result.ShouldContain("splitter_1x2");
+        result.ShouldContain("grating_coupler");
+    }
+
+    [Fact]
+    public void Export_ComponentGroupWithFrozenPath_ExportsWaveguideSegments()
+    {
+        // Arrange
+        var canvas = new DesignCanvasViewModel();
+        var group = CreateTestGroupWithFrozenPath();
+        canvas.Components.Add(new ComponentViewModel(group));
+
+        var exporter = new SimpleNazcaExporter();
+
+        // Act
+        var result = exporter.Export(canvas);
+
+        // Assert: frozen waveguide is exported as nd.strt segment
+        result.ShouldContain("nd.strt(");
+        result.ShouldContain("# Waveguide Connections");
+    }
+
+    [Fact]
+    public void Export_ComponentGroupChildren_AreNotExportedAsGroupItself()
+    {
+        // Arrange: a group should not appear as its own component (identifier "group")
+        var canvas = new DesignCanvasViewModel();
+        var group = CreateTestGroupWithTwoChildren();
+        canvas.Components.Add(new ComponentViewModel(group));
+
+        var exporter = new SimpleNazcaExporter();
+
+        // Act
+        var result = exporter.Export(canvas);
+
+        // The group identifier itself should not be placed, only its children
+        result.ShouldNotContain($"# {group.Identifier}");
+    }
+
+    [Fact]
+    public void Export_NestedComponentGroup_FlattensAllDescendants()
+    {
+        // Arrange: outer group contains an inner group with one child
+        var inner = CreateTestGroupWithTwoChildren();
+        inner.GroupName = "InnerGroup";
+
+        var outer = new ComponentGroup("OuterGroup");
+        outer.PhysicalX = 0;
+        outer.PhysicalY = 0;
+        outer.AddChild(inner);
+
+        var canvas = new DesignCanvasViewModel();
+        canvas.Components.Add(new ComponentViewModel(outer));
+
+        var exporter = new SimpleNazcaExporter();
+
+        // Act
+        var result = exporter.Export(canvas);
+
+        // Both children of the inner group should be exported
+        result.ShouldContain("comp_0 =");
+        result.ShouldContain("comp_1 =");
+    }
+
+    private static ComponentGroup CreateTestGroupWithTwoChildren()
+    {
+        var group = new ComponentGroup("TestGroup");
+        group.PhysicalX = 100;
+        group.PhysicalY = 50;
+
+        var child1 = CreateComponentWithName("splitter_1x2");
+        child1.PhysicalX = 100;
+        child1.PhysicalY = 50;
+
+        var child2 = CreateComponentWithName("grating_coupler");
+        child2.PhysicalX = 200;
+        child2.PhysicalY = 50;
+
+        group.AddChild(child1);
+        group.AddChild(child2);
+
+        return group;
+    }
+
+    private static ComponentGroup CreateTestGroupWithFrozenPath()
+    {
+        var group = new ComponentGroup("GroupWithPath");
+        group.PhysicalX = 0;
+        group.PhysicalY = 0;
+
+        var child = CreateComponentWithName("splitter_1x2");
+        child.PhysicalX = 50;
+        child.PhysicalY = 50;
+        group.AddChild(child);
+
+        // Create a frozen path (straight segment from (50,50) to (150,50))
+        var routedPath = new RoutedPath();
+        routedPath.Segments.Add(new StraightSegment(50, 50, 150, 50, 0));
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            Path = routedPath,
+            StartPin = new PhysicalPin { Name = "b0", ParentComponent = child },
+            EndPin = new PhysicalPin { Name = "a0", ParentComponent = child }
+        };
+
+        group.AddInternalPath(frozenPath);
+
+        return group;
+    }
+
     private static int CountOccurrences(string text, string pattern)
     {
         int count = 0;


### PR DESCRIPTION
Automated implementation for #296

The 1 failing test (`ComponentGroupSimulationTests.ComponentGroup_WithComputedSMatrix_SimulatesSuccessfully`) is a **pre-existing failure** per project memory — it's in the ComponentGroup simulation code unrelated to this issue.

All 1272 other tests pass, including all 27 `SimpleNazcaExporter` tests.

## Summary

**Changes made:**

### `CAP.Avalonia/Services/SimpleNazcaExporter.cs`

1. **`AppendPdkComponentStubs`** — now detects ComponentGroups and generates PDK stubs for all child components recursively via new `AppendComponentStub` helper.

2. **`AppendComponents`** — flattens ComponentGroups: iterates `GetAllComponentsRecursive()` for group VMs, exporting each child at its absolute position. Extracted the per-component logic into `AppendSingleComponent` and `CalculateOriginOffset` helpers.

3. **`AppendConnections`** — after regular waveguide connections, calls new `AppendGroupFrozenPaths` which exports `FrozenWaveguidePath.Path.Segments` from all ComponentGroups (and nested groups recursively).

### `UnitTests/Services/SimpleNazcaExporterTests.cs`

Added 4 new tests:
- `Export_ComponentGroupWithTwoChildren_ExportsBothChildren` — verifies both child components appear in script
- `Export_ComponentGroupWithFrozenPath_ExportsWaveguideSegments` — verifies frozen waveguides generate `nd.strt(` calls
- `Export_ComponentGroupChildren_AreNotExportedAsGroupItself` — verifies the group container itself is not placed
- `Export_NestedComponentGroup_FlattensAllDescendants` — verifies recursive flattening works

**Design decision:** Option A (flatten groups) was used — simpler, avoids Nazca hierarchical cell complexity, and keeps child components at their absolute physical positions which are already computed.

MCP Tools used: None (direct file reads and grep were sufficient).


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 11,652
- **Estimated cost:** $0.1746 USD

---
*Generated by autonomous agent using Claude Code.*