### PR TITLE
Agent: Bug: Analyze Routes only exports subset of connections

### DIFF
--- a/CAP.Avalonia/ViewModels/Diagnostics/RoutingDiagnosticsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/RoutingDiagnosticsViewModel.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using CAP_Core;
+using CAP_Core.Components.Core;
 using CAP_Core.Routing;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -59,7 +60,7 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Runs diagnostics on all routed connections.
+    /// Runs diagnostics on all routed connections, including paths inside ComponentGroups.
     /// </summary>
     [RelayCommand]
     private void RunDiagnostics()
@@ -74,7 +75,8 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
         try
         {
             var connections = _canvas.Connections;
-            TotalConnections = connections.Count;
+            var frozenPaths = CollectFrozenPaths();
+            TotalConnections = connections.Count + frozenPaths.Count;
 
             if (TotalConnections == 0)
             {
@@ -100,29 +102,12 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
                     continue;
                 }
 
-                var report = diagnostics.Validate(path);
-                bool isOk = report.IsValid && !path.IsBlockedFallback;
+                AppendPathDiagnostics(sb, diagnostics, path, GetConnectionLabel(conn), ref valid, ref totalIssues);
+            }
 
-                if (isOk) valid++;
-
-                string status = isOk ? "OK" : "ISSUES";
-                sb.AppendLine($"  {GetConnectionLabel(conn)}: {status}");
-                sb.AppendLine($"    Length: {path.TotalLengthMicrometers:F1}µm");
-                sb.AppendLine($"    Segments: {path.Segments.Count}");
-                sb.AppendLine($"    Bends: {path.TotalEquivalent90DegreeBends:F1}×90°");
-
-                if (path.IsBlockedFallback)
-                    sb.AppendLine("    ⚠ Blocked fallback");
-                if (path.IsInvalidGeometry)
-                    sb.AppendLine("    ⚠ Invalid geometry");
-
-                foreach (var issue in report.Issues)
-                {
-                    sb.AppendLine($"    [{issue.Severity}] {issue.Message}");
-                    totalIssues++;
-                }
-
-                sb.AppendLine();
+            foreach (var frozen in frozenPaths)
+            {
+                AppendPathDiagnostics(sb, diagnostics, frozen.Path, GetFrozenPathLabel(frozen), ref valid, ref totalIssues);
             }
 
             ValidConnections = valid;
@@ -141,13 +126,42 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
         }
     }
 
+    private static void AppendPathDiagnostics(StringBuilder sb, RoutingDiagnostics diagnostics,
+        RoutedPath path, string label, ref int valid, ref int totalIssues)
+    {
+        var report = diagnostics.Validate(path);
+        bool isOk = report.IsValid && !path.IsBlockedFallback;
+
+        if (isOk) valid++;
+
+        string status = isOk ? "OK" : "ISSUES";
+        sb.AppendLine($"  {label}: {status}");
+        sb.AppendLine($"    Length: {path.TotalLengthMicrometers:F1}µm");
+        sb.AppendLine($"    Segments: {path.Segments.Count}");
+        sb.AppendLine($"    Bends: {path.TotalEquivalent90DegreeBends:F1}×90°");
+
+        if (path.IsBlockedFallback)
+            sb.AppendLine("    ⚠ Blocked fallback");
+        if (path.IsInvalidGeometry)
+            sb.AppendLine("    ⚠ Invalid geometry");
+
+        foreach (var issue in report.Issues)
+        {
+            sb.AppendLine($"    [{issue.Severity}] {issue.Message}");
+            totalIssues++;
+        }
+
+        sb.AppendLine();
+    }
+
     /// <summary>
-    /// Exports all routed paths to a JSON file for external visualization.
+    /// Exports all routed paths to a JSON file for external visualization,
+    /// including paths inside ComponentGroups.
     /// </summary>
     [RelayCommand]
     private async Task ExportPathsJson()
     {
-        if (_canvas == null || _canvas.Connections.Count == 0)
+        if (_canvas == null)
         {
             StatusText = "No connections to export";
             return;
@@ -155,13 +169,12 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
 
         try
         {
-            var paths = new Dictionary<string, RoutedPath>();
-            foreach (var conn in _canvas.Connections)
+            var paths = CollectAllPaths();
+
+            if (paths.Count == 0)
             {
-                if (conn.Connection.RoutedPath != null)
-                {
-                    paths[GetConnectionLabel(conn)] = conn.Connection.RoutedPath;
-                }
+                StatusText = "No connections to export";
+                return;
             }
 
             var json = RoutedPathSerializer.ToJson(paths);
@@ -199,12 +212,13 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
     public Func<string, Task>? CopyToClipboard { get; set; }
 
     /// <summary>
-    /// Copies all routed paths as JSON to the clipboard.
+    /// Copies all routed paths as JSON to the clipboard,
+    /// including paths inside ComponentGroups.
     /// </summary>
     [RelayCommand]
     private async Task CopyPathsJsonToClipboard()
     {
-        if (_canvas == null || _canvas.Connections.Count == 0)
+        if (_canvas == null)
         {
             StatusText = "No connections to copy";
             return;
@@ -212,13 +226,12 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
 
         try
         {
-            var paths = new Dictionary<string, RoutedPath>();
-            foreach (var conn in _canvas.Connections)
+            var paths = CollectAllPaths();
+
+            if (paths.Count == 0)
             {
-                if (conn.Connection.RoutedPath != null)
-                {
-                    paths[GetConnectionLabel(conn)] = conn.Connection.RoutedPath;
-                }
+                StatusText = "No connections to copy";
+                return;
             }
 
             var json = RoutedPathSerializer.ToJson(paths);
@@ -248,5 +261,60 @@ public partial class RoutingDiagnosticsViewModel : ObservableObject
         var startId = start.ParentComponent?.Identifier ?? "?";
         var endId = end.ParentComponent?.Identifier ?? "?";
         return $"{startId}.{start.Name} -> {endId}.{end.Name}";
+    }
+
+    private static string GetFrozenPathLabel(FrozenWaveguidePath frozen)
+    {
+        var startId = frozen.StartPin?.ParentComponent?.Identifier ?? "?";
+        var startName = frozen.StartPin?.Name ?? "?";
+        var endId = frozen.EndPin?.ParentComponent?.Identifier ?? "?";
+        var endName = frozen.EndPin?.Name ?? "?";
+        return $"{startId}.{startName} -> {endId}.{endName} [group]";
+    }
+
+    /// <summary>
+    /// Collects all routed paths: canvas connections + frozen paths from ComponentGroups.
+    /// </summary>
+    private Dictionary<string, RoutedPath> CollectAllPaths()
+    {
+        var paths = new Dictionary<string, RoutedPath>();
+
+        foreach (var conn in _canvas!.Connections)
+        {
+            if (conn.Connection.RoutedPath != null)
+                paths[GetConnectionLabel(conn)] = conn.Connection.RoutedPath;
+        }
+
+        foreach (var frozen in CollectFrozenPaths())
+        {
+            if (frozen.Path != null)
+                paths[GetFrozenPathLabel(frozen)] = frozen.Path;
+        }
+
+        return paths;
+    }
+
+    /// <summary>
+    /// Recursively collects all frozen waveguide paths from ComponentGroups on the canvas.
+    /// </summary>
+    private List<FrozenWaveguidePath> CollectFrozenPaths()
+    {
+        var result = new List<FrozenWaveguidePath>();
+        foreach (var compVm in _canvas!.Components)
+        {
+            if (compVm.Component is ComponentGroup group)
+                CollectFrozenPathsRecursive(group, result);
+        }
+        return result;
+    }
+
+    private static void CollectFrozenPathsRecursive(ComponentGroup group, List<FrozenWaveguidePath> result)
+    {
+        result.AddRange(group.InternalPaths);
+        foreach (var child in group.ChildComponents)
+        {
+            if (child is ComponentGroup nestedGroup)
+                CollectFrozenPathsRecursive(nestedGroup, result);
+        }
     }
 }

--- a/UnitTests/Routing/RoutingDiagnosticsIntegrationTests.cs
+++ b/UnitTests/Routing/RoutingDiagnosticsIntegrationTests.cs
@@ -1,5 +1,10 @@
+using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
+using CAP_Core.Tiles;
 using Shouldly;
 using Xunit;
 
@@ -81,6 +86,139 @@ public class RoutingDiagnosticsIntegrationTests
         // Verify diagnostics report is meaningful
         var summary = connResult.Diagnostics!.FormatSummary();
         summary.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void RunDiagnostics_WithGroupHavingFrozenPaths_IncludesFrozenPathsInCount()
+    {
+        // Arrange: create a canvas with a ComponentGroup that has an internal frozen path
+        var canvas = new DesignCanvasViewModel();
+
+        var child = CreateMinimalComponent("Child1", 0, 0);
+        var group = new ComponentGroup("TestGroup");
+        group.AddChild(child);
+
+        var startPin = new PhysicalPin { Name = "in", ParentComponent = child, OffsetXMicrometers = 0, OffsetYMicrometers = 0, AngleDegrees = 180 };
+        var endPin = new PhysicalPin { Name = "out", ParentComponent = child, OffsetXMicrometers = 100, OffsetYMicrometers = 0, AngleDegrees = 0 };
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            Path = new RoutedPath(),
+            StartPin = startPin,
+            EndPin = endPin
+        };
+        frozenPath.Path.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+        group.AddInternalPath(frozenPath);
+
+        canvas.AddComponent(group);
+
+        var vm = new RoutingDiagnosticsViewModel();
+        vm.Configure(canvas);
+
+        // Act
+        vm.RunDiagnosticsCommand.Execute(null);
+
+        // Assert: TotalConnections includes the 1 frozen path from the group
+        vm.TotalConnections.ShouldBe(1);
+        vm.ValidConnections.ShouldBe(1);
+        vm.ResultText.ShouldContain("[group]");
+    }
+
+    [Fact]
+    public void RunDiagnostics_WithNestedGroups_IncludesAllFrozenPaths()
+    {
+        // Arrange: nested groups with frozen paths
+        var canvas = new DesignCanvasViewModel();
+
+        var child = CreateMinimalComponent("Child", 0, 0);
+        var innerGroup = new ComponentGroup("Inner");
+        innerGroup.AddChild(child);
+
+        var pin1 = new PhysicalPin { Name = "in", ParentComponent = child };
+        var pin2 = new PhysicalPin { Name = "out", ParentComponent = child };
+        var innerFrozen = new FrozenWaveguidePath { Path = new RoutedPath(), StartPin = pin1, EndPin = pin2 };
+        innerFrozen.Path.Segments.Add(new StraightSegment(0, 0, 50, 0, 0));
+        innerGroup.AddInternalPath(innerFrozen);
+
+        var outerGroup = new ComponentGroup("Outer");
+        outerGroup.AddChild(innerGroup);
+
+        var pin3 = new PhysicalPin { Name = "a", ParentComponent = child };
+        var pin4 = new PhysicalPin { Name = "b", ParentComponent = child };
+        var outerFrozen = new FrozenWaveguidePath { Path = new RoutedPath(), StartPin = pin3, EndPin = pin4 };
+        outerFrozen.Path.Segments.Add(new StraightSegment(0, 0, 80, 0, 0));
+        outerGroup.AddInternalPath(outerFrozen);
+
+        canvas.AddComponent(outerGroup);
+
+        var vm = new RoutingDiagnosticsViewModel();
+        vm.Configure(canvas);
+
+        // Act
+        vm.RunDiagnosticsCommand.Execute(null);
+
+        // Assert: both frozen paths (inner + outer) are included
+        vm.TotalConnections.ShouldBe(2);
+    }
+
+    [Fact]
+    public void RunDiagnostics_WithCanvasConnectionsAndGroups_CountsAll()
+    {
+        // Arrange: canvas has one direct connection and one group with a frozen path
+        var canvas = new DesignCanvasViewModel();
+
+        var compA = CreateMinimalComponent("A", 0, 0);
+        var pinA = new PhysicalPin { Name = "out", ParentComponent = compA, OffsetXMicrometers = 50, OffsetYMicrometers = 0, AngleDegrees = 0 };
+        compA.PhysicalPins.Add(pinA);
+        canvas.AddComponent(compA);
+
+        var compB = CreateMinimalComponent("B", 200, 0);
+        var pinB = new PhysicalPin { Name = "in", ParentComponent = compB, OffsetXMicrometers = 0, OffsetYMicrometers = 0, AngleDegrees = 180 };
+        compB.PhysicalPins.Add(pinB);
+        canvas.AddComponent(compB);
+
+        var directPath = new RoutedPath();
+        directPath.Segments.Add(new StraightSegment(50, 0, 200, 0, 0));
+        canvas.ConnectPinsWithCachedRoute(pinA, pinB, directPath);
+
+        var groupChild = CreateMinimalComponent("GChild", 0, 100);
+        var group = new ComponentGroup("Group1");
+        group.AddChild(groupChild);
+        var gp1 = new PhysicalPin { Name = "x", ParentComponent = groupChild };
+        var gp2 = new PhysicalPin { Name = "y", ParentComponent = groupChild };
+        var frozen = new FrozenWaveguidePath { Path = new RoutedPath(), StartPin = gp1, EndPin = gp2 };
+        frozen.Path.Segments.Add(new StraightSegment(0, 100, 50, 100, 0));
+        group.AddInternalPath(frozen);
+        canvas.AddComponent(group);
+
+        var vm = new RoutingDiagnosticsViewModel();
+        vm.Configure(canvas);
+
+        // Act
+        vm.RunDiagnosticsCommand.Execute(null);
+
+        // Assert: 1 canvas connection + 1 frozen group path = 2 total
+        vm.TotalConnections.ShouldBe(2);
+    }
+
+    private static Component CreateMinimalComponent(string id, double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+        var comp = new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: $"test_{id.ToLower()}",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: id,
+            rotationCounterClock: DiscreteRotation.R0,
+            physicalPins: new List<PhysicalPin>()
+        );
+        comp.PhysicalX = x;
+        comp.PhysicalY = y;
+        return comp;
     }
 
     [Fact]


### PR DESCRIPTION
Automated implementation for #306

The implementation is clean and complete. Here's a summary of what was done:

## Fix: Analyze Routes now exports all connections

**Root cause:** `RoutingDiagnosticsViewModel` only iterated `_canvas.Connections` (top-level waveguide connections) and completely ignored `FrozenWaveguidePath` objects stored inside `ComponentGroup.InternalPaths`.

**Changes made:**

### `CAP.Avalonia/ViewModels/Diagnostics/RoutingDiagnosticsViewModel.cs`
- Added `CollectFrozenPaths()` — mirrors the pattern from `PowerFlowVisualizer`, recursively walks all `ComponentGroup` instances on the canvas collecting their `InternalPaths`
- Added `CollectFrozenPathsRecursive()` — handles nested groups
- Added `CollectAllPaths()` — combines canvas connections + frozen group paths into one dictionary
- Added `GetFrozenPathLabel()` — formats frozen paths with `[group]` suffix for clarity
- Extracted `AppendPathDiagnostics()` — eliminates code duplication between canvas and frozen path processing
- Updated `RunDiagnostics()`, `ExportPathsJson()`, and `CopyPathsJsonToClipboard()` to use the combined collection

### `UnitTests/Routing/RoutingDiagnosticsIntegrationTests.cs`
- Added 3 new integration tests verifying frozen path inclusion:
  - Single group with one frozen path
  - Nested groups (both levels collected)
  - Mixed scenario (canvas connection + group frozen path = 2 total)

**Result:** All 1280 tests pass. Designs with ComponentGroups will now show all internal waveguide paths in the diagnostics panel and JSON export.

---

MCP Tools used: None (used direct file reads and grep for efficient targeted search).


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 14,167
- **Estimated cost:** $0.2120 USD

---
*Generated by autonomous agent using Claude Code.*