### PR TITLE
Agent: Add power loss labels to frozen waveguide visualization

### DIFF
--- a/CAP.Avalonia/Controls/Rendering/ComponentGroupRenderer.cs
+++ b/CAP.Avalonia/Controls/Rendering/ComponentGroupRenderer.cs
@@ -97,6 +97,71 @@ public static class ComponentGroupRenderer
                 RenderBendSegment(context, frozenPen, bend);
             }
         }
+
+        // Render power loss label at midpoint when power flow visualization is active
+        if (powerFlowResult != null)
+        {
+            powerFlowResult.ConnectionFlows.TryGetValue(frozenPath.PathId, out var labelFlow);
+            var midPoint = CalculateFrozenPathMidpoint(frozenPath);
+            DrawFrozenPathLabel(context, labelFlow, midPoint);
+        }
+    }
+
+    /// <summary>
+    /// Calculates the visual midpoint of a frozen path from its first and last segment endpoints.
+    /// </summary>
+    private static Point CalculateFrozenPathMidpoint(FrozenWaveguidePath frozenPath)
+    {
+        var segments = frozenPath.Path.Segments;
+        var firstStart = segments[0].StartPoint;
+        var lastEnd = segments[^1].EndPoint;
+        return new Point(
+            (firstStart.X + lastEnd.X) / 2,
+            (firstStart.Y + lastEnd.Y) / 2
+        );
+    }
+
+    /// <summary>
+    /// Draws a power loss label at the specified midpoint position.
+    /// Shows dB and percentage when signal is present, "no signal" otherwise.
+    /// </summary>
+    private static void DrawFrozenPathLabel(
+        DrawingContext context,
+        ConnectionPowerFlow? flow,
+        Point midPoint)
+    {
+        string labelText;
+        IBrush labelBrush;
+
+        if (flow != null && flow.AveragePower > 0)
+        {
+            labelText = $"{flow.NormalizedPowerDb:F1}dB ({flow.NormalizedPowerFraction * 100:F0}%)";
+            var fraction = Math.Clamp(flow.NormalizedPowerFraction, 0, 1);
+            labelBrush = new SolidColorBrush(PowerFlowRenderer.InterpolatePowerColor(fraction));
+        }
+        else
+        {
+            labelText = "no signal";
+            labelBrush = new SolidColorBrush(Color.FromArgb(120, 150, 150, 150));
+        }
+
+        var labelPosition = new Point(midPoint.X, midPoint.Y - 15);
+        var formatted = new FormattedText(
+            labelText,
+            CultureInfo.CurrentCulture,
+            FlowDirection.LeftToRight,
+            new Typeface("Arial"),
+            10,
+            labelBrush);
+
+        var textBounds = new Rect(
+            labelPosition.X - 2,
+            labelPosition.Y - 2,
+            formatted.Width + 4,
+            formatted.Height + 4);
+
+        context.FillRectangle(new SolidColorBrush(Color.FromArgb(160, 0, 0, 0)), textBounds);
+        context.DrawText(formatted, labelPosition);
     }
 
     /// <summary>

--- a/UnitTests/Visualization/PowerFlowFrozenPathTests.cs
+++ b/UnitTests/Visualization/PowerFlowFrozenPathTests.cs
@@ -100,6 +100,61 @@ public class PowerFlowFrozenPathTests
     }
 
     /// <summary>
+    /// Verifies that power flow data required for label rendering is available for frozen paths.
+    /// This ensures ComponentGroupRenderer can display loss labels like "-5.5dB (70%)".
+    /// </summary>
+    [Fact]
+    public void FrozenWaveguidePath_WithPowerFlow_HasLabelDataAvailable()
+    {
+        // Arrange
+        var analyzer = new PowerFlowAnalyzer();
+        var (frozenPath, fieldResults) = CreateTestFrozenPathWithFields(inputPower: 1.0);
+        var frozenPaths = new List<FrozenWaveguidePath> { frozenPath };
+
+        // Act
+        var result = analyzer.Analyze(new List<WaveguideConnection>(), frozenPaths, fieldResults);
+
+        // Assert: flow data required for rendering labels is present
+        result.ConnectionFlows.TryGetValue(frozenPath.PathId, out var flow).ShouldBeTrue();
+        flow.ShouldNotBeNull();
+        flow!.AveragePower.ShouldBeGreaterThan(0);
+        flow.NormalizedPowerFraction.ShouldBeInRange(0.0, 1.0);
+
+        // Verify the label text would be non-trivial (dB value is finite)
+        double.IsNegativeInfinity(flow.NormalizedPowerDb).ShouldBeFalse();
+    }
+
+    /// <summary>
+    /// Verifies that frozen path midpoint calculation produces a point between start and end.
+    /// </summary>
+    [Fact]
+    public void FrozenWaveguidePath_Midpoint_IsBetweenStartAndEnd()
+    {
+        // Arrange: path from (0,0) to (100,0)
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            Path = path,
+            StartPin = new PhysicalPin { Name = "s", OffsetXMicrometers = 0, OffsetYMicrometers = 0 },
+            EndPin = new PhysicalPin { Name = "e", OffsetXMicrometers = 100, OffsetYMicrometers = 0 }
+        };
+
+        var firstStart = frozenPath.Path.Segments[0].StartPoint;
+        var lastEnd = frozenPath.Path.Segments[^1].EndPoint;
+
+        // Act: calculate midpoint the same way ComponentGroupRenderer does
+        double midX = (firstStart.X + lastEnd.X) / 2;
+        double midY = (firstStart.Y + lastEnd.Y) / 2;
+
+        // Assert: midpoint should be at (50, 0)
+        midX.ShouldBe(50.0, tolerance: 0.001);
+        midY.ShouldBe(0.0, tolerance: 0.001);
+    }
+
+    /// <summary>
     /// Verifies that fade threshold works correctly for frozen paths.
     /// </summary>
     [Fact]


### PR DESCRIPTION
Automated implementation for #327

The implementation is complete. Here's a summary of what was done:

## Changes Made

### 1. `CAP.Avalonia/Controls/Rendering/ComponentGroupRenderer.cs`

Added two new private static helper methods and called them in `RenderFrozenWaveguidePath()`:

- **`CalculateFrozenPathMidpoint()`** — Calculates midpoint as the average of the first segment's start point and last segment's end point, matching the approach used for regular waveguide labels.

- **`DrawFrozenPathLabel()`** — Draws the power loss label at `midPoint.Y - 15` (above the path). Shows `"-X.XdB (Y%)"` format with color-coded text (matching regular waveguides) when signal is present, or a dimmed "no signal" when no power flows. Includes a semi-transparent dark background for readability.

- In `RenderFrozenWaveguidePath()`: after rendering all segments, when `powerFlowResult != null`, calculates midpoint and calls `DrawFrozenPathLabel()`.

### 2. `UnitTests/Visualization/PowerFlowFrozenPathTests.cs`

Added two new tests:

- **`FrozenWaveguidePath_WithPowerFlow_HasLabelDataAvailable`** — Verifies the `ConnectionPowerFlow` data (dB, fraction) required for label rendering is present in `PowerFlowResult` for frozen paths.

- **`FrozenWaveguidePath_Midpoint_IsBetweenStartAndEnd`** — Verifies the midpoint calculation logic produces the correct geometric midpoint.

**MCP Tools used:** None (used direct file reads and grep).


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 8,786
- **Estimated cost:** $0.1316 USD

---
*Generated by autonomous agent using Claude Code.*