### PR TITLE
Agent: [Bug] Frozen waveguides in ComponentGroups show gray (no power flow) after simulation

### DIFF
--- a/CAP.Avalonia/Visualization/PowerFlowVisualizer.cs
+++ b/CAP.Avalonia/Visualization/PowerFlowVisualizer.cs
@@ -48,6 +48,9 @@ public class PowerFlowVisualizer
     /// <summary>
     /// Updates the power flow data from simulation results.
     /// Includes both regular connections and frozen paths inside groups.
+    /// Augments fieldResults with computed internal pin amplitudes so that frozen
+    /// paths (whose pins are absent from the global simulation's fieldResults) can
+    /// be visualized with correct power values.
     /// </summary>
     /// <param name="connections">Current waveguide connections.</param>
     /// <param name="components">Current components (to extract frozen paths from groups).</param>
@@ -58,7 +61,45 @@ public class PowerFlowVisualizer
         IReadOnlyDictionary<Guid, Complex> fieldResults)
     {
         var frozenPaths = CollectAllFrozenPaths(components);
-        CurrentResult = _analyzer.Analyze(connections, frozenPaths, fieldResults);
+        var augmentedFields = AugmentWithGroupInternalAmplitudes(components, fieldResults);
+        CurrentResult = _analyzer.Analyze(connections, frozenPaths, augmentedFields);
+    }
+
+    /// <summary>
+    /// Augments fieldResults with estimated amplitudes for all internal group pins.
+    /// The global simulation only produces amplitudes for external group pins; this method
+    /// propagates those amplitudes inward through each group's cached internal system matrix.
+    /// </summary>
+    private static Dictionary<Guid, Complex> AugmentWithGroupInternalAmplitudes(
+        IReadOnlyList<Component> components,
+        IReadOnlyDictionary<Guid, Complex> fieldResults)
+    {
+        var augmented = new Dictionary<Guid, Complex>(fieldResults);
+        foreach (var component in components)
+        {
+            if (component is ComponentGroup group)
+                AddGroupInternalAmplitudes(group, augmented);
+        }
+        return augmented;
+    }
+
+    /// <summary>
+    /// Adds estimated internal pin amplitudes for a group and its nested groups.
+    /// Outer groups are processed before inner groups so nested group external pins
+    /// are already populated when inner groups are processed.
+    /// </summary>
+    private static void AddGroupInternalAmplitudes(
+        ComponentGroup group,
+        Dictionary<Guid, Complex> fieldResults)
+    {
+        foreach (var (pinId, amplitude) in group.ComputeInternalPinAmplitudes(fieldResults))
+            fieldResults[pinId] = amplitude;
+
+        foreach (var child in group.ChildComponents)
+        {
+            if (child is ComponentGroup nestedGroup)
+                AddGroupInternalAmplitudes(nestedGroup, fieldResults);
+        }
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using CAP_Core.Components.Creation;
@@ -107,6 +108,60 @@ public class ComponentGroup : Component, INotifyPropertyChanged
     /// </summary>
     [JsonIgnore]
     public double MinChildOffsetY { get; private set; }
+
+    /// <summary>
+    /// Full internal system matrix including all child component pin IDs.
+    /// Cached by ComponentGroupSMatrixBuilder during ComputeSMatrix() to support
+    /// power flow visualization of frozen waveguide paths inside this group.
+    /// Null until ComputeSMatrix() has been called at least once.
+    /// </summary>
+    [JsonIgnore]
+    public SMatrix? InternalSystemMatrix { get; internal set; }
+
+    /// <summary>
+    /// Computes estimated light amplitudes for all internal pins (including frozen path pins)
+    /// based on the external group pin amplitudes present in simulation field results.
+    /// Used by PowerFlowVisualizer to show power flow through frozen waveguide paths.
+    /// </summary>
+    /// <param name="fieldResults">Simulation field results containing external pin amplitudes.</param>
+    /// <returns>Dictionary mapping internal pin IDs to their estimated complex amplitudes.</returns>
+    public Dictionary<Guid, Complex> ComputeInternalPinAmplitudes(
+        IReadOnlyDictionary<Guid, Complex> fieldResults)
+    {
+        var result = new Dictionary<Guid, Complex>();
+        if (InternalSystemMatrix == null) return result;
+
+        foreach (var (pinId, rowIdx) in InternalSystemMatrix.PinReference)
+        {
+            if (fieldResults.ContainsKey(pinId)) continue;
+            var amplitude = ComputePinAmplitudeFromExternalInputs(rowIdx, fieldResults);
+            if (amplitude != Complex.Zero)
+                result[pinId] = amplitude;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Computes the amplitude at a given matrix row index by applying the internal system
+    /// matrix to the external group pin inflow amplitudes from field results.
+    /// Only IDInFlow values of external pins are used as inputs (light entering from outside).
+    /// </summary>
+    private Complex ComputePinAmplitudeFromExternalInputs(
+        int rowIdx,
+        IReadOnlyDictionary<Guid, Complex> fieldResults)
+    {
+        var amplitude = Complex.Zero;
+        foreach (var extPin in ExternalPins)
+        {
+            if (extPin.InternalPin?.LogicalPin == null) continue;
+            var idInFlow = extPin.InternalPin.LogicalPin.IDInFlow;
+            if (!InternalSystemMatrix!.PinReference.TryGetValue(idInFlow, out int colIdx)) continue;
+            if (!fieldResults.TryGetValue(idInFlow, out var extAmp)) continue;
+            amplitude += InternalSystemMatrix.SMat[rowIdx, colIdx] * extAmp;
+        }
+        return amplitude;
+    }
 
     /// <summary>
     /// Creates an empty ComponentGroup with default S-matrices.

--- a/Connect-A-Pic-Core/LightCalculation/ComponentGroupSMatrixBuilder.cs
+++ b/Connect-A-Pic-Core/LightCalculation/ComponentGroupSMatrixBuilder.cs
@@ -173,6 +173,11 @@ public class ComponentGroupSMatrixBuilder
         // (M + M^2 + ... + M^N) accumulates multi-step paths.
         var systemMatrix = ComputeTransitiveMatrix(mergedMatrix, allChildPinIds.Count);
 
+        // Cache the full internal matrix (all child pins) so that frozen path power flow
+        // can be computed during visualization. ExtractExternalPinMatrix discards internal
+        // pins, making it impossible to look them up in fieldResults without this cache.
+        group.InternalSystemMatrix = systemMatrix;
+
         // Create the external pin mapping
         var externalPinIds = new List<Guid>();
         foreach (var extPin in group.ExternalPins)

--- a/UnitTests/Visualization/GroupPowerFlowIntegrationTests.cs
+++ b/UnitTests/Visualization/GroupPowerFlowIntegrationTests.cs
@@ -139,6 +139,124 @@ public class GroupPowerFlowIntegrationTests
     }
 
     /// <summary>
+    /// Regression test for issue #314: frozen paths showed gray (zero power) after simulation
+    /// because fieldResults from the global simulation only contains external group pin IDs,
+    /// not the internal frozen path pin IDs. The fix augments fieldResults by propagating
+    /// external amplitudes inward through the group's cached InternalSystemMatrix.
+    /// </summary>
+    [Fact]
+    public void UpdateFromSimulation_WhenFieldResultsOnlyHaveExternalGroupPins_FrozenPathsShowPower()
+    {
+        // Arrange: create a group with two components connected by a frozen path.
+        // Both components have real S-Matrices so InternalSystemMatrix is computed.
+        var (group, frozenPath, externalInputPinId) = CreateGroupWithSMatrixComponents();
+
+        var components = new List<Component> { group };
+        var connections = new List<WaveguideConnection>();
+
+        // Simulate what the real global simulation produces:
+        // fieldResults ONLY contains external group pin amplitudes — NOT internal frozen path pins.
+        var fieldResults = new Dictionary<Guid, Complex>
+        {
+            [externalInputPinId] = new Complex(1.0, 0)
+        };
+
+        var visualizer = new PowerFlowVisualizer();
+
+        // Act
+        visualizer.UpdateFromSimulation(connections, components, fieldResults);
+
+        // Assert: frozen path must show non-zero power (was always 0 before the fix)
+        var flow = visualizer.GetFlowForConnection(frozenPath.PathId);
+        flow.ShouldNotBeNull();
+        flow!.AveragePower.ShouldBeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// Creates a group with two components that have actual S-Matrices:
+    ///   Comp1: external pin A (left) → internal pin B (right, frozen path start)
+    ///   Comp2: internal pin C (left, frozen path end) → external pin D (right)
+    /// Returns the group, frozen path, and the IDInFlow of external pin A.
+    /// </summary>
+    private static (ComponentGroup group, FrozenWaveguidePath frozenPath, Guid externalInputPinId)
+        CreateGroupWithSMatrixComponents()
+    {
+        const int Wavelength = 1550;
+
+        var pinA = new Pin("pinA", 0, MatterType.Light, RectSide.Left);
+        var pinB = new Pin("pinB", 1, MatterType.Light, RectSide.Right);
+        var physPinA = new PhysicalPin { Name = "pinA", LogicalPin = pinA };
+        var physPinB = new PhysicalPin { Name = "pinB", LogicalPin = pinB };
+        var comp1 = CreatePassthroughComponent("comp1", pinA, pinB, physPinA, physPinB, Wavelength);
+
+        var pinC = new Pin("pinC", 0, MatterType.Light, RectSide.Left);
+        var pinD = new Pin("pinD", 1, MatterType.Light, RectSide.Right);
+        var physPinC = new PhysicalPin { Name = "pinC", LogicalPin = pinC };
+        var physPinD = new PhysicalPin { Name = "pinD", LogicalPin = pinD };
+        var comp2 = CreatePassthroughComponent("comp2", pinC, pinD, physPinC, physPinD, Wavelength);
+
+        var group = new ComponentGroup("BugReproGroup");
+        group.AddChild(comp1);
+        group.AddChild(comp2);
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            Path = CreateSimpleStraightPath(),
+            StartPin = physPinB,
+            EndPin = physPinC
+        };
+        group.AddInternalPath(frozenPath);
+
+        group.AddExternalPin(new GroupPin { Name = "groupA", InternalPin = physPinA });
+        group.AddExternalPin(new GroupPin { Name = "groupD", InternalPin = physPinD });
+
+        // ComputeSMatrix caches InternalSystemMatrix — required for the fix to work
+        group.ComputeSMatrix();
+
+        return (group, frozenPath, pinA.IDInFlow);
+    }
+
+    /// <summary>
+    /// Creates a component whose S-Matrix transfers light from inPin's IDInFlow to outPin's IDOutFlow.
+    /// </summary>
+    private static Component CreatePassthroughComponent(
+        string id, Pin inPin, Pin outPin,
+        PhysicalPin physIn, PhysicalPin physOut,
+        int wavelength)
+    {
+        var pinIds = new List<Guid>
+        {
+            inPin.IDInFlow, inPin.IDOutFlow,
+            outPin.IDInFlow, outPin.IDOutFlow
+        };
+        var sMatrix = new SMatrix(pinIds, new());
+        sMatrix.SetValues(new Dictionary<(Guid, Guid), Complex>
+        {
+            { (inPin.IDInFlow, outPin.IDOutFlow), Complex.One }
+        });
+        var comp = new Component(
+            new Dictionary<int, SMatrix> { [wavelength] = sMatrix },
+            new List<Slider>(), "passthrough", "",
+            new Part[1, 1] { { new Part() } },
+            0, id, new DiscreteRotation(),
+            new List<PhysicalPin> { physIn, physOut });
+        physIn.ParentComponent = comp;
+        physOut.ParentComponent = comp;
+        return comp;
+    }
+
+    /// <summary>
+    /// Creates a simple single-segment straight path for frozen path geometry.
+    /// </summary>
+    private static RoutedPath CreateSimpleStraightPath()
+    {
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+        return path;
+    }
+
+    /// <summary>
     /// Helper method to create a test component group with a frozen path.
     /// </summary>
     private static (ComponentGroup group, FrozenWaveguidePath frozenPath)


### PR DESCRIPTION
Automated implementation for #314

## Summary

**Bug fixed**: Frozen waveguide paths inside `ComponentGroup`s now show correct power flow visualization after simulation.

### Root Cause

`ComponentGroupSMatrixBuilder` computes a full internal system matrix (all child pins), then **discards internal pin rows** when extracting only the external pin sub-matrix. The global simulation's `fieldResults` therefore only contains external group pin IDs. When `PowerFlowAnalyzer` tried to look up frozen path pins in `fieldResults`, it got `Complex.Zero` → zero power → gray visualization.

### Changes

**`ComponentGroupSMatrixBuilder.cs`** — Cache the full internal system matrix before discarding:
```csharp
group.InternalSystemMatrix = systemMatrix;  // cache before ExtractExternalPinMatrix
```

**`ComponentGroup.cs`** — New property + methods:
- `InternalSystemMatrix`: cached full-child-pin S-Matrix (JsonIgnore)
- `ComputeInternalPinAmplitudes()`: propagates external pin amplitudes inward through the cached matrix to estimate amplitudes at all internal pins (including frozen path pins)
- `ComputePinAmplitudeFromExternalInputs()`: applies `SMat[rowIdx, extPin.IDInFlow_colIdx]` × external amplitude for each external group pin

**`PowerFlowVisualizer.cs`** — Augment before analysis:
- `UpdateFromSimulation()` now calls `AugmentWithGroupInternalAmplitudes()` which adds the computed internal pin amplitudes to a copy of `fieldResults` before passing to `_analyzer.Analyze()`

**`GroupPowerFlowIntegrationTests.cs`** — Regression test `UpdateFromSimulation_WhenFieldResultsOnlyHaveExternalGroupPins_FrozenPathsShowPower` that specifically reproduces the bug: two components with real S-Matrices in a group, `fieldResults` seeded with only the external group pin amplitude, asserts frozen path shows non-zero power.

---

MCP Tools used: None (standard file reads, grep, and direct implementation).


## 🤖 Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 40,344
- **Estimated cost:** $0.6048 USD

---
*Generated by autonomous agent using Claude Code.*