### PR TITLE
feat: Add startup update check and 'Skip for Today' option (#398)

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -109,6 +109,9 @@ public partial class App : Application
             {
                 DataContext = mainVm
             };
+
+            // Auto-check for updates after a short delay to avoid blocking startup
+            _ = CheckForUpdatesOnStartupAsync(mainVm);
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
         {
@@ -120,5 +123,22 @@ public partial class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    /// <summary>
+    /// Checks for updates on startup after a 2-second delay.
+    /// Runs on the UI thread so ViewModel properties update correctly.
+    /// </summary>
+    private static async Task CheckForUpdatesOnStartupAsync(MainViewModel mainVm)
+    {
+        try
+        {
+            await Task.Delay(2000);
+            await mainVm.RightPanel.Update.CheckForUpdatesOnStartup();
+        }
+        catch
+        {
+            // Startup update check should never crash the app
+        }
     }
 }

--- a/CAP.Avalonia/Services/UserPreferencesService.cs
+++ b/CAP.Avalonia/Services/UserPreferencesService.cs
@@ -207,6 +207,30 @@ public class UserPreferencesService
         _preferences.SkippedUpdateVersion = null;
         Save();
     }
+
+    /// <summary>
+    /// Marks today as skipped so the startup update check won't show again until tomorrow.
+    /// </summary>
+    public void SkipToday()
+    {
+        _preferences.SkippedTodayDate = DateTime.UtcNow.Date.ToString("yyyy-MM-dd");
+        Save();
+    }
+
+    /// <summary>
+    /// Returns true if the startup update check should run today.
+    /// Returns false if the user already chose "Skip for Today" today.
+    /// </summary>
+    public bool ShouldCheckToday()
+    {
+        if (string.IsNullOrEmpty(_preferences.SkippedTodayDate))
+            return true;
+
+        if (DateTime.TryParse(_preferences.SkippedTodayDate, out var skippedDate))
+            return DateTime.UtcNow.Date > skippedDate;
+
+        return true;
+    }
 }
 
 /// <summary>
@@ -245,4 +269,10 @@ public class UserPreferences
     /// Null means no version is skipped.
     /// </summary>
     public string? SkippedUpdateVersion { get; set; }
+
+    /// <summary>
+    /// Date string (yyyy-MM-dd, UTC) when the user chose "Skip for Today".
+    /// Null means no daily skip is active.
+    /// </summary>
+    public string? SkippedTodayDate { get; set; }
 }

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -42,6 +42,13 @@ public partial class UpdateViewModel : ObservableObject
     [ObservableProperty]
     private string _releaseNotes = "";
 
+    /// <summary>
+    /// True when the update notification was triggered by the startup auto-check.
+    /// Startup notifications show "Skip for Today" and "Skip This Version" buttons.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isStartupNotification;
+
     /// <summary>Gets the current application version as a display string.</summary>
     public string CurrentVersionText => $"Current: v{_currentVersion}";
 
@@ -68,6 +75,7 @@ public partial class UpdateViewModel : ObservableObject
 
         IsChecking = true;
         UpdateAvailable = false;
+        IsStartupNotification = false;
         StatusText = "Checking for updates...";
 
         try
@@ -186,7 +194,65 @@ public partial class UpdateViewModel : ObservableObject
     private void RemindLater()
     {
         UpdateAvailable = false;
+        IsStartupNotification = false;
         StatusText = "Update available — will remind again next check.";
+    }
+
+    /// <summary>
+    /// Marks today as skipped so the startup check won't show again until tomorrow.
+    /// </summary>
+    [RelayCommand]
+    private void SkipToday()
+    {
+        _preferences.SkipToday();
+        UpdateAvailable = false;
+        IsStartupNotification = false;
+        StatusText = "Update notification skipped for today.";
+        _availableRelease = null;
+    }
+
+    /// <summary>
+    /// Checks for updates automatically on startup. Respects "Skip for Today"
+    /// and "Skip This Version" preferences. Shows a non-blocking notification
+    /// if an update is available.
+    /// </summary>
+    public async Task CheckForUpdatesOnStartup()
+    {
+        if (!_preferences.ShouldCheckToday())
+            return;
+
+        if (IsChecking || IsDownloading) return;
+
+        IsChecking = true;
+
+        try
+        {
+            var release = await _updateChecker.GetLatestReleaseAsync();
+            if (release == null) return;
+
+            if (!UpdateChecker.IsNewerThan(release, _currentVersion))
+                return;
+
+            var skipped = _preferences.GetSkippedUpdateVersion();
+            if (skipped != null && release.ParsedVersion != null
+                && release.ParsedVersion.Equals(skipped))
+                return;
+
+            _availableRelease = release;
+            LatestVersionText = $"New version: v{release.ParsedVersion}";
+            ReleaseNotes = TruncateReleaseNotes(release.Body);
+            UpdateAvailable = true;
+            IsStartupNotification = true;
+            StatusText = $"Update available: v{release.ParsedVersion}";
+        }
+        catch
+        {
+            // Startup check fails silently — don't disrupt the user
+        }
+        finally
+        {
+            IsChecking = false;
+        }
     }
 
     private static SemanticVersion ResolveCurrentVersion()

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -745,9 +745,22 @@
                                     Command="{Binding RightPanel.Update.InstallUpdateCommand}"
                                     Width="90" Background="#3d5d3d"
                                     IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                            <!-- Manual check: simple "Later" button -->
                             <Button Content="Later"
                                     Command="{Binding RightPanel.Update.RemindLaterCommand}"
                                     Width="55" Background="#3d3d3d"
+                                    IsVisible="{Binding RightPanel.Update.IsStartupNotification, Converter={x:Static BoolConverters.Not}}"
+                                    IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                            <!-- Startup notification: Skip for Today + Skip This Version -->
+                            <Button Content="Skip Today"
+                                    Command="{Binding RightPanel.Update.SkipTodayCommand}"
+                                    Width="80" Background="#3d3d5d"
+                                    IsVisible="{Binding RightPanel.Update.IsStartupNotification}"
+                                    IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                            <Button Content="Skip Version"
+                                    Command="{Binding RightPanel.Update.SkipThisVersionCommand}"
+                                    Width="90" Background="#3d3d3d"
+                                    IsVisible="{Binding RightPanel.Update.IsStartupNotification}"
                                     IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
                         </StackPanel>
                     </StackPanel>

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -220,6 +220,168 @@ public class UpdateViewModelTests
         vm.StatusText.ShouldContain("GitHub releases page");
     }
 
+    [Fact]
+    public async Task CheckForUpdatesOnStartup_NewerVersion_ShowsStartupNotification()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var vm = CreateViewModel(NewerReleaseJson, tempPrefsPath: tempPath);
+
+            await vm.CheckForUpdatesOnStartup();
+
+            vm.UpdateAvailable.ShouldBeTrue();
+            vm.IsStartupNotification.ShouldBeTrue();
+            vm.LatestVersionText.ShouldContain("99");
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task CheckForUpdatesOnStartup_SkippedToday_DoesNotCheck()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs = new UserPreferencesService(tempPath);
+            prefs.SkipToday();
+
+            var handler = new FakeHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(NewerReleaseJson)
+                });
+            var httpClient = new HttpClient(handler);
+            var checker = new UpdateChecker(httpClient, "owner", "repo");
+            var downloader = new UpdateDownloader(httpClient);
+            var vm = new UpdateViewModel(checker, downloader, prefs);
+
+            await vm.CheckForUpdatesOnStartup();
+
+            vm.UpdateAvailable.ShouldBeFalse();
+            vm.IsStartupNotification.ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task CheckForUpdatesOnStartup_SkippedVersion_DoesNotShow()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs = new UserPreferencesService(tempPath);
+            prefs.SetSkippedUpdateVersion(new SemanticVersion(99, 0, 0));
+
+            var handler = new FakeHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(NewerReleaseJson)
+                });
+            var httpClient = new HttpClient(handler);
+            var vm = new UpdateViewModel(
+                new UpdateChecker(httpClient, "o", "r"),
+                new UpdateDownloader(httpClient), prefs);
+
+            await vm.CheckForUpdatesOnStartup();
+
+            vm.UpdateAvailable.ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task ManualCheck_AlwaysWorks_RegardlessOfSkipToday()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs = new UserPreferencesService(tempPath);
+            prefs.SkipToday();
+
+            var handler = new FakeHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(NewerReleaseJson)
+                });
+            var httpClient = new HttpClient(handler);
+            var vm = new UpdateViewModel(
+                new UpdateChecker(httpClient, "o", "r"),
+                new UpdateDownloader(httpClient), prefs);
+
+            // Manual check should ignore skip-today preference
+            await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+
+            vm.UpdateAvailable.ShouldBeTrue();
+            vm.IsStartupNotification.ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task SkipTodayCommand_HidesNotificationAndPersists()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs = new UserPreferencesService(tempPath);
+            var handler = new FakeHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(NewerReleaseJson)
+                });
+            var httpClient = new HttpClient(handler);
+            var vm = new UpdateViewModel(
+                new UpdateChecker(httpClient, "o", "r"),
+                new UpdateDownloader(httpClient), prefs);
+
+            await vm.CheckForUpdatesOnStartup();
+            vm.UpdateAvailable.ShouldBeTrue();
+            vm.IsStartupNotification.ShouldBeTrue();
+
+            vm.SkipTodayCommand.Execute(null);
+
+            vm.UpdateAvailable.ShouldBeFalse();
+            vm.IsStartupNotification.ShouldBeFalse();
+            prefs.ShouldCheckToday().ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task CheckForUpdatesOnStartup_HttpFailure_FailsSilently()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var vm = CreateViewModel("", HttpStatusCode.ServiceUnavailable, tempPath);
+
+            await vm.CheckForUpdatesOnStartup();
+
+            vm.UpdateAvailable.ShouldBeFalse();
+            vm.IsStartupNotification.ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
     private sealed class FakeHttpMessageHandler : HttpMessageHandler
     {
         private readonly HttpResponseMessage _response;

--- a/UnitTests/Update/UserPreferencesSkipTodayTests.cs
+++ b/UnitTests/Update/UserPreferencesSkipTodayTests.cs
@@ -1,0 +1,131 @@
+using CAP.Avalonia.Services;
+using Shouldly;
+
+namespace UnitTests.Update;
+
+/// <summary>
+/// Unit tests for the "Skip for Today" feature in UserPreferencesService.
+/// Verifies daily skip persistence, reset after a day, and independence from version skip.
+/// </summary>
+public class UserPreferencesSkipTodayTests
+{
+    [Fact]
+    public void ShouldCheckToday_Default_ReturnsTrue()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs = new UserPreferencesService(tempPath);
+            prefs.ShouldCheckToday().ShouldBeTrue();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void SkipToday_SameDay_ShouldCheckTodayReturnsFalse()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs = new UserPreferencesService(tempPath);
+
+            prefs.SkipToday();
+
+            prefs.ShouldCheckToday().ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void SkipToday_PersistsToDisk_SurvivesReload()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs1 = new UserPreferencesService(tempPath);
+            prefs1.SkipToday();
+
+            // Reload from disk
+            var prefs2 = new UserPreferencesService(tempPath);
+            prefs2.ShouldCheckToday().ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void ShouldCheckToday_PastDate_ReturnsTrue()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            // Write a preference file with yesterday's date
+            var yesterday = DateTime.UtcNow.Date.AddDays(-1).ToString("yyyy-MM-dd");
+            var json = $$"""
+                {
+                  "SkippedTodayDate": "{{yesterday}}"
+                }
+                """;
+            File.WriteAllText(tempPath, json);
+
+            var prefs = new UserPreferencesService(tempPath);
+            prefs.ShouldCheckToday().ShouldBeTrue();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void SkipToday_DoesNotAffectSkippedVersion()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var prefs = new UserPreferencesService(tempPath);
+            var version = new CAP_Core.Update.SemanticVersion(2, 0, 0);
+            prefs.SetSkippedUpdateVersion(version);
+
+            prefs.SkipToday();
+
+            // Version skip should still be set
+            prefs.GetSkippedUpdateVersion().ShouldNotBeNull();
+            prefs.GetSkippedUpdateVersion()!.Major.ShouldBe(2);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public void ShouldCheckToday_InvalidDate_ReturnsTrue()
+    {
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var json = """
+                {
+                  "SkippedTodayDate": "not-a-date"
+                }
+                """;
+            File.WriteAllText(tempPath, json);
+
+            var prefs = new UserPreferencesService(tempPath);
+            prefs.ShouldCheckToday().ShouldBeTrue();
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add automatic update check on app startup with a 2-second delay to avoid blocking the UI
- Add `SkipToday()` / `ShouldCheckToday()` to `UserPreferencesService` for daily skip persistence
- Add `CheckForUpdatesOnStartup()` to `UpdateViewModel` that respects both "Skip Today" and "Skip Version" preferences
- Add startup notification UI in `MainWindow.axaml` with three buttons: Install Now, Skip for Today, Skip This Version
- Wire up startup check in `App.axaml.cs` after main window is shown

## Test plan

- [x] Unit tests for `UserPreferencesService.SkipToday()` — same day returns false, next day returns true
- [x] Unit tests for `UpdateViewModel.CheckForUpdatesOnStartup()` — respects skip preferences
- [x] All 1544 tests pass
- [x] Build passes with 0 errors

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)