### PR TITLE
Agent: Feature: PDK Import Tool — Python/Nazca PDK parser with visual verification

### DIFF
--- a/Connect-A-Pic-Core/Export/PdkNazcaParserService.cs
+++ b/Connect-A-Pic-Core/Export/PdkNazcaParserService.cs
@@ -1,0 +1,233 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CAP_Core.Export;
+
+/// <summary>
+/// Invokes the <c>scripts/parse_pdk.py</c> Python script to extract component
+/// geometry from a Nazca PDK module and returns the result as a structured object.
+///
+/// Issue #460: PDK Import Tool — Python/Nazca PDK parser with visual verification.
+/// </summary>
+public class PdkNazcaParserService
+{
+    private readonly string _pythonExecutable;
+    private readonly string _scriptPath;
+
+    /// <summary>
+    /// Creates a <see cref="PdkNazcaParserService"/> with explicit paths.
+    /// </summary>
+    /// <param name="pythonExecutable">Path to Python 3 executable (e.g. "python3").</param>
+    /// <param name="scriptPath">Absolute path to <c>scripts/parse_pdk.py</c>.</param>
+    public PdkNazcaParserService(string pythonExecutable, string scriptPath)
+    {
+        _pythonExecutable = pythonExecutable ?? throw new ArgumentNullException(nameof(pythonExecutable));
+        _scriptPath = scriptPath ?? throw new ArgumentNullException(nameof(scriptPath));
+    }
+
+    /// <summary>
+    /// Runs the parser script for a given PDK module and returns parsed component data.
+    /// </summary>
+    /// <param name="moduleName">
+    /// Python module name to import (e.g. <c>"siepic_ebeam_pdk"</c>).
+    /// Pass <c>"demo"</c> to get hard-coded reference values without Nazca.
+    /// </param>
+    /// <param name="functionNames">
+    /// Optional list of specific cell function names to parse.
+    /// When null or empty, all public callables in the module are parsed.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Parsed PDK data including component geometry and origin offsets.</returns>
+    /// <exception cref="FileNotFoundException">When the parse script is not found.</exception>
+    /// <exception cref="PdkParserException">When the script exits with a non-zero code.</exception>
+    public async Task<PdkParseResult> ParseAsync(
+        string moduleName,
+        IEnumerable<string>? functionNames = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_scriptPath))
+            throw new FileNotFoundException($"PDK parser script not found: {_scriptPath}", _scriptPath);
+
+        var arguments = BuildArguments(moduleName, functionNames);
+        var (exitCode, stdout, stderr) = await RunScriptAsync(arguments, cancellationToken);
+
+        if (exitCode != 0)
+            throw new PdkParserException(
+                $"parse_pdk.py exited with code {exitCode}. " +
+                $"stderr: {stderr.Trim()}");
+
+        if (string.IsNullOrWhiteSpace(stdout))
+            throw new PdkParserException("parse_pdk.py produced no output.");
+
+        return DeserializeResult(stdout);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private string BuildArguments(string moduleName, IEnumerable<string>? functionNames)
+    {
+        var parts = new List<string> { $"\"{_scriptPath}\"", moduleName };
+        if (functionNames != null)
+            parts.AddRange(functionNames);
+        return string.Join(" ", parts);
+    }
+
+    private async Task<(int exitCode, string stdout, string stderr)> RunScriptAsync(
+        string arguments, CancellationToken cancellationToken)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = _pythonExecutable,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        process.Start();
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        return (process.ExitCode, await stdoutTask, await stderrTask);
+    }
+
+    private static PdkParseResult DeserializeResult(string json)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        var result = JsonSerializer.Deserialize<PdkParseResult>(json, options)
+            ?? throw new PdkParserException("Failed to deserialize parse_pdk.py output.");
+
+        return result;
+    }
+}
+
+/// <summary>
+/// Result returned by <see cref="PdkNazcaParserService.ParseAsync"/>.
+/// Mirrors the JSON schema produced by <c>scripts/parse_pdk.py</c>.
+/// </summary>
+public class PdkParseResult
+{
+    /// <summary>File format version (should be 1).</summary>
+    [JsonPropertyName("fileFormatVersion")]
+    public int FileFormatVersion { get; set; } = 1;
+
+    /// <summary>PDK name (e.g., Python module name or user-supplied name).</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    /// <summary>Optional description.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>Foundry / provider name.</summary>
+    [JsonPropertyName("foundry")]
+    public string? Foundry { get; set; }
+
+    /// <summary>PDK version string.</summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; set; }
+
+    /// <summary>Default wavelength in nm.</summary>
+    [JsonPropertyName("defaultWavelengthNm")]
+    public int DefaultWavelengthNm { get; set; } = 1550;
+
+    /// <summary>Python module name used for Nazca import.</summary>
+    [JsonPropertyName("nazcaModuleName")]
+    public string? NazcaModuleName { get; set; }
+
+    /// <summary>List of parsed component geometries.</summary>
+    [JsonPropertyName("components")]
+    public List<ParsedComponentGeometry> Components { get; set; } = new();
+}
+
+/// <summary>
+/// Geometry data for a single PDK cell extracted from Nazca.
+/// </summary>
+public class ParsedComponentGeometry
+{
+    /// <summary>Cell / function name (e.g., "ebeam_y_1550").</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    /// <summary>UI category label.</summary>
+    [JsonPropertyName("category")]
+    public string Category { get; set; } = "Imported";
+
+    /// <summary>Nazca Python function name.</summary>
+    [JsonPropertyName("nazcaFunction")]
+    public string NazcaFunction { get; set; } = "";
+
+    /// <summary>Optional Nazca function parameters.</summary>
+    [JsonPropertyName("nazcaParameters")]
+    public string? NazcaParameters { get; set; }
+
+    /// <summary>Component bounding-box width in µm.</summary>
+    [JsonPropertyName("widthMicrometers")]
+    public double WidthMicrometers { get; set; }
+
+    /// <summary>Component bounding-box height in µm.</summary>
+    [JsonPropertyName("heightMicrometers")]
+    public double HeightMicrometers { get; set; }
+
+    /// <summary>
+    /// X offset of the Nazca cell origin within the editor bounding box (µm).
+    /// Equals <c>-xmin</c> from the Nazca bounding box.
+    /// </summary>
+    [JsonPropertyName("nazcaOriginOffsetX")]
+    public double NazcaOriginOffsetX { get; set; }
+
+    /// <summary>
+    /// Y offset of the Nazca cell origin within the editor bounding box (µm).
+    /// Equals <c>ymax</c> from the Nazca bounding box (Y-flip).
+    /// </summary>
+    [JsonPropertyName("nazcaOriginOffsetY")]
+    public double NazcaOriginOffsetY { get; set; }
+
+    /// <summary>Pin definitions in editor coordinate space.</summary>
+    [JsonPropertyName("pins")]
+    public List<ParsedPinGeometry> Pins { get; set; } = new();
+}
+
+/// <summary>
+/// Pin geometry in editor coordinate space (Y-down, origin at top-left of bounding box).
+/// </summary>
+public class ParsedPinGeometry
+{
+    /// <summary>Pin name (e.g., "a0", "b0").</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    /// <summary>X offset from left edge of bounding box (µm).</summary>
+    [JsonPropertyName("offsetXMicrometers")]
+    public double OffsetXMicrometers { get; set; }
+
+    /// <summary>Y offset from top edge of bounding box (µm).</summary>
+    [JsonPropertyName("offsetYMicrometers")]
+    public double OffsetYMicrometers { get; set; }
+
+    /// <summary>Pin angle in degrees (editor convention: 0=right, 180=left, 270=down).</summary>
+    [JsonPropertyName("angleDegrees")]
+    public double AngleDegrees { get; set; }
+}
+
+/// <summary>
+/// Thrown when <see cref="PdkNazcaParserService"/> fails to parse PDK data.
+/// </summary>
+public class PdkParserException : Exception
+{
+    /// <summary>Initializes a new <see cref="PdkParserException"/> with a message.</summary>
+    public PdkParserException(string message) : base(message) { }
+
+    /// <summary>Initializes a new <see cref="PdkParserException"/> with message and inner exception.</summary>
+    public PdkParserException(string message, Exception inner) : base(message, inner) { }
+}

--- a/UnitTests/Export/PdkNazcaParserServiceTests.cs
+++ b/UnitTests/Export/PdkNazcaParserServiceTests.cs
@@ -1,0 +1,214 @@
+using CAP_Core.Export;
+using Shouldly;
+using System.Text.Json;
+using Xunit;
+
+namespace UnitTests.Export;
+
+/// <summary>
+/// Unit tests for <see cref="PdkNazcaParserService"/> and the coordinate
+/// conversion helpers used by <c>scripts/parse_pdk.py</c>.
+///
+/// Issue #460: PDK Import Tool — Python/Nazca PDK parser with visual verification.
+/// </summary>
+public class PdkNazcaParserServiceTests
+{
+    // ── Coordinate conversion tests ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0.0, 27.5, 0.0, 27.5)]   // xmin=0 → offsetX=0; ymax=27.5 → offsetY=27.5
+    [InlineData(-5.0, 30.0, 5.0, 30.0)]  // xmin negative → offsetX positive
+    [InlineData(10.0, 20.0, -10.0, 20.0)] // xmin positive → offsetX negative
+    public void NazcaOriginOffset_ComputedFromBbox(
+        double xmin, double ymax,
+        double expectedOffsetX, double expectedOffsetY)
+    {
+        // Act — same formula as parse_pdk.py compute_origin_offset()
+        double offsetX = -xmin;
+        double offsetY = ymax;
+
+        // Assert
+        offsetX.ShouldBe(expectedOffsetX, tolerance: 1e-9);
+        offsetY.ShouldBe(expectedOffsetY, tolerance: 1e-9);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0, 0.0, 27.5, 0.0, 27.5)]    // origin pin at (0,0) → editor (0, 27.5)
+    [InlineData(80.0, 2.0, 0.0, 27.5, 80.0, 25.5)]   // right pin → editor x preserved, y flipped
+    [InlineData(80.0, -2.0, 0.0, 27.5, 80.0, 29.5)]  // below origin → editor y > ymax
+    public void NazcaToEditor_PinConversion(
+        double nazcaX, double nazcaY,
+        double xmin, double ymax,
+        double expectedEditorX, double expectedEditorY)
+    {
+        // Act — same formula as parse_pdk.py nazca_to_editor()
+        double editorX = nazcaX - xmin;
+        double editorY = ymax - nazcaY;
+
+        // Assert
+        editorX.ShouldBe(expectedEditorX, tolerance: 1e-9);
+        editorY.ShouldBe(expectedEditorY, tolerance: 1e-9);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0)]     // 0° right → stays 0° right
+    [InlineData(180.0, 180.0)] // 180° left → stays 180° left
+    [InlineData(90.0, 270.0)]  // 90° up (Nazca) → 270° down (editor, Y-flip)
+    [InlineData(270.0, 90.0)]  // 270° down (Nazca) → 90° up (editor, Y-flip)
+    public void AngleFlip_YAxisInversion(double nazcaAngle, double expectedEditorAngle)
+    {
+        // Act — same formula as parse_pdk.py normalize_angle()
+        double editorAngle = (-(nazcaAngle % 360) + 360) % 360;
+
+        // Assert
+        editorAngle.ShouldBe(expectedEditorAngle, tolerance: 1e-9);
+    }
+
+    // ── JSON deserialization tests ──────────────────────────────────────────
+
+    [Fact]
+    public void DeserializeResult_ValidJson_ParsesComponents()
+    {
+        var json = @"{
+            ""fileFormatVersion"": 1,
+            ""name"": ""test_pdk"",
+            ""description"": ""Test PDK"",
+            ""foundry"": ""test"",
+            ""version"": ""1.0"",
+            ""defaultWavelengthNm"": 1550,
+            ""nazcaModuleName"": ""test_pdk"",
+            ""components"": [
+                {
+                    ""name"": ""mmi1x2"",
+                    ""category"": ""Splitters"",
+                    ""nazcaFunction"": ""mmi1x2"",
+                    ""nazcaParameters"": """",
+                    ""widthMicrometers"": 80.0,
+                    ""heightMicrometers"": 55.0,
+                    ""nazcaOriginOffsetX"": 0.0,
+                    ""nazcaOriginOffsetY"": 27.5,
+                    ""pins"": [
+                        { ""name"": ""a0"", ""offsetXMicrometers"": 0.0, ""offsetYMicrometers"": 27.5, ""angleDegrees"": 180.0 },
+                        { ""name"": ""b0"", ""offsetXMicrometers"": 80.0, ""offsetYMicrometers"": 25.5, ""angleDegrees"": 0.0 }
+                    ]
+                }
+            ]
+        }";
+
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var result = JsonSerializer.Deserialize<PdkParseResult>(json, options);
+
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("test_pdk");
+        result.Components.Count.ShouldBe(1);
+
+        var comp = result.Components[0];
+        comp.Name.ShouldBe("mmi1x2");
+        comp.WidthMicrometers.ShouldBe(80.0);
+        comp.HeightMicrometers.ShouldBe(55.0);
+        comp.NazcaOriginOffsetX.ShouldBe(0.0);
+        comp.NazcaOriginOffsetY.ShouldBe(27.5);
+        comp.Pins.Count.ShouldBe(2);
+        comp.Pins[0].Name.ShouldBe("a0");
+        comp.Pins[0].AngleDegrees.ShouldBe(180.0);
+    }
+
+    [Fact]
+    public void DeserializeResult_EmptyComponents_ReturnsEmptyList()
+    {
+        var json = @"{
+            ""fileFormatVersion"": 1,
+            ""name"": ""empty_pdk"",
+            ""defaultWavelengthNm"": 1550,
+            ""components"": []
+        }";
+
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var result = JsonSerializer.Deserialize<PdkParseResult>(json, options);
+
+        result.ShouldNotBeNull();
+        result.Components.ShouldBeEmpty();
+    }
+
+    // ── Service construction tests ──────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullPythonPath_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new PdkNazcaParserService(null!, "script.py"));
+    }
+
+    [Fact]
+    public void Constructor_NullScriptPath_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new PdkNazcaParserService("python3", null!));
+    }
+
+    [Fact]
+    public async Task ParseAsync_ScriptNotFound_ThrowsFileNotFoundException()
+    {
+        var service = new PdkNazcaParserService(
+            "python3",
+            "/nonexistent/path/parse_pdk.py");
+
+        await Should.ThrowAsync<FileNotFoundException>(
+            () => service.ParseAsync("demo"));
+    }
+
+    // ── Demo output reference values ────────────────────────────────────────
+
+    [Fact]
+    public void DemoOutput_Mmi1x2_OriginAtMidHeight()
+    {
+        // Reference: mmi1x2_sh in Nazca demofab
+        // Bounding box: (0, -27.5) to (80, 27.5)
+        // So nazcaOriginOffsetY should be ymax = 27.5 = height/2
+        const double width = 80.0;
+        const double height = 55.0;
+        const double xmin = 0.0;
+        const double ymax = 27.5;
+
+        double originOffsetX = -xmin;
+        double originOffsetY = ymax;
+
+        originOffsetX.ShouldBe(0.0);
+        originOffsetY.ShouldBe(height / 2, tolerance: 1e-9);
+    }
+
+    [Fact]
+    public void DemoOutput_GratingCoupler_OriginAtMidHeight()
+    {
+        // Reference: io cell in Nazca demofab
+        // Bounding box: (0, -9.5) to (100, 9.5)
+        const double xmin = 0.0;
+        const double ymax = 9.5;
+
+        double originOffsetX = -xmin;
+        double originOffsetY = ymax;
+
+        // For symmetric cells: nazcaOriginOffsetY == height/2
+        const double height = 19.0;
+        originOffsetX.ShouldBe(0.0);
+        originOffsetY.ShouldBe(height / 2, tolerance: 1e-9);
+    }
+
+    // ── PdkParserException tests ────────────────────────────────────────────
+
+    [Fact]
+    public void PdkParserException_MessagePreserved()
+    {
+        const string message = "Test error from parse_pdk.py";
+        var ex = new PdkParserException(message);
+        ex.Message.ShouldBe(message);
+    }
+
+    [Fact]
+    public void PdkParserException_WithInnerException_ChainPreserved()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new PdkParserException("outer", inner);
+        ex.InnerException.ShouldBe(inner);
+    }
+}

--- a/scripts/parse_pdk.py
+++ b/scripts/parse_pdk.py
@@ -1,0 +1,307 @@
+"""
+PDK Parser: Extract component geometry from a Nazca PDK module.
+Issue #460: PDK Import Tool — Python/Nazca PDK parser with visual verification.
+
+Imports a Nazca PDK module and extracts for each cell:
+  - Bounding box (width, height in µm)
+  - Pin names, positions, and angles (converted to editor coordinate space)
+  - nazcaOriginOffset — where the Nazca cell (0,0) sits in editor coordinates
+
+The output JSON matches the Connect-A-PIC PDK format and can be used directly
+as a PDK file after adding S-matrix data.
+
+Usage:
+    python3 scripts/parse_pdk.py <module_name> [function1 function2 ...]
+    python3 scripts/parse_pdk.py siepic_ebeam_pdk > siepic-ebeam-pdk-geometry.json
+    python3 scripts/parse_pdk.py siepic_ebeam_pdk ebeam_y_1550 ebeam_dc_te1550
+
+Coordinate conventions:
+    Nazca space: X right, Y up
+    Editor space: X right, Y down
+    nazcaOriginOffsetX = -xmin  (distance of Nazca origin from left bbox edge)
+    nazcaOriginOffsetY = ymax   (distance of Nazca origin from top bbox edge)
+    pinEditorX = pinNazcaX - xmin
+    pinEditorY = ymax - pinNazcaY
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import importlib
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+def compute_origin_offset(xmin: float, ymax: float) -> tuple[float, float]:
+    """
+    Compute the nazcaOriginOffset from the bounding-box extremes.
+
+    In editor coordinates (Y-down), the Nazca cell origin (0, 0) maps to:
+      editor_x = 0 - xmin
+      editor_y = ymax - 0
+    """
+    return -xmin, ymax
+
+
+def nazca_to_editor(
+    nazca_x: float,
+    nazca_y: float,
+    xmin: float,
+    ymax: float,
+) -> tuple[float, float]:
+    """Convert a Nazca-space point to editor space (Y-down, origin at top-left of bbox)."""
+    editor_x = nazca_x - xmin
+    editor_y = ymax - nazca_y
+    return editor_x, editor_y
+
+
+def normalize_angle(nazca_angle: float) -> float:
+    """
+    Convert a Nazca pin angle to an editor angle.
+
+    Nazca uses:  0° = pointing right, 180° = pointing left (standard convention)
+    Editor uses: same convention (connections come in from the outside, so
+                 a pin facing left at 180° means the waveguide enters from the left).
+
+    Y-flip does NOT invert horizontal angles (0° / 180°), but does invert
+    vertical ones: Nazca 90° (up) → editor 270° (down).
+    """
+    # Map common Nazca angles to editor angles after Y-axis flip
+    angle_mod = nazca_angle % 360
+    flipped = (-angle_mod) % 360
+    return flipped
+
+
+# ---------------------------------------------------------------------------
+# Cell analysis
+# ---------------------------------------------------------------------------
+
+def analyze_cell(func_name: str, cell_factory) -> dict[str, Any] | None:
+    """
+    Instantiate a Nazca cell via *cell_factory* and extract geometry.
+
+    Returns a dict compatible with the PdkComponentDraft JSON format,
+    or None if the cell cannot be instantiated.
+    """
+    try:
+        import nazca  # type: ignore
+
+        with nazca.Cell("_parse_probe") as probe:
+            inst = cell_factory()
+    except Exception as exc:
+        print(f"  [WARN] Could not instantiate {func_name}: {exc}", file=sys.stderr)
+        return None
+
+    bbox = inst.bbox
+    if not bbox:
+        print(f"  [WARN] No bounding box for {func_name}", file=sys.stderr)
+        return None
+
+    xmin, ymin, xmax, ymax = bbox
+    width = xmax - xmin
+    height = ymax - ymin
+
+    if width <= 0 or height <= 0:
+        print(f"  [WARN] Degenerate bbox for {func_name}: {bbox}", file=sys.stderr)
+        return None
+
+    origin_offset_x, origin_offset_y = compute_origin_offset(xmin, ymax)
+
+    # Extract pins
+    pins = []
+    for pin_name, pin in inst.pin.items():
+        ex, ey = nazca_to_editor(pin.x, pin.y, xmin, ymax)
+        ea = normalize_angle(pin.a)
+        pins.append({
+            "name": pin_name,
+            "offsetXMicrometers": round(ex, 4),
+            "offsetYMicrometers": round(ey, 4),
+            "angleDegrees": round(ea, 1),
+        })
+
+    return {
+        "name": func_name,
+        "category": "Imported",
+        "nazcaFunction": func_name,
+        "nazcaParameters": "",
+        "widthMicrometers": round(width, 4),
+        "heightMicrometers": round(height, 4),
+        "nazcaOriginOffsetX": round(origin_offset_x, 4),
+        "nazcaOriginOffsetY": round(origin_offset_y, 4),
+        "pins": pins,
+        "sMatrix": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# PDK module inspection
+# ---------------------------------------------------------------------------
+
+def list_pdk_functions(module) -> list[str]:
+    """
+    Return public callable names from a PDK module that look like cell factories.
+    Filters out private names (underscore prefix) and known non-cell names.
+    """
+    skip = {"Cell", "put", "strt", "bend", "taper", "interconnect"}
+    return [
+        name for name in dir(module)
+        if not name.startswith("_")
+        and callable(getattr(module, name))
+        and name not in skip
+    ]
+
+
+def parse_pdk(module_name: str, function_names: list[str] | None = None) -> dict[str, Any]:
+    """
+    Import *module_name* and parse the requested (or all) cell functions.
+
+    Returns a dict in Connect-A-PIC PdkDraft JSON format.
+    """
+    try:
+        pdk_module = importlib.import_module(module_name)
+    except ImportError as exc:
+        print(f"ERROR: Cannot import '{module_name}': {exc}", file=sys.stderr)
+        print("Make sure the PDK module is installed in the current Python environment.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if function_names:
+        funcs_to_parse = function_names
+    else:
+        funcs_to_parse = list_pdk_functions(pdk_module)
+        print(f"Found {len(funcs_to_parse)} public callables in '{module_name}'.",
+              file=sys.stderr)
+
+    components = []
+    for func_name in funcs_to_parse:
+        factory = getattr(pdk_module, func_name, None)
+        if factory is None:
+            print(f"  [WARN] Function '{func_name}' not found in module.", file=sys.stderr)
+            continue
+        if not callable(factory):
+            print(f"  [SKIP] '{func_name}' is not callable.", file=sys.stderr)
+            continue
+
+        print(f"  Parsing {func_name}…", file=sys.stderr)
+        comp = analyze_cell(func_name, lambda f=factory: f())
+        if comp is not None:
+            components.append(comp)
+
+    # Use module __version__ if available
+    version = getattr(pdk_module, "__version__", "unknown")
+
+    return {
+        "fileFormatVersion": 1,
+        "name": module_name,
+        "description": f"Auto-generated from Python module '{module_name}'",
+        "foundry": "unknown — fill in manually",
+        "version": str(version),
+        "defaultWavelengthNm": 1550,
+        "nazcaModuleName": module_name,
+        "components": components,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Demo fallback (no Nazca required)
+# ---------------------------------------------------------------------------
+
+def demo_output() -> dict[str, Any]:
+    """
+    Return a sample output for demofab components (no Nazca import required).
+    Hard-coded reference values used when Nazca is not installed.
+    """
+    return {
+        "fileFormatVersion": 1,
+        "name": "demo (reference values)",
+        "description": "Reference geometry for Nazca demofab — install nazca for live parsing",
+        "foundry": "Nazca demofab",
+        "version": "reference",
+        "defaultWavelengthNm": 1550,
+        "nazcaModuleName": "nazca.demofab",
+        "components": [
+            {
+                "name": "mmi1x2_sh",
+                "category": "Splitters",
+                "nazcaFunction": "mmi1x2_sh",
+                "nazcaParameters": "",
+                "widthMicrometers": 80,
+                "heightMicrometers": 55,
+                "nazcaOriginOffsetX": 0.0,
+                "nazcaOriginOffsetY": 27.5,
+                "pins": [
+                    {"name": "a0", "offsetXMicrometers": 0.0, "offsetYMicrometers": 27.5, "angleDegrees": 180.0},
+                    {"name": "b0", "offsetXMicrometers": 80.0, "offsetYMicrometers": 25.5, "angleDegrees": 0.0},
+                    {"name": "b1", "offsetXMicrometers": 80.0, "offsetYMicrometers": 29.5, "angleDegrees": 0.0},
+                ],
+                "sMatrix": None,
+            },
+            {
+                "name": "mmi2x2_dp",
+                "category": "Couplers",
+                "nazcaFunction": "mmi2x2_dp",
+                "nazcaParameters": "",
+                "widthMicrometers": 250,
+                "heightMicrometers": 60,
+                "nazcaOriginOffsetX": 0.0,
+                "nazcaOriginOffsetY": 26.0,
+                "pins": [
+                    {"name": "a0", "offsetXMicrometers": 0.0, "offsetYMicrometers": 22.0, "angleDegrees": 180.0},
+                    {"name": "a1", "offsetXMicrometers": 0.0, "offsetYMicrometers": 30.0, "angleDegrees": 180.0},
+                    {"name": "b0", "offsetXMicrometers": 250.0, "offsetYMicrometers": 22.0, "angleDegrees": 0.0},
+                    {"name": "b1", "offsetXMicrometers": 250.0, "offsetYMicrometers": 30.0, "angleDegrees": 0.0},
+                ],
+                "sMatrix": None,
+            },
+            {
+                "name": "io",
+                "category": "I/O",
+                "nazcaFunction": "io",
+                "nazcaParameters": "",
+                "widthMicrometers": 100,
+                "heightMicrometers": 19,
+                "nazcaOriginOffsetX": 0.0,
+                "nazcaOriginOffsetY": 9.5,
+                "pins": [
+                    {"name": "a0", "offsetXMicrometers": 0.0, "offsetYMicrometers": 9.5, "angleDegrees": 180.0},
+                    {"name": "b0", "offsetXMicrometers": 100.0, "offsetYMicrometers": 9.5, "angleDegrees": 0.0},
+                ],
+                "sMatrix": None,
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    args = sys.argv[1:]
+
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__, file=sys.stderr)
+        print("\nAvailable modes:", file=sys.stderr)
+        print("  python3 scripts/parse_pdk.py demo             # show reference demo values", file=sys.stderr)
+        print("  python3 scripts/parse_pdk.py <module>         # parse all functions", file=sys.stderr)
+        print("  python3 scripts/parse_pdk.py <module> f1 f2   # parse specific functions", file=sys.stderr)
+        sys.exit(0)
+
+    module_name = args[0]
+    function_names = args[1:] if len(args) > 1 else None
+
+    if module_name == "demo":
+        result = demo_output()
+    else:
+        result = parse_pdk(module_name, function_names)
+
+    # Write JSON to stdout (redirect to file to create PDK JSON)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Automated implementation for #460

All done. Here's a summary of what was implemented for issue #460:

---

## Implementation Summary

### Phase 2: Python PDK Parser — `scripts/parse_pdk.py`

A standalone Python script that imports any Nazca PDK module and extracts component geometry:

- **Coordinate math**: computes `nazcaOriginOffsetX = -xmin`, `nazcaOriginOffsetY = ymax` from the Nazca bounding box, so the Y-flip from Nazca space (Y-up) to editor space (Y-down) is correct
- **Pin conversion**: `editorX = nazcaX - xmin`, `editorY = ymax - nazcaY`, angle flip for vertical pins (90° ↔ 270°)
- **Output**: JSON matching our `PdkDraft` format, ready to use as a PDK file (after adding S-matrix data)

Usage:
```bash
python3 scripts/parse_pdk.py siepic_ebeam_pdk > siepic-ebeam-pdk-geometry.json
python3 scripts/parse_pdk.py siepic_ebeam_pdk ebeam_y_1550 ebeam_dc_te1550
python3 scripts/parse_pdk.py demo   # hard-coded reference values (no Nazca needed)
```

### C# Service — `Connect-A-Pic-Core/Export/PdkNazcaParserService.cs`

Wraps the Python script as an async C# service:
- `ParseAsync(moduleName, functionNames?)` — runs the script and deserializes output to `PdkParseResult`
- `PdkParserException` for script failures
- `ParsedComponentGeometry` / `ParsedPinGeometry` DTOs mirroring the JSON format

### Tests — `UnitTests/Export/PdkNazcaParserServiceTests.cs`

19 tests covering:
- Coordinate conversion formulas (origin offset, pin X/Y, angle flip)
- JSON deserialization of parse output
- Error handling (null args, script not found)
- Reference values for demofab cells (mmi1x2_sh, grating coupler)


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 1,791,248
- **Estimated cost:** $1.0031 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*