### PR TITLE
Agent: AI Assistant: Add tool to inspect inside ComponentGroups

### DIFF
--- a/CAP.Avalonia/Services/AiGridService.cs
+++ b/CAP.Avalonia/Services/AiGridService.cs
@@ -225,6 +225,46 @@ public class AiGridService : IAiGridService
         return $"Saved group '{groupId}' as prefab '{prefabName}' in component library.";
     }
 
+    /// <inheritdoc/>
+    public string InspectGroup(string groupId)
+    {
+        var groupVm = _canvas.Components.FirstOrDefault(c => c.Component.Identifier == groupId);
+        if (groupVm?.Component is not ComponentGroup group)
+            return $"Component '{groupId}' is not a group or does not exist.";
+
+        var result = new
+        {
+            group_id = group.Identifier,
+            group_name = group.GroupName,
+            description = group.Description,
+            position = new { x = Math.Round(group.PhysicalX, 1), y = Math.Round(group.PhysicalY, 1) },
+            child_components = group.ChildComponents.Select(child => new
+            {
+                id = child.Identifier,
+                type = child.HumanReadableName ?? child.NazcaFunctionName ?? child.Identifier,
+                position = new { x = Math.Round(child.PhysicalX, 1), y = Math.Round(child.PhysicalY, 1) },
+                rotation = child.RotationDegrees,
+                is_group = child is ComponentGroup
+            }).ToList(),
+            internal_connections = group.InternalPaths.Select(path => new
+            {
+                from = $"{path.StartPin.ParentComponent?.Identifier}:{path.StartPin.Name}",
+                to = $"{path.EndPin.ParentComponent?.Identifier}:{path.EndPin.Name}"
+            }).ToList(),
+            external_pins = group.ExternalPins.Select(pin => new
+            {
+                name = pin.Name,
+                angle_degrees = pin.AngleDegrees,
+                relative_position = new { x = Math.Round(pin.RelativeX, 1), y = Math.Round(pin.RelativeY, 1) },
+                maps_to_internal = $"{pin.InternalPin?.ParentComponent?.Identifier}:{pin.InternalPin?.Name}"
+            }).ToList(),
+            nested_group_count = group.ChildComponents.Count(c => c is ComponentGroup),
+            total_child_count = group.ChildComponents.Count
+        };
+
+        return JsonSerializer.Serialize(result, JsonOptions);
+    }
+
     private HashSet<PhysicalPin> GetConnectedPins() =>
         _canvas.Connections
             .SelectMany(c => new[] { c.Connection.StartPin, c.Connection.EndPin })

--- a/CAP.Avalonia/Services/IAiGridService.cs
+++ b/CAP.Avalonia/Services/IAiGridService.cs
@@ -66,4 +66,11 @@ public interface IAiGridService
     /// Returns a status message with the template name.
     /// </summary>
     string SaveGroupAsPrefab(string groupId, string prefabName, string? description = null);
+
+    /// <summary>
+    /// Returns detailed information about a ComponentGroup's internal structure.
+    /// Shows child components, internal connections (frozen waveguide paths), external pins, and nested group hierarchy.
+    /// Returns an error message if the component is not found or is not a group.
+    /// </summary>
+    string InspectGroup(string groupId);
 }

--- a/CAP.Avalonia/ViewModels/AI/AiAssistantViewModel.cs
+++ b/CAP.Avalonia/ViewModels/AI/AiAssistantViewModel.cs
@@ -196,6 +196,8 @@ public partial class AiAssistantViewModel : ObservableObject
                     GetString(input, "group_id"),
                     GetString(input, "prefab_name"),
                     GetString(input, "description")),
+                "inspect_group" => _gridService.InspectGroup(
+                    GetString(input, "group_id")),
                 _ => $"Unknown tool: {toolName}"
             };
         }
@@ -348,6 +350,20 @@ public partial class AiAssistantViewModel : ObservableObject
                     description = new { type = "string", description = "Optional description of the prefab" }
                 },
                 required = new[] { "group_id", "prefab_name" }
+            }
+        },
+        new AiToolDefinition
+        {
+            Name = "inspect_group",
+            Description = "Get detailed internal structure of a ComponentGroup: child components with types and positions, internal waveguide connections, external pins, and nested group hierarchy. Use this to understand what's inside a group.",
+            InputSchema = new
+            {
+                type = "object",
+                properties = new
+                {
+                    group_id = new { type = "string", description = "ID of the group to inspect (use id from get_grid_state)" }
+                },
+                required = new[] { "group_id" }
             }
         }
     };

--- a/UnitTests/AI/AiGridServiceTests.cs
+++ b/UnitTests/AI/AiGridServiceTests.cs
@@ -1,9 +1,16 @@
+using System.Text.Json;
+using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.ComponentHelpers;
 using CAP_Core.Components.Creation;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using Shouldly;
 
@@ -125,6 +132,148 @@ public class AiGridServiceTests
 
         result.ShouldNotBeNullOrEmpty();
         result.ShouldContain("cleared");
+    }
+
+    // ── InspectGroup tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public void InspectGroup_NonExistentId_ReturnsErrorMessage()
+    {
+        var result = _svc.InspectGroup("does_not_exist");
+
+        result.ShouldContain("does_not_exist");
+        result.ShouldNotStartWith("{");
+    }
+
+    [Fact]
+    public void InspectGroup_PlainComponent_ReturnsNotAGroupMessage()
+    {
+        var comp = CreateTestComponent("plain_comp", 100, 100);
+        _canvas.AddComponent(comp);
+
+        var result = _svc.InspectGroup(comp.Identifier);
+
+        result.ShouldContain("not a group");
+    }
+
+    [Fact]
+    public void InspectGroup_Group_ReturnsValidJson()
+    {
+        var group = CreateGroupWithTwoChildren();
+
+        var result = _svc.InspectGroup(group.Identifier);
+
+        result.ShouldNotBeNullOrEmpty();
+        var doc = JsonDocument.Parse(result); // must not throw
+        doc.RootElement.GetProperty("group_id").GetString().ShouldBe(group.Identifier);
+    }
+
+    [Fact]
+    public void InspectGroup_Group_ReturnsGroupNameAndChildCount()
+    {
+        var group = CreateGroupWithTwoChildren("MyMZI");
+
+        var result = _svc.InspectGroup(group.Identifier);
+
+        result.ShouldContain("\"group_name\"");
+        result.ShouldContain("MyMZI");
+        result.ShouldContain("\"total_child_count\":2");
+    }
+
+    [Fact]
+    public void InspectGroup_Group_ChildComponentsIncludeTypeAndPosition()
+    {
+        var group = CreateGroupWithTwoChildren();
+
+        var result = _svc.InspectGroup(group.Identifier);
+
+        result.ShouldContain("\"child_components\"");
+        result.ShouldContain("\"type\"");
+        result.ShouldContain("\"position\"");
+    }
+
+    [Fact]
+    public void InspectGroup_Group_ExternalPinsFieldPresent()
+    {
+        var group = CreateGroupWithTwoChildren();
+
+        var result = _svc.InspectGroup(group.Identifier);
+
+        result.ShouldContain("\"external_pins\"");
+    }
+
+    [Fact]
+    public void InspectGroup_Group_InternalConnectionsFieldPresent()
+    {
+        var group = CreateGroupWithTwoChildren();
+
+        var result = _svc.InspectGroup(group.Identifier);
+
+        result.ShouldContain("\"internal_connections\"");
+    }
+
+    [Fact]
+    public void InspectGroup_NestedGroup_ReportsNestedGroupCount()
+    {
+        // Arrange: outer group contains an inner group as one of its children
+        var inner = new ComponentGroup("InnerGroup");
+        var child = CreateTestComponent("child_in_inner", 50, 50);
+        inner.AddChild(child);
+        inner.Identifier = $"group_{Guid.NewGuid():N}";
+        inner.PhysicalX = 100;
+        inner.PhysicalY = 100;
+
+        var outer = new ComponentGroup("OuterGroup");
+        outer.AddChild(inner);
+        outer.Identifier = $"group_{Guid.NewGuid():N}";
+        outer.PhysicalX = 0;
+        outer.PhysicalY = 0;
+
+        _canvas.AddComponent(outer);
+
+        var result = _svc.InspectGroup(outer.Identifier);
+
+        result.ShouldContain("\"nested_group_count\":1");
+    }
+
+    /// <summary>
+    /// Creates a group with two plain child components and places it on the canvas.
+    /// </summary>
+    private ComponentGroup CreateGroupWithTwoChildren(string groupName = "TestGroup")
+    {
+        var comp1 = CreateTestComponent("child1", 100, 100);
+        var comp2 = CreateTestComponent("child2", 200, 100);
+
+        var vm1 = _canvas.AddComponent(comp1);
+        var vm2 = _canvas.AddComponent(comp2);
+
+        var cmd = new CreateGroupCommand(_canvas, new[] { vm1, vm2 }.ToList());
+        cmd.Execute();
+
+        var groupVm = _canvas.Components[0];
+        var group = (ComponentGroup)groupVm.Component;
+        group.GroupName = groupName;
+        return group;
+    }
+
+    private static Component CreateTestComponent(string identifier, double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin> { new("west0", 0, MatterType.Light, RectSide.Left) });
+        var allPins = Component.GetAllPins(parts).SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+        var matrix = new SMatrix(allPins, new());
+        var connections = new Dictionary<int, SMatrix>
+        {
+            { StandardWaveLengths.RedNM, matrix }
+        };
+        return new Component(connections, new(), "stub", "", parts, 0, identifier, new DiscreteRotation())
+        {
+            PhysicalX = x,
+            PhysicalY = y,
+            WidthMicrometers = 50,
+            HeightMicrometers = 50,
+            HumanReadableName = identifier
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
Automated implementation for #448

Done. Here's what was implemented:

**Changes made:**

1. **`IAiGridService.cs`** — Added `InspectGroup(string groupId)` to the interface.

2. **`AiGridService.cs`** — Implemented `InspectGroup`: finds the group by ID on the canvas, serializes its child components (id, type, position, rotation, is_group flag), internal waveguide connections (frozen paths start→end), external pins (name, angle, relative position, internal mapping), plus `nested_group_count` and `total_child_count`. Returns an error string if not found or not a group.

3. **`AiAssistantViewModel.cs`** — Added:
   - `inspect_group` case in `DispatchToolAsync`
   - Tool definition in `BuildGridToolDefinitions()` with `group_id` as required parameter

4. **`UnitTests/AI/AiGridServiceTests.cs`** — Added 8 new tests covering:
   - Non-existent group ID → error message
   - Plain component (not a group) → error message
   - Valid group → returns valid JSON with `group_id`
   - Group name and `total_child_count` in response
   - `child_components`, `external_pins`, `internal_connections` fields present
   - Nested group → `nested_group_count` reported correctly


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 1,968,505
- **Estimated cost:** $1.1024 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*