### PR TITLE
Agent: AI Assistant: Add verification and fit-to-view after component placement

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -76,8 +76,6 @@ public partial class App : Application
         services.AddTransient<IAiTool, CopyComponentTool>();
         services.AddTransient<IAiTool, FitToViewTool>();
         services.AddSingleton<IAiToolRegistry, AiToolRegistry>();
-        // Expose ViewportControlViewModel from MainViewModel for DI injection (e.g. FitToViewTool)
-        services.AddSingleton(sp => sp.GetRequiredService<MainViewModel>().ViewportControl);
 
         services.AddTransient<AiAssistantViewModel>(sp => new AiAssistantViewModel(
             sp.GetRequiredService<IAiService>(),
@@ -102,6 +100,7 @@ public partial class App : Application
 
         // Register DesignCanvasViewModel as singleton (shared across all panel VMs)
         services.AddSingleton<DesignCanvasViewModel>();
+        services.AddSingleton<ViewportControlViewModel>();
 
         // Register sub-ViewModels (Left panel)
         services.AddTransient<HierarchyPanelViewModel>();

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -74,7 +74,10 @@ public partial class App : Application
         services.AddTransient<IAiTool, SaveAsPrefabTool>();
         services.AddTransient<IAiTool, InspectGroupTool>();
         services.AddTransient<IAiTool, CopyComponentTool>();
+        services.AddTransient<IAiTool, FitToViewTool>();
         services.AddSingleton<IAiToolRegistry, AiToolRegistry>();
+        // Expose ViewportControlViewModel from MainViewModel for DI injection (e.g. FitToViewTool)
+        services.AddSingleton(sp => sp.GetRequiredService<MainViewModel>().ViewportControl);
 
         services.AddTransient<AiAssistantViewModel>(sp => new AiAssistantViewModel(
             sp.GetRequiredService<IAiService>(),

--- a/CAP.Avalonia/Services/AiService.cs
+++ b/CAP.Avalonia/Services/AiService.cs
@@ -29,6 +29,11 @@ public class AiService : IAiService
         "Typical grid coordinates are 0–5000 micrometers. Space components 150–300µm apart for compact designs. " +
         "IMPORTANT: NEVER call clear_grid unless the user explicitly asks you to clear, reset, or start fresh. " +
         "Always preserve existing components. Find empty space on the grid to place new circuits alongside existing ones. " +
+        "AFTER placing or connecting components, ALWAYS do the following in order: " +
+        "1. Call get_grid_state() to verify the components were actually placed and count them. " +
+        "2. Call fit_to_view() so the user can immediately see the result. " +
+        "3. Report the actual component count (e.g. 'Placed 5 components: 2 MMI, 2 phase shifters, 1 waveguide'). " +
+        "If get_grid_state() shows fewer components than expected, report the discrepancy honestly — do NOT claim success. " +
         "Be concise and report what you did. Keep responses under 300 words.";
 
     /// <inheritdoc/>

--- a/CAP.Avalonia/Services/AiTools/GridTools/FitToViewTool.cs
+++ b/CAP.Avalonia/Services/AiTools/GridTools/FitToViewTool.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using CAP.Avalonia.ViewModels.Panels;
+
+namespace CAP.Avalonia.Services.AiTools.GridTools;
+
+/// <summary>
+/// AI tool that adjusts zoom and pan so all placed components are visible in the viewport.
+/// Call this after placing components so the user can immediately see the design.
+/// </summary>
+public class FitToViewTool : IAiTool
+{
+    private readonly ViewportControlViewModel _viewport;
+
+    private const double DefaultViewportWidth = 900.0;
+    private const double DefaultViewportHeight = 800.0;
+
+    /// <summary>Initializes the tool with the viewport ViewModel.</summary>
+    public FitToViewTool(ViewportControlViewModel viewport) => _viewport = viewport;
+
+    /// <inheritdoc/>
+    public string Name => "fit_to_view";
+
+    /// <inheritdoc/>
+    public string Description =>
+        "Adjusts zoom and pan to fit all placed components in the viewport. " +
+        "Always call this after placing or connecting components so the user can see the result immediately.";
+
+    /// <inheritdoc/>
+    public object InputSchema => new { type = "object", properties = new { } };
+
+    /// <inheritdoc/>
+    public Task<string> ExecuteAsync(JsonElement input)
+    {
+        var (width, height) = _viewport.GetViewportSize?.Invoke() ?? (DefaultViewportWidth, DefaultViewportHeight);
+        _viewport.ZoomToFit(width, height);
+        return Task.FromResult(JsonSerializer.Serialize(new { success = true, message = "Viewport fitted to show all components." }));
+    }
+}

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -93,7 +93,8 @@ public partial class MainViewModel : ObservableObject
         ErrorConsoleService errorConsoleService,
         LeftPanelViewModel leftPanel,
         RightPanelViewModel rightPanel,
-        BottomPanelViewModel bottomPanel)
+        BottomPanelViewModel bottomPanel,
+        ViewportControlViewModel viewportControl)
     {
         Simulation = simulationService;
         CommandManager = commandManager;
@@ -110,7 +111,7 @@ public partial class MainViewModel : ObservableObject
         gdsExportVm.Initialize(preferencesService.GetCustomPythonPath());
         gdsExportVm.OnPythonPathChanged = path => preferencesService.SetCustomPythonPath(path);
         FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, LeftPanel.AllTemplates, gdsExportVm, errorConsoleService);
-        ViewportControl = new ViewportControlViewModel(_canvas);
+        ViewportControl = viewportControl;
 
         // Wire up status callbacks
         CanvasInteraction.UpdateStatus = UpdateStatusText;

--- a/UnitTests/AI/FitToViewToolTests.cs
+++ b/UnitTests/AI/FitToViewToolTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using CAP.Avalonia.Services.AiTools.GridTools;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Panels;
+using Shouldly;
+
+namespace UnitTests.AI;
+
+/// <summary>
+/// Unit tests for <see cref="FitToViewTool"/>.
+/// </summary>
+public class FitToViewToolTests
+{
+    private static ViewportControlViewModel CreateViewport(out DesignCanvasViewModel canvas)
+    {
+        canvas = new DesignCanvasViewModel();
+        return new ViewportControlViewModel(canvas);
+    }
+
+    [Fact]
+    public void Name_ShouldBe_FitToView()
+    {
+        var tool = new FitToViewTool(CreateViewport(out _));
+        tool.Name.ShouldBe("fit_to_view");
+    }
+
+    [Fact]
+    public void Description_ShouldMentionViewport()
+    {
+        var tool = new FitToViewTool(CreateViewport(out _));
+        tool.Description.ShouldContain("viewport");
+    }
+
+    [Fact]
+    public void InputSchema_ShouldBeEmptyObjectSchema()
+    {
+        var tool = new FitToViewTool(CreateViewport(out _));
+        var schemaJson = JsonSerializer.Serialize(tool.InputSchema);
+        schemaJson.ShouldContain("\"type\"");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyCanvas_ReturnsSuccessJson()
+    {
+        var tool = new FitToViewTool(CreateViewport(out _));
+        using var doc = JsonDocument.Parse("{}");
+        var result = await tool.ExecuteAsync(doc.RootElement);
+
+        result.ShouldNotBeNullOrEmpty();
+        var json = JsonDocument.Parse(result);
+        json.RootElement.GetProperty("success").GetBoolean().ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UsesGetViewportSizeCallback_WhenProvided()
+    {
+        var viewport = CreateViewport(out _);
+        double capturedWidth = 0;
+        double capturedHeight = 0;
+        viewport.GetViewportSize = () => (1200.0, 900.0);
+
+        // Hook into ZoomToFit via UpdateStatus to verify execution
+        viewport.UpdateStatus = _ => { };
+
+        var tool = new FitToViewTool(viewport);
+        using var doc = JsonDocument.Parse("{}");
+
+        // Should not throw even with no components
+        var result = await tool.ExecuteAsync(doc.RootElement);
+        result.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoViewportSizeCallback_UsesDefaultSize()
+    {
+        var viewport = CreateViewport(out _);
+        // GetViewportSize is null — fallback to 900×800
+        viewport.GetViewportSize = null;
+
+        var tool = new FitToViewTool(viewport);
+        using var doc = JsonDocument.Parse("{}");
+
+        var result = await tool.ExecuteAsync(doc.RootElement);
+        result.ShouldNotBeNullOrEmpty();
+    }
+}

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -56,7 +56,8 @@ public static class MainViewModelTestHelper
             new CAP_Core.ErrorConsoleService(),
             leftPanel,
             rightPanel,
-            bottomPanel);
+            bottomPanel,
+            new ViewportControlViewModel(canvas));
     }
 
     /// <summary>


### PR DESCRIPTION
Automated implementation for #478

Full suite: **1694 passed, 5 failed** — same 5 pre-existing failures that existed before my changes (confirmed via git stash earlier). No regressions introduced.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 146,897
- **Estimated cost:** $0.0823 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*