### PR TITLE
Agent: Phase Shifter size changes after save/load (roundtrip test needed)

### DIFF
--- a/CAP.Avalonia/Commands/PlaceComponentCommand.cs
+++ b/CAP.Avalonia/Commands/PlaceComponentCommand.cs
@@ -69,7 +69,7 @@ public class PlaceComponentCommand : IUndoableCommand
             if (_createdViewModel == null)
             {
                 // Component not in canvas, add it
-                _createdViewModel = _canvas.AddComponent(_component, _template.Name);
+                _createdViewModel = _canvas.AddComponent(_component, _template.Name, _template.PdkSource);
             }
         }
     }

--- a/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
@@ -818,9 +818,9 @@ public partial class DesignCanvasViewModel : ObservableObject
         return (minX, minY, maxX - minX, maxY - minY);
     }
 
-    public ComponentViewModel AddComponent(Component component, string? templateName = null)
+    public ComponentViewModel AddComponent(Component component, string? templateName = null, string? templatePdkSource = null)
     {
-        var vm = new ComponentViewModel(component, templateName);
+        var vm = new ComponentViewModel(component, templateName, templatePdkSource);
         vm.OnSliderChanged = () => RequestResimulation();
         Components.Add(vm);
 
@@ -1346,6 +1346,13 @@ public partial class ComponentViewModel : ObservableObject
     /// </summary>
     public string? TemplateName { get; set; }
 
+    /// <summary>
+    /// The PDK source of the template (e.g. "Built-in", "Demo PDK").
+    /// Used together with TemplateName to uniquely identify the correct template during load,
+    /// preventing size corruption when multiple PDKs share the same component name.
+    /// </summary>
+    public string? TemplatePdkSource { get; set; }
+
     [ObservableProperty]
     private double _x;
 
@@ -1432,10 +1439,11 @@ public partial class ComponentViewModel : ObservableObject
     public double SliderMin => Component.GetSlider(0)?.MinValue ?? 0;
     public double SliderMax => Component.GetSlider(0)?.MaxValue ?? 1;
 
-    public ComponentViewModel(Component component, string? templateName = null)
+    public ComponentViewModel(Component component, string? templateName = null, string? templatePdkSource = null)
     {
         Component = component;
         TemplateName = templateName;
+        TemplatePdkSource = templatePdkSource;
         _x = component.PhysicalX;
         _y = component.PhysicalY;
 

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -522,6 +522,13 @@ public class ChildComponentData
     public string? ComponentGuid { get; set; }
 
     public string TemplateName { get; set; } = "";
+
+    /// <summary>
+    /// PDK source name used to disambiguate templates with the same name.
+    /// Null in old files — falls back to name-only lookup.
+    /// </summary>
+    public string? PdkSource { get; set; }
+
     public double X { get; set; }
     public double Y { get; set; }
     public int Rotation { get; set; }
@@ -535,6 +542,14 @@ public class ChildComponentData
 public class ComponentData
 {
     public string TemplateName { get; set; } = "";
+
+    /// <summary>
+    /// PDK source name (e.g. "Built-in", "Demo PDK").
+    /// Used to disambiguate templates with the same name from different PDKs.
+    /// Null in old files — falls back to name-only lookup.
+    /// </summary>
+    public string? PdkSource { get; set; }
+
     public double X { get; set; }
     public double Y { get; set; }
     public string Identifier { get; set; } = "";

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -206,6 +206,7 @@ public partial class FileOperationsViewModel : ObservableObject
         return new ComponentData
         {
             TemplateName = FindTemplateName(c.Component),
+            PdkSource = c.TemplatePdkSource ?? FindTemplatePdkSource(c.Component),
             X = c.X,
             Y = c.Y,
             Identifier = c.Component.Identifier,
@@ -216,6 +217,25 @@ public partial class FileOperationsViewModel : ObservableObject
             IsLocked = c.Component.IsLocked ? true : null,
             HumanReadableName = c.Component.HumanReadableName
         };
+    }
+
+    /// <summary>
+    /// Finds the PDK source for a component by matching its NazcaFunctionName against the library.
+    /// Returns null if no match is found.
+    /// </summary>
+    private string? FindTemplatePdkSource(Component component)
+    {
+        var nazcaFunc = component.NazcaFunctionName;
+        if (string.IsNullOrEmpty(nazcaFunc))
+            return null;
+
+        var match = _componentLibrary.FirstOrDefault(t =>
+        {
+            var templateFunc = t.NazcaFunctionName
+                ?? $"nazca_{t.Name.ToLower().Replace(" ", "_")}";
+            return templateFunc == nazcaFunc;
+        });
+        return match?.PdkSource;
     }
 
     /// <summary>
@@ -305,12 +325,14 @@ public partial class FileOperationsViewModel : ObservableObject
             }
 
             var templateName = FindTemplateName(child);
+            var pdkSource = FindTemplatePdkSource(child);
 
             childDataList.Add(new ChildComponentData
             {
                 Identifier = child.Identifier,
                 ComponentGuid = child.Id.ToString(),
                 TemplateName = templateName,
+                PdkSource = pdkSource,
                 X = child.PhysicalX,
                 Y = child.PhysicalY,
                 Rotation = (int)child.Rotation90CounterClock,
@@ -556,12 +578,30 @@ public partial class FileOperationsViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Finds a template by name and optional PDK source.
+    /// When PdkSource is provided, prefers an exact match; falls back to name-only for old files.
+    /// </summary>
+    private ComponentTemplate? FindTemplate(string templateName, string? pdkSource)
+    {
+        if (!string.IsNullOrEmpty(pdkSource))
+        {
+            var exact = _componentLibrary.FirstOrDefault(t =>
+                t.Name.Equals(templateName, StringComparison.OrdinalIgnoreCase)
+                && t.PdkSource.Equals(pdkSource, StringComparison.OrdinalIgnoreCase));
+            if (exact != null)
+                return exact;
+        }
+
+        return _componentLibrary.FirstOrDefault(t =>
+            t.Name.Equals(templateName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
     /// Loads a single component from saved data and adds it to the canvas.
     /// </summary>
     private ComponentViewModel? LoadComponentFromData(ComponentData compData)
     {
-        var template = _componentLibrary.FirstOrDefault(t =>
-            t.Name.Equals(compData.TemplateName, StringComparison.OrdinalIgnoreCase));
+        var template = FindTemplate(compData.TemplateName, compData.PdkSource);
 
         if (template == null)
             return null;
@@ -581,7 +621,7 @@ public partial class FileOperationsViewModel : ObservableObject
             ApplyRotationToComponent(component);
         }
 
-        var vm = _canvas.AddComponent(component, template.Name);
+        var vm = _canvas.AddComponent(component, template.Name, template.PdkSource);
 
         // Restore slider value
         if (compData.SliderValue.HasValue && vm.HasSliders)
@@ -629,8 +669,7 @@ public partial class FileOperationsViewModel : ObservableObject
                 if (!hasGuid && nameFallback.ContainsKey(childData.Identifier))
                     continue;
 
-                var template = _componentLibrary.FirstOrDefault(t =>
-                    t.Name.Equals(childData.TemplateName, StringComparison.OrdinalIgnoreCase));
+                var template = FindTemplate(childData.TemplateName, childData.PdkSource);
 
                 if (template == null)
                     continue;

--- a/UnitTests/Integration/ComponentSizePersistenceTests.cs
+++ b/UnitTests/Integration/ComponentSizePersistenceTests.cs
@@ -1,0 +1,273 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Integration tests for Phase Shifter and other parameterized component
+/// size persistence across save/load roundtrips.
+///
+/// Root cause under test: when two templates share the same name (e.g. built-in
+/// "Phase Shifter" at 500×60 µm and Demo PDK "Phase Shifter" at 200×20 µm),
+/// the old code always matched the *first* template in the library, silently
+/// replacing the saved component with the wrong size.  The fix stores the
+/// PdkSource alongside TemplateName so the correct template is found.
+/// </summary>
+public class ComponentSizePersistenceTests
+{
+    // ── Built-in template dimensions ──────────────────────────────────────────
+    private const double BuiltInWidth  = 500;
+    private const double BuiltInHeight = 60;
+    private const string BuiltInPdkSource = "Built-in";
+
+    // ── Demo PDK template dimensions (name collision with built-in) ───────────
+    private const double PdkWidth  = 200;
+    private const double PdkHeight = 20;
+    private const string DemoPdkSource = "Demo PDK";
+
+    // ── Template / component names ────────────────────────────────────────────
+    private const string PhaseShifterName = "Phase Shifter";
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helper: create a minimal test setup.
+    // The returned template library always contains BOTH a built-in AND a PDK
+    // template named "Phase Shifter" so that name-only lookup is ambiguous.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static (FileOperationsViewModel fileOps,
+                    DesignCanvasViewModel canvas,
+                    ObservableCollection<ComponentTemplate> templates,
+                    string tempFile)
+        CreateTestSetup()
+    {
+        var canvas    = new DesignCanvasViewModel();
+        var templates = new ObservableCollection<ComponentTemplate>();
+
+        // 1. Add ALL built-in templates (Phase Shifter is among them)
+        foreach (var t in ComponentTemplates.GetAllTemplates())
+            templates.Add(t);
+
+        // 2. Add a Demo PDK "Phase Shifter" with DIFFERENT dimensions.
+        //    This causes the name-collision that the fix addresses.
+        var pdkTemplate = CreatePdkPhaseShifterTemplate();
+        templates.Add(pdkTemplate);
+
+        var commandManager = new CommandManager();
+        var nazcaExporter  = new SimpleNazcaExporter();
+        var gdsExportVm    = new GdsExportViewModel(new GdsExportService());
+        var fileOps = new FileOperationsViewModel(
+            canvas, commandManager, nazcaExporter, templates, gdsExportVm);
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"cap_test_{Guid.NewGuid():N}.lun");
+        return (fileOps, canvas, templates, tempFile);
+    }
+
+    /// <summary>Creates the fake PDK Phase Shifter template (200×20 µm).</summary>
+    private static ComponentTemplate CreatePdkPhaseShifterTemplate()
+    {
+        return new ComponentTemplate
+        {
+            Name              = PhaseShifterName,
+            Category          = "Modulators",
+            WidthMicrometers  = PdkWidth,
+            HeightMicrometers = PdkHeight,
+            PdkSource         = DemoPdkSource,
+            NazcaFunctionName = "demo_pdk.phase_shifter",
+            HasSlider         = true,
+            SliderMin         = 0,
+            SliderMax         = 360,
+            NazcaOriginOffsetX = 0,
+            NazcaOriginOffsetY = PdkHeight / 2,
+            PinDefinitions = new[]
+            {
+                new PinDefinition("in",  0,         PdkHeight / 2, 180),
+                new PinDefinition("out", PdkWidth,  PdkHeight / 2, 0)
+            },
+            CreateSMatrixWithSliders = (pins, sliders) =>
+            {
+                var pinIds    = pins.SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+                var sliderIds = sliders.Select(s => (s.ID, s.Value)).ToList();
+                return new CAP_Core.LightCalculation.SMatrix(pinIds, sliderIds);
+            }
+        };
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static Mock<IFileDialogService> CreateDialogMock(string savePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog
+            .Setup(d => d.ShowSaveFileDialogAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(savePath);
+        dialog
+            .Setup(d => d.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(savePath);
+        return dialog;
+    }
+
+    private static ComponentTemplate GetBuiltInPhaseShifter(ObservableCollection<ComponentTemplate> templates)
+        => templates.First(t => t.Name == PhaseShifterName && t.PdkSource == BuiltInPdkSource);
+
+    private static ComponentTemplate GetPdkPhaseShifter(ObservableCollection<ComponentTemplate> templates)
+        => templates.First(t => t.Name == PhaseShifterName && t.PdkSource == DemoPdkSource);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Tests
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Basic roundtrip: built-in Phase Shifter (500×60 µm).
+    /// Even when a same-named PDK template is in the library, the built-in
+    /// component must load back at exactly 500×60.
+    /// </summary>
+    [Fact]
+    public async Task BuiltInPhaseShifter_SaveLoadRoundtrip_PreservesSize()
+    {
+        var (fileOps, canvas, templates, tempFile) = CreateTestSetup();
+        try
+        {
+            var template  = GetBuiltInPhaseShifter(templates);
+            var component = ComponentTemplates.CreateFromTemplate(template, 100, 100);
+            canvas.AddComponent(component, template.Name, template.PdkSource);
+
+            var dialogMock = CreateDialogMock(tempFile);
+            fileOps.FileDialogService = dialogMock.Object;
+
+            await fileOps.SaveDesignCommand.ExecuteAsync(null);
+            canvas.Components.Clear();
+            canvas.Connections.Clear();
+            canvas.AllPins.Clear();
+            await fileOps.LoadDesignCommand.ExecuteAsync(null);
+
+            canvas.Components.Count.ShouldBe(1);
+            var loaded = canvas.Components[0].Component;
+            loaded.WidthMicrometers.ShouldBe(BuiltInWidth,  tolerance: 0.01);
+            loaded.HeightMicrometers.ShouldBe(BuiltInHeight, tolerance: 0.01);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Regression test for the PDK name-collision bug.
+    /// A Phase Shifter placed from the Demo PDK (200×20 µm) must load back at
+    /// 200×20, not at the built-in 500×60.
+    /// </summary>
+    [Fact]
+    public async Task PdkPhaseShifter_SaveLoadRoundtrip_PreservesSize_NotBuiltInSize()
+    {
+        var (fileOps, canvas, templates, tempFile) = CreateTestSetup();
+        try
+        {
+            var template  = GetPdkPhaseShifter(templates);
+            var component = ComponentTemplates.CreateFromTemplate(template, 100, 100);
+            canvas.AddComponent(component, template.Name, template.PdkSource);
+
+            var dialogMock = CreateDialogMock(tempFile);
+            fileOps.FileDialogService = dialogMock.Object;
+
+            await fileOps.SaveDesignCommand.ExecuteAsync(null);
+            canvas.Components.Clear();
+            canvas.Connections.Clear();
+            canvas.AllPins.Clear();
+            await fileOps.LoadDesignCommand.ExecuteAsync(null);
+
+            canvas.Components.Count.ShouldBe(1);
+            var loaded = canvas.Components[0].Component;
+
+            // PDK dimensions must be preserved (bug: was loading built-in 500×60 instead)
+            loaded.WidthMicrometers.ShouldBe(PdkWidth,   tolerance: 0.01,
+                $"Expected PDK Phase Shifter width {PdkWidth} but got {loaded.WidthMicrometers}. " +
+                "This is the template name-collision bug: wrong template was selected during load.");
+            loaded.HeightMicrometers.ShouldBe(PdkHeight, tolerance: 0.01,
+                $"Expected PDK Phase Shifter height {PdkHeight} but got {loaded.HeightMicrometers}.");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Slider value is preserved during save/load for a Phase Shifter.
+    /// </summary>
+    [Fact]
+    public async Task PhaseShifter_SaveLoadRoundtrip_PreservesSliderValue()
+    {
+        var (fileOps, canvas, templates, tempFile) = CreateTestSetup();
+        try
+        {
+            const double savedSliderValue = 270.0;
+
+            var template  = GetBuiltInPhaseShifter(templates);
+            var component = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+            var vm        = canvas.AddComponent(component, template.Name, template.PdkSource);
+
+            // Set a non-default slider value
+            vm.SliderValue = savedSliderValue;
+
+            var dialogMock = CreateDialogMock(tempFile);
+            fileOps.FileDialogService = dialogMock.Object;
+
+            await fileOps.SaveDesignCommand.ExecuteAsync(null);
+            canvas.Components.Clear();
+            canvas.Connections.Clear();
+            canvas.AllPins.Clear();
+            await fileOps.LoadDesignCommand.ExecuteAsync(null);
+
+            canvas.Components.Count.ShouldBe(1);
+            var loadedVm = canvas.Components[0];
+            loadedVm.HasSliders.ShouldBeTrue();
+            loadedVm.SliderValue.ShouldBe(savedSliderValue, tolerance: 0.01);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the save file contains the PdkSource field.
+    /// This confirms the fix is actually writing PdkSource to disk.
+    /// </summary>
+    [Fact]
+    public async Task PdkPhaseShifter_SavedJson_ContainsPdkSource()
+    {
+        var (fileOps, canvas, templates, tempFile) = CreateTestSetup();
+        try
+        {
+            var template  = GetPdkPhaseShifter(templates);
+            var component = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+            canvas.AddComponent(component, template.Name, template.PdkSource);
+
+            var dialogMock = CreateDialogMock(tempFile);
+            fileOps.FileDialogService = dialogMock.Object;
+
+            await fileOps.SaveDesignCommand.ExecuteAsync(null);
+
+            var json = await File.ReadAllTextAsync(tempFile);
+            json.ShouldContain("pdkSource", Case.Insensitive);
+            json.ShouldContain(DemoPdkSource);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
Automated implementation for #356

All done. Here's a summary:

---

## Summary

### Root Cause

When two templates share the same `Name` (e.g. built-in "Phase Shifter" 500×60 µm and Demo PDK "Phase Shifter" 200×20 µm), the old `LoadComponentFromData` used `FirstOrDefault` by name alone — always returning the first match, which was the built-in template. A PDK Phase Shifter placed at 200 µm wide would reload as 500 µm wide.

### Fix

Introduced `PdkSource` tracking throughout the save/load pipeline:

| File | Change |
|------|--------|
| `MainViewModel.cs` | Added `PdkSource` field to `ComponentData` and `ChildComponentData` |
| `DesignCanvasViewModel.cs` | Added `TemplatePdkSource` to `ComponentViewModel`; updated `AddComponent` to accept `pdkSource` |
| `PlaceComponentCommand.cs` | Passes `_template.PdkSource` to `AddComponent` when placing |
| `FileOperationsViewModel.cs` | New `FindTemplate(name, pdkSource)` helper prefers exact PDK match; new `FindTemplatePdkSource` resolver; updated `CreateComponentData`, `LoadComponentFromData`, `CollectChildComponentData`, and `LoadGroups` to save/use `PdkSource` |

Old `.lun` files without `PdkSource` still load correctly via a name-only fallback.

### Tests

`UnitTests/Integration/ComponentSizePersistenceTests.cs` — 4 new tests:
1. **Built-in Phase Shifter roundtrip** — 500×60 preserved with PDK template in library
2. **PDK Phase Shifter roundtrip** (regression) — 200×20 correctly preserved, not replaced by built-in 500×60
3. **Slider value roundtrip** — slider value preserved
4. **JSON contains PdkSource** — verifies fix writes `PdkSource` to disk

**MCP Tools used:** None — all searches used Glob, Grep, and Read tools directly.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 48,199
- **Estimated cost:** $0.7219 USD

---
*Generated by autonomous agent using Claude Code.*