### PR TITLE
Agent: Fix router to avoid frozen paths - make DesignValidator test pass

### DIFF
--- a/Connect-A-Pic-Core/Analysis/WaveguideOverlapDetector.cs
+++ b/Connect-A-Pic-Core/Analysis/WaveguideOverlapDetector.cs
@@ -122,16 +122,61 @@ public class WaveguideOverlapDetector
 
     /// <summary>
     /// Checks a pair of segments for overlap.
-    /// Straight–straight uses exact intersection; any bend uses AABB proximity.
+    /// Straight–straight uses exact intersection.
+    /// Bend–straight uses precise arc sampling to avoid false positives from AABB.
+    /// Bend–bend falls back to AABB (acceptable approximation).
     /// </summary>
     private static (double X, double Y)? CheckSegmentPairOverlap(PathSegment a, PathSegment b)
     {
         if (a is StraightSegment sa && b is StraightSegment sb)
             return StraightStraightIntersection(sa, sb);
 
+        if (a is BendSegment bendA && b is StraightSegment straightB)
+            return ArcStraightIntersection(bendA, straightB);
+
+        if (a is StraightSegment straightA && b is BendSegment bendB)
+            return ArcStraightIntersection(bendB, straightA);
+
         if (SegmentBoundsOverlap(a, b))
             return ((a.StartPoint.X + b.StartPoint.X) / 2.0,
                     (a.StartPoint.Y + b.StartPoint.Y) / 2.0);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if a bend arc intersects a straight segment using arc sampling.
+    /// Samples the arc into small chords and tests each chord against the straight segment.
+    /// This avoids false positives that occur with the coarser AABB approach.
+    /// </summary>
+    private static (double X, double Y)? ArcStraightIntersection(BendSegment bend, StraightSegment straight)
+    {
+        double startRad = bend.StartAngleDegrees * Math.PI / 180;
+        double sweepRad = bend.SweepAngleDegrees * Math.PI / 180;
+        double sign = Math.Sign(bend.SweepAngleDegrees);
+        if (sign == 0) sign = 1;
+
+        int numSamples = Math.Max(20, (int)(Math.Abs(bend.SweepAngleDegrees) / 3));
+
+        double prevX = 0, prevY = 0;
+        for (int i = 0; i <= numSamples; i++)
+        {
+            double t = (double)i / numSamples;
+            double angle = startRad + sweepRad * t;
+            double px = bend.Center.X + bend.RadiusMicrometers * Math.Cos(angle - Math.PI / 2 * sign);
+            double py = bend.Center.Y + bend.RadiusMicrometers * Math.Sin(angle - Math.PI / 2 * sign);
+
+            if (i > 0)
+            {
+                var chord = new StraightSegment(prevX, prevY, px, py, angleDegrees: 0);
+                var intersection = StraightStraightIntersection(chord, straight);
+                if (intersection.HasValue)
+                    return intersection;
+            }
+
+            prevX = px;
+            prevY = py;
+        }
 
         return null;
     }

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
@@ -163,8 +163,12 @@ public class PathfindingGrid
             }
 
             // Mark these cells as frozen path obstacles (state=3) which are NEVER cleared by ClearPinCorridor
-            // This prevents external routing from going through internal group connections
-            var pathCells = GetWaveguidePathCells(pathSegments, 2.0); // 2µm waveguide width
+            // This prevents external routing from going through internal group connections.
+            // Use at least CellSizeMicrometers as width to guarantee cells are always marked:
+            // a circle-based mark only covers a cell if the cell center is within the radius,
+            // so the radius must be >= CellSizeMicrometers/2 to cover the containing cell.
+            double frozenPathMarkWidth = Math.Max(2.0, CellSizeMicrometers);
+            var pathCells = GetWaveguidePathCells(pathSegments, frozenPathMarkWidth);
             foreach (var cell in pathCells)
             {
                 if (IsInBounds(cell.Item1, cell.Item2))

--- a/UnitTests/Routing/FrozenPathObstacleTests.cs
+++ b/UnitTests/Routing/FrozenPathObstacleTests.cs
@@ -498,4 +498,5 @@ public class FrozenPathObstacleTests
         router.PathfindingGrid!.GetBlockedCellCount().ShouldBeGreaterThan(0,
             "Grid should have blocked cells after loading frozen path groups");
     }
+
 }


### PR DESCRIPTION
Automated implementation for #360

All 48 FrozenPath tests pass. Let me review what was changed:

## Summary

**Root Cause:** The frozen waveguide path cells were not being properly marked as state=3 obstacles in the pathfinding grid when `CellSizeMicrometers` was larger than `waveguideWidth`. In `GetWaveguidePathCells`, a circle-based marking with `halfWidth=1µm` (half of the 2µm waveguide width) failed to mark any cells when the grid cell size was 4µm, because no cell center falls within 1µm of any sample point on the path.

**Fix 1 — `PathfindingGrid.cs`:** Changed the frozen path mark width to `Math.Max(2.0, CellSizeMicrometers)`, ensuring the effective radius is always `≥ CellSizeMicrometers/2`. This guarantees the cell containing each sample point is always marked as state=3.

**Fix 2 — `WaveguideOverlapDetector.cs`:** Added a precise `ArcStraightIntersection` method for bend+straight segment pairs, replacing the coarse AABB check. It samples the arc into small chords and uses exact `StraightStraightIntersection` on each chord — eliminating false-positive overlap reports when bends are geometrically close to (but not crossing) a straight segment.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 32,442
- **Estimated cost:** $0.4860 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*