### PR TITLE
Agent: GDS Export: Grating Coupler pin Y-offset 9.5 µm - waveguide pin position incorrect

### DIFF
--- a/Connect-A-Pic-Core/Components/Core/PhysicalPin.cs
+++ b/Connect-A-Pic-Core/Components/Core/PhysicalPin.cs
@@ -42,9 +42,13 @@ namespace CAP_Core.Components.Core
             double nazcaCompX = ParentComponent.PhysicalX + originOffsetX;
             double nazcaCompY = -(ParentComponent.PhysicalY + originOffsetY);
 
-            // Local pin Nazca coordinates in unrotated component space
+            // Local pin Nazca coordinates in unrotated component space.
+            // Use originOffsetY (from CalculateOriginOffset) to stay consistent with component placement:
+            // - Legacy: originOffsetY = HeightMicrometers → localPinNazcaY = h - OffsetY (unchanged)
+            // - PDK/explicit: originOffsetY = NazcaOriginOffsetY → localPinNazcaY = offset - OffsetY
+            // Both cases correctly produce absNazcaY = -(physY + OffsetY). Fix for Issue #371.
             double localPinNazcaX = OffsetXMicrometers;
-            double localPinNazcaY = ParentComponent.HeightMicrometers - OffsetYMicrometers;
+            double localPinNazcaY = originOffsetY - OffsetYMicrometers;
 
             // Apply component rotation to local pin coordinates
             // Nazca places cells with .put(x, y, -RotationDegrees), so pin world positions


### PR DESCRIPTION
Automated implementation for #371

All 1312 tests pass. The fix is complete.

## Summary

**Root cause:** In `PhysicalPin.GetAbsoluteNazcaPosition()` (line 47), the local pin Y was computed as `HeightMicrometers - OffsetYMicrometers`, but the component placement used `NazcaOriginOffsetY` (9.5) via `CalculateOriginOffset`. These were inconsistent for the Grating Coupler.

**Fix (one line):** Changed `PhysicalPin.cs:47` to use `originOffsetY` (already returned by `CalculateOriginOffset`) instead of hardcoded `HeightMicrometers`:
```csharp
// Before:
double localPinNazcaY = ParentComponent.HeightMicrometers - OffsetYMicrometers;

// After:
double localPinNazcaY = originOffsetY - OffsetYMicrometers;
```

This is consistent for all component types:
- **Legacy** (no PDK, no explicit offset): `originOffsetY = HeightMicrometers` → unchanged behavior
- **GC with NazcaOriginOffsetY=9.5**: `originOffsetY = 9.5` → `localPinNazcaY = 9.5 - 9.5 = 0` → `absNazcaY = -(physY + 9.5)` ✓
- **PDK components** (ebeam_, demo_pdk.): same formula, already working correctly

✅ Tools: smart_test.py (~100K saved)


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 21,649
- **Estimated cost:** $0.3244 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*