### PR TITLE
Agent: Bug: Last waveguide segments Y-offset in GDS (NazcaOriginOffset not applied)

### DIFF
--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -396,10 +396,11 @@ public class SimpleNazcaExporter
     /// that occur with Nazca's chaining syntax (.put() without coordinates).
     ///
     /// Fix #355 (single straight): direct pin-to-pin geometry avoids NazcaOriginOffset mismatch.
-    /// Fix #366 (multi-segment): absolute positioning for each segment. Only the first segment
-    /// uses startPin.GetAbsoluteNazcaPosition(); all others use a simple Y-flip.
+    /// Fix #366 (multi-segment): absolute positioning for each segment.
+    /// Fix #456 (last segment Y-offset): all segments now use the SAME delta offset derived from
+    /// startPin, ensuring a continuous waveguide path with no coordinate-system jump between segments.
     /// </summary>
-    /// <param name="startPin">Start pin for correct Nazca coordinate calculation of the first segment.</param>
+    /// <param name="startPin">Start pin used to calculate the editor-to-Nazca offset for all segments.</param>
     /// <param name="endPin">End pin used only for single-straight-segment paths (direct pin-to-pin geometry).</param>
     internal static void AppendSegmentExport(
         StringBuilder sb, IReadOnlyList<PathSegment> segments,
@@ -412,33 +413,26 @@ public class SimpleNazcaExporter
             return;
         }
 
-        // Multi-segment: use absolute Nazca coordinates for every segment.
-        // For mixed-PDK designs, we can't use a single global offset because each component
-        // has its own NazcaOriginOffset.
-
-        // Strategy: Use pin position for the first segment only; all other segments use simple Y-flip.
+        // Multi-segment: calculate a SINGLE offset from editor space to Nazca space.
+        // Derived from the start pin's Nazca position vs. the first segment's editor start point.
+        // Applying the SAME delta to every segment ensures path continuity with no Y-jump.
+        // Fix #456: previously segment[0] used GetAbsoluteNazcaPosition() while segment[1+] used
+        // a plain Y-flip — mixing coordinate systems and causing a visible Y-offset on later segments.
+        double deltaX = 0;
+        double deltaY = 0;
+        if (startPin != null && segments.Count > 0)
+        {
+            var (nazcaPinX, nazcaPinY) = startPin.GetAbsoluteNazcaPosition();
+            double editorStartX = segments[0].StartPoint.X;
+            double editorStartY = segments[0].StartPoint.Y;
+            deltaX = nazcaPinX - editorStartX;
+            deltaY = nazcaPinY - (-editorStartY); // nazcaY = -editorY + deltaY → deltaY = nazcaY + editorY
+        }
 
         for (int i = 0; i < segments.Count; i++)
         {
-            bool isFirst = (i == 0);
-
-            double nX, nY;
-
-            if (isFirst && startPin != null)
-            {
-                // First segment: Start at the StartPin's Nazca position
-                (nX, nY) = startPin.GetAbsoluteNazcaPosition();
-            }
-            else
-            {
-                // All other segments (including last): Simple Y-flip from editor coordinates
-                // The segment coordinates from the pathfinding already line up correctly
-                // with the component pins. No special handling needed for the last segment.
-                nX = segments[i].StartPoint.X;
-                nY = -segments[i].StartPoint.Y;
-            }
-
-            // Export the segment with its correct Nazca coordinates
+            double nX = segments[i].StartPoint.X + deltaX;
+            double nY = -segments[i].StartPoint.Y + deltaY;
             sb.AppendLine(FormatSegmentAbsolute(segments[i], nX, nY));
         }
     }

--- a/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
+++ b/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
@@ -188,6 +188,57 @@ public class WaveguideEndpointAlignmentTests
         AssertAligned(endPt, (expectedEndX, expectedEndY), $"end PDK (rot={rotation}°)");
     }
 
+    // ── Multi-segment: verify uniform coordinate transformation (Issue #456) ──
+
+    /// <summary>
+    /// Multi-segment path with PDK component: adjacent segments must be continuous in Nazca space.
+    /// Root cause (Issue #456): segment[0] used GetAbsoluteNazcaPosition() (includes NazcaOriginOffset)
+    /// while segment[1+] used a plain Y-flip — different coordinate systems caused a visible Y-gap.
+    /// Fix: all segments use the same delta offset derived from the start pin.
+    /// </summary>
+    [Fact]
+    public void MultiSegmentWaveguide_PdkComponent_SegmentsAreContinuousInNazca_Issue456()
+    {
+        // PDK component with NazcaOriginOffset — like an MMI 2x2 (H=38µm, NazcaOriginOffsetY=9.5µm).
+        // NazcaOriginOffsetY=9.5 means deltaY = nazcaPinY + editorPinY = 0 + 19 = 19.
+        // Without the fix, segment[1] would be shifted by 19 µm in Y relative to segment[0].
+        var (_, pinOut) = CreatePdkComponent("MmiOut", x: 0, y: 0, width: 100, height: 38,
+            nazcaOriginOffsetY: 9.5, pinOffsetX: 100, pinOffsetY: 19, pinAngle: 0);
+        var (_, pinIn) = CreatePdkComponent("MmiIn", x: 300, y: 0, width: 100, height: 38,
+            nazcaOriginOffsetY: 9.5, pinOffsetX: 0, pinOffsetY: 19, pinAngle: 180);
+
+        var (sx, sy) = pinOut.GetAbsolutePosition(); // (100, 19)
+        var (ex, ey) = pinIn.GetAbsolutePosition();  // (300, 19) — same Y, both horizontal
+
+        // Two horizontal segments sharing the midpoint — deliberately split to expose the Y-gap bug.
+        double midX = (sx + ex) / 2.0; // 200
+        var segments = new List<PathSegment>
+        {
+            new StraightSegment(sx, sy, midX, sy, 0),   // seg[0]: 100→200, editor Y=19
+            new StraightSegment(midX, sy, ex, ey, 0)    // seg[1]: 200→300, editor Y=19 (the "last" segment)
+        };
+
+        var sb = new StringBuilder();
+        SimpleNazcaExporter.AppendSegmentExport(sb, segments, pinOut, pinIn);
+        var nazcaCode = sb.ToString();
+
+        var lines = nazcaCode.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(l => l.Contains("nd.strt(") || l.Contains("nd.bend("))
+            .ToList();
+        lines.Count.ShouldBe(2, "Expected 2 exported segments");
+
+        // Compute where segment[0] ends in Nazca space: start + length along angle.
+        var seg0End = ComputeEndPoint(lines[0]);
+
+        // Segment[1] must start exactly where segment[0] ends — no Y-gap.
+        var (seg1StartX, seg1StartY) = ExtractStartPoint(lines[1]);
+        Math.Abs(seg1StartX - seg0End.X).ShouldBeLessThan(AlignmentTolerance,
+            $"Issue #456: Seg[0] ends at X={seg0End.X:F3} but seg[1] starts at X={seg1StartX:F3}");
+        Math.Abs(seg1StartY - seg0End.Y).ShouldBeLessThan(AlignmentTolerance,
+            $"Issue #456: Y-gap between segments (NazcaOriginOffset not applied uniformly). " +
+            $"Seg[0] ends at Y={seg0End.Y:F3} but seg[1] starts at Y={seg1StartY:F3}");
+    }
+
     // ── Multi-segment: verify start pin alignment is preserved ────────────────
 
     [Fact]


### PR DESCRIPTION
Automated implementation for #456

All 1638 tests pass. Here's a summary of what was done:

## Fix: Issue #456 — Last waveguide segment Y-offset

**Root cause:** In `AppendSegmentExport`, segment[0] used `startPin.GetAbsoluteNazcaPosition()` (includes `NazcaOriginOffset`) while segments[1+] used a plain Y-flip `nY = -editorY`. These are **different coordinate systems**, creating a visible gap at the segment[0]/segment[1] boundary. All segments after the first were offset by the component's `NazcaOriginOffset` in Y.

**Fix** (`SimpleNazcaExporter.cs:427-443`): Calculate a single delta offset **once** from the start pin's Nazca position vs. the first segment's editor position, then apply the **same delta uniformly** to ALL segments:
```
deltaX = nazcaPinX − editorStartX
deltaY = nazcaPinY − (−editorStartY)   // = nazcaY + editorY
nX[i] = segments[i].StartPoint.X + deltaX
nY[i] = −segments[i].StartPoint.Y + deltaY
```

**Regression test** (`WaveguideEndpointAlignmentTests.cs`): Creates two consecutive horizontal segments through a PDK component with `NazcaOriginOffsetY=9.5` (like MMI 2x2) and verifies that segment[0]'s Nazca endpoint equals segment[1]'s Nazca start point — fails without the fix (19 µm Y-gap), passes with it.

✅ Complete! Tools: smart_test.py (~100K saved)


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 1,254,569
- **Estimated cost:** $0.7026 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*