### PR TITLE
Agent: Prefab connection persistence: Waveguides reconnect to wrong instance after save/load

### DIFF
--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -567,6 +567,19 @@ public class ConnectionData
     public string StartPinName { get; set; } = "";
     public int EndComponentIndex { get; set; }
     public string EndPinName { get; set; } = "";
+
+    /// <summary>
+    /// Stable component identifier for the start endpoint (preferred over StartComponentIndex).
+    /// Populated in new saves; null in old files (fall back to StartComponentIndex).
+    /// </summary>
+    public string? StartComponentId { get; set; }
+
+    /// <summary>
+    /// Stable component identifier for the end endpoint (preferred over EndComponentIndex).
+    /// Populated in new saves; null in old files (fall back to EndComponentIndex).
+    /// </summary>
+    public string? EndComponentId { get; set; }
+
     public List<PathSegmentData>? CachedSegments { get; set; }
     public bool? IsBlockedFallback { get; set; }
     public bool? IsLocked { get; set; }

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -157,6 +157,8 @@ public partial class FileOperationsViewModel : ObservableObject
                         StartPinName = startPinName,
                         EndComponentIndex = endIdx,
                         EndPinName = endPinName,
+                        StartComponentId = startIdx >= 0 ? componentsList[startIdx].Component.Identifier : null,
+                        EndComponentId = endIdx >= 0 ? componentsList[endIdx].Component.Identifier : null,
                         CachedSegments = c.Connection.RoutedPath != null
                             ? PathSegmentConverter.ToDtoList(c.Connection.RoutedPath.Segments)
                             : null,
@@ -802,20 +804,33 @@ public partial class FileOperationsViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Finds a canvas component by identifier string (preferred) or by index (fallback for old files).
+    /// Returns null if the component cannot be found.
+    /// </summary>
+    private ComponentViewModel? ResolveComponentForLoad(string? componentId, int fallbackIndex)
+    {
+        if (!string.IsNullOrEmpty(componentId))
+            return _canvas.Components.FirstOrDefault(c => c.Component.Identifier == componentId);
+
+        if (fallbackIndex >= 0 && fallbackIndex < _canvas.Components.Count)
+            return _canvas.Components[fallbackIndex];
+
+        return null;
+    }
+
+    /// <summary>
     /// Loads a single connection from saved data.
+    /// Prefers identifier-based lookup (StartComponentId/EndComponentId) over index-based
+    /// to correctly handle mixed standalone+group designs where load order differs from save order.
+    /// Falls back to index-based for old files that predate the identifier fields.
     /// </summary>
     private void LoadConnectionFromData(ConnectionData connData)
     {
-        if (connData.StartComponentIndex < 0 ||
-            connData.StartComponentIndex >= _canvas.Components.Count ||
-            connData.EndComponentIndex < 0 ||
-            connData.EndComponentIndex >= _canvas.Components.Count)
-        {
-            return;
-        }
+        var startComp = ResolveComponentForLoad(connData.StartComponentId, connData.StartComponentIndex);
+        var endComp = ResolveComponentForLoad(connData.EndComponentId, connData.EndComponentIndex);
 
-        var startComp = _canvas.Components[connData.StartComponentIndex];
-        var endComp = _canvas.Components[connData.EndComponentIndex];
+        if (startComp == null || endComp == null)
+            return;
 
         var startPin = ResolvePin(startComp.Component, connData.StartPinName);
         var endPin = ResolvePin(endComp.Component, connData.EndPinName);

--- a/UnitTests/Integration/PrefabConnectionPersistenceTests.cs
+++ b/UnitTests/Integration/PrefabConnectionPersistenceTests.cs
@@ -1,0 +1,256 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using System.Collections.ObjectModel;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Regression tests for issue #358: Prefab connection persistence.
+/// Waveguides should reconnect to the correct prefab instance after save/load.
+/// Root cause: ConnectionData used integer indices that became wrong because
+/// standalone components are loaded before groups, changing all indices.
+/// Fix: ConnectionData now stores component identifiers (StartComponentId/EndComponentId)
+/// for robust lookup instead of relying on positional indices.
+/// </summary>
+public class PrefabConnectionPersistenceTests
+{
+    private readonly ObservableCollection<ComponentTemplate> _library;
+
+    /// <summary>Initializes the test suite with the full component library.</summary>
+    public PrefabConnectionPersistenceTests()
+    {
+        _library = new ObservableCollection<ComponentTemplate>(ComponentTemplates.GetAllTemplates());
+    }
+
+    /// <summary>
+    /// Core regression test for issue #358.
+    /// Creates 3 prefab instances + 1 standalone component where the groups are added
+    /// to the canvas BEFORE the standalone (creating the index mismatch on load).
+    /// Connects the standalone to instance1, saves, loads, and verifies
+    /// the waveguide reconnects to instance1 — not instance2 or instance3.
+    /// </summary>
+    [Fact]
+    public async Task PrefabInstances_SaveLoadRoundtrip_WaveguideReconnectsToCorrectInstance()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"prefab_conn_{Guid.NewGuid():N}.cappro");
+        try
+        {
+            // ── Arrange: build save state ──────────────────────────────────────────
+            var (saveVm, saveCanvas) = CreateSetup();
+
+            // Create 3 distinct prefab instances (ComponentGroups)
+            var instance1 = CreateGroupWithExternalPin("instance_1", "ext_pin");
+            var instance2 = CreateGroupWithExternalPin("instance_2", "ext_pin");
+            var instance3 = CreateGroupWithExternalPin("instance_3", "ext_pin");
+
+            // Add groups BEFORE standalone — this is the critical ordering that triggers
+            // the index-mismatch bug on load (standalones are loaded first during load).
+            saveCanvas.AddComponent(instance1);
+            saveCanvas.AddComponent(instance2);
+            saveCanvas.AddComponent(instance3);
+
+            // Create and add a standalone component
+            var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+            var standalone = ComponentTemplates.CreateFromTemplate(mmiTemplate, 200, 200);
+            standalone.Identifier = "standalone_mmi";
+            saveCanvas.AddComponent(standalone, mmiTemplate.Name);
+
+            // Canvas order at save time: [instance1(0), instance2(1), instance3(2), standalone(3)]
+            // Connection: standalone → instance1.ExternalPin
+            var externalPin1 = instance1.ExternalPins.First();
+            var standalonePin = standalone.PhysicalPins.First();
+
+            saveCanvas.ConnectPins(externalPin1.InternalPin, standalonePin);
+
+            saveCanvas.Connections.Count.ShouldBe(1, "One connection must be created before save");
+
+            // Record what we expect to survive the roundtrip
+            var expectedGroupId = instance1.Identifier;
+            var expectedPinName = externalPin1.Name;
+            var expectedStandaloneId = standalone.Identifier;
+            var expectedStandalonePinName = standalonePin.Name;
+
+            // ── Act: save and load ─────────────────────────────────────────────────
+            await SaveToFile(saveVm, tempFile);
+
+            var (loadVm, loadCanvas) = CreateSetup();
+            await LoadFromFile(loadVm, tempFile);
+
+            // ── Assert ─────────────────────────────────────────────────────────────
+            loadCanvas.Connections.Count.ShouldBe(1,
+                "Exactly one waveguide connection must survive roundtrip");
+
+            var loadedConn = loadCanvas.Connections[0].Connection;
+
+            // Resolve which canvas component owns each pin
+            var startComp = loadCanvas.Components
+                .FirstOrDefault(c => c.Component.PhysicalPins.Contains(loadedConn.StartPin)
+                    || (c.Component is ComponentGroup g
+                        && g.ExternalPins.Any(ep => ep.InternalPin == loadedConn.StartPin)));
+
+            var endComp = loadCanvas.Components
+                .FirstOrDefault(c => c.Component.PhysicalPins.Contains(loadedConn.EndPin)
+                    || (c.Component is ComponentGroup g
+                        && g.ExternalPins.Any(ep => ep.InternalPin == loadedConn.EndPin)));
+
+            startComp.ShouldNotBeNull("Start component must be found on canvas");
+            endComp.ShouldNotBeNull("End component must be found on canvas");
+
+            // One end must be group instance1, the other must be standalone
+            var groupEnd = startComp!.Component is ComponentGroup ? startComp : endComp;
+            var standaloneEnd = startComp.Component is ComponentGroup ? endComp : startComp;
+
+            groupEnd.ShouldNotBeNull("One endpoint must be a ComponentGroup");
+            standaloneEnd.ShouldNotBeNull("One endpoint must be the standalone component");
+
+            groupEnd!.Component.Identifier.ShouldBe(expectedGroupId,
+                "Waveguide must reconnect to INSTANCE 1 (the original), not instance 2 or 3!");
+
+            standaloneEnd!.Component.Identifier.ShouldBe(expectedStandaloneId,
+                "The standalone end must still reference the original standalone component");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a standalone-to-group connection with the standalone added AFTER groups
+    /// still resolves correctly — the exact ordering that causes the index mismatch bug.
+    /// Standalone is at index 3 during save but index 0 during load.
+    /// </summary>
+    [Fact]
+    public async Task StandaloneAddedAfterGroups_SaveLoadRoundtrip_IndexMismatchDoesNotOccur()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"index_mismatch_{Guid.NewGuid():N}.cappro");
+        try
+        {
+            var (saveVm, saveCanvas) = CreateSetup();
+
+            // Add two groups first (indices 0, 1 at save time)
+            var groupA = CreateGroupWithExternalPin("group_a_id", "pin_out");
+            var groupB = CreateGroupWithExternalPin("group_b_id", "pin_out");
+            saveCanvas.AddComponent(groupA);
+            saveCanvas.AddComponent(groupB);
+
+            // Add standalone last (index 2 at save time, will be index 0 after load!)
+            var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+            var standalone = ComponentTemplates.CreateFromTemplate(mmiTemplate, 300, 100);
+            standalone.Identifier = "the_standalone";
+            saveCanvas.AddComponent(standalone, mmiTemplate.Name);
+
+            // Connect: standalone → groupA
+            saveCanvas.ConnectPins(
+                groupA.ExternalPins[0].InternalPin,
+                standalone.PhysicalPins.First());
+
+            await SaveToFile(saveVm, tempFile);
+
+            var (loadVm, loadCanvas) = CreateSetup();
+            await LoadFromFile(loadVm, tempFile);
+
+            loadCanvas.Connections.Count.ShouldBe(1, "Connection must survive roundtrip");
+
+            var conn = loadCanvas.Connections[0].Connection;
+
+            // Both ends must resolve to real, correct components
+            var allPins = loadCanvas.Components.SelectMany(c =>
+            {
+                if (c.Component is ComponentGroup grp)
+                    return grp.ExternalPins.Select(ep => ep.InternalPin).Cast<object>();
+                return c.Component.PhysicalPins.Cast<object>();
+            }).ToList();
+
+            allPins.ShouldContain(conn.StartPin,
+                "StartPin must belong to a loaded component");
+            allPins.ShouldContain(conn.EndPin,
+                "EndPin must belong to a loaded component");
+
+            // The group end must be groupA — not groupB
+            var groupEndComp = loadCanvas.Components.FirstOrDefault(c =>
+                c.Component is ComponentGroup g
+                && g.ExternalPins.Any(ep => ep.InternalPin == conn.StartPin || ep.InternalPin == conn.EndPin));
+
+            groupEndComp.ShouldNotBeNull("One end must be a group");
+            groupEndComp!.Component.Identifier.ShouldBe("group_a_id",
+                "Connection must be to groupA, not groupB");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a ComponentGroup with a single child MMI component and one external pin.
+    /// The group identifier is set to <paramref name="groupId"/> for stable test assertions.
+    /// </summary>
+    private ComponentGroup CreateGroupWithExternalPin(string groupId, string externalPinName)
+    {
+        var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+        var child = ComponentTemplates.CreateFromTemplate(mmiTemplate, 0, 0);
+        child.Identifier = $"child_{groupId}";
+
+        var group = new ComponentGroup($"Group_{groupId}")
+        {
+            PhysicalX = 0,
+            PhysicalY = 0
+        };
+        group.AddChild(child);
+        group.Identifier = groupId;
+
+        var externalPin = new GroupPin
+        {
+            Name = externalPinName,
+            InternalPin = child.PhysicalPins.First(),
+            RelativeX = child.PhysicalPins.First().OffsetXMicrometers,
+            RelativeY = child.PhysicalPins.First().OffsetYMicrometers,
+            AngleDegrees = child.PhysicalPins.First().AngleDegrees
+        };
+        group.AddExternalPin(externalPin);
+        return group;
+    }
+
+    private (FileOperationsViewModel vm, DesignCanvasViewModel canvas) CreateSetup()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var vm = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            _library,
+            new GdsExportViewModel(new CAP_Core.Export.GdsExportService()));
+        return (vm, canvas);
+    }
+
+    private async Task SaveToFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowSaveFileDialogAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(filePath).ShouldBeTrue("Design file must be created during save");
+    }
+
+    private async Task LoadFromFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.LoadDesignCommand.ExecuteAsync(null);
+    }
+}


### PR DESCRIPTION
Automated implementation for #358

All 1312 tests pass. Let me provide a summary of what was done.

---

## Summary

**Root Cause Identified:**

`ConnectionData` stored component references as **integer indices** into `_canvas.Components`. During save, this list contains groups and standalone components in their original canvas order (e.g., `[group1(0), group2(1), group3(2), standalone(3)]`).

During load, standalone components are always loaded *first*, then groups — so the list becomes `[standalone(0), group1(1), group2(2), group3(3)]`. The saved index `3` (standalone) now points to `group3`, and index `0` (group1) now points to `standalone` — causing waveguides to reconnect to the wrong instances.

**Fix:**

Three changes in `CAP.Avalonia/ViewModels/`:

1. **`MainViewModel.cs`** — Added `StartComponentId?` and `EndComponentId?` to `ConnectionData` with documentation explaining these are stable identifiers preferred over indices.

2. **`FileOperationsViewModel.cs` (save side)** — Populated `StartComponentId` / `EndComponentId` with `component.Identifier` when serializing connections.

3. **`FileOperationsViewModel.cs` (load side)** — Added `ResolveComponentForLoad()` helper that looks up by identifier first, falling back to index for old files that predate these fields. `LoadConnectionFromData()` now uses this helper.

**Tests added:** `UnitTests/Integration/PrefabConnectionPersistenceTests.cs` with 2 tests:
- `PrefabInstances_SaveLoadRoundtrip_WaveguideReconnectsToCorrectInstance` — 3 prefab instances + 1 standalone, groups added before standalone
- `StandaloneAddedAfterGroups_SaveLoadRoundtrip_IndexMismatchDoesNotOccur` — directly tests the index-mismatch scenario

**No MCP tools used** (only standard file/grep tools).


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 14,963
- **Estimated cost:** $0.2241 USD

---
*Generated by autonomous agent using Claude Code.*