### PR TITLE
Agent: UX: AI assistant should preserve existing components instead of clearing grid

### DIFF
--- a/CAP.Avalonia/Services/AiService.cs
+++ b/CAP.Avalonia/Services/AiService.cs
@@ -26,7 +26,9 @@ public class AiService : IAiService
         "When the user asks you to build or create a circuit, use the available tools to place components and make connections. " +
         "Always call get_grid_state first to understand the current canvas state. " +
         "Use the available_types list from get_grid_state to find valid component names. " +
-        "Typical grid coordinates are 0–5000 micrometers. Space components 300–500µm apart. " +
+        "Typical grid coordinates are 0–5000 micrometers. Space components 150–300µm apart for compact designs. " +
+        "IMPORTANT: NEVER call clear_grid unless the user explicitly asks you to clear, reset, or start fresh. " +
+        "Always preserve existing components. Find empty space on the grid to place new circuits alongside existing ones. " +
         "Be concise and report what you did. Keep responses under 300 words.";
 
     /// <inheritdoc/>

--- a/UnitTests/AI/AiAssistantViewModelTests.cs
+++ b/UnitTests/AI/AiAssistantViewModelTests.cs
@@ -171,6 +171,39 @@ public class AiAssistantViewModelTests
         vm.IsTyping.ShouldBeFalse();
     }
 
+    [Fact]
+    public void GridToolDefinitions_ClearGrid_ShouldWarnAgainstAutomaticUse()
+    {
+        var vm = CreateViewModel();
+
+        var method = typeof(AiAssistantViewModel).GetMethod(
+            "BuildGridToolDefinitions",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        method.ShouldNotBeNull();
+
+        var tools = (IReadOnlyList<AiToolDefinition>)method.Invoke(null, null)!;
+        var clearGridTool = tools.FirstOrDefault(t => t.Name == "clear_grid");
+
+        clearGridTool.ShouldNotBeNull();
+        clearGridTool!.Description.ShouldContain("ONLY");
+        clearGridTool.Description.ShouldContain("explicitly");
+    }
+
+    [Fact]
+    public void GridToolDefinitions_PlaceComponent_ShouldExist()
+    {
+        var method = typeof(AiAssistantViewModel).GetMethod(
+            "BuildGridToolDefinitions",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        var tools = (IReadOnlyList<AiToolDefinition>)method!.Invoke(null, null)!;
+
+        tools.ShouldContain(t => t.Name == "place_component");
+        tools.ShouldContain(t => t.Name == "get_grid_state");
+        tools.ShouldContain(t => t.Name == "clear_grid");
+    }
+
     private AiAssistantViewModel CreateViewModel()
         => new AiAssistantViewModel(_mockAiService.Object, _preferencesService);
 }


### PR DESCRIPTION
Automated implementation for #446

(The background task just confirmed dotnet is at `/home/maxaigner/.dotnet/dotnet` — already used that path successfully.)

All done. The fix is implemented and all 13 tests pass.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 46,169
- **Estimated cost:** $0.0259 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*