### PR TITLE
Fix #388 — Prefab instantiation no longer crashes when simulation is active

### DIFF
--- a/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
+++ b/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
@@ -1,7 +1,9 @@
+using System.Numerics;
 using System.Text.Json;
 using CAP_Core.Components.Core;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
+using CAP_Core.Tiles;
 
 namespace CAP_Core.Components.Creation;
 
@@ -146,6 +148,7 @@ public static class GroupTemplateSerializer
 
     /// <summary>
     /// Serializes a regular Component to a DTO with all data inline.
+    /// Includes S-matrix transfer data and LogicalPin info for simulation support.
     /// </summary>
     private static ChildComponentDto SerializeComponent(Component comp)
     {
@@ -154,8 +157,14 @@ public static class GroupTemplateSerializer
             Name = p.Name,
             OffsetX = p.OffsetXMicrometers,
             OffsetY = p.OffsetYMicrometers,
-            AngleDegrees = p.AngleDegrees
+            AngleDegrees = p.AngleDegrees,
+            HasLogicalPin = p.LogicalPin != null,
+            PinNumber = p.LogicalPin?.PinNumber ?? 0,
+            MatterType = (int)(p.LogicalPin?.MatterType ?? MatterType.Light),
+            Side = (int)(p.LogicalPin?.Side ?? RectSide.Right)
         }).ToList();
+
+        var transfers = SerializeSMatrixData(comp);
 
         return new ChildComponentDto
         {
@@ -171,25 +180,94 @@ public static class GroupTemplateSerializer
             WidthMicrometers = comp.WidthMicrometers,
             HeightMicrometers = comp.HeightMicrometers,
             Rotation = (int)comp.Rotation90CounterClock,
-            Pins = pins
+            Pins = pins,
+            SMatrixTransfers = transfers
         };
     }
 
     /// <summary>
+    /// Extracts S-matrix transfer data from a component for serialization.
+    /// Maps pin Guids to pin indices and flow directions for portable storage.
+    /// </summary>
+    private static List<SMatrixTransferDto> SerializeSMatrixData(Component comp)
+    {
+        var transfers = new List<SMatrixTransferDto>();
+
+        // Build reverse lookup: Guid → (pinIndex, isInFlow)
+        var guidToPin = new Dictionary<Guid, (int PinIndex, bool IsInFlow)>();
+        for (int i = 0; i < comp.PhysicalPins.Count; i++)
+        {
+            var logicalPin = comp.PhysicalPins[i].LogicalPin;
+            if (logicalPin != null)
+            {
+                guidToPin[logicalPin.IDInFlow] = (i, true);
+                guidToPin[logicalPin.IDOutFlow] = (i, false);
+            }
+        }
+
+        foreach (var (wavelength, sMatrix) in comp.WaveLengthToSMatrixMap)
+        {
+            var nonNullValues = sMatrix.GetNonNullValues();
+            foreach (var ((inflowGuid, outflowGuid), value) in nonNullValues)
+            {
+                if (guidToPin.TryGetValue(inflowGuid, out var inflowPin) &&
+                    guidToPin.TryGetValue(outflowGuid, out var outflowPin))
+                {
+                    transfers.Add(new SMatrixTransferDto
+                    {
+                        Wavelength = wavelength,
+                        InFlowPinIndex = inflowPin.PinIndex,
+                        InFlowIsInFlow = inflowPin.IsInFlow,
+                        OutFlowPinIndex = outflowPin.PinIndex,
+                        OutFlowIsInFlow = outflowPin.IsInFlow,
+                        Real = value.Real,
+                        Imaginary = value.Imaginary
+                    });
+                }
+            }
+        }
+
+        return transfers;
+    }
+
+    /// <summary>
     /// Deserializes a regular Component from a DTO.
+    /// Reconstructs LogicalPins and S-matrices from serialized transfer data.
     /// </summary>
     private static Component DeserializeComponent(ChildComponentDto dto)
     {
-        var physicalPins = dto.Pins.Select(p => new PhysicalPin
+        // Create LogicalPins for each physical pin that had one
+        var logicalPins = new List<Pin?>();
+        foreach (var p in dto.Pins)
+        {
+            if (p.HasLogicalPin)
+            {
+                logicalPins.Add(new Pin(
+                    p.Name,
+                    p.PinNumber,
+                    (MatterType)p.MatterType,
+                    (RectSide)p.Side));
+            }
+            else
+            {
+                logicalPins.Add(null);
+            }
+        }
+
+        var physicalPins = dto.Pins.Select((p, i) => new PhysicalPin
         {
             Name = p.Name,
             OffsetXMicrometers = p.OffsetX,
             OffsetYMicrometers = p.OffsetY,
-            AngleDegrees = p.AngleDegrees
+            AngleDegrees = p.AngleDegrees,
+            LogicalPin = logicalPins[i]
         }).ToList();
 
+        // Reconstruct S-matrices from serialized transfer data
+        var sMatrixMap = DeserializeSMatrixData(dto.SMatrixTransfers, logicalPins);
+
         return new Component(
-            new Dictionary<int, SMatrix>(),
+            sMatrixMap,
             new List<Slider>(),
             dto.NazcaFunctionName ?? "",
             dto.NazcaFunctionParameters ?? "",
@@ -206,6 +284,65 @@ public static class GroupTemplateSerializer
             NazcaModuleName = dto.NazcaModuleName,
             HumanReadableName = dto.HumanReadableName
         };
+    }
+
+    /// <summary>
+    /// Reconstructs S-matrix data from serialized transfer entries.
+    /// Creates new SMatrix objects with the deserialized LogicalPin Guids.
+    /// </summary>
+    private static Dictionary<int, SMatrix> DeserializeSMatrixData(
+        List<SMatrixTransferDto>? transfers,
+        List<Pin?> logicalPins)
+    {
+        var sMatrixMap = new Dictionary<int, SMatrix>();
+        if (transfers == null || transfers.Count == 0)
+            return sMatrixMap;
+
+        // Collect all pin Guids (InFlow + OutFlow for each LogicalPin)
+        var allPinGuids = logicalPins
+            .Where(p => p != null)
+            .SelectMany(p => new[] { p!.IDInFlow, p.IDOutFlow })
+            .ToList();
+
+        if (allPinGuids.Count == 0)
+            return sMatrixMap;
+
+        // Group transfers by wavelength
+        foreach (var group in transfers.GroupBy(t => t.Wavelength))
+        {
+            var wavelength = group.Key;
+            var sMatrix = new SMatrix(allPinGuids, new List<(Guid, double)>());
+
+            var transferDict = new Dictionary<(Guid, Guid), Complex>();
+            foreach (var t in group)
+            {
+                var inflowGuid = ResolveGuid(logicalPins, t.InFlowPinIndex, t.InFlowIsInFlow);
+                var outflowGuid = ResolveGuid(logicalPins, t.OutFlowPinIndex, t.OutFlowIsInFlow);
+                if (inflowGuid.HasValue && outflowGuid.HasValue)
+                {
+                    transferDict[(inflowGuid.Value, outflowGuid.Value)] =
+                        new Complex(t.Real, t.Imaginary);
+                }
+            }
+
+            sMatrix.SetValues(transferDict);
+            sMatrixMap[wavelength] = sMatrix;
+        }
+
+        return sMatrixMap;
+    }
+
+    /// <summary>
+    /// Resolves a pin index and flow direction to the corresponding Guid.
+    /// </summary>
+    private static Guid? ResolveGuid(List<Pin?> logicalPins, int pinIndex, bool isInFlow)
+    {
+        if (pinIndex < 0 || pinIndex >= logicalPins.Count)
+            return null;
+        var pin = logicalPins[pinIndex];
+        if (pin == null)
+            return null;
+        return isInFlow ? pin.IDInFlow : pin.IDOutFlow;
     }
 
     /// <summary>
@@ -408,11 +545,13 @@ public class ChildComponentDto
     public double HeightMicrometers { get; set; }
     public int Rotation { get; set; }
     public List<PinDto> Pins { get; set; } = new();
+    public List<SMatrixTransferDto>? SMatrixTransfers { get; set; }
     public GroupTemplateDto? NestedGroup { get; set; }
 }
 
 /// <summary>
 /// DTO for a physical pin on a child component.
+/// Includes LogicalPin metadata for S-matrix reconstruction.
 /// </summary>
 public class PinDto
 {
@@ -420,6 +559,25 @@ public class PinDto
     public double OffsetX { get; set; }
     public double OffsetY { get; set; }
     public double AngleDegrees { get; set; }
+    public bool HasLogicalPin { get; set; }
+    public int PinNumber { get; set; }
+    public int MatterType { get; set; }
+    public int Side { get; set; }
+}
+
+/// <summary>
+/// DTO for a single S-matrix transfer entry.
+/// References pins by index in the parent component's Pins list.
+/// </summary>
+public class SMatrixTransferDto
+{
+    public int Wavelength { get; set; }
+    public int InFlowPinIndex { get; set; }
+    public bool InFlowIsInFlow { get; set; }
+    public int OutFlowPinIndex { get; set; }
+    public bool OutFlowIsInFlow { get; set; }
+    public double Real { get; set; }
+    public double Imaginary { get; set; }
 }
 
 /// <summary>

--- a/Connect-A-Pic-Core/LightCalculation/SystemMatrixBuilder.cs
+++ b/Connect-A-Pic-Core/LightCalculation/SystemMatrixBuilder.cs
@@ -144,10 +144,12 @@ namespace CAP_Core.LightCalculation
                 {
                     CollectChildSMatrices(nestedGroup, waveLength, result);
                 }
-                else
+                else if (child.WaveLengthToSMatrixMap.Count > 0)
                 {
                     AddComponentSMatrix(child, waveLength, result);
                 }
+                // Children with no S-matrix (e.g., from deserialized templates) are skipped.
+                // Their connectivity is still captured via frozen path transfers.
             }
         }
 

--- a/UnitTests/Simulation/PrefabInstantiationSimulationTests.cs
+++ b/UnitTests/Simulation/PrefabInstantiationSimulationTests.cs
@@ -1,0 +1,275 @@
+using System.Numerics;
+using CAP_Core;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Creation;
+using CAP_Core.ExternalPorts;
+using CAP_Core.Grid;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Simulation;
+
+/// <summary>
+/// Integration tests for Issue #388: Prefab instantiation must not crash
+/// when simulation is active. Verifies that deserialized group templates
+/// have valid S-matrices and can be simulated without exceptions.
+/// </summary>
+public class PrefabInstantiationSimulationTests : IDisposable
+{
+    private const int WavelengthNm = 1550;
+    private static readonly int[] Wavelengths = { WavelengthNm };
+    private readonly string _testLibraryPath;
+    private readonly GroupLibraryManager _libraryManager;
+
+    public PrefabInstantiationSimulationTests()
+    {
+        _testLibraryPath = Path.Combine(
+            Path.GetTempPath(),
+            $"PrefabSimTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testLibraryPath);
+        _libraryManager = new GroupLibraryManager(_testLibraryPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testLibraryPath))
+            Directory.Delete(_testLibraryPath, true);
+    }
+
+    /// <summary>
+    /// Reproduces Issue #388: saving a group as template, reloading from disk,
+    /// instantiating, and running simulation should NOT throw.
+    /// </summary>
+    [Fact]
+    public void DeserializedPrefab_DoesNotCrash_WhenSimulationRuns()
+    {
+        // Arrange: create a group with real S-matrix components
+        var group = CreateGroupWithSimulationComponents();
+        _libraryManager.SaveTemplate(group, "TestPrefab");
+
+        // Simulate app restart: reload templates from disk
+        var freshManager = new GroupLibraryManager(_testLibraryPath);
+        freshManager.LoadTemplates();
+        var reloadedTemplate = freshManager.Templates.First();
+
+        // Act: instantiate the deserialized prefab
+        var instance = freshManager.InstantiateTemplate(reloadedTemplate, 50, 50);
+
+        // Build a circuit with the prefab instance and run simulation
+        var tileManager = new ComponentListTileManager();
+        tileManager.AddComponent(instance);
+
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
+        var portManager = new PhysicalExternalPortManager();
+
+        var grid = GridManager.CreateForSimulation(tileManager, connectionManager, portManager);
+        var builder = new SystemMatrixBuilder(grid);
+
+        // Assert: simulation must not throw
+        Should.NotThrow(() => builder.GetSystemSMatrix(WavelengthNm));
+    }
+
+    /// <summary>
+    /// Verifies that S-matrix data survives serialization round-trip.
+    /// Child components must have non-empty S-matrices after deserialization.
+    /// </summary>
+    [Fact]
+    public void DeserializedPrefab_HasValidSMatrices()
+    {
+        // Arrange
+        var group = CreateGroupWithSimulationComponents();
+        var json = GroupTemplateSerializer.Serialize(group);
+
+        // Act
+        var deserialized = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        deserialized.ShouldNotBeNull();
+        deserialized!.ChildComponents.Count.ShouldBe(2);
+
+        foreach (var child in deserialized.ChildComponents)
+        {
+            child.WaveLengthToSMatrixMap.ShouldNotBeEmpty(
+                $"Child '{child.Identifier}' should have S-matrices after deserialization");
+            child.WaveLengthToSMatrixMap.ShouldContainKey(WavelengthNm);
+
+            // Verify S-matrix has non-zero entries
+            var sMatrix = child.WaveLengthToSMatrixMap[WavelengthNm];
+            var nonNull = sMatrix.GetNonNullValues();
+            nonNull.Count.ShouldBeGreaterThan(0,
+                $"Child '{child.Identifier}' S-matrix should have non-zero entries");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that deserialized physical pins have LogicalPins with valid IDs.
+    /// </summary>
+    [Fact]
+    public void DeserializedPrefab_HasLogicalPinsOnPhysicalPins()
+    {
+        // Arrange
+        var group = CreateGroupWithSimulationComponents();
+        var json = GroupTemplateSerializer.Serialize(group);
+
+        // Act
+        var deserialized = GroupTemplateSerializer.Deserialize(json);
+
+        // Assert
+        deserialized.ShouldNotBeNull();
+        foreach (var child in deserialized!.ChildComponents)
+        {
+            foreach (var physPin in child.PhysicalPins)
+            {
+                physPin.LogicalPin.ShouldNotBeNull(
+                    $"Pin '{physPin.Name}' on '{child.Identifier}' should have a LogicalPin");
+                physPin.LogicalPin.IDInFlow.ShouldNotBe(Guid.Empty);
+                physPin.LogicalPin.IDOutFlow.ShouldNotBe(Guid.Empty);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that S-matrix transfer values are preserved through serialization.
+    /// </summary>
+    [Fact]
+    public void SMatrixTransferValues_ArePreserved_ThroughSerialization()
+    {
+        // Arrange
+        var group = CreateGroupWithSimulationComponents();
+        var originalChild = group.ChildComponents[0];
+        var originalTransfers = originalChild.WaveLengthToSMatrixMap[WavelengthNm]
+            .GetNonNullValues();
+
+        // Act
+        var json = GroupTemplateSerializer.Serialize(group);
+        var deserialized = GroupTemplateSerializer.Deserialize(json)!;
+        var deserializedChild = deserialized.ChildComponents[0];
+        var deserializedTransfers = deserializedChild.WaveLengthToSMatrixMap[WavelengthNm]
+            .GetNonNullValues();
+
+        // Assert: same number of transfer entries
+        deserializedTransfers.Count.ShouldBe(originalTransfers.Count);
+
+        // Assert: transfer magnitudes match (Guids will differ, but values should be same)
+        var originalMagnitudes = originalTransfers.Values
+            .Select(v => v.Magnitude).OrderBy(m => m).ToList();
+        var deserializedMagnitudes = deserializedTransfers.Values
+            .Select(v => v.Magnitude).OrderBy(m => m).ToList();
+
+        for (int i = 0; i < originalMagnitudes.Count; i++)
+        {
+            deserializedMagnitudes[i].ShouldBe(originalMagnitudes[i], 1e-10);
+        }
+    }
+
+    /// <summary>
+    /// End-to-end test: prefab from disk can participate in a full simulation
+    /// circuit with light sources and produce valid output.
+    /// </summary>
+    [Fact]
+    public async Task DeserializedPrefab_ProducesValidSimulationResults()
+    {
+        // Arrange: create and save a group with two waveguide components
+        var group = CreateGroupWithSimulationComponents();
+        _libraryManager.SaveTemplate(group, "SimPrefab");
+
+        // Reload from disk
+        var freshManager = new GroupLibraryManager(_testLibraryPath);
+        freshManager.LoadTemplates();
+        var instance = freshManager.InstantiateTemplate(
+            freshManager.Templates.First(), 50, 50);
+
+        // Build circuit: GC_in → [PrefabInstance] → GC_out
+        var gcIn = IntegrationCircuitBuilder.CreateGratingCoupler(
+            "GC_In", 0, 0, Wavelengths);
+        var gcOut = IntegrationCircuitBuilder.CreateGratingCoupler(
+            "GC_Out", 200, 0, Wavelengths);
+
+        var tileManager = new ComponentListTileManager();
+        tileManager.AddComponent(gcIn.Component);
+        tileManager.AddComponent(instance);
+        tileManager.AddComponent(gcOut.Component);
+
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
+
+        // Connect GC_in to first child's input pin
+        var firstChild = instance.ChildComponents[0];
+        var firstChildInPin = firstChild.PhysicalPins.First(p => p.Name == "in");
+        connectionManager.AddExistingConnection(new WaveguideConnection
+        {
+            StartPin = gcIn.Pins["waveguide"],
+            EndPin = firstChildInPin
+        });
+
+        // Connect second child's output pin to GC_out
+        var secondChild = instance.ChildComponents[1];
+        var secondChildOutPin = secondChild.PhysicalPins.First(p => p.Name == "out");
+        connectionManager.AddExistingConnection(new WaveguideConnection
+        {
+            StartPin = secondChildOutPin,
+            EndPin = gcOut.Pins["waveguide"]
+        });
+
+        var portManager = new PhysicalExternalPortManager();
+        portManager.AddLightSource(
+            new ExternalInput("laser", LaserType.Red, 0, new Complex(1.0, 0)),
+            gcIn.LogicalPins[0].IDInFlow);
+
+        var grid = GridManager.CreateForSimulation(tileManager, connectionManager, portManager);
+
+        var builder2 = new SystemMatrixBuilder(grid);
+        var calculator = new GridLightCalculator(builder2, grid);
+
+        // Act & Assert: simulation should not throw
+        var cts = new CancellationTokenSource();
+        await Should.NotThrowAsync(
+            () => calculator.CalculateFieldPropagationAsync(cts, WavelengthNm));
+    }
+
+    /// <summary>
+    /// Creates a ComponentGroup with two waveguide components that have valid
+    /// S-matrices and physical pins, connected by a frozen path.
+    /// </summary>
+    private ComponentGroup CreateGroupWithSimulationComponents()
+    {
+        var comp1 = TestComponentFactory.CreateSimpleTwoPortComponent();
+        comp1.PhysicalX = 0;
+        comp1.PhysicalY = 0;
+        comp1.Identifier = "wg_1";
+
+        var comp2 = TestComponentFactory.CreateSimpleTwoPortComponent();
+        comp2.PhysicalX = 20;
+        comp2.PhysicalY = 0;
+        comp2.Identifier = "wg_2";
+
+        var group = new ComponentGroup("TestPrefabGroup")
+        {
+            PhysicalX = 0,
+            PhysicalY = 0,
+            WidthMicrometers = 30,
+            HeightMicrometers = 1
+        };
+
+        group.AddChild(comp1);
+        group.AddChild(comp2);
+
+        // Add frozen path: comp1.out → comp2.in
+        var outPin = comp1.PhysicalPins.First(p => p.Name == "out");
+        var inPin = comp2.PhysicalPins.First(p => p.Name == "in");
+        var frozenPath = new FrozenWaveguidePath
+        {
+            PathId = Guid.NewGuid(),
+            Path = new RoutedPath(),
+            StartPin = outPin,
+            EndPin = inPin
+        };
+        group.AddInternalPath(frozenPath);
+
+        return group;
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `SystemMatrixBuilder.CollectChildSMatrices` threw a `KeyNotFoundException` when iterating deserialized group children that had no S-matrix data (empty `WaveLengthToSMatrixMap`).
- **Fix**: Added a guard (`child.WaveLengthToSMatrixMap.Count > 0`) in `SystemMatrixBuilder` so children without S-matrices are safely skipped — their connectivity is still captured via frozen path transfers.
- **Serialization improvement**: `GroupTemplateSerializer` now serializes and deserializes S-matrix transfer data and `LogicalPin` info, so prefab instances carry simulation-relevant data through save/load cycles.
- **Tests**: Added 275-line test file `PrefabInstantiationSimulationTests.cs` covering prefab instantiation during active simulation, S-matrix serialization round-trips, and edge cases.

Fixes #388

## Test plan

- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (1533 tests, 0 failures)
- [ ] Manual: Place components, group them, save as prefab, start simulation, instantiate prefab — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)