### PR TITLE
Agent: implement #344 — Refactoring: Remove backward-compat delegates and simplify MainWindow

### DIFF
--- a/CAP.Avalonia/Controls/DesignCanvas.ComponentRendering.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.ComponentRendering.cs
@@ -239,7 +239,7 @@ public partial class DesignCanvas
     private void DrawComponentPins(DrawingContext context, ComponentViewModel comp, bool isDimmed = false)
     {
         var mainVm = MainViewModel;
-        bool isConnectMode = mainVm?.CurrentMode == InteractionMode.Connect;
+        bool isConnectMode = mainVm?.CanvasInteraction.CurrentMode == InteractionMode.Connect;
         var highlightedPin = ViewModel?.HighlightedPin?.Pin;
         byte alpha = (byte)(isDimmed ? 128 : 255);
 

--- a/CAP.Avalonia/Controls/DesignCanvas.KeyboardHandling.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.KeyboardHandling.cs
@@ -95,7 +95,7 @@ public partial class DesignCanvas
                 if (ctrlPressed)
                 {
                     // Ctrl+L toggles lock state of selected components
-                    mainVm?.ElementLock.ToggleSelectedComponentsCommand.Execute(null);
+                    mainVm?.BottomPanel.ElementLock.ToggleSelectedComponentsCommand.Execute(null);
                     e.Handled = true;
                 }
                 else

--- a/CAP.Avalonia/Controls/DesignCanvas.MouseHandling.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.MouseHandling.cs
@@ -42,19 +42,19 @@ public partial class DesignCanvas
 
     private void HandleLeftButtonPressed(PointerPressedEventArgs e, Point canvasPoint, DesignCanvasViewModel vm, MainViewModel? mainVm)
     {
-        if (mainVm?.CurrentMode == InteractionMode.Connect)
+        if (mainVm?.CanvasInteraction.CurrentMode == InteractionMode.Connect)
         {
             HandleConnectModeClick(e, canvasPoint, vm, mainVm);
         }
-        else if (mainVm?.CurrentMode == InteractionMode.PlaceComponent)
+        else if (mainVm?.CanvasInteraction.CurrentMode == InteractionMode.PlaceComponent)
         {
             HandlePlaceComponentClick(canvasPoint, vm, mainVm);
         }
-        else if (mainVm?.CurrentMode == InteractionMode.PlaceGroupTemplate)
+        else if (mainVm?.CanvasInteraction.CurrentMode == InteractionMode.PlaceGroupTemplate)
         {
             HandlePlaceGroupTemplateClick(canvasPoint, vm, mainVm);
         }
-        else if (mainVm?.CurrentMode == InteractionMode.Delete)
+        else if (mainVm?.CanvasInteraction.CurrentMode == InteractionMode.Delete)
         {
             HandleDeleteModeClick(canvasPoint, mainVm);
         }
@@ -177,7 +177,7 @@ public partial class DesignCanvas
                 {
                     vm.EnterGroupEditMode(clickedGroup);
                 }
-                mainVm?.HierarchyPanel?.RebuildTree();
+                mainVm?.LeftPanel.HierarchyPanel?.RebuildTree();
                 _interactionState.DraggingComponent = null;
                 InvalidateVisual();
                 return;
@@ -200,7 +200,7 @@ public partial class DesignCanvas
                 {
                     vm.ExitGroupEditMode();
                 }
-                mainVm?.HierarchyPanel?.RebuildTree();
+                mainVm?.LeftPanel.HierarchyPanel?.RebuildTree();
                 InvalidateVisual();
                 return;
             }
@@ -341,11 +341,11 @@ public partial class DesignCanvas
 
     private void UpdatePlacementPreview(Point canvasPoint, DesignCanvasViewModel vm)
     {
-        if (MainViewModel?.CurrentMode == InteractionMode.PlaceComponent &&
-            MainViewModel?.SelectedTemplate != null)
+        if (MainViewModel?.CanvasInteraction.CurrentMode == InteractionMode.PlaceComponent &&
+            MainViewModel?.CanvasInteraction.SelectedTemplate != null)
         {
             _interactionState.ShowPlacementPreview = true;
-            _interactionState.PlacementPreviewTemplate = MainViewModel.SelectedTemplate;
+            _interactionState.PlacementPreviewTemplate = MainViewModel.CanvasInteraction.SelectedTemplate;
             var snapSettings = vm.GridSnap;
 
             var (snappedCenterX, snappedCenterY) = snapSettings.Snap(canvasPoint.X, canvasPoint.Y);
@@ -362,11 +362,11 @@ public partial class DesignCanvas
         }
 
         // Update group template placement preview
-        if (MainViewModel?.CurrentMode == InteractionMode.PlaceGroupTemplate &&
-            MainViewModel?.SelectedGroupTemplate != null)
+        if (MainViewModel?.CanvasInteraction.CurrentMode == InteractionMode.PlaceGroupTemplate &&
+            MainViewModel?.CanvasInteraction.SelectedGroupTemplate != null)
         {
             _interactionState.ShowGroupTemplatePlacementPreview = true;
-            _interactionState.GroupTemplatePlacementPreview = MainViewModel.SelectedGroupTemplate;
+            _interactionState.GroupTemplatePlacementPreview = MainViewModel.CanvasInteraction.SelectedGroupTemplate;
             var snapSettings = vm.GridSnap;
 
             var (snappedCenterX, snappedCenterY) = snapSettings.Snap(canvasPoint.X, canvasPoint.Y);
@@ -479,7 +479,7 @@ public partial class DesignCanvas
 
     private void UpdatePinHighlighting(Point canvasPoint, DesignCanvasViewModel vm)
     {
-        if (MainViewModel?.CurrentMode == InteractionMode.Connect)
+        if (MainViewModel?.CanvasInteraction.CurrentMode == InteractionMode.Connect)
         {
             if (_interactionState.ConnectionDragStartPin != null)
             {
@@ -533,7 +533,7 @@ public partial class DesignCanvas
 
     private void UpdateComponentDrag(Point delta, Point canvasPoint, DesignCanvasViewModel vm)
     {
-        if (_interactionState.DraggingComponent != null && MainViewModel?.CurrentMode == InteractionMode.Select)
+        if (_interactionState.DraggingComponent != null && MainViewModel?.CanvasInteraction.CurrentMode == InteractionMode.Select)
         {
             double deltaX = delta.X / Zoom;
             double deltaY = delta.Y / Zoom;

--- a/CAP.Avalonia/Controls/DesignCanvas.PreviewRendering.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.PreviewRendering.cs
@@ -168,7 +168,7 @@ public partial class DesignCanvas
         var mainVm = MainViewModel;
         if (mainVm == null) return;
 
-        string modeText = mainVm.CurrentMode switch
+        string modeText = mainVm.CanvasInteraction.CurrentMode switch
         {
             InteractionMode.Select => "[S] Select",
             InteractionMode.PlaceComponent => "[P] Place",
@@ -177,7 +177,7 @@ public partial class DesignCanvas
             _ => ""
         };
 
-        var brush = mainVm.CurrentMode switch
+        var brush = mainVm.CanvasInteraction.CurrentMode switch
         {
             InteractionMode.Select => Brushes.LightBlue,
             InteractionMode.PlaceComponent => Brushes.LightGreen,

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CAP_Core.Components.Core;
@@ -63,72 +62,6 @@ public partial class MainViewModel : ObservableObject
     /// </summary>
     public BottomPanelViewModel BottomPanel { get; }
 
-    // Backward-compatible properties - delegate to Panel ViewModels
-    // TODO: Update XAML bindings and remove these properties
-    public ParameterSweepViewModel Sweep => RightPanel.Sweep;
-    public RoutingDiagnosticsViewModel RoutingDiagnostics => RightPanel.RoutingDiagnostics;
-    public DesignValidationViewModel DesignValidation => RightPanel.DesignValidation;
-    public PdkManagerViewModel PdkManager => LeftPanel.PdkManager;
-    public ComponentDimensionDiagnosticsViewModel? DimensionDiagnostics => RightPanel.DimensionDiagnostics;
-    public ElementLockViewModel ElementLock => BottomPanel.ElementLock;
-    public ComponentDimensionViewModel DimensionValidator => RightPanel.DimensionValidator;
-    public ExportValidationViewModel ExportValidation => RightPanel.ExportValidation;
-    public SMatrixPerformanceViewModel SMatrixPerformance => RightPanel.SMatrixPerformance;
-    public CompressLayoutViewModel CompressLayout => RightPanel.CompressLayout;
-    public GroupSMatrixViewModel GroupSMatrix => RightPanel.GroupSMatrix;
-    public ArchitectureReportViewModel ArchitectureReport => RightPanel.ArchitectureReport;
-    public WaveguideLengthViewModel WaveguideLength => BottomPanel.WaveguideLength;
-    public HierarchyPanelViewModel HierarchyPanel => LeftPanel.HierarchyPanel;
-    public ComponentLibraryViewModel GroupLibrary => LeftPanel.ComponentLibrary;
-
-    /// <summary>
-    /// ViewModel for the error console panel (collapsible, bottom of window).
-    /// </summary>
-    public ErrorConsoleViewModel ErrorConsole => BottomPanel.ErrorConsole;
-
-    // Backward-compatible library properties
-    public ObservableCollection<ComponentTemplate> ComponentLibrary => LeftPanel.AllTemplates;
-    public ObservableCollection<ComponentTemplate> FilteredComponentLibrary => LeftPanel.FilteredTemplates;
-    public ObservableCollection<string> Categories => LeftPanel.Categories;
-    public string SearchText
-    {
-        get => LeftPanel.SearchText;
-        set => LeftPanel.SearchText = value;
-    }
-
-    // Backward-compatible interaction properties
-    public InteractionMode CurrentMode
-    {
-        get => CanvasInteraction.CurrentMode;
-        set => CanvasInteraction.CurrentMode = value;
-    }
-    public ComponentTemplate? SelectedTemplate
-    {
-        get => CanvasInteraction.SelectedTemplate;
-        set => CanvasInteraction.SelectedTemplate = value;
-    }
-    public CAP_Core.Components.Creation.GroupTemplate? SelectedGroupTemplate
-    {
-        get => CanvasInteraction.SelectedGroupTemplate;
-        set => CanvasInteraction.SelectedGroupTemplate = value;
-    }
-    public ComponentViewModel? SelectedComponent
-    {
-        get => CanvasInteraction.SelectedComponent;
-        set => CanvasInteraction.SelectedComponent = value;
-    }
-    public WaveguideConnectionViewModel? SelectedWaveguideConnection
-    {
-        get => CanvasInteraction.SelectedWaveguideConnection;
-        set => CanvasInteraction.SelectedWaveguideConnection = value;
-    }
-
-    // Backward-compatible zoom property
-    public double ZoomLevel
-    {
-        get => ViewportControl.ZoomLevel;
-        set => ViewportControl.ZoomLevel = value;
-    }
 
     /// <summary>
     /// Available wavelength options for the laser configuration dropdown.
@@ -194,30 +127,19 @@ public partial class MainViewModel : ObservableObject
             }
         };
 
-        // Wire up ZoomLevel property change forwarding from ViewportControl to MainViewModel
-        // This ensures that when ViewportControl.ZoomLevel changes (e.g., via ZoomToFit),
-        // the UI binding on MainViewModel.ZoomLevel gets notified
-        ViewportControl.PropertyChanged += (s, e) =>
-        {
-            if (e.PropertyName == nameof(ViewportControl.ZoomLevel))
-            {
-                OnPropertyChanged(nameof(ZoomLevel));
-            }
-        };
-
         // Wire up callbacks
         CanvasInteraction.OnSelectionChanged = comp =>
         {
-            Sweep.ConfigureForComponent(comp, Canvas);
-            HierarchyPanel.SyncSelectionFromCanvas(comp);
+            RightPanel.Sweep.ConfigureForComponent(comp, Canvas);
+            LeftPanel.HierarchyPanel.SyncSelectionFromCanvas(comp);
         };
 
         // Wire rename from hierarchy panel through undo-aware command manager
-        HierarchyPanel.RenameComponent = (component, newName) =>
+        LeftPanel.HierarchyPanel.RenameComponent = (component, newName) =>
         {
             var cmd = new Commands.RenameComponentCommand(component, newName);
             CommandManager.ExecuteCommand(cmd);
-            HierarchyPanel.RefreshNode(component);
+            LeftPanel.HierarchyPanel.RefreshNode(component);
         };
 
         CanvasInteraction.ClearLeftPanelGroupSelection = () =>
@@ -227,11 +149,7 @@ public partial class MainViewModel : ObservableObject
 
         CanvasInteraction.ClearComponentTemplateSelection = () =>
         {
-            // Setting CanvasInteraction.SelectedTemplate to null will automatically update
-            // MainViewModel.SelectedTemplate (which is bound to the UI ListBox)
             CanvasInteraction.SelectedTemplate = null;
-            // Force PropertyChanged notification on the wrapper property to ensure UI updates
-            OnPropertyChanged(nameof(SelectedTemplate));
         };
 
         // Wire up mode changes and template selection to keep UI in sync
@@ -290,7 +208,7 @@ public partial class MainViewModel : ObservableObject
                 catch (Exception ex)
                 {
                     StatusText = $"Failed to load template '{template.Name}': {ex.Message}";
-                    ErrorConsole.Log($"Failed to load template '{template.Name}': {ex.Message}", CAP_Contracts.Logger.LogLevel.Error, ex);
+                    BottomPanel.ErrorConsole.Log($"Failed to load template '{template.Name}': {ex.Message}", CAP_Contracts.Logger.LogLevel.Error, ex);
                     return;
                 }
 
@@ -337,14 +255,14 @@ public partial class MainViewModel : ObservableObject
 
     private void WireHierarchyPanel()
     {
-        HierarchyPanel.NavigateToPosition = ViewportControl.NavigateCanvasTo;
-        HierarchyPanel.GetViewportSize = ViewportControl.GetViewportSize;
+        LeftPanel.HierarchyPanel.NavigateToPosition = ViewportControl.NavigateCanvasTo;
+        LeftPanel.HierarchyPanel.GetViewportSize = ViewportControl.GetViewportSize;
     }
 
     private void WireDesignValidation()
     {
-        DesignValidation.NavigateToPosition = ViewportControl.NavigateCanvasTo;
-        DesignValidation.HighlightConnection = (connection) =>
+        RightPanel.DesignValidation.NavigateToPosition = ViewportControl.NavigateCanvasTo;
+        RightPanel.DesignValidation.HighlightConnection = (connection) =>
         {
             foreach (var conn in Canvas.Connections)
             {
@@ -355,7 +273,7 @@ public partial class MainViewModel : ObservableObject
 
     private void WireFileOperations()
     {
-        FileOperations.RebuildHierarchy = HierarchyPanel.RebuildTree;
+        FileOperations.RebuildHierarchy = LeftPanel.HierarchyPanel.RebuildTree;
         FileOperations.ZoomToFitAfterLoad = (w, h) =>
         {
             var (vpWidth, vpHeight) = ViewportControl.GetViewportSize?.Invoke() ?? (w, h);
@@ -513,7 +431,7 @@ public partial class MainViewModel : ObservableObject
 
                 if (result.SystemMatrix != null)
                 {
-                    SMatrixPerformance.AnalyzeMatrix(result.SystemMatrix);
+                    RightPanel.SMatrixPerformance.AnalyzeMatrix(result.SystemMatrix);
                 }
             }
             else
@@ -524,7 +442,7 @@ public partial class MainViewModel : ObservableObject
         catch (Exception ex)
         {
             StatusText = $"Simulation error: {ex.Message}";
-            ErrorConsole.Log($"Simulation failed: {ex.Message}", CAP_Contracts.Logger.LogLevel.Error, ex);
+            BottomPanel.ErrorConsole.Log($"Simulation failed: {ex.Message}", CAP_Contracts.Logger.LogLevel.Error, ex);
 
         }
         finally
@@ -545,8 +463,8 @@ public partial class MainViewModel : ObservableObject
             .OfType<CAP_Core.Components.Core.ComponentGroup>()
             .ToList();
 
-        DesignValidation.RunValidation(connections, groups);
-        StatusText = DesignValidation.StatusText;
+        RightPanel.DesignValidation.RunValidation(connections, groups);
+        StatusText = RightPanel.DesignValidation.StatusText;
     }
 }
 

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -15,7 +15,7 @@
     <Window.KeyBindings>
         <KeyBinding Gesture="Ctrl+G" Command="{Binding CreateGroupCommand}" />
         <KeyBinding Gesture="Ctrl+Shift+G" Command="{Binding UngroupCommand}" />
-        <KeyBinding Gesture="F12" Command="{Binding ErrorConsole.ToggleCommand}" />
+        <KeyBinding Gesture="F12" Command="{Binding BottomPanel.ErrorConsole.ToggleCommand}" />
     </Window.KeyBindings>
 
     <DockPanel>
@@ -127,20 +127,20 @@
                     <!-- Action buttons on the right -->
                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="4,0">
                         <Button Content="📋"
-                                Command="{Binding ErrorConsole.CopyAllCommand}"
+                                Command="{Binding BottomPanel.ErrorConsole.CopyAllCommand}"
                                 Width="28" Height="20" Margin="2,0" Padding="0"
                                 Background="#3d3d3d" Foreground="LightGray"
                                 FontSize="11"
                                 ToolTip.Tip="Copy all entries to clipboard"/>
                         <Button Content="✕"
-                                Command="{Binding ErrorConsole.ClearCommand}"
+                                Command="{Binding BottomPanel.ErrorConsole.ClearCommand}"
                                 Width="24" Height="20" Margin="2,0" Padding="0"
                                 Background="#3d3d3d" Foreground="LightGray"
                                 FontSize="11"
                                 ToolTip.Tip="Clear console"/>
                     </StackPanel>
                     <!-- Toggle button fills remaining space -->
-                    <Button Command="{Binding ErrorConsole.ToggleCommand}"
+                    <Button Command="{Binding BottomPanel.ErrorConsole.ToggleCommand}"
                             Background="Transparent"
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Left"
@@ -148,20 +148,20 @@
                             ToolTip.Tip="Toggle error console (F12)">
                         <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                             <TextBlock Text="▶" Foreground="Gray" FontSize="9" VerticalAlignment="Center"
-                                       IsVisible="{Binding ErrorConsole.IsVisible, Converter={x:Static BoolConverters.Not}}"/>
+                                       IsVisible="{Binding BottomPanel.ErrorConsole.IsVisible, Converter={x:Static BoolConverters.Not}}"/>
                             <TextBlock Text="▼" Foreground="Gray" FontSize="9" VerticalAlignment="Center"
-                                       IsVisible="{Binding ErrorConsole.IsVisible}"/>
+                                       IsVisible="{Binding BottomPanel.ErrorConsole.IsVisible}"/>
                             <TextBlock Text="Error Console" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
                             <!-- Error badge -->
                             <Border Background="#5d2020" CornerRadius="8" Padding="5,1"
-                                    IsVisible="{Binding ErrorConsole.HasErrors}">
-                                <TextBlock Text="{Binding ErrorConsole.ErrorCount}"
+                                    IsVisible="{Binding BottomPanel.ErrorConsole.HasErrors}">
+                                <TextBlock Text="{Binding BottomPanel.ErrorConsole.ErrorCount}"
                                            Foreground="#FF6B6B" FontSize="10" VerticalAlignment="Center"/>
                             </Border>
                             <!-- Warning badge -->
                             <Border Background="#5d4510" CornerRadius="8" Padding="5,1"
-                                    IsVisible="{Binding ErrorConsole.HasWarnings}">
-                                <TextBlock Text="{Binding ErrorConsole.WarningCount}"
+                                    IsVisible="{Binding BottomPanel.ErrorConsole.HasWarnings}">
+                                <TextBlock Text="{Binding BottomPanel.ErrorConsole.WarningCount}"
                                            Foreground="#FFD93D" FontSize="10" VerticalAlignment="Center"/>
                             </Border>
                         </StackPanel>
@@ -169,9 +169,9 @@
                 </DockPanel>
 
                 <!-- Content area: only shown when IsVisible is true -->
-                <Border IsVisible="{Binding ErrorConsole.IsVisible}" Height="180" Background="#161616">
+                <Border IsVisible="{Binding BottomPanel.ErrorConsole.IsVisible}" Height="180" Background="#161616">
                     <ListBox x:Name="ErrorConsoleListBox"
-                             ItemsSource="{Binding ErrorConsole.DisplayEntries}"
+                             ItemsSource="{Binding BottomPanel.ErrorConsole.DisplayEntries}"
                              Background="Transparent"
                              BorderThickness="0"
                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
@@ -200,7 +200,7 @@
                 <Grid RowDefinitions="Auto,5,*">
                 <!-- Hierarchy Panel -->
                 <views:HierarchyPanel Grid.Row="0"
-                                      DataContext="{Binding HierarchyPanel}"
+                                      DataContext="{Binding LeftPanel.HierarchyPanel}"
                                       Height="250"/>
 
                 <!-- Splitter -->
@@ -214,7 +214,7 @@
                     <TextBlock DockPanel.Dock="Top" Text="Component Library"
                                FontWeight="Bold" Margin="10,10,10,4" Foreground="White"/>
                     <TextBox DockPanel.Dock="Top" Watermark="Search components..."
-                             Text="{Binding SearchText}"
+                             Text="{Binding LeftPanel.SearchText}"
                              Margin="10,0,10,6" FontSize="11"
                              Background="#1e1e1e" Foreground="White"
                              BorderBrush="#3e3e3e"/>
@@ -225,7 +225,7 @@
                     <Expander DockPanel.Dock="Top" Header="Saved Groups" IsExpanded="True"
                               Margin="5,0,5,5" Background="#2d2d2d">
                         <StackPanel Margin="5">
-                            <TextBlock Text="{Binding GroupLibrary.StatusText}"
+                            <TextBlock Text="{Binding LeftPanel.ComponentLibrary.StatusText}"
                                        FontSize="10" Foreground="LightGray" Margin="0,0,0,5"/>
                             <TextBlock Text="Click to select, then click canvas to place"
                                        FontSize="10" Margin="0,0,0,5" Foreground="Gray" TextWrapping="Wrap"/>
@@ -233,9 +233,9 @@
                             <!-- User Groups -->
                             <TextBlock Text="User Groups:" Foreground="LightBlue" FontWeight="SemiBold"
                                        FontSize="10" Margin="0,5,0,3"
-                                       IsVisible="{Binding GroupLibrary.UserGroups.Count}"/>
+                                       IsVisible="{Binding LeftPanel.ComponentLibrary.UserGroups.Count}"/>
                             <ListBox x:Name="UserGroupsListBox"
-                                     ItemsSource="{Binding GroupLibrary.UserGroups}"
+                                     ItemsSource="{Binding LeftPanel.ComponentLibrary.UserGroups}"
                                      SelectionChanged="OnUserGroupsSelectionChanged"
                                      Background="Transparent"
                                      MaxHeight="150">
@@ -308,9 +308,9 @@
                             <!-- PDK Groups -->
                             <TextBlock Text="PDK Macros:" Foreground="Orange" FontWeight="SemiBold"
                                        FontSize="10" Margin="0,10,0,3"
-                                       IsVisible="{Binding GroupLibrary.PdkGroups.Count}"/>
+                                       IsVisible="{Binding LeftPanel.ComponentLibrary.PdkGroups.Count}"/>
                             <ListBox x:Name="PdkGroupsListBox"
-                                     ItemsSource="{Binding GroupLibrary.PdkGroups}"
+                                     ItemsSource="{Binding LeftPanel.ComponentLibrary.PdkGroups}"
                                      SelectionChanged="OnPdkGroupsSelectionChanged"
                                      Background="Transparent"
                                      MaxHeight="150">
@@ -386,13 +386,13 @@
                     <Expander DockPanel.Dock="Top" Header="PDK Management" IsExpanded="False"
                               Margin="5,0,5,5" Background="#2d2d2d">
                         <StackPanel Margin="5">
-                            <TextBlock Text="{Binding PdkManager.StatusText}"
+                            <TextBlock Text="{Binding LeftPanel.PdkManager.StatusText}"
                                        FontSize="10" Foreground="LightGray" Margin="0,0,0,5"/>
 
                             <!-- PDK Filter List -->
                             <ScrollViewer MaxHeight="150" VerticalScrollBarVisibility="Auto"
                                           HorizontalScrollBarVisibility="Disabled">
-                                <ItemsControl ItemsSource="{Binding PdkManager.LoadedPdks}">
+                                <ItemsControl ItemsSource="{Binding LeftPanel.PdkManager.LoadedPdks}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="vmLib:PdkInfoViewModel">
                                             <StackPanel Margin="0,3">
@@ -416,10 +416,10 @@
 
                             <!-- PDK Action Buttons -->
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Center">
-                                <Button Content="Enable All" Command="{Binding PdkManager.EnableAllCommand}"
+                                <Button Content="Enable All" Command="{Binding LeftPanel.PdkManager.EnableAllCommand}"
                                         Width="75" Height="24" Margin="2" FontSize="10"
                                         Background="#3d3d3d"/>
-                                <Button Content="Disable All" Command="{Binding PdkManager.DisableAllCommand}"
+                                <Button Content="Disable All" Command="{Binding LeftPanel.PdkManager.DisableAllCommand}"
                                         Width="75" Height="24" Margin="2" FontSize="10"
                                         Background="#3d3d3d"/>
                             </StackPanel>
@@ -430,8 +430,8 @@
                                   VerticalScrollBarVisibility="Auto"
                                   HorizontalScrollBarVisibility="Disabled"
                                   behaviors:ScrollPositionBehavior.VerticalOffset="{Binding LeftPanel.LibraryScrollOffset, Mode=TwoWay}">
-                        <ListBox ItemsSource="{Binding FilteredComponentLibrary}"
-                                 SelectedItem="{Binding SelectedTemplate}"
+                        <ListBox ItemsSource="{Binding LeftPanel.FilteredTemplates}"
+                                 SelectedItem="{Binding CanvasInteraction.SelectedTemplate}"
                                  Background="Transparent" Foreground="White"
                                  Margin="5">
                             <ListBox.ItemTemplate>
@@ -556,79 +556,79 @@
                         <TextBlock Text="Parameter Sweep:" Foreground="Orange" Margin="0,0,0,5" FontWeight="SemiBold"/>
                         <StackPanel Orientation="Horizontal" Margin="0,5,0,5">
                             <TextBlock Text="Start:" Foreground="Gray" VerticalAlignment="Center" Width="45"/>
-                            <NumericUpDown Value="{Binding Sweep.StartValue}"
+                            <NumericUpDown Value="{Binding RightPanel.Sweep.StartValue}"
                                            Minimum="{Binding CanvasInteraction.SelectedComponent.SliderMin}"
                                            Maximum="{Binding CanvasInteraction.SelectedComponent.SliderMax}"
                                            Increment="10" Width="130" FormatString="F0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                             <TextBlock Text="End:" Foreground="Gray" VerticalAlignment="Center" Width="45"/>
-                            <NumericUpDown Value="{Binding Sweep.EndValue}"
+                            <NumericUpDown Value="{Binding RightPanel.Sweep.EndValue}"
                                            Minimum="{Binding CanvasInteraction.SelectedComponent.SliderMin}"
                                            Maximum="{Binding CanvasInteraction.SelectedComponent.SliderMax}"
                                            Increment="10" Width="130" FormatString="F0"/>
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                             <TextBlock Text="Steps:" Foreground="Gray" VerticalAlignment="Center" Width="45"/>
-                            <NumericUpDown Value="{Binding Sweep.StepCount}"
+                            <NumericUpDown Value="{Binding RightPanel.Sweep.StepCount}"
                                            Minimum="2" Maximum="100"
                                            Increment="1" Width="130" FormatString="F0"/>
                         </StackPanel>
-                        <Button Content="Run Sweep" Command="{Binding Sweep.RunSweepCommand}"
+                        <Button Content="Run Sweep" Command="{Binding RightPanel.Sweep.RunSweepCommand}"
                                 Width="120" Margin="0,5,0,5" Background="#3d5d3d"
-                                IsEnabled="{Binding Sweep.IsSweeping, Converter={x:Static BoolConverters.Not}}"/>
-                        <TextBlock Text="{Binding Sweep.StatusText}" Foreground="Gray" FontSize="10" Margin="0,0,0,5"
-                                   IsVisible="{Binding Sweep.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                                IsEnabled="{Binding RightPanel.Sweep.IsSweeping, Converter={x:Static BoolConverters.Not}}"/>
+                        <TextBlock Text="{Binding RightPanel.Sweep.StatusText}" Foreground="Gray" FontSize="10" Margin="0,0,0,5"
+                                   IsVisible="{Binding RightPanel.Sweep.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                         <ScrollViewer MaxHeight="200" Margin="0,5,0,0"
-                                      IsVisible="{Binding Sweep.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                            <TextBlock Text="{Binding Sweep.ResultText}" Foreground="LightGreen"
+                                      IsVisible="{Binding RightPanel.Sweep.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                            <TextBlock Text="{Binding RightPanel.Sweep.ResultText}" Foreground="LightGreen"
                                        FontFamily="Consolas" FontSize="10" TextWrapping="NoWrap"/>
                         </ScrollViewer>
-                        <Button Content="Export CSV" Command="{Binding Sweep.ExportCsvCommand}"
+                        <Button Content="Export CSV" Command="{Binding RightPanel.Sweep.ExportCsvCommand}"
                                 Width="100" Margin="0,5,0,0" Background="#3d3d5d"
-                                IsVisible="{Binding Sweep.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                                IsVisible="{Binding RightPanel.Sweep.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                     </StackPanel>
 
                     <!-- Waveguide Length Configuration (visible when connection is selected) -->
-                    <StackPanel IsVisible="{Binding SelectedWaveguideConnection, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <StackPanel IsVisible="{Binding CanvasInteraction.SelectedWaveguideConnection, Converter={x:Static ObjectConverters.IsNotNull}}">
                         <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
                         <TextBlock Text="Waveguide Length:" Foreground="Magenta" Margin="0,0,0,5" FontWeight="SemiBold"/>
-                        <TextBlock Text="{Binding WaveguideLength.ConnectionName}"
+                        <TextBlock Text="{Binding BottomPanel.WaveguideLength.ConnectionName}"
                                    Foreground="White" FontSize="10" Margin="0,0,0,8" TextWrapping="Wrap"/>
 
                         <TextBlock Text="Current Length:" Foreground="Gray" Margin="0,5,0,3"/>
                         <TextBlock Foreground="White" Margin="0,0,0,5">
-                            <Run Text="{Binding WaveguideLength.CurrentLengthMicrometers, StringFormat={}{0:F2}}"/>
+                            <Run Text="{Binding BottomPanel.WaveguideLength.CurrentLengthMicrometers, StringFormat={}{0:F2}}"/>
                             <Run Text=" µm" Foreground="Gray"/>
                         </TextBlock>
 
                         <CheckBox Content="Enable Target Length"
-                                  IsChecked="{Binding WaveguideLength.IsTargetLengthEnabled}"
+                                  IsChecked="{Binding BottomPanel.WaveguideLength.IsTargetLengthEnabled}"
                                   Foreground="White" Margin="0,5,0,8"/>
 
-                        <StackPanel IsVisible="{Binding WaveguideLength.IsTargetLengthEnabled}">
+                        <StackPanel IsVisible="{Binding BottomPanel.WaveguideLength.IsTargetLengthEnabled}">
                             <TextBlock Text="Target Length (µm):" Foreground="Gray" Margin="0,5,0,3"/>
-                            <NumericUpDown Value="{Binding WaveguideLength.TargetLengthMicrometers}"
+                            <NumericUpDown Value="{Binding BottomPanel.WaveguideLength.TargetLengthMicrometers}"
                                            Minimum="10" Maximum="10000"
                                            Increment="10" Width="180" FormatString="F2" Margin="0,0,0,5"/>
 
                             <TextBlock Text="Tolerance (µm):" Foreground="Gray" Margin="0,5,0,3"/>
-                            <NumericUpDown Value="{Binding WaveguideLength.ToleranceMicrometers}"
+                            <NumericUpDown Value="{Binding BottomPanel.WaveguideLength.ToleranceMicrometers}"
                                            Minimum="0.1" Maximum="100"
                                            Increment="0.5" Width="180" FormatString="F2" Margin="0,0,0,8"/>
 
                             <Button Content="Set Target to Current"
-                                    Command="{Binding WaveguideLength.SetTargetToCurrentCommand}"
+                                    Command="{Binding BottomPanel.WaveguideLength.SetTargetToCurrentCommand}"
                                     Width="160" Margin="0,5,0,5"
                                     Background="#5d3d5d"/>
 
                             <Button Content="Apply"
-                                    Command="{Binding WaveguideLength.ApplyTargetLengthCommand}"
+                                    Command="{Binding BottomPanel.WaveguideLength.ApplyTargetLengthCommand}"
                                     Width="100" Margin="0,5,0,5"
                                     Background="#3d5d3d"/>
 
-                            <TextBlock Text="{Binding WaveguideLength.LengthStatusText}"
-                                       Foreground="{Binding WaveguideLength.LengthStatusColor}"
+                            <TextBlock Text="{Binding BottomPanel.WaveguideLength.LengthStatusText}"
+                                       Foreground="{Binding BottomPanel.WaveguideLength.LengthStatusColor}"
                                        FontSize="10" Margin="0,5,0,5"
                                        TextWrapping="Wrap"/>
                         </StackPanel>
@@ -640,25 +640,25 @@
                     <TextBlock Text="Minimize chip area while maintaining connectivity."
                                Foreground="Gray" FontSize="10" Margin="0,0,0,8" TextWrapping="Wrap"/>
                     <Button Content="Compress Layout"
-                            Command="{Binding CompressLayout.CompressLayoutCommand}"
+                            Command="{Binding RightPanel.CompressLayout.CompressLayoutCommand}"
                             Width="160" Margin="0,5,0,5"
                             Background="#3d5d5d"
-                            IsEnabled="{Binding CompressLayout.IsCompressing, Converter={x:Static BoolConverters.Not}}"/>
+                            IsEnabled="{Binding RightPanel.CompressLayout.IsCompressing, Converter={x:Static BoolConverters.Not}}"/>
 
                     <!-- Progress Bar -->
-                    <ProgressBar Value="{Binding CompressLayout.CurrentIteration}"
-                                 Maximum="{Binding CompressLayout.MaxIterations}"
+                    <ProgressBar Value="{Binding RightPanel.CompressLayout.CurrentIteration}"
+                                 Maximum="{Binding RightPanel.CompressLayout.MaxIterations}"
                                  Height="4" Margin="0,5,0,5"
-                                 IsVisible="{Binding CompressLayout.IsCompressing}"
+                                 IsVisible="{Binding RightPanel.CompressLayout.IsCompressing}"
                                  Foreground="Cyan"/>
 
-                    <TextBlock Text="{Binding CompressLayout.StatusText}"
+                    <TextBlock Text="{Binding RightPanel.CompressLayout.StatusText}"
                                Foreground="Gray" FontSize="10" Margin="0,0,0,5"
-                               IsVisible="{Binding CompressLayout.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-                    <TextBlock Text="{Binding CompressLayout.ResultText}"
+                               IsVisible="{Binding RightPanel.CompressLayout.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                    <TextBlock Text="{Binding RightPanel.CompressLayout.ResultText}"
                                Foreground="LightCyan" FontSize="10" Margin="0,5,0,5"
                                TextWrapping="Wrap"
-                               IsVisible="{Binding CompressLayout.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                               IsVisible="{Binding RightPanel.CompressLayout.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
                     <!-- Design Checks Panel -->
                     <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
@@ -667,19 +667,19 @@
                             Command="{Binding RunDesignChecksCommand}"
                             Width="160" Margin="0,5,0,5"
                             Background="#5d3d3d"/>
-                    <TextBlock Text="{Binding DesignValidation.StatusText}"
+                    <TextBlock Text="{Binding RightPanel.DesignValidation.StatusText}"
                                Foreground="Gray" FontSize="10" Margin="0,0,0,5"
-                               IsVisible="{Binding DesignValidation.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                               IsVisible="{Binding RightPanel.DesignValidation.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                     <StackPanel Orientation="Horizontal" Margin="0,5,0,5"
-                                IsVisible="{Binding DesignValidation.HasIssues}">
+                                IsVisible="{Binding RightPanel.DesignValidation.HasIssues}">
                         <Button Content="&lt;&lt; Prev"
-                                Command="{Binding DesignValidation.PreviousIssueCommand}"
+                                Command="{Binding RightPanel.DesignValidation.PreviousIssueCommand}"
                                 Width="70" Margin="0,0,5,0" Background="#3d3d3d"/>
-                        <TextBlock Text="{Binding DesignValidation.NavigationText}"
+                        <TextBlock Text="{Binding RightPanel.DesignValidation.NavigationText}"
                                    Foreground="White" VerticalAlignment="Center"
                                    Width="50" TextAlignment="Center"/>
                         <Button Content="Next &gt;&gt;"
-                                Command="{Binding DesignValidation.NextIssueCommand}"
+                                Command="{Binding RightPanel.DesignValidation.NextIssueCommand}"
                                 Width="70" Margin="5,0,0,0" Background="#3d3d3d"/>
                     </StackPanel>
 
@@ -691,46 +691,46 @@
                     </TextBlock>
 
                     <!-- Selection-based lock controls -->
-                    <StackPanel IsVisible="{Binding ElementLock.HasSelection}">
+                    <StackPanel IsVisible="{Binding BottomPanel.ElementLock.HasSelection}">
                         <TextBlock Text="Selected Components:" Foreground="Gray" Margin="0,0,0,5"/>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                             <Button Content="Lock"
-                                    Command="{Binding ElementLock.LockSelectedComponentsCommand}"
+                                    Command="{Binding BottomPanel.ElementLock.LockSelectedComponentsCommand}"
                                     Width="80" Margin="0,0,5,0" Background="#5d3d3d"/>
                             <Button Content="Unlock"
-                                    Command="{Binding ElementLock.UnlockSelectedComponentsCommand}"
+                                    Command="{Binding BottomPanel.ElementLock.UnlockSelectedComponentsCommand}"
                                     Width="80" Margin="5,0,0,0" Background="#3d5d3d"/>
                         </StackPanel>
                     </StackPanel>
 
                     <!-- Global unlock controls -->
                     <Button Content="Unlock All Components"
-                            Command="{Binding ElementLock.UnlockAllComponentsCommand}"
+                            Command="{Binding BottomPanel.ElementLock.UnlockAllComponentsCommand}"
                             Width="160" Margin="0,5,0,5"
                             Background="#3d4d5d"/>
 
                     <Button Content="Unlock All Connections"
-                            Command="{Binding ElementLock.UnlockAllConnectionsCommand}"
+                            Command="{Binding BottomPanel.ElementLock.UnlockAllConnectionsCommand}"
                             Width="160" Margin="0,0,0,5"
                             Background="#3d4d5d"/>
 
                     <!-- Status display -->
                     <StackPanel Orientation="Horizontal" Margin="0,10,0,5">
                         <TextBlock Text="Locked: " Foreground="Gray"/>
-                        <TextBlock Text="{Binding ElementLock.LockedComponentCount}" Foreground="Orange"/>
+                        <TextBlock Text="{Binding BottomPanel.ElementLock.LockedComponentCount}" Foreground="Orange"/>
                         <TextBlock Text=" components, " Foreground="Gray"/>
-                        <TextBlock Text="{Binding ElementLock.LockedConnectionCount}" Foreground="Orange"/>
+                        <TextBlock Text="{Binding BottomPanel.ElementLock.LockedConnectionCount}" Foreground="Orange"/>
                         <TextBlock Text=" connections" Foreground="Gray"/>
                     </StackPanel>
 
-                    <TextBlock Text="{Binding ElementLock.StatusText}"
+                    <TextBlock Text="{Binding BottomPanel.ElementLock.StatusText}"
                                Foreground="LightGreen" FontSize="10" Margin="0,0,0,5"
-                               IsVisible="{Binding ElementLock.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                               IsVisible="{Binding BottomPanel.ElementLock.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
                     <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
 
                     <TextBlock Text="Current Mode:" Foreground="Gray" Margin="0,0,0,5"/>
-                    <TextBlock Text="{Binding CurrentMode}" Foreground="Cyan" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding CanvasInteraction.CurrentMode}" Foreground="Cyan" FontWeight="Bold"/>
 
                     <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
 
@@ -759,42 +759,42 @@
                     <!-- Routing Diagnostics -->
                     <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
                     <TextBlock Text="Routing Diagnostics:" Foreground="Salmon" Margin="0,0,0,5" FontWeight="SemiBold"/>
-                    <Button Content="Analyze Routes" Command="{Binding RoutingDiagnostics.RunDiagnosticsCommand}"
+                    <Button Content="Analyze Routes" Command="{Binding RightPanel.RoutingDiagnostics.RunDiagnosticsCommand}"
                             MinWidth="110" Margin="0,5,0,5" Padding="8,4" Background="#5d3d3d" HorizontalAlignment="Stretch"
-                            IsEnabled="{Binding RoutingDiagnostics.IsAnalyzing, Converter={x:Static BoolConverters.Not}}"/>
+                            IsEnabled="{Binding RightPanel.RoutingDiagnostics.IsAnalyzing, Converter={x:Static BoolConverters.Not}}"/>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                        <Button Content="Export JSON" Command="{Binding RoutingDiagnostics.ExportPathsJsonCommand}"
+                        <Button Content="Export JSON" Command="{Binding RightPanel.RoutingDiagnostics.ExportPathsJsonCommand}"
                                 MinWidth="100" Margin="0,0,5,0" Padding="8,4" Background="#3d3d5d"/>
-                        <Button Content="📋" Command="{Binding RoutingDiagnostics.CopyPathsJsonToClipboardCommand}"
+                        <Button Content="📋" Command="{Binding RightPanel.RoutingDiagnostics.CopyPathsJsonToClipboardCommand}"
                                 Width="36" Background="#3d3d5d" ToolTip.Tip="Copy JSON to clipboard"/>
                     </StackPanel>
-                    <TextBlock Text="{Binding RoutingDiagnostics.StatusText}" Foreground="Gray" FontSize="10" Margin="0,0,0,3"
-                               IsVisible="{Binding RoutingDiagnostics.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                    <TextBlock Text="{Binding RightPanel.RoutingDiagnostics.StatusText}" Foreground="Gray" FontSize="10" Margin="0,0,0,3"
+                               IsVisible="{Binding RightPanel.RoutingDiagnostics.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,5"
-                                IsVisible="{Binding RoutingDiagnostics.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                                IsVisible="{Binding RightPanel.RoutingDiagnostics.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
                         <TextBlock Text="Valid: " Foreground="Gray"/>
-                        <TextBlock Text="{Binding RoutingDiagnostics.ValidConnections}" Foreground="LightGreen"/>
+                        <TextBlock Text="{Binding RightPanel.RoutingDiagnostics.ValidConnections}" Foreground="LightGreen"/>
                         <TextBlock Text="/" Foreground="Gray"/>
-                        <TextBlock Text="{Binding RoutingDiagnostics.TotalConnections}" Foreground="White"/>
+                        <TextBlock Text="{Binding RightPanel.RoutingDiagnostics.TotalConnections}" Foreground="White"/>
                         <TextBlock Text="  Issues: " Foreground="Gray"/>
-                        <TextBlock Text="{Binding RoutingDiagnostics.IssueCount}" Foreground="Salmon"/>
+                        <TextBlock Text="{Binding RightPanel.RoutingDiagnostics.IssueCount}" Foreground="Salmon"/>
                     </StackPanel>
                     <ScrollViewer MaxHeight="150" Margin="0,5,0,0"
-                                  IsVisible="{Binding RoutingDiagnostics.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                        <TextBlock Text="{Binding RoutingDiagnostics.ResultText}" Foreground="LightGray"
+                                  IsVisible="{Binding RightPanel.RoutingDiagnostics.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <TextBlock Text="{Binding RightPanel.RoutingDiagnostics.ResultText}" Foreground="LightGray"
                                    FontFamily="Consolas" FontSize="9" TextWrapping="NoWrap"/>
                     </ScrollViewer>
 
                     <!-- Component Dimension Diagnostics -->
                     <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
                     <TextBlock Text="Component Dimensions:" Foreground="Salmon" Margin="0,0,0,5" FontWeight="SemiBold"/>
-                    <Button Content="Check Dimensions" Command="{Binding DimensionDiagnostics.RefreshDiagnosticsCommand}"
+                    <Button Content="Check Dimensions" Command="{Binding RightPanel.DimensionDiagnostics.RefreshDiagnosticsCommand}"
                             MinWidth="110" Margin="0,5,0,5" Padding="8,4" Background="#5d3d3d" HorizontalAlignment="Stretch"/>
                     <TextBlock Text="Validates that component dimensions in GDS export match the UI display."
                                Foreground="Gray" FontSize="9" Margin="0,0,0,5" TextWrapping="Wrap"/>
                     <ScrollViewer MaxHeight="200" Margin="0,5,0,0"
-                                  IsVisible="{Binding DimensionDiagnostics.DiagnosticsText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                        <TextBlock Text="{Binding DimensionDiagnostics.DiagnosticsText}" Foreground="LightGray"
+                                  IsVisible="{Binding RightPanel.DimensionDiagnostics.DiagnosticsText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <TextBlock Text="{Binding RightPanel.DimensionDiagnostics.DiagnosticsText}" Foreground="LightGray"
                                    FontFamily="Consolas" FontSize="9" TextWrapping="NoWrap"/>
                     </ScrollViewer>
 
@@ -900,7 +900,7 @@
             <!-- Design Canvas -->
             <controls:DesignCanvas x:Name="DesignCanvasControl"
                                    ViewModel="{Binding Canvas}"
-                                   Zoom="{Binding ZoomLevel, Mode=TwoWay}"
+                                   Zoom="{Binding ViewportControl.ZoomLevel, Mode=TwoWay}"
                                    MainViewModel="{Binding}">
                 <controls:DesignCanvas.ContextMenu>
                 <ContextMenu>

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -22,19 +22,19 @@ public partial class MainWindow : Window
             {
                 vm.FileDialogService = new FileDialogService(this);
                 vm.FileOperations.MessageBoxService = new MessageBoxService();
-                vm.Sweep.FileDialogService = vm.FileDialogService;
-                vm.RoutingDiagnostics.FileDialogService = vm.FileDialogService;
+                vm.RightPanel.Sweep.FileDialogService = vm.FileDialogService;
+                vm.RightPanel.RoutingDiagnostics.FileDialogService = vm.FileDialogService;
                 vm.ViewportControl.GetViewportSize = GetActualViewportSize;
 
                 // Wire up rename dialog for group templates
-                vm.GroupLibrary.ShowRenameDialogAsync = async (currentName) =>
+                vm.LeftPanel.ComponentLibrary.ShowRenameDialogAsync = async (currentName) =>
                 {
                     var dialog = new RenameDialog(currentName);
                     return await dialog.ShowDialog<string?>(this);
                 };
 
                 // Wire up clipboard for RoutingDiagnostics
-                vm.RoutingDiagnostics.CopyToClipboard = async (text) =>
+                vm.RightPanel.RoutingDiagnostics.CopyToClipboard = async (text) =>
                 {
                     var clipboard = Clipboard;
                     if (clipboard != null)
@@ -44,7 +44,7 @@ public partial class MainWindow : Window
                 };
 
                 // Wire up clipboard for DimensionValidator
-                vm.DimensionValidator.CopyToClipboard = async (text) =>
+                vm.RightPanel.DimensionValidator.CopyToClipboard = async (text) =>
                 {
                     var clipboard = Clipboard;
                     if (clipboard != null)
@@ -54,7 +54,7 @@ public partial class MainWindow : Window
                 };
 
                 // Wire up clipboard for ErrorConsole
-                vm.ErrorConsole.CopyToClipboard = async (text) =>
+                vm.BottomPanel.ErrorConsole.CopyToClipboard = async (text) =>
                 {
                     var clipboard = Clipboard;
                     if (clipboard != null)
@@ -64,9 +64,9 @@ public partial class MainWindow : Window
                 };
 
                 // Wire up auto-scroll: scroll to the newest entry when entries are added
-                vm.ErrorConsole.PropertyChanged += (s, e) =>
+                vm.BottomPanel.ErrorConsole.PropertyChanged += (s, e) =>
                 {
-                    if (e.PropertyName == nameof(vm.ErrorConsole.EntryCount) && ErrorConsoleListBox != null)
+                    if (e.PropertyName == nameof(vm.BottomPanel.ErrorConsole.EntryCount) && ErrorConsoleListBox != null)
                     {
                         var items = ErrorConsoleListBox.ItemsSource;
                         if (items is System.Collections.IList list && list.Count > 0)
@@ -442,7 +442,7 @@ public partial class MainWindow : Window
         else
         {
             // Find and select the matching item in UserGroups
-            var userItem = vm.GroupLibrary.UserGroups.FirstOrDefault(vm => vm.Template == template);
+            var userItem = vm.LeftPanel.ComponentLibrary.UserGroups.FirstOrDefault(vm => vm.Template == template);
             if (userItem != null)
             {
                 if (UserGroupsListBox != null)
@@ -454,7 +454,7 @@ public partial class MainWindow : Window
             }
 
             // Find and select the matching item in PdkGroups
-            var pdkItem = vm.GroupLibrary.PdkGroups.FirstOrDefault(vm => vm.Template == template);
+            var pdkItem = vm.LeftPanel.ComponentLibrary.PdkGroups.FirstOrDefault(vm => vm.Template == template);
             if (pdkItem != null)
             {
                 if (PdkGroupsListBox != null)

--- a/UnitTests/ViewModels/ZoomToFitDebugTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitDebugTests.cs
@@ -34,14 +34,14 @@ public class ZoomToFitDebugTests
         vm.Canvas.AddComponent(comp);
 
         // Simulate manual zoom (like mouse wheel)
-        vm.ZoomLevel = 3.0;
-        vm.ZoomLevel.ShouldBe(3.0, "Manual zoom should be applied");
+        vm.ViewportControl.ZoomLevel = 3.0;
+        vm.ViewportControl.ZoomLevel.ShouldBe(3.0, "Manual zoom should be applied");
 
         // Now call ZoomToFit
         vm.ZoomToFit(800, 600);
 
         // Zoom should have changed from 3.0 to something else
-        vm.ZoomLevel.ShouldNotBe(3.0, "ZoomToFit should change the zoom level!");
-        vm.ZoomLevel.ShouldBeInRange(0.3, 1.0, "Zoom should fit the 1000x1000 component in 800x600 viewport");
+        vm.ViewportControl.ZoomLevel.ShouldNotBe(3.0, "ZoomToFit should change the zoom level!");
+        vm.ViewportControl.ZoomLevel.ShouldBeInRange(0.3, 1.0, "Zoom should fit the 1000x1000 component in 800x600 viewport");
     }
 }

--- a/UnitTests/ViewModels/ZoomToFitGroupsTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitGroupsTests.cs
@@ -42,7 +42,7 @@ public class ZoomToFitGroupsTests
         // Padded: (-55, -25) relative to the bounding box origin
         // Padded width = 660, padded height = 300
         // Zoom = min(1000/660, 1000/300) = min(1.515, 3.333) ≈ 1.515
-        vm.ZoomLevel.ShouldBeInRange(1.0, 2.0, "Zoom should be calculated to fit the group");
+        vm.ViewportControl.ZoomLevel.ShouldBeInRange(1.0, 2.0, "Zoom should be calculated to fit the group");
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ public class ZoomToFitGroupsTests
         // With 10% padding: width=240, height=120
         // Zoom = min(1000/240, 1000/120) = min(4.17, 8.33) ≈ 4.17
         // But clamped to maxZoom=10
-        vm.ZoomLevel.ShouldBeGreaterThan(1.0, "Zoom should be calculated based on moved group position");
+        vm.ViewportControl.ZoomLevel.ShouldBeGreaterThan(1.0, "Zoom should be calculated based on moved group position");
     }
 
     /// <summary>
@@ -126,7 +126,7 @@ public class ZoomToFitGroupsTests
 
         // Bounding box spans from (0, 0) to (900+width, 900+height)
         // This is a large area, so zoom should be small
-        vm.ZoomLevel.ShouldBeInRange(0.1, 2.0, "Zoom should fit both standalone and group");
+        vm.ViewportControl.ZoomLevel.ShouldBeInRange(0.1, 2.0, "Zoom should fit both standalone and group");
     }
 
     /// <summary>
@@ -154,6 +154,6 @@ public class ZoomToFitGroupsTests
         // Should not crash and should zoom to fit the regular component
         vm.ZoomToFit(1000, 1000);
 
-        vm.ZoomLevel.ShouldBeGreaterThan(0, "Zoom should be set based on non-empty components");
+        vm.ViewportControl.ZoomLevel.ShouldBeGreaterThan(0, "Zoom should be set based on non-empty components");
     }
 }

--- a/UnitTests/ViewModels/ZoomToFitTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitTests.cs
@@ -21,11 +21,11 @@ public class ZoomToFitTests
     public void ZoomToFit_EmptyCanvas_DoesNotChangeZoom()
     {
         var vm = CreateViewModel();
-        double originalZoom = vm.ZoomLevel;
+        double originalZoom = vm.ViewportControl.ZoomLevel;
 
         vm.ZoomToFit(800, 600);
 
-        vm.ZoomLevel.ShouldBe(originalZoom);
+        vm.ViewportControl.ZoomLevel.ShouldBe(originalZoom);
         vm.StatusText.ShouldContain("No components");
     }
 
@@ -42,7 +42,7 @@ public class ZoomToFitTests
 
         vm.ZoomToFit(800, 600);
 
-        vm.ZoomLevel.ShouldBeGreaterThan(0);
+        vm.ViewportControl.ZoomLevel.ShouldBeGreaterThan(0);
         vm.StatusText.ShouldContain("Zoom to fit");
     }
 
@@ -50,22 +50,22 @@ public class ZoomToFitTests
     public void ZoomToFit_ZeroViewport_DoesNothing()
     {
         var vm = CreateViewModel();
-        double originalZoom = vm.ZoomLevel;
+        double originalZoom = vm.ViewportControl.ZoomLevel;
 
         vm.ZoomToFit(0, 0);
 
-        vm.ZoomLevel.ShouldBe(originalZoom);
+        vm.ViewportControl.ZoomLevel.ShouldBe(originalZoom);
     }
 
     [Fact]
     public void ZoomToFit_NegativeViewport_DoesNothing()
     {
         var vm = CreateViewModel();
-        double originalZoom = vm.ZoomLevel;
+        double originalZoom = vm.ViewportControl.ZoomLevel;
 
         vm.ZoomToFit(-100, -100);
 
-        vm.ZoomLevel.ShouldBe(originalZoom);
+        vm.ViewportControl.ZoomLevel.ShouldBe(originalZoom);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class ZoomToFitTests
         // Bounding box: (0,0)-(1000,1000), with 10% padding: (-100,-100)-(1100,1100)
         // padded size: 1200x1200, viewport: 1000x1000
         // zoom = 1000/1200 ≈ 0.833
-        vm.ZoomLevel.ShouldBeInRange(0.8, 0.9);
+        vm.ViewportControl.ZoomLevel.ShouldBeInRange(0.8, 0.9);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #344

- Removed all ~15 backward-compatibility delegate properties from `MainViewModel.cs` (`public ParameterSweepViewModel Sweep => RightPanel.Sweep;` etc.)
- Updated all AXAML bindings in `MainWindow.axaml` to use full panel paths (`BottomPanel.*`, `RightPanel.*`, `LeftPanel.*`, `FileOperations.*`)
- Updated `MainWindow.axaml.cs` code-behind to use explicit panel paths (`vm.RightPanel.Sweep`, `vm.BottomPanel.ErrorConsole`, etc.)
- Updated ZoomToFit tests to use `vm.ViewportControl.ZoomLevel` instead of old `vm.ZoomLevel`
- `MainViewModel.cs` reduced from ~654 → 574 lines

## Changes

| File | Change |
|------|--------|
| `CAP.Avalonia/ViewModels/MainViewModel.cs` | Removed ~80 lines of backward-compat delegates |
| `CAP.Avalonia/Views/MainWindow.axaml` | Updated all bindings to use full panel hierarchy paths |
| `CAP.Avalonia/Views/MainWindow.axaml.cs` | Updated code-behind to reference panels directly |
| `CAP.Avalonia/Controls/DesignCanvas.*.cs` | Minor: updated MainViewModel access patterns |
| `UnitTests/ViewModels/ZoomToFit*.cs` | Updated to use `ViewportControl.ZoomLevel` |

## Verification

- `dotnet build` — 0 errors
- `dotnet test` — 1404 passing, 2 pre-existing failures (GDS grating coupler Y-deviation — unrelated to this PR, tracked separately)

## MCP Tools Used

None used (straightforward refactoring, targeted file reads sufficient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)