### PR TITLE
Agent: Fix Zoom-to-Fit (F key) viewport initialization bug (#339)

### DIFF
--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -245,7 +245,7 @@ public partial class MainWindow : Window
                     {
                         canvas.GridSnap.Toggle();
                         mainVm.StatusText = canvas.GridSnap.IsEnabled
-                            ? $"Grid snap ON ({canvas.GridSnap.GridSizeMicrometers}µm)"
+                            ? $"Grid snap ON ({canvas.GridSnap.GridSizeMicrometers}\u00b5m)"
                             : "Grid snap OFF";
                     }
                 }
@@ -303,25 +303,30 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Gets the actual viewport size (visible area) independent of zoom level.
-    /// Uses the Window's client area bounds as the viewport.
+    /// Uses the DesignCanvas control's own layout bounds, which correctly excludes
+    /// the left panel, right panel, and toolbar from the viewport dimensions.
+    /// The rendering coordinate space is the canvas local space, so ZoomToFit
+    /// must use canvas dimensions — not window dimensions — for correct centering.
     /// </summary>
     private (double width, double height) GetActualViewportSize()
     {
-        // The viewport is the visible area of the window where the canvas is displayed.
-        // We use ClientSize (or Bounds) of the Window, which is independent of canvas zoom.
-        // This ensures ZoomToFit calculates correctly regardless of current zoom level.
+        // Use the canvas control's actual layout bounds.
+        // This is correct because PanX/PanY are in canvas-local coordinates,
+        // and ZoomToFit computes pan as: vpWidth/2 - boxCenterX * zoom.
+        // Using window ClientSize (which includes sidebars) would shift the
+        // computed pan center by (windowWidth - canvasWidth) / 2, causing the
+        // "wrong position on first F-press" bug.
+        var canvasBounds = DesignCanvasControl.Bounds;
+        if (canvasBounds.Width > 0 && canvasBounds.Height > 0)
+            return (canvasBounds.Width, canvasBounds.Height);
 
-        // Use the window's client area size
+        // Fallback: if the canvas has not been laid out yet, use window client size.
         var windowWidth = ClientSize.Width;
         var windowHeight = ClientSize.Height;
+        if (windowWidth > 0 && windowHeight > 0)
+            return (windowWidth, windowHeight);
 
-        // Fallback to reasonable defaults if window size is not available
-        if (windowWidth <= 0 || windowHeight <= 0)
-        {
-            return (1400, 900); // Default window size
-        }
-
-        return (windowWidth, windowHeight);
+        return (1400, 900); // Last-resort default matching the initial window size
     }
 
     /// <summary>

--- a/UnitTests/ViewModels/ZoomToFitTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitTests.cs
@@ -1,6 +1,7 @@
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Panels;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_Core.Export;
 using Shouldly;
@@ -9,7 +10,7 @@ using Xunit;
 namespace UnitTests.ViewModels;
 
 /// <summary>
-/// Tests for <see cref="MainViewModel.ZoomToFit"/>.
+/// Tests for <see cref="MainViewModel.ZoomToFit"/> and viewport centering.
 /// </summary>
 public class ZoomToFitTests
 {
@@ -92,5 +93,92 @@ public class ZoomToFitTests
         // padded size: 1200x1200, viewport: 1000x1000
         // zoom = 1000/1200 ≈ 0.833
         vm.ZoomLevel.ShouldBeInRange(0.8, 0.9);
+    }
+
+    [Fact]
+    public void ZoomToFit_ContentCenteredInViewport_PanCorrect()
+    {
+        // Verifies that ZoomToFit centers content at (vpWidth/2, vpHeight/2).
+        // This test guards against the bug where window ClientSize (including sidebars)
+        // was used instead of the canvas control bounds, causing wrong pan centering.
+        var vm = CreateViewModel();
+
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        comp.PhysicalX = 0;
+        comp.PhysicalY = 0;
+        comp.WidthMicrometers = 200;
+        comp.HeightMicrometers = 200;
+        vm.Canvas.AddComponent(comp);
+
+        const double vpWidth = 800;
+        const double vpHeight = 600;
+        vm.ZoomToFit(vpWidth, vpHeight);
+
+        // After ZoomToFit, the bounding box center should appear at the viewport center.
+        // boxCenter = (100, 100), with 10% padding: padded = (-20,-20)-(220,220)
+        // paddedCenter = (100, 100), zoom = min(800/240, 600/240) = min(3.33, 2.5) = 2.5
+        // panX = 800/2 - 100 * 2.5 = 400 - 250 = 150
+        // panY = 600/2 - 100 * 2.5 = 300 - 250 = 50
+        // Verify: boxCenter * zoom + pan = vpCenter
+        double centerX = 100;
+        double centerY = 100;
+        var zoom = vm.ZoomLevel;
+        var panX = vm.Canvas.PanX;
+        var panY = vm.Canvas.PanY;
+
+        (centerX * zoom + panX).ShouldBeInRange(vpWidth / 2 - 1, vpWidth / 2 + 1);
+        (centerY * zoom + panY).ShouldBeInRange(vpHeight / 2 - 1, vpHeight / 2 + 1);
+    }
+
+    [Fact]
+    public void ZoomToFit_WithIncorrectlyLargerViewport_ProducesDifferentPan()
+    {
+        // Documents that using window width (e.g. 1400) instead of canvas width (e.g. 800)
+        // produces a different (wrong) pan. This is the root cause of the initialization bug.
+        var vm1 = CreateViewModel();
+        var vm2 = CreateViewModel();
+
+        var comp1 = TestComponentFactory.CreateStraightWaveGuide();
+        comp1.PhysicalX = 100;
+        comp1.PhysicalY = 100;
+        comp1.WidthMicrometers = 200;
+        comp1.HeightMicrometers = 200;
+        vm1.Canvas.AddComponent(comp1);
+
+        var comp2 = TestComponentFactory.CreateStraightWaveGuide();
+        comp2.PhysicalX = 100;
+        comp2.PhysicalY = 100;
+        comp2.WidthMicrometers = 200;
+        comp2.HeightMicrometers = 200;
+        vm2.Canvas.AddComponent(comp2);
+
+        // Correct: use canvas viewport size
+        vm1.ZoomToFit(800, 600);
+        // Wrong: use full window size (includes 300px left panel + 300px right panel)
+        vm2.ZoomToFit(1400, 600);
+
+        // PanX differs because the center used in calculation differs
+        vm1.Canvas.PanX.ShouldNotBe(vm2.Canvas.PanX);
+        // PanY is the same because height is identical
+        vm1.Canvas.PanY.ShouldBe(vm2.Canvas.PanY, tolerance: 0.01);
+    }
+
+    [Fact]
+    public void ViewportControl_GetViewportSize_UsedInNavigateCanvasTo()
+    {
+        // Verifies that NavigateCanvasTo uses the GetViewportSize callback,
+        // meaning fixing GetActualViewportSize in the view also fixes navigation.
+        var vm = CreateViewModel();
+        const double canvasWidth = 800.0;
+        const double canvasHeight = 600.0;
+        vm.ViewportControl.GetViewportSize = () => (canvasWidth, canvasHeight);
+        vm.ViewportControl.ZoomLevel = 1.0;
+
+        vm.ViewportControl.NavigateCanvasTo(centerX: 100, centerY: 150);
+
+        // panX = vpWidth/2 - centerX * zoom = 400 - 100 = 300
+        vm.Canvas.PanX.ShouldBe(300, tolerance: 0.01);
+        // panY = vpHeight/2 - centerY * zoom = 300 - 150 = 150
+        vm.Canvas.PanY.ShouldBe(150, tolerance: 0.01);
     }
 }


### PR DESCRIPTION
## Root Cause

`GetActualViewportSize()` was returning `ClientSize` (the full window width/height), but the rendering coordinate space is the `DesignCanvas` control's **local bounds** — which excludes the left panel (~250px), right panel (~250px), and toolbar (40px).

When `ZoomToFit` computes:
```
panX = viewportWidth / 2 - boxCenterX * zoom
```
…using window width (e.g. 1400) instead of canvas width (e.g. 900) shifts the computed center rightward by `(windowWidth - canvasWidth) / 2 ≈ 250px`. Zoom is unaffected because it only depends on the *ratio* of viewport to bounding box dimensions, hence "zoom is correct but position is wrong."

## Fix

**`CAP.Avalonia/Views/MainWindow.axaml.cs`** — `GetActualViewportSize()` now reads `DesignCanvasControl.Bounds.Width/Height` (the canvas control's actual layout size), with `ClientSize` as a fallback if the control hasn't completed its first layout pass yet.

```csharp
// Before (wrong — includes sidebars in viewport dimensions)
var windowWidth = ClientSize.Width;
return (windowWidth, windowHeight);

// After (correct — canvas-local coordinate space)
var canvasBounds = DesignCanvasControl.Bounds;
if (canvasBounds.Width > 0 && canvasBounds.Height > 0)
    return (canvasBounds.Width, canvasBounds.Height);
```

## Tests Added (`UnitTests/ViewModels/ZoomToFitTests.cs`)

| Test | What it verifies |
|------|-----------------|
| `ZoomToFit_ContentCenteredInViewport_PanCorrect` | After ZoomToFit, `boxCenter * zoom + pan == vpCenter` to within 1px |
| `ZoomToFit_WithIncorrectlyLargerViewport_ProducesDifferentPan` | Documents that window width ≠ canvas width produces a different (wrong) PanX — the exact regression this PR fixes |
| `ViewportControl_GetViewportSize_UsedInNavigateCanvasTo` | `NavigateCanvasTo` correctly uses the `GetViewportSize` callback (so fixing the callback also fixes navigation) |

All 1312 tests pass.

## MCP Tools Used
None — semantic search and smart_test used directly via CLI tools.

Closes #339