### PR TITLE
fix: auto-compute ComponentGroup S-Matrix in SystemMatrixBuilder (#305)

### DIFF
--- a/Connect-A-Pic-Core/LightCalculation/SystemMatrixBuilder.cs
+++ b/Connect-A-Pic-Core/LightCalculation/SystemMatrixBuilder.cs
@@ -61,6 +61,14 @@ namespace CAP_Core.LightCalculation
             var allSMatrices = new List<SMatrix>();
             foreach (var component in allComponents)
             {
+                // ComponentGroups may not have their S-Matrix pre-computed (e.g. when using
+                // LightCalculationService or ParameterSweeper which bypass SimulationService).
+                // Auto-compute on demand so all simulation paths work correctly.
+                if (component is CAP_Core.Components.Core.ComponentGroup group && group.WaveLengthToSMatrixMap.Count == 0)
+                {
+                    group.EnsureSMatrixComputed();
+                }
+
                 if (component.WaveLengthToSMatrixMap.TryGetValue(waveLength, out var matrixFound))
                 {
                     allSMatrices.Add(matrixFound);

--- a/UnitTests/Simulation/ComponentGroupSimulationTests.cs
+++ b/UnitTests/Simulation/ComponentGroupSimulationTests.cs
@@ -145,9 +145,11 @@ public class ComponentGroupSimulationTests
     }
 
     [Fact]
-    public void ComponentGroup_WithoutComputedSMatrix_ThrowsException()
+    public void ComponentGroup_WithoutExplicitCompute_AutoComputesSMatrix()
     {
-        // Arrange - Create a group WITHOUT computing S-Matrix
+        // Regression test for issue #305: SystemMatrixBuilder should auto-compute
+        // S-Matrix for ComponentGroups that haven't been pre-computed (e.g. when
+        // LightCalculationService or ParameterSweeper bypass SimulationService).
         var group = new ComponentGroup("NoMatrix");
         var comp = TestComponentFactory.CreateSimpleTwoPortComponent();
         group.AddChild(comp);
@@ -158,7 +160,7 @@ public class ComponentGroupSimulationTests
             InternalPin = comp.PhysicalPins[0]
         });
 
-        // Don't call group.ComputeSMatrix()
+        // Intentionally skip group.ComputeSMatrix() / EnsureSMatrixComputed()
 
         var tileManager = new ComponentListTileManager();
         tileManager.AddComponent(group);
@@ -169,13 +171,53 @@ public class ComponentGroupSimulationTests
         var gridManager = GridManager.CreateForSimulation(
             tileManager, connectionManager, portManager);
 
-        // Act & Assert - Building system matrix should throw
         var builder = new SystemMatrixBuilder(gridManager);
 
-        Should.Throw<InvalidDataException>(() =>
+        // Should NOT throw — SystemMatrixBuilder auto-computes the S-Matrix
+        var systemMatrix = builder.GetSystemSMatrix(StandardWaveLengths.RedNM);
+        systemMatrix.ShouldNotBeNull();
+
+        // Group's S-Matrix should now be populated
+        group.WaveLengthToSMatrixMap.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void ComponentGroup_SMatrixAutoComputed_WorksFor1550nm()
+    {
+        // Regression test for issue #305: ComponentGroup S-Matrix must be available
+        // for wavelength 1550nm (StandardWaveLengths.RedNM).
+        var group = new ComponentGroup("Group1550");
+        var comp = TestComponentFactory.CreateSimpleTwoPortComponent();
+        group.AddChild(comp);
+
+        group.AddExternalPin(new GroupPin
         {
-            builder.GetSystemSMatrix(StandardWaveLengths.RedNM);
+            Name = "In",
+            InternalPin = comp.PhysicalPins[0]
         });
+
+        group.AddExternalPin(new GroupPin
+        {
+            Name = "Out",
+            InternalPin = comp.PhysicalPins[1]
+        });
+
+        // No pre-computation — rely on auto-compute in SystemMatrixBuilder
+        var tileManager = new ComponentListTileManager();
+        tileManager.AddComponent(group);
+
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
+        var portManager = new PhysicalExternalPortManager();
+
+        var gridManager = GridManager.CreateForSimulation(
+            tileManager, connectionManager, portManager);
+
+        var builder = new SystemMatrixBuilder(gridManager);
+
+        // Must not throw InvalidDataException for 1550nm
+        var systemMatrix = builder.GetSystemSMatrix(1550);
+        systemMatrix.ShouldNotBeNull();
+        group.WaveLengthToSMatrixMap.ShouldContainKey(1550);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #305 — `InvalidDataException: The Matrix was not defined for the specific waveLength: 1550` when simulating designs containing ComponentGroups.

## Root Cause

There are three simulation paths in the codebase:
1. **`SimulationService.RunAsync()`** — calls `group.EnsureSMatrixComputed()` ✅
2. **`LightCalculationService.ShowLightPropagationAsync()`** — does NOT call `EnsureSMatrixComputed()` ❌
3. **`ParameterSweepViewModel.RunSingleSimulation()`** — does NOT call `EnsureSMatrixComputed()` ❌

Paths 2 and 3 reach `SystemMatrixBuilder.GetAllComponentsSMatrices()` with a `ComponentGroup` whose `WaveLengthToSMatrixMap` is empty, hitting the throw branch.

## Fix

`SystemMatrixBuilder.GetAllComponentsSMatrices()` now calls `group.EnsureSMatrixComputed()` for any `ComponentGroup` with an empty map before the wavelength lookup. This makes the fix apply uniformly across all simulation paths without requiring each caller to be updated.

## Changes

- **`Connect-A-Pic-Core/LightCalculation/SystemMatrixBuilder.cs`**: Auto-compute S-Matrix for uninitialized ComponentGroups
- **`UnitTests/Simulation/ComponentGroupSimulationTests.cs`**: Updated test to verify auto-computation (was testing the old throw behavior); added dedicated 1550nm regression test

## Test Results

All 1278 tests pass ✅

MCP Tools used: none (direct code path analysis was sufficient)
