### PR TITLE
Agent: AI Assistant: Add copy/paste tool for duplicating components and groups

### DIFF
--- a/CAP.Avalonia/Services/AiGridService.cs
+++ b/CAP.Avalonia/Services/AiGridService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CAP.Avalonia.Commands;
+using CAP.Avalonia.Selection;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP_Core.Components.Core;
@@ -223,6 +224,37 @@ public class AiGridService : IAiGridService
         cmd.Execute();
 
         return $"Saved group '{groupId}' as prefab '{prefabName}' in component library.";
+    }
+
+    /// <inheritdoc/>
+    public Task<string> CopyComponentAsync(string sourceId, double x, double y, int rotation = -1)
+    {
+        var sourceVm = _canvas.Components.FirstOrDefault(c =>
+            c.Component.Identifier.Equals(sourceId, StringComparison.OrdinalIgnoreCase));
+
+        if (sourceVm == null)
+            return Task.FromResult($"Component '{sourceId}' not found.");
+
+        var tempClipboard = new ComponentClipboard();
+        tempClipboard.Copy(new[] { sourceVm }, _canvas.Connections);
+
+        var result = tempClipboard.Paste(_canvas, x, y);
+        if (result == null || result.Components.Count == 0)
+            return Task.FromResult($"Failed to copy '{sourceId}'.");
+
+        var copiedVm = result.Components[0];
+        var copiedId = copiedVm.Component.Identifier;
+
+        if (rotation >= 0 && rotation != copiedVm.Component.RotationDegrees
+            && copiedVm.Component is not ComponentGroup)
+        {
+            copiedVm.Component.RotationDegrees = rotation;
+        }
+
+        var px = Math.Round(copiedVm.Component.PhysicalX, 0);
+        var py = Math.Round(copiedVm.Component.PhysicalY, 0);
+        return Task.FromResult(
+            $"Copied '{sourceId}' to ({px}, {py})µm. New ID: '{copiedId}'.");
     }
 
     private HashSet<PhysicalPin> GetConnectedPins() =>

--- a/CAP.Avalonia/Services/IAiGridService.cs
+++ b/CAP.Avalonia/Services/IAiGridService.cs
@@ -66,4 +66,12 @@ public interface IAiGridService
     /// Returns a status message with the template name.
     /// </summary>
     string SaveGroupAsPrefab(string groupId, string prefabName, string? description = null);
+
+    /// <summary>
+    /// Duplicates a component or group and places the copy at the specified position.
+    /// Preserves all internal structure, connections, and frozen paths for groups.
+    /// Optionally applies a new rotation to the copy.
+    /// Returns a status message with the new component's identifier.
+    /// </summary>
+    Task<string> CopyComponentAsync(string sourceId, double x, double y, int rotation = -1);
 }

--- a/CAP.Avalonia/ViewModels/AI/AiAssistantViewModel.cs
+++ b/CAP.Avalonia/ViewModels/AI/AiAssistantViewModel.cs
@@ -196,6 +196,11 @@ public partial class AiAssistantViewModel : ObservableObject
                     GetString(input, "group_id"),
                     GetString(input, "prefab_name"),
                     GetString(input, "description")),
+                "copy_component" => await _gridService.CopyComponentAsync(
+                    GetString(input, "source_id"),
+                    GetDouble(input, "x"),
+                    GetDouble(input, "y"),
+                    GetInt(input, "rotation", -1)),
                 _ => $"Unknown tool: {toolName}"
             };
         }
@@ -348,6 +353,23 @@ public partial class AiAssistantViewModel : ObservableObject
                     description = new { type = "string", description = "Optional description of the prefab" }
                 },
                 required = new[] { "group_id", "prefab_name" }
+            }
+        },
+        new AiToolDefinition
+        {
+            Name = "copy_component",
+            Description = "Duplicate a component or group to a new position. Preserves all internal structure, frozen paths, and settings. Much faster than manually recreating circuits — use this for arrays, meshes, and symmetric designs.",
+            InputSchema = new
+            {
+                type = "object",
+                properties = new
+                {
+                    source_id = new { type = "string", description = "ID of the component or group to copy (use id from get_grid_state)" },
+                    x = new { type = "number", description = "Target X position for the copy in micrometers" },
+                    y = new { type = "number", description = "Target Y position for the copy in micrometers" },
+                    rotation = new { type = "integer", description = "Rotation in degrees (0, 90, 180, 270). Optional, omit to keep source rotation. Not applied to groups." }
+                },
+                required = new[] { "source_id", "x", "y" }
             }
         }
     };

--- a/UnitTests/AI/AiGridServiceTests.cs
+++ b/UnitTests/AI/AiGridServiceTests.cs
@@ -127,6 +127,79 @@ public class AiGridServiceTests
         result.ShouldContain("cleared");
     }
 
+    // ── CopyComponentAsync ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CopyComponentAsync_UnknownSourceId_ReturnsNotFoundMessage()
+    {
+        var result = await _svc.CopyComponentAsync("nonexistent_1", 200, 200);
+
+        result.ShouldContain("not found");
+        result.ShouldContain("nonexistent_1");
+    }
+
+    [Fact]
+    public async Task CopyComponentAsync_ValidComponent_CreatesNewComponentOnCanvas()
+    {
+        var component = TestComponentFactory.CreateBasicComponent();
+        component.Identifier = "source_1";
+        component.PhysicalX = 100;
+        component.PhysicalY = 100;
+        _canvas.AddComponent(component, "TestWG");
+
+        var initialCount = _canvas.Components.Count;
+
+        var result = await _svc.CopyComponentAsync("source_1", 500, 500);
+
+        result.ShouldContain("source_1");
+        _canvas.Components.Count.ShouldBe(initialCount + 1);
+    }
+
+    [Fact]
+    public async Task CopyComponentAsync_ValidComponent_ReturnsNewComponentId()
+    {
+        var component = TestComponentFactory.CreateBasicComponent();
+        component.Identifier = "wg_1";
+        component.PhysicalX = 0;
+        component.PhysicalY = 0;
+        _canvas.AddComponent(component, "Straight");
+
+        var result = await _svc.CopyComponentAsync("wg_1", 300, 300);
+
+        result.ShouldContain("New ID:");
+        result.ShouldNotContain("Failed");
+    }
+
+    [Fact]
+    public async Task CopyComponentAsync_ValidComponent_CopyHasDifferentIdentifier()
+    {
+        var component = TestComponentFactory.CreateBasicComponent();
+        component.Identifier = "wg_source";
+        _canvas.AddComponent(component, "Straight");
+
+        await _svc.CopyComponentAsync("wg_source", 400, 400);
+
+        var allIds = _canvas.Components.Select(c => c.Component.Identifier).ToList();
+        allIds.Distinct().Count().ShouldBe(allIds.Count); // All IDs must be unique
+    }
+
+    [Fact]
+    public async Task CopyComponentAsync_ValidComponent_ResultMentionsTargetPosition()
+    {
+        var component = TestComponentFactory.CreateBasicComponent();
+        component.Identifier = "comp_1";
+        component.PhysicalX = 0;
+        component.PhysicalY = 0;
+        _canvas.AddComponent(component, "Straight");
+
+        var result = await _svc.CopyComponentAsync("comp_1", 600, 700);
+
+        result.ShouldNotContain("Failed");
+        result.ShouldNotContain("not found");
+        var copy = _canvas.Components.Skip(1).FirstOrDefault();
+        copy.ShouldNotBeNull();
+    }
+
     /// <summary>
     /// Creates a minimal <see cref="LeftPanelViewModel"/> with real but empty dependencies.
     /// No PDKs are loaded so <see cref="LeftPanelViewModel.AllTemplates"/> is empty.


### PR DESCRIPTION
Automated implementation for #449

All done. Here's a summary of what was implemented:

## Implementation Summary

### Changes Made

**`IAiGridService.cs`** — Added `CopyComponentAsync` method to the interface:
```csharp
Task<string> CopyComponentAsync(string sourceId, double x, double y, int rotation = -1);
```

**`AiGridService.cs`** — Implemented `CopyComponentAsync` using a temporary clipboard (doesn't affect user's clipboard):
- Looks up the source component by ID
- Creates a temporary `ComponentClipboard`, copies the source, then pastes at the target position
- For groups: preserves all internal structure, frozen paths, and child components via the existing `DeepCopy()` path in clipboard
- Optionally applies rotation to non-group components

**`AiAssistantViewModel.cs`** — Added:
- Tool definition for `copy_component` in `BuildGridToolDefinitions()`
- Dispatch case in `DispatchToolAsync()`

**`AiGridServiceTests.cs`** — Added 5 new unit tests:
- `CopyComponentAsync_UnknownSourceId_ReturnsNotFoundMessage`
- `CopyComponentAsync_ValidComponent_CreatesNewComponentOnCanvas`
- `CopyComponentAsync_ValidComponent_ReturnsNewComponentId`
- `CopyComponentAsync_ValidComponent_CopyHasDifferentIdentifier`
- `CopyComponentAsync_ValidComponent_ResultMentionsTargetPosition`

**Build:** ✅ 0 errors | **Tests:** ✅ 16/16 passed


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 1,707,978
- **Estimated cost:** $0.9565 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*