### PR TITLE
Fix #388 — Prefab/SavedGroup instantiation crashes when simulation is active

### DIFF
--- a/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
+++ b/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using CAP_Core.Components.Core;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
+using CAP_Core.Tiles;
 
 namespace CAP_Core.Components.Creation;
 
@@ -145,7 +146,8 @@ public static class GroupTemplateSerializer
     }
 
     /// <summary>
-    /// Serializes a regular Component to a DTO with all data inline.
+    /// Serializes a regular Component to a DTO with all data inline,
+    /// including logical pin IDs and S-Matrix data so simulation survives a round-trip.
     /// </summary>
     private static ChildComponentDto SerializeComponent(Component comp)
     {
@@ -154,7 +156,32 @@ public static class GroupTemplateSerializer
             Name = p.Name,
             OffsetX = p.OffsetXMicrometers,
             OffsetY = p.OffsetYMicrometers,
-            AngleDegrees = p.AngleDegrees
+            AngleDegrees = p.AngleDegrees,
+            LogicalPinIdInFlow = p.LogicalPin?.IDInFlow ?? Guid.Empty,
+            LogicalPinIdOutFlow = p.LogicalPin?.IDOutFlow ?? Guid.Empty
+        }).ToList();
+
+        // Serialize S-Matrices so child components keep their simulation data after reload.
+        // Without this, deserialized children have empty WaveLengthToSMatrixMap → crash.
+        var sMatrices = comp.WaveLengthToSMatrixMap.Select(kvp =>
+        {
+            var allPinIds = kvp.Value.PinReference.Keys.ToList();
+            var transfers = kvp.Value.GetNonNullValues()
+                .Select(t => new TransferEntryDto
+                {
+                    FromPinId = t.Key.PinIdStart,
+                    ToPinId = t.Key.PinIdEnd,
+                    Real = t.Value.Real,
+                    Imaginary = t.Value.Imaginary
+                })
+                .ToList();
+
+            return new SMatrixEntryDto
+            {
+                WavelengthNm = kvp.Key,
+                AllPinIds = allPinIds,
+                Transfers = transfers
+            };
         }).ToList();
 
         return new ChildComponentDto
@@ -171,25 +198,51 @@ public static class GroupTemplateSerializer
             WidthMicrometers = comp.WidthMicrometers,
             HeightMicrometers = comp.HeightMicrometers,
             Rotation = (int)comp.Rotation90CounterClock,
-            Pins = pins
+            Pins = pins,
+            SMatrices = sMatrices
         };
     }
 
     /// <summary>
-    /// Deserializes a regular Component from a DTO.
+    /// Deserializes a regular Component from a DTO, restoring logical pin references
+    /// and S-Matrices so the component can participate in simulation after reload.
     /// </summary>
     private static Component DeserializeComponent(ChildComponentDto dto)
     {
-        var physicalPins = dto.Pins.Select(p => new PhysicalPin
+        // Reconstruct logical pins with the original Guids so S-Matrix pin references remain valid.
+        var physicalPins = dto.Pins.Select(p =>
         {
-            Name = p.Name,
-            OffsetXMicrometers = p.OffsetX,
-            OffsetYMicrometers = p.OffsetY,
-            AngleDegrees = p.AngleDegrees
+            Pin? logicalPin = null;
+            if (p.LogicalPinIdInFlow != Guid.Empty)
+            {
+                logicalPin = new Pin(p.Name, 0, MatterType.Light, RectSide.Left,
+                    p.LogicalPinIdInFlow, p.LogicalPinIdOutFlow);
+            }
+
+            return new PhysicalPin
+            {
+                Name = p.Name,
+                OffsetXMicrometers = p.OffsetX,
+                OffsetYMicrometers = p.OffsetY,
+                AngleDegrees = p.AngleDegrees,
+                LogicalPin = logicalPin
+            };
         }).ToList();
 
+        // Rebuild S-Matrices from serialized data so children are simulation-ready.
+        var sMatrixMap = new Dictionary<int, SMatrix>();
+        foreach (var entry in dto.SMatrices)
+        {
+            var sMatrix = new SMatrix(entry.AllPinIds, new());
+            var transfers = entry.Transfers.ToDictionary(
+                t => (t.FromPinId, t.ToPinId),
+                t => new System.Numerics.Complex(t.Real, t.Imaginary));
+            sMatrix.SetValues(transfers);
+            sMatrixMap[entry.WavelengthNm] = sMatrix;
+        }
+
         return new Component(
-            new Dictionary<int, SMatrix>(),
+            sMatrixMap,
             new List<Slider>(),
             dto.NazcaFunctionName ?? "",
             dto.NazcaFunctionParameters ?? "",
@@ -409,10 +462,17 @@ public class ChildComponentDto
     public int Rotation { get; set; }
     public List<PinDto> Pins { get; set; } = new();
     public GroupTemplateDto? NestedGroup { get; set; }
+
+    /// <summary>
+    /// S-Matrix data per wavelength. Populated during serialization so that
+    /// deserialized components remain simulation-ready without PDK re-loading.
+    /// </summary>
+    public List<SMatrixEntryDto> SMatrices { get; set; } = new();
 }
 
 /// <summary>
 /// DTO for a physical pin on a child component.
+/// Logical pin IDs are preserved so S-Matrix pin references survive a round-trip.
 /// </summary>
 public class PinDto
 {
@@ -420,6 +480,34 @@ public class PinDto
     public double OffsetX { get; set; }
     public double OffsetY { get; set; }
     public double AngleDegrees { get; set; }
+    public Guid LogicalPinIdInFlow { get; set; }
+    public Guid LogicalPinIdOutFlow { get; set; }
+}
+
+/// <summary>
+/// DTO for one wavelength's S-Matrix inside a serialized child component.
+/// Stores all pin IDs and the non-zero transfer coefficients.
+/// </summary>
+public class SMatrixEntryDto
+{
+    public int WavelengthNm { get; set; }
+
+    /// <summary>All pin IDs present in the matrix (needed to reconstruct dimensions).</summary>
+    public List<Guid> AllPinIds { get; set; } = new();
+
+    /// <summary>Non-zero transfer entries (inflow→outflow with complex coefficient).</summary>
+    public List<TransferEntryDto> Transfers { get; set; } = new();
+}
+
+/// <summary>
+/// DTO for a single transfer coefficient inside an S-Matrix.
+/// </summary>
+public class TransferEntryDto
+{
+    public Guid FromPinId { get; set; }
+    public Guid ToPinId { get; set; }
+    public double Real { get; set; }
+    public double Imaginary { get; set; }
 }
 
 /// <summary>

--- a/UnitTests/Simulation/PrefabInstantiationSimulationTests.cs
+++ b/UnitTests/Simulation/PrefabInstantiationSimulationTests.cs
@@ -1,0 +1,244 @@
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Creation;
+using CAP_Core.ExternalPorts;
+using CAP_Core.Grid;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Simulation;
+
+/// <summary>
+/// Integration tests for prefab (SavedGroup) instantiation while simulation is active.
+/// Reproduces issue #388: placing a prefab crashes when simulation is running because
+/// GroupTemplateSerializer did not preserve S-Matrix data or logical pin IDs.
+/// </summary>
+public class PrefabInstantiationSimulationTests
+{
+    /// <summary>
+    /// Regression test for issue #388.
+    /// When a prefab is saved and reloaded (serialize → deserialize), child components
+    /// must retain their S-Matrices and logical pin references so that simulation
+    /// does not crash with InvalidDataException.
+    /// </summary>
+    [Fact]
+    public void PrefabInstantiation_AfterSerializeDeserialize_DoesNotCrashSimulation()
+    {
+        // Arrange — create a group with a component that has a valid S-Matrix
+        var group = new ComponentGroup("TestPrefab");
+        var comp = TestComponentFactory.CreateSimpleTwoPortComponent();
+        comp.PhysicalX = 0;
+        comp.PhysicalY = 0;
+
+        group.AddChild(comp);
+
+        group.AddExternalPin(new GroupPin
+        {
+            Name = "In",
+            InternalPin = comp.PhysicalPins[0],
+            RelativeX = 0,
+            RelativeY = 0,
+            AngleDegrees = 180
+        });
+
+        group.AddExternalPin(new GroupPin
+        {
+            Name = "Out",
+            InternalPin = comp.PhysicalPins[1],
+            RelativeX = 10,
+            RelativeY = 0,
+            AngleDegrees = 0
+        });
+
+        group.ComputeSMatrix();
+        group.IsPrefab = true;
+
+        // Simulate save + load from disk (the step that previously stripped S-Matrices)
+        var serialized = GroupTemplateSerializer.Serialize(group);
+        var deserialized = GroupTemplateSerializer.Deserialize(serialized);
+
+        deserialized.ShouldNotBeNull();
+
+        // Instantiate the template (deep copy + ensure S-Matrix, as done during drag-and-drop)
+        deserialized!.EnsureSMatrixComputed();
+
+        // Set up simulation with the instantiated group
+        var tileManager = new ComponentListTileManager();
+        tileManager.AddComponent(deserialized);
+
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
+        var portManager = new PhysicalExternalPortManager();
+
+        var gridManager = GridManager.CreateForSimulation(
+            tileManager, connectionManager, portManager);
+
+        var builder = new SystemMatrixBuilder(gridManager);
+
+        // Act — must not throw InvalidDataException ("Matrix was not defined for waveLength")
+        var act = () => builder.GetSystemSMatrix(StandardWaveLengths.RedNM);
+
+        // Assert
+        act.ShouldNotThrow();
+        deserialized.WaveLengthToSMatrixMap.Count.ShouldBeGreaterThan(0);
+    }
+
+    /// <summary>
+    /// After deserialization, child components must have their S-Matrices restored.
+    /// </summary>
+    [Fact]
+    public void PrefabDeserialization_ChildComponentsHaveSMatrices()
+    {
+        // Arrange
+        var group = new ComponentGroup("MatrixCheckGroup");
+        var comp = TestComponentFactory.CreateSimpleTwoPortComponent();
+        group.AddChild(comp);
+
+        group.AddExternalPin(new GroupPin
+        {
+            Name = "In",
+            InternalPin = comp.PhysicalPins[0]
+        });
+
+        group.ComputeSMatrix();
+
+        // Act — serialize and deserialize
+        var serialized = GroupTemplateSerializer.Serialize(group);
+        var deserialized = GroupTemplateSerializer.Deserialize(serialized);
+
+        // Assert — deserialized children must have S-Matrices
+        deserialized.ShouldNotBeNull();
+        deserialized!.ChildComponents.Count.ShouldBe(1);
+
+        var childAfterDeserialize = deserialized.ChildComponents[0];
+        childAfterDeserialize.WaveLengthToSMatrixMap.Count.ShouldBeGreaterThan(0,
+            "Child component S-Matrices must survive serialization round-trip");
+    }
+
+    /// <summary>
+    /// After deserialization, physical pins must have valid LogicalPin references
+    /// so that frozen internal paths and simulation connections resolve correctly.
+    /// </summary>
+    [Fact]
+    public void PrefabDeserialization_PhysicalPinsHaveLogicalPinReferences()
+    {
+        // Arrange
+        var group = new ComponentGroup("PinRefGroup");
+        var comp = TestComponentFactory.CreateSimpleTwoPortComponent();
+        group.AddChild(comp);
+
+        group.AddExternalPin(new GroupPin
+        {
+            Name = "In",
+            InternalPin = comp.PhysicalPins[0]
+        });
+
+        group.ComputeSMatrix();
+
+        // Act
+        var serialized = GroupTemplateSerializer.Serialize(group);
+        var deserialized = GroupTemplateSerializer.Deserialize(serialized);
+
+        // Assert — physical pins must have LogicalPin references with non-empty Guids
+        deserialized.ShouldNotBeNull();
+        var child = deserialized!.ChildComponents[0];
+
+        foreach (var physicalPin in child.PhysicalPins)
+        {
+            physicalPin.LogicalPin.ShouldNotBeNull(
+                $"Physical pin '{physicalPin.Name}' must have a LogicalPin after deserialization");
+            physicalPin.LogicalPin!.IDInFlow.ShouldNotBe(Guid.Empty);
+            physicalPin.LogicalPin.IDOutFlow.ShouldNotBe(Guid.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Full prefab lifecycle: create group → save to library → load from library → place while
+    /// simulation is active → simulation must complete without errors.
+    /// Reproduces issue #388 end-to-end.
+    /// </summary>
+    [Fact]
+    public void PrefabLifecycle_SaveLoadInstantiate_SimulatesWithoutCrash()
+    {
+        // Arrange — two-component group with internal path
+        var group = new ComponentGroup("LifecyclePrefab");
+        var comp1 = TestComponentFactory.CreateSimpleTwoPortComponent();
+        var comp2 = TestComponentFactory.CreateSimpleTwoPortComponent();
+        comp1.PhysicalX = 0;
+        comp1.PhysicalY = 0;
+        comp2.PhysicalX = 20;
+        comp2.PhysicalY = 0;
+
+        group.AddChild(comp1);
+        group.AddChild(comp2);
+
+        var frozenPath = new FrozenWaveguidePath
+        {
+            StartPin = comp1.PhysicalPins[1],
+            EndPin = comp2.PhysicalPins[0],
+            Path = new RoutedPath()
+        };
+        frozenPath.Path.Segments.Add(new StraightSegment(10, 0, 20, 0, 0));
+        group.AddInternalPath(frozenPath);
+
+        group.AddExternalPin(new GroupPin
+        {
+            Name = "In",
+            InternalPin = comp1.PhysicalPins[0],
+            RelativeX = 0,
+            RelativeY = 0,
+            AngleDegrees = 180
+        });
+
+        group.AddExternalPin(new GroupPin
+        {
+            Name = "Out",
+            InternalPin = comp2.PhysicalPins[1],
+            RelativeX = 30,
+            RelativeY = 0,
+            AngleDegrees = 0
+        });
+
+        group.ComputeSMatrix();
+        group.IsPrefab = true;
+
+        // Save as template using GroupLibraryManager
+        var tempDir = Path.Combine(Path.GetTempPath(), $"lunima_test_{Guid.NewGuid():N}");
+        var libraryManager = new GroupLibraryManager(tempDir);
+        var template = libraryManager.SaveTemplate(group, "LifecyclePrefab");
+
+        // Simulate app restart: reload templates from disk, then instantiate
+        var freshLibrary = new GroupLibraryManager(tempDir);
+        freshLibrary.LoadTemplates();
+
+        var loadedTemplate = freshLibrary.Templates.FirstOrDefault(t => t.Name == "LifecyclePrefab");
+        loadedTemplate.ShouldNotBeNull("Template must be found after reload");
+
+        // InstantiateTemplate: deep copy + EnsureSMatrixComputed (the fix must work here)
+        var instance = freshLibrary.InstantiateTemplate(loadedTemplate!, 50, 0);
+
+        // Set up simulation with the instantiated prefab
+        var tileManager = new ComponentListTileManager();
+        tileManager.AddComponent(instance);
+
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
+        var portManager = new PhysicalExternalPortManager();
+
+        var gridManager = GridManager.CreateForSimulation(
+            tileManager, connectionManager, portManager);
+
+        var builder = new SystemMatrixBuilder(gridManager);
+
+        // Act — simulate: must not crash
+        var act = () => builder.GetSystemSMatrix(StandardWaveLengths.RedNM);
+
+        // Assert
+        act.ShouldNotThrow();
+        instance.WaveLengthToSMatrixMap.Count.ShouldBeGreaterThan(0);
+
+        // Cleanup
+        try { Directory.Delete(tempDir, recursive: true); } catch { /* ignore */ }
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `GroupTemplateSerializer` did not persist S-Matrix data or logical pin GUIDs when saving a prefab (SavedGroup). On reload, child components had empty `WaveLengthToSMatrixMap`, causing `InvalidDataException` ("Matrix was not defined for waveLength") when simulation tried to use the instantiated prefab.
- **Fix**: Extended `GroupTemplateSerializer` to embed S-Matrix entries (`SMatrixEntryDto`, `TransferEntryDto`) and logical pin GUIDs (`LogicalPinIdInFlow`/`IDOutFlow`) inline in the JSON, so a round-trip fully restores simulation-ready components.
- **Tests**: Added `UnitTests/Simulation/PrefabInstantiationSimulationTests.cs` with 4 regression tests covering the full prefab lifecycle (serialize → deserialize → simulate).

## Test plan

- [ ] Build passes: `dotnet build` — 0 errors
- [ ] All 1319 tests pass: `dotnet test`
- [ ] `PrefabInstantiation_AfterSerializeDeserialize_DoesNotCrashSimulation` — no exception when simulating a round-tripped prefab
- [ ] `PrefabDeserialization_ChildComponentsHaveSMatrices` — child S-Matrices survive serialization
- [ ] `PrefabDeserialization_PhysicalPinsHaveLogicalPinReferences` — pin GUIDs survive serialization
- [ ] `PrefabLifecycle_SaveLoadInstantiate_SimulatesWithoutCrash` — full end-to-end prefab lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)