### PR TITLE
Agent: Tool: per-component NazcaOriginOffset editor with visual pin overlay

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
@@ -33,35 +33,5 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             var json = JsonSerializer.Serialize(pdk, WriteOptions);
             File.WriteAllText(filePath, json);
         }
-
-        /// <summary>
-        /// Updates a single component's NazcaOriginOffset in the given PDK and writes the file.
-        /// Returns false if the component is not found in the PDK.
-        /// </summary>
-        /// <param name="pdk">The PDK draft to update.</param>
-        /// <param name="componentName">Name of the component to update.</param>
-        /// <param name="offsetX">New X offset in micrometers.</param>
-        /// <param name="offsetY">New Y offset in micrometers.</param>
-        /// <param name="filePath">Destination file path.</param>
-        /// <returns>True when the component was found and saved; false if not found.</returns>
-        public bool UpdateComponentOffset(
-            PdkDraft pdk,
-            string componentName,
-            double offsetX,
-            double offsetY,
-            string filePath)
-        {
-            var comp = pdk.Components.FirstOrDefault(c =>
-                string.Equals(c.Name, componentName, StringComparison.OrdinalIgnoreCase));
-
-            if (comp == null)
-                return false;
-
-            comp.NazcaOriginOffsetX = offsetX;
-            comp.NazcaOriginOffsetY = offsetY;
-
-            SaveToFile(pdk, filePath);
-            return true;
-        }
     }
 }

--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
@@ -17,13 +17,20 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
 
         /// <summary>
         /// Writes a <see cref="PdkDraft"/> to the specified file path as formatted JSON.
-        /// Overwrites the file if it already exists.
+        /// The write is atomic: content is first written to a sibling <c>.tmp</c>
+        /// file and then renamed, so a crash mid-write leaves the original PDK
+        /// JSON intact (this file is the source of truth for GDS export).
         /// </summary>
         /// <param name="pdk">The PDK draft to serialize.</param>
         /// <param name="filePath">Destination file path.</param>
-        /// <exception cref="InvalidOperationException">Thrown when the file path is invalid or the directory does not exist.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pdk"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="filePath"/> is null or empty.</exception>
+        /// <exception cref="InvalidOperationException">The destination directory does not exist.</exception>
         public void SaveToFile(PdkDraft pdk, string filePath)
         {
+            ArgumentNullException.ThrowIfNull(pdk);
+            ArgumentException.ThrowIfNullOrEmpty(filePath);
+
             var directory = Path.GetDirectoryName(filePath);
             if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
             {
@@ -31,7 +38,9 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             }
 
             var json = JsonSerializer.Serialize(pdk, WriteOptions);
-            File.WriteAllText(filePath, json);
+            var tempPath = filePath + ".tmp";
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, filePath, overwrite: true);
         }
     }
 }

--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP_DataAccess.Components.ComponentDraftMapper
+{
+    /// <summary>
+    /// Serializes and writes a <see cref="PdkDraft"/> back to a JSON file.
+    /// Used by the PDK Offset Editor to persist corrected NazcaOriginOffset values.
+    /// </summary>
+    public class PdkJsonSaver
+    {
+        private static readonly JsonSerializerOptions WriteOptions = new()
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        /// <summary>
+        /// Writes a <see cref="PdkDraft"/> to the specified file path as formatted JSON.
+        /// Overwrites the file if it already exists.
+        /// </summary>
+        /// <param name="pdk">The PDK draft to serialize.</param>
+        /// <param name="filePath">Destination file path.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the file path is invalid or the directory does not exist.</exception>
+        public void SaveToFile(PdkDraft pdk, string filePath)
+        {
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                throw new InvalidOperationException($"Directory does not exist: {directory}");
+            }
+
+            var json = JsonSerializer.Serialize(pdk, WriteOptions);
+            File.WriteAllText(filePath, json);
+        }
+
+        /// <summary>
+        /// Updates a single component's NazcaOriginOffset in the given PDK and writes the file.
+        /// Returns false if the component is not found in the PDK.
+        /// </summary>
+        /// <param name="pdk">The PDK draft to update.</param>
+        /// <param name="componentName">Name of the component to update.</param>
+        /// <param name="offsetX">New X offset in micrometers.</param>
+        /// <param name="offsetY">New Y offset in micrometers.</param>
+        /// <param name="filePath">Destination file path.</param>
+        /// <returns>True when the component was found and saved; false if not found.</returns>
+        public bool UpdateComponentOffset(
+            PdkDraft pdk,
+            string componentName,
+            double offsetX,
+            double offsetY,
+            string filePath)
+        {
+            var comp = pdk.Components.FirstOrDefault(c =>
+                string.Equals(c.Name, componentName, StringComparison.OrdinalIgnoreCase));
+
+            if (comp == null)
+                return false;
+
+            comp.NazcaOriginOffsetX = offsetX;
+            comp.NazcaOriginOffsetY = offsetY;
+
+            SaveToFile(pdk, filePath);
+            return true;
+        }
+    }
+}

--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
@@ -39,8 +39,26 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
 
             var json = JsonSerializer.Serialize(pdk, WriteOptions);
             var tempPath = filePath + ".tmp";
-            File.WriteAllText(tempPath, json);
-            File.Move(tempPath, filePath, overwrite: true);
+            var moved = false;
+            try
+            {
+                File.WriteAllText(tempPath, json);
+                File.Move(tempPath, filePath, overwrite: true);
+                moved = true;
+            }
+            finally
+            {
+                if (!moved && File.Exists(tempPath))
+                {
+                    try { File.Delete(tempPath); }
+                    catch
+                    {
+                        // Best-effort cleanup only — the caller sees the real
+                        // save failure, and a leftover <path>.tmp is overwritten
+                        // on the next successful save anyway.
+                    }
+                }
+            }
         }
     }
 }

--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkLoader.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkLoader.cs
@@ -16,9 +16,23 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
         };
 
         /// <summary>
-        /// Loads a PDK from a JSON file.
+        /// Loads a PDK from a JSON file. Validates that every component has a
+        /// NazcaOriginOffset — use this for simulation and export paths.
         /// </summary>
         public PdkDraft LoadFromFile(string filePath)
+            => LoadFromFileInternal(filePath, requireNazcaOffset: true);
+
+        /// <summary>
+        /// Loads a PDK from a JSON file for editing, tolerating components
+        /// whose NazcaOriginOffset is still null. Used by the PDK Offset
+        /// Editor — the tool that fixes missing offsets cannot itself reject
+        /// PDKs with missing offsets. Structural validation (names, pins,
+        /// dimensions) still applies.
+        /// </summary>
+        public PdkDraft LoadFromFileForEditing(string filePath)
+            => LoadFromFileInternal(filePath, requireNazcaOffset: false);
+
+        private PdkDraft LoadFromFileInternal(string filePath, bool requireNazcaOffset)
         {
             if (!File.Exists(filePath))
             {
@@ -26,13 +40,17 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             }
 
             var json = File.ReadAllText(filePath);
-            return LoadFromJson(json);
+            return LoadFromJson(json, requireNazcaOffset);
         }
 
         /// <summary>
-        /// Loads a PDK from a JSON string.
+        /// Loads a PDK from a JSON string. Validates that every component has
+        /// a NazcaOriginOffset.
         /// </summary>
         public PdkDraft LoadFromJson(string json)
+            => LoadFromJson(json, requireNazcaOffset: true);
+
+        private PdkDraft LoadFromJson(string json, bool requireNazcaOffset)
         {
             var pdk = JsonSerializer.Deserialize<PdkDraft>(json, JsonOptions);
             if (pdk == null)
@@ -40,7 +58,7 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
                 throw new InvalidOperationException("Failed to deserialize PDK JSON");
             }
 
-            ValidatePdk(pdk);
+            ValidatePdk(pdk, requireNazcaOffset);
             return pdk;
         }
 
@@ -74,7 +92,7 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             return pdks;
         }
 
-        private void ValidatePdk(PdkDraft pdk)
+        private void ValidatePdk(PdkDraft pdk, bool requireNazcaOffset)
         {
             if (string.IsNullOrWhiteSpace(pdk.Name))
             {
@@ -84,7 +102,7 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             var errors = new List<string>();
             foreach (var comp in pdk.Components)
             {
-                ValidateComponent(comp, pdk.Name, errors);
+                ValidateComponent(comp, pdk.Name, errors, requireNazcaOffset);
             }
 
             if (errors.Count > 0)
@@ -93,7 +111,7 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             }
         }
 
-        private static void ValidateComponent(PdkComponentDraft comp, string pdkName, List<string> errors)
+        private static void ValidateComponent(PdkComponentDraft comp, string pdkName, List<string> errors, bool requireNazcaOffset)
         {
             var compLabel = !string.IsNullOrWhiteSpace(comp.Name) ? comp.Name : "(unnamed)";
 
@@ -117,15 +135,20 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
                 errors.Add($"[{pdkName}/{compLabel}] Must have at least one pin");
             }
 
-            // NazcaOriginOffset is required — no silent fallback allowed.
-            // Without it, GDS export produces misaligned waveguides.
-            if (comp.NazcaOriginOffsetX == null)
+            // NazcaOriginOffset is required on the main load path — no silent
+            // fallback allowed. Without it, GDS export produces misaligned
+            // waveguides. The Offset Editor bypasses this check (it exists
+            // precisely to fix PDKs in this state).
+            if (requireNazcaOffset)
             {
-                errors.Add($"[{pdkName}/{compLabel}] Missing nazcaOriginOffsetX (required for GDS export)");
-            }
-            if (comp.NazcaOriginOffsetY == null)
-            {
-                errors.Add($"[{pdkName}/{compLabel}] Missing nazcaOriginOffsetY (required for GDS export)");
+                if (comp.NazcaOriginOffsetX == null)
+                {
+                    errors.Add($"[{pdkName}/{compLabel}] Missing nazcaOriginOffsetX (required for GDS export)");
+                }
+                if (comp.NazcaOriginOffsetY == null)
+                {
+                    errors.Add($"[{pdkName}/{compLabel}] Missing nazcaOriginOffsetY (required for GDS export)");
+                }
             }
 
             if (comp.Pins != null)

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -14,6 +14,8 @@ using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
+using CAP.Avalonia.ViewModels.PdkOffset;
+using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP.Avalonia.Views;
 using CAP.Avalonia.Services.AiTools;
 using CAP.Avalonia.Services.AiTools.GridTools;
@@ -134,6 +136,10 @@ public partial class App : Application
         services.AddSingleton<LeftPanelViewModel>();
         services.AddSingleton<RightPanelViewModel>();
         services.AddSingleton<BottomPanelViewModel>();
+
+        // Register PDK offset editor services and ViewModel
+        services.AddTransient<PdkJsonSaver>();
+        services.AddTransient<PdkOffsetEditorViewModel>();
 
         // Register main ViewModel
         services.AddSingleton<MainViewModel>();

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -137,9 +137,13 @@ public partial class App : Application
         services.AddSingleton<RightPanelViewModel>();
         services.AddSingleton<BottomPanelViewModel>();
 
-        // Register PDK offset editor services and ViewModel
-        services.AddTransient<PdkJsonSaver>();
-        services.AddTransient<PdkOffsetEditorViewModel>();
+        // Register PDK offset editor services and ViewModel.
+        // The ViewModel is Singleton so that MainViewModel can hold it as a
+        // property — this preserves editor state (loaded PDK, unsaved edits)
+        // when the user re-opens the window. Transient here would give the
+        // MainViewModel a different instance than any other DI resolution.
+        services.AddSingleton<PdkJsonSaver>();
+        services.AddSingleton<PdkOffsetEditorViewModel>();
 
         // Register main ViewModel
         services.AddSingleton<MainViewModel>();

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -22,7 +22,6 @@ using CAP.Avalonia.Services.AiTools.GridTools;
 using CAP_Contracts;
 using CAP_Core.Helpers;
 using CAP_Core.Export;
-using CAP_DataAccess.Components.ComponentDraftMapper;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CAP.Avalonia;

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -14,6 +14,7 @@ using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Export;
 using CAP_Core.Export;
+using CAP.Avalonia.ViewModels.PdkOffset;
 using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.ViewModels;
@@ -83,6 +84,12 @@ public partial class MainViewModel : ObservableObject
 
     private bool _isSimulating;
 
+    /// <summary>
+    /// ViewModel for the PDK Component Offset Editor window.
+    /// Exposed so the code-behind can pass the FileDialogService.
+    /// </summary>
+    public PdkOffsetEditorViewModel PdkOffsetEditor { get; }
+
     public MainViewModel(
         DesignCanvasViewModel canvas,
         SimulationService simulationService,
@@ -97,11 +104,13 @@ public partial class MainViewModel : ObservableObject
         LeftPanelViewModel leftPanel,
         RightPanelViewModel rightPanel,
         BottomPanelViewModel bottomPanel,
-        ViewportControlViewModel viewportControl)
+        ViewportControlViewModel viewportControl,
+        PdkOffsetEditorViewModel pdkOffsetEditor)
     {
         Simulation = simulationService;
         CommandManager = commandManager;
         _canvas = canvas;
+        PdkOffsetEditor = pdkOffsetEditor;
         _canvas.SimulationRequested = async () => await ExecuteSimulation();
 
         // Wire panel ViewModels (injected via DI)
@@ -391,6 +400,18 @@ public partial class MainViewModel : ObservableObject
 
     [RelayCommand]
     private async Task LoadPdk() => await LeftPanel.LoadPdkCommand.ExecuteAsync(null);
+
+    /// <summary>
+    /// Raised when the user requests to open the PDK Offset Editor window.
+    /// The View layer subscribes and shows the window.
+    /// </summary>
+    public Action? ShowPdkOffsetEditorRequested { get; set; }
+
+    [RelayCommand]
+    private void OpenPdkOffsetEditor()
+    {
+        ShowPdkOffsetEditorRequested?.Invoke();
+    }
 
     [RelayCommand]
     private void OpenPdkHelp()

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkComponentOffsetItemViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkComponentOffsetItemViewModel.cs
@@ -1,0 +1,99 @@
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CAP.Avalonia.ViewModels.PdkOffset;
+
+/// <summary>
+/// Offset verification status for a PDK component's NazcaOriginOffset.
+/// </summary>
+public enum OffsetStatus
+{
+    /// <summary>nazcaOriginOffsetX or nazcaOriginOffsetY is null in the JSON.</summary>
+    Missing,
+
+    /// <summary>Both offsets are present but both are zero — may need calibration.</summary>
+    ZeroOffset,
+
+    /// <summary>At least one offset is explicitly non-zero — likely calibrated.</summary>
+    Set
+}
+
+/// <summary>
+/// List-item ViewModel for one PDK component in the PDK Offset Editor.
+/// Exposes name, status badge, and the current offset values for display.
+/// </summary>
+public partial class PdkComponentOffsetItemViewModel : ObservableObject
+{
+    /// <summary>Display name of the component.</summary>
+    public string ComponentName { get; }
+
+    /// <summary>Name of the PDK this component belongs to.</summary>
+    public string PdkName { get; }
+
+    /// <summary>Reference to the mutable draft — used for save-back.</summary>
+    public PdkComponentDraft Draft { get; }
+
+    /// <summary>Offset X value in micrometers, null when missing from JSON.</summary>
+    public double? OffsetX => Draft.NazcaOriginOffsetX;
+
+    /// <summary>Offset Y value in micrometers, null when missing from JSON.</summary>
+    public double? OffsetY => Draft.NazcaOriginOffsetY;
+
+    /// <summary>Computed status based on whether offsets are present and non-zero.</summary>
+    public OffsetStatus Status { get; private set; }
+
+    /// <summary>Unicode badge for the current <see cref="Status"/>.</summary>
+    public string StatusBadge => Status switch
+    {
+        OffsetStatus.Missing     => "❌",
+        OffsetStatus.ZeroOffset  => "⚠️",
+        OffsetStatus.Set         => "✅",
+        _                        => "?"
+    };
+
+    /// <summary>One-line description shown in the component list tooltip.</summary>
+    public string StatusDescription => Status switch
+    {
+        OffsetStatus.Missing    => "NazcaOriginOffset missing — GDS export will fail",
+        OffsetStatus.ZeroOffset => "Offset present but both X and Y are zero — may need calibration",
+        OffsetStatus.Set        => $"Offset set: X={OffsetX:F3} µm, Y={OffsetY:F3} µm",
+        _                       => ""
+    };
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PdkComponentOffsetItemViewModel"/>.
+    /// </summary>
+    public PdkComponentOffsetItemViewModel(PdkComponentDraft draft, string pdkName)
+    {
+        Draft = draft;
+        ComponentName = draft.Name;
+        PdkName = pdkName;
+        RefreshStatus();
+    }
+
+    /// <summary>
+    /// Re-evaluates the offset status from the current draft values.
+    /// Call after editing the offset so the badge updates.
+    /// </summary>
+    public void RefreshStatus()
+    {
+        if (Draft.NazcaOriginOffsetX == null || Draft.NazcaOriginOffsetY == null)
+        {
+            Status = OffsetStatus.Missing;
+        }
+        else if (Draft.NazcaOriginOffsetX == 0.0 && Draft.NazcaOriginOffsetY == 0.0)
+        {
+            Status = OffsetStatus.ZeroOffset;
+        }
+        else
+        {
+            Status = OffsetStatus.Set;
+        }
+
+        OnPropertyChanged(nameof(Status));
+        OnPropertyChanged(nameof(StatusBadge));
+        OnPropertyChanged(nameof(StatusDescription));
+        OnPropertyChanged(nameof(OffsetX));
+        OnPropertyChanged(nameof(OffsetY));
+    }
+}

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkComponentOffsetItemViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkComponentOffsetItemViewModel.cs
@@ -72,6 +72,14 @@ public partial class PdkComponentOffsetItemViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Epsilon in µm below which an offset is treated as "exactly zero" for
+    /// the purposes of the ZeroOffset status. PDK offsets are calibrated in
+    /// whole or fractional µm, so 1e-9 µm (≈ sub-atomic scale) is
+    /// unambiguously floating-point noise from a GUI round-trip.
+    /// </summary>
+    private const double ZeroOffsetEpsilonMicrometers = 1e-9;
+
+    /// <summary>
     /// Re-evaluates the offset status from the current draft values.
     /// Call after editing the offset so the badge updates.
     /// </summary>
@@ -81,7 +89,8 @@ public partial class PdkComponentOffsetItemViewModel : ObservableObject
         {
             Status = OffsetStatus.Missing;
         }
-        else if (Draft.NazcaOriginOffsetX == 0.0 && Draft.NazcaOriginOffsetY == 0.0)
+        else if (Math.Abs(Draft.NazcaOriginOffsetX.Value) < ZeroOffsetEpsilonMicrometers
+                 && Math.Abs(Draft.NazcaOriginOffsetY.Value) < ZeroOffsetEpsilonMicrometers)
         {
             Status = OffsetStatus.ZeroOffset;
         }

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
@@ -1,0 +1,213 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Services;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.PdkOffset;
+
+/// <summary>
+/// ViewModel for the PDK Component Offset Editor window.
+/// Allows browsing all PDK components, inspecting NazcaOriginOffset status,
+/// editing offset values with a live pin-position preview, and saving back to JSON.
+/// </summary>
+public partial class PdkOffsetEditorViewModel : ObservableObject
+{
+    private readonly PdkLoader _pdkLoader;
+    private readonly PdkJsonSaver _pdkSaver;
+    private PdkDraft? _loadedPdk;
+    private string? _loadedFilePath;
+
+    [ObservableProperty]
+    private string _statusText = "Load a PDK file to begin.";
+
+    [ObservableProperty]
+    private PdkComponentOffsetItemViewModel? _selectedComponent;
+
+    [ObservableProperty]
+    private double _offsetX;
+
+    [ObservableProperty]
+    private double _offsetY;
+
+    [ObservableProperty]
+    private bool _hasUnsavedChanges;
+
+    /// <summary>All components from the loaded PDK, with offset status badges.</summary>
+    public ObservableCollection<PdkComponentOffsetItemViewModel> Components { get; } = new();
+
+    /// <summary>Pin positions for the currently selected component, recalculated on offset change.</summary>
+    public ObservableCollection<PinPositionViewModel> PinPositions { get; } = new();
+
+    /// <summary>File dialog service for picking a PDK JSON file to load.</summary>
+    public IFileDialogService? FileDialogService { get; set; }
+
+    /// <summary>
+    /// Canvas geometry properties for the visual pin overlay.
+    /// These are updated when a component is selected or offset changes.
+    /// </summary>
+    public double CanvasComponentWidth { get; private set; }
+    public double CanvasComponentHeight { get; private set; }
+    public double CanvasOriginX { get; private set; }
+    public double CanvasOriginY { get; private set; }
+
+    /// <summary>Pin markers for visual canvas overlay (canvas-pixel coordinates).</summary>
+    public ObservableCollection<PinMarker> PinMarkers { get; } = new();
+
+    private const double CanvasScale = 2.0;    // pixels per µm
+    private const double CanvasPadding = 20.0;
+
+    /// <summary>
+    /// Initializes the ViewModel with required services.
+    /// </summary>
+    public PdkOffsetEditorViewModel(PdkLoader pdkLoader, PdkJsonSaver pdkSaver)
+    {
+        _pdkLoader = pdkLoader;
+        _pdkSaver = pdkSaver;
+    }
+
+    /// <summary>Opens a file dialog and loads the selected PDK JSON file.</summary>
+    [RelayCommand]
+    private async Task LoadPdkFile()
+    {
+        if (FileDialogService == null)
+        {
+            StatusText = "File dialog service not available.";
+            return;
+        }
+
+        var path = await FileDialogService.ShowOpenFileDialogAsync(
+            "Open PDK JSON",
+            "JSON Files|*.json|All Files|*.*");
+
+        if (string.IsNullOrEmpty(path)) return;
+
+        try
+        {
+            _loadedPdk = _pdkLoader.LoadFromFile(path);
+            _loadedFilePath = path;
+            HasUnsavedChanges = false;
+
+            Components.Clear();
+            foreach (var comp in _loadedPdk.Components)
+            {
+                Components.Add(new PdkComponentOffsetItemViewModel(comp, _loadedPdk.Name));
+            }
+
+            var missing = Components.Count(c => c.Status == OffsetStatus.Missing);
+            var zero   = Components.Count(c => c.Status == OffsetStatus.ZeroOffset);
+            StatusText = $"Loaded {_loadedPdk.Name}: {Components.Count} components " +
+                         $"({missing} missing offset, {zero} at zero).";
+            SelectedComponent = null;
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Failed to load PDK: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// Applies the current OffsetX/OffsetY to the selected component draft
+    /// and refreshes the pin position table.
+    /// </summary>
+    [RelayCommand]
+    private void ApplyOffset()
+    {
+        if (SelectedComponent == null) return;
+
+        SelectedComponent.Draft.NazcaOriginOffsetX = OffsetX;
+        SelectedComponent.Draft.NazcaOriginOffsetY = OffsetY;
+        SelectedComponent.RefreshStatus();
+
+        RefreshPinPositions(SelectedComponent.Draft);
+        RefreshCanvasMarkers(SelectedComponent.Draft);
+        HasUnsavedChanges = true;
+        StatusText = $"Offset updated for '{SelectedComponent.ComponentName}'. Click Save to persist.";
+    }
+
+    /// <summary>
+    /// Saves the current PDK draft (with all edited offsets) back to its source JSON file.
+    /// </summary>
+    [RelayCommand]
+    private void SavePdk()
+    {
+        if (_loadedPdk == null || string.IsNullOrEmpty(_loadedFilePath))
+        {
+            StatusText = "No PDK loaded — nothing to save.";
+            return;
+        }
+
+        try
+        {
+            _pdkSaver.SaveToFile(_loadedPdk, _loadedFilePath);
+            HasUnsavedChanges = false;
+            StatusText = $"Saved to {Path.GetFileName(_loadedFilePath)}";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Save failed: {ex.Message}";
+        }
+    }
+
+    partial void OnSelectedComponentChanged(PdkComponentOffsetItemViewModel? value)
+    {
+        if (value == null)
+        {
+            PinPositions.Clear();
+            PinMarkers.Clear();
+            return;
+        }
+
+        OffsetX = value.Draft.NazcaOriginOffsetX ?? 0;
+        OffsetY = value.Draft.NazcaOriginOffsetY ?? 0;
+
+        RefreshPinPositions(value.Draft);
+        RefreshCanvasMarkers(value.Draft);
+    }
+
+    private void RefreshPinPositions(PdkComponentDraft draft)
+    {
+        PinPositions.Clear();
+        foreach (var pin in draft.Pins)
+        {
+            PinPositions.Add(new PinPositionViewModel(
+                pin.Name,
+                pin.OffsetXMicrometers,
+                pin.OffsetYMicrometers,
+                draft.HeightMicrometers,
+                OffsetX,
+                OffsetY));
+        }
+    }
+
+    private void RefreshCanvasMarkers(PdkComponentDraft draft)
+    {
+        CanvasComponentWidth  = draft.WidthMicrometers  * CanvasScale;
+        CanvasComponentHeight = draft.HeightMicrometers * CanvasScale;
+        CanvasOriginX = CanvasPadding + OffsetX  * CanvasScale;
+        CanvasOriginY = CanvasPadding + (draft.HeightMicrometers - OffsetY) * CanvasScale;
+
+        PinMarkers.Clear();
+        foreach (var pin in draft.Pins)
+        {
+            PinMarkers.Add(new PinMarker(
+                pin.Name,
+                CanvasPadding + pin.OffsetXMicrometers * CanvasScale,
+                CanvasPadding + pin.OffsetYMicrometers * CanvasScale));
+        }
+
+        OnPropertyChanged(nameof(CanvasComponentWidth));
+        OnPropertyChanged(nameof(CanvasComponentHeight));
+        OnPropertyChanged(nameof(CanvasOriginX));
+        OnPropertyChanged(nameof(CanvasOriginY));
+    }
+}
+
+/// <summary>
+/// Position of a pin marker on the visual canvas overlay.
+/// </summary>
+/// <param name="Name">Pin name for the tooltip label.</param>
+/// <param name="CanvasX">X coordinate in canvas pixels.</param>
+/// <param name="CanvasY">Y coordinate in canvas pixels.</param>
+public record PinMarker(string Name, double CanvasX, double CanvasY);

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
@@ -52,6 +52,18 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
     public double CanvasOriginX { get; private set; }
     public double CanvasOriginY { get; private set; }
 
+    /// <summary>Total canvas width in pixels (component plus both paddings).</summary>
+    public double CanvasTotalWidth => CanvasComponentWidth + CanvasPadding * 2;
+
+    /// <summary>Total canvas height in pixels (component plus both paddings).</summary>
+    public double CanvasTotalHeight => CanvasComponentHeight + CanvasPadding * 2;
+
+    /// <summary>X offset of the component bounding box inside the canvas (= padding).</summary>
+    public double CanvasComponentLeft => CanvasPadding;
+
+    /// <summary>Y offset of the component bounding box inside the canvas (= padding).</summary>
+    public double CanvasComponentTop => CanvasPadding;
+
     /// <summary>Pin markers for visual canvas overlay (canvas-pixel coordinates).</summary>
     public ObservableCollection<PinMarker> PinMarkers { get; } = new();
 
@@ -85,7 +97,10 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
 
         try
         {
-            _loadedPdk = _pdkLoader.LoadFromFile(path);
+            // Use the editing-tolerant loader — this window's whole purpose
+            // is to calibrate components whose offsets are still null. The
+            // strict LoadFromFile path would reject exactly those PDKs.
+            _loadedPdk = _pdkLoader.LoadFromFileForEditing(path);
             _loadedFilePath = path;
             HasUnsavedChanges = false;
 
@@ -224,13 +239,7 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
         OnPropertyChanged(nameof(CanvasComponentHeight));
         OnPropertyChanged(nameof(CanvasOriginX));
         OnPropertyChanged(nameof(CanvasOriginY));
+        OnPropertyChanged(nameof(CanvasTotalWidth));
+        OnPropertyChanged(nameof(CanvasTotalHeight));
     }
 }
-
-/// <summary>
-/// Position of a pin marker on the visual canvas overlay.
-/// </summary>
-/// <param name="Name">Pin name for the tooltip label.</param>
-/// <param name="CanvasX">X coordinate in canvas pixels.</param>
-/// <param name="CanvasY">Y coordinate in canvas pixels.</param>
-public record PinMarker(string Name, double CanvasX, double CanvasY);

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
@@ -109,12 +109,24 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
 
     /// <summary>
     /// Applies the current OffsetX/OffsetY to the selected component draft
-    /// and refreshes the pin position table.
+    /// and refreshes the pin position table. Rejects non-finite values
+    /// (NaN / ±Infinity) — they would silently propagate into the JSON and
+    /// later break GDS export with cryptic coordinate errors.
     /// </summary>
     [RelayCommand]
     private void ApplyOffset()
     {
-        if (SelectedComponent == null) return;
+        if (SelectedComponent == null)
+        {
+            StatusText = "Select a component before applying an offset.";
+            return;
+        }
+
+        if (!double.IsFinite(OffsetX) || !double.IsFinite(OffsetY))
+        {
+            StatusText = $"Offset values must be finite numbers (got X={OffsetX}, Y={OffsetY}).";
+            return;
+        }
 
         SelectedComponent.Draft.NazcaOriginOffsetX = OffsetX;
         SelectedComponent.Draft.NazcaOriginOffsetY = OffsetY;
@@ -161,6 +173,17 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
 
         OffsetX = value.Draft.NazcaOriginOffsetX ?? 0;
         OffsetY = value.Draft.NazcaOriginOffsetY ?? 0;
+
+        // Warn when the selected component has no offset in the JSON. The edit
+        // fields show 0/0 as a display default, but hitting Apply without
+        // realizing would flip the JSON from "null" (missing) to "0.0" (set
+        // to zero) — the file would then claim the component has been
+        // calibrated when it hasn't. Make the state visible.
+        if (value.Status == OffsetStatus.Missing)
+        {
+            StatusText = $"'{value.ComponentName}' has no offset in the JSON. Entering 0 and " +
+                         "clicking Apply will record it as calibrated-to-zero.";
+        }
 
         RefreshPinPositions(value.Draft);
         RefreshCanvasMarkers(value.Draft);

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
@@ -43,14 +43,23 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
     /// <summary>File dialog service for picking a PDK JSON file to load.</summary>
     public IFileDialogService? FileDialogService { get; set; }
 
-    /// <summary>
-    /// Canvas geometry properties for the visual pin overlay.
-    /// These are updated when a component is selected or offset changes.
-    /// </summary>
-    public double CanvasComponentWidth { get; private set; }
-    public double CanvasComponentHeight { get; private set; }
-    public double CanvasOriginX { get; private set; }
-    public double CanvasOriginY { get; private set; }
+    /// <summary>Component bounding-box width in canvas pixels.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanvasTotalWidth))]
+    private double _canvasComponentWidth;
+
+    /// <summary>Component bounding-box height in canvas pixels.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanvasTotalHeight))]
+    private double _canvasComponentHeight;
+
+    /// <summary>Nazca origin X position in canvas pixels (for the crosshair).</summary>
+    [ObservableProperty]
+    private double _canvasOriginX;
+
+    /// <summary>Nazca origin Y position in canvas pixels (for the crosshair).</summary>
+    [ObservableProperty]
+    private double _canvasOriginY;
 
     /// <summary>Total canvas width in pixels (component plus both paddings).</summary>
     public double CanvasTotalWidth => CanvasComponentWidth + CanvasPadding * 2;
@@ -234,12 +243,5 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
                 CanvasPadding + pin.OffsetXMicrometers * CanvasScale,
                 CanvasPadding + pin.OffsetYMicrometers * CanvasScale));
         }
-
-        OnPropertyChanged(nameof(CanvasComponentWidth));
-        OnPropertyChanged(nameof(CanvasComponentHeight));
-        OnPropertyChanged(nameof(CanvasOriginX));
-        OnPropertyChanged(nameof(CanvasOriginY));
-        OnPropertyChanged(nameof(CanvasTotalWidth));
-        OnPropertyChanged(nameof(CanvasTotalHeight));
     }
 }

--- a/CAP.Avalonia/ViewModels/PdkOffset/PinPositionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PinPositionViewModel.cs
@@ -66,3 +66,11 @@ public class PinPositionViewModel
         NazcaRelY = (componentHeight - localY) - nazcaOffsetY;
     }
 }
+
+/// <summary>
+/// Position of a pin marker on the visual canvas overlay.
+/// </summary>
+/// <param name="Name">Pin name for the tooltip label.</param>
+/// <param name="CanvasX">X coordinate in canvas pixels.</param>
+/// <param name="CanvasY">Y coordinate in canvas pixels.</param>
+public record PinMarker(string Name, double CanvasX, double CanvasY);

--- a/CAP.Avalonia/ViewModels/PdkOffset/PinPositionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PinPositionViewModel.cs
@@ -1,0 +1,68 @@
+namespace CAP.Avalonia.ViewModels.PdkOffset;
+
+/// <summary>
+/// Display data for a single physical pin in the PDK Offset Editor.
+/// Shows the pin's local-component coordinates and its position relative
+/// to the Nazca origin (which depends on the current NazcaOriginOffset).
+/// </summary>
+public class PinPositionViewModel
+{
+    /// <summary>Pin name (e.g. "a0", "b1").</summary>
+    public string PinName { get; }
+
+    /// <summary>Pin X position in component-local µm (from the PDK JSON).</summary>
+    public double LocalX { get; }
+
+    /// <summary>Pin Y position in component-local µm (from the PDK JSON).</summary>
+    public double LocalY { get; }
+
+    /// <summary>
+    /// Pin X position relative to the Nazca cell origin.
+    /// Computed as: LocalX - NazcaOriginOffsetX
+    /// </summary>
+    public double NazcaRelX { get; }
+
+    /// <summary>
+    /// Pin Y position relative to the Nazca cell origin in Nazca coordinate space.
+    /// Computed as: (ComponentHeight - LocalY) - NazcaOriginOffsetY
+    /// Note: Y is flipped because Nazca uses a top-down Y axis vs Lunima's bottom-up.
+    /// </summary>
+    public double NazcaRelY { get; }
+
+    /// <summary>Formatted string for table display.</summary>
+    public string LocalXText => $"{LocalX:F3} µm";
+
+    /// <summary>Formatted string for table display.</summary>
+    public string LocalYText => $"{LocalY:F3} µm";
+
+    /// <summary>Formatted string for table display.</summary>
+    public string NazcaXText => $"{NazcaRelX:F3} µm";
+
+    /// <summary>Formatted string for table display.</summary>
+    public string NazcaYText => $"{NazcaRelY:F3} µm";
+
+    /// <summary>
+    /// Initializes pin position data given local coordinates and the component's
+    /// current NazcaOriginOffset and height.
+    /// </summary>
+    /// <param name="pinName">Pin identifier.</param>
+    /// <param name="localX">Pin X offset in µm from component origin.</param>
+    /// <param name="localY">Pin Y offset in µm from component origin.</param>
+    /// <param name="componentHeight">Component height in µm (for Y-flip).</param>
+    /// <param name="nazcaOffsetX">Current NazcaOriginOffsetX in µm.</param>
+    /// <param name="nazcaOffsetY">Current NazcaOriginOffsetY in µm.</param>
+    public PinPositionViewModel(
+        string pinName,
+        double localX,
+        double localY,
+        double componentHeight,
+        double nazcaOffsetX,
+        double nazcaOffsetY)
+    {
+        PinName = pinName;
+        LocalX = localX;
+        LocalY = localY;
+        NazcaRelX = localX - nazcaOffsetX;
+        NazcaRelY = (componentHeight - localY) - nazcaOffsetY;
+    }
+}

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -104,6 +104,8 @@
                 <!-- PDK -->
                 <Button Content="📦 Load PDK" Command="{Binding LoadPdkCommand}"
                         MinWidth="95" Margin="2" Padding="8,4" Background="#3d3d5d" ToolTip.Tip="Load PDK component library"/>
+                <Button Content="📐 Offset Editor" Command="{Binding OpenPdkOffsetEditorCommand}"
+                        MinWidth="110" Margin="2" Padding="8,4" Background="#3d3d5d" ToolTip.Tip="Open PDK Component Offset Editor — calibrate NazcaOriginOffset per component"/>
                 <Button Content="❓" Command="{Binding OpenPdkHelpCommand}"
                         Width="28" Margin="0,2,2,2" Padding="2,4" Background="#3d3d5d" ToolTip.Tip="PDK JSON format help and AI assistance guide"/>
 

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -47,6 +47,18 @@ public partial class MainWindow : Window
                     };
                 }
 
+                // Wire up PDK Offset Editor window
+                vm.ShowPdkOffsetEditorRequested = () =>
+                {
+                    var editorVm = vm.PdkOffsetEditor;
+                    editorVm.FileDialogService = new FileDialogService(this);
+                    var editorWindow = new PdkOffsetEditorWindow
+                    {
+                        DataContext = editorVm
+                    };
+                    editorWindow.Show(this);
+                };
+
                 // Wire up clipboard for RoutingDiagnostics
                 vm.RightPanel.RoutingDiagnostics.CopyToClipboard = async (text) =>
                 {

--- a/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml
+++ b/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml
@@ -1,0 +1,154 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:CAP.Avalonia.ViewModels.PdkOffset"
+        x:Class="CAP.Avalonia.Views.PdkOffsetEditorWindow"
+        x:DataType="vm:PdkOffsetEditorViewModel"
+        Title="PDK Component Offset Editor"
+        Width="1000" Height="700"
+        MinWidth="700" MinHeight="500"
+        Background="#1e1e1e"
+        Foreground="White">
+
+    <Grid ColumnDefinitions="250,4,*" RowDefinitions="*">
+
+        <!-- Left panel: component list -->
+        <DockPanel Grid.Column="0" Margin="8">
+            <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
+                <TextBlock Text="PDK Components" FontWeight="Bold" Foreground="LightGray"
+                           VerticalAlignment="Center" DockPanel.Dock="Left"/>
+                <Button Content="Load PDK..." Command="{Binding LoadPdkFileCommand}"
+                        DockPanel.Dock="Right" Padding="8,4" Background="#3d3d5d"/>
+            </DockPanel>
+
+            <ListBox ItemsSource="{Binding Components}"
+                     SelectedItem="{Binding SelectedComponent}"
+                     Background="#252525"
+                     SelectionMode="Single">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="vm:PdkComponentOffsetItemViewModel">
+                        <StackPanel Orientation="Horizontal" Spacing="6" Margin="4,3"
+                                    ToolTip.Tip="{Binding StatusDescription}">
+                            <TextBlock Text="{Binding StatusBadge}" FontSize="14"/>
+                            <TextBlock Text="{Binding ComponentName}"
+                                       Foreground="White" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </DockPanel>
+
+        <!-- Splitter -->
+        <GridSplitter Grid.Column="1" Background="#3d3d3d" ResizeDirection="Columns"/>
+
+        <!-- Right panel: editor -->
+        <ScrollViewer Grid.Column="2" Margin="8" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="10">
+
+                <!-- Component header -->
+                <Border Background="#252525" CornerRadius="4" Padding="10,8">
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="No component selected." Foreground="LightGray"
+                                   IsVisible="{Binding SelectedComponent, Converter={x:Static ObjectConverters.IsNull}}"/>
+                        <StackPanel Spacing="2"
+                                    IsVisible="{Binding SelectedComponent, Converter={x:Static ObjectConverters.IsNotNull}}">
+                            <TextBlock Text="{Binding SelectedComponent.ComponentName}"
+                                       FontSize="16" FontWeight="Bold" Foreground="White"/>
+                            <TextBlock Text="{Binding SelectedComponent.PdkName}"
+                                       Foreground="Gray" FontSize="11"/>
+                            <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,4,0,0">
+                                <TextBlock Text="{Binding SelectedComponent.StatusBadge}" FontSize="14"/>
+                                <TextBlock Text="{Binding SelectedComponent.StatusDescription}"
+                                           Foreground="LightGray" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
+                <!-- Offset editor -->
+                <Border Background="#252525" CornerRadius="4" Padding="10,8"
+                        IsVisible="{Binding SelectedComponent, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="NazcaOriginOffset (µm)" FontWeight="Bold" Foreground="LightGray"/>
+                        <Grid ColumnDefinitions="Auto,120,20,Auto,120,*,Auto">
+                            <TextBlock Grid.Column="0" Text="X:" VerticalAlignment="Center" Foreground="LightGray" Margin="0,0,6,0"/>
+                            <NumericUpDown Grid.Column="1"
+                                          Value="{Binding OffsetX}"
+                                          FormatString="F3"
+                                          Increment="0.5"
+                                          Background="#2d2d2d" Foreground="White"/>
+                            <TextBlock Grid.Column="3" Text="Y:" VerticalAlignment="Center" Foreground="LightGray" Margin="0,0,6,0"/>
+                            <NumericUpDown Grid.Column="4"
+                                          Value="{Binding OffsetY}"
+                                          FormatString="F3"
+                                          Increment="0.5"
+                                          Background="#2d2d2d" Foreground="White"/>
+                            <Button Grid.Column="6" Content="Apply" Command="{Binding ApplyOffsetCommand}"
+                                    Padding="12,4" Background="#3d5d3d"/>
+                        </Grid>
+                        <TextBlock Text="Apply updates the preview and marks the file as changed. Click Save PDK to persist."
+                                   Foreground="Gray" FontSize="11"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Visual overlay canvas -->
+                <Border Background="#252525" CornerRadius="4" Padding="10,8"
+                        IsVisible="{Binding SelectedComponent, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="Visual Pin Overlay" FontWeight="Bold" Foreground="LightGray"/>
+                        <TextBlock Text="Blue = component bounding box  |  Cyan dots = pins  |  Orange crosshair = Nazca origin"
+                                   Foreground="Gray" FontSize="11"/>
+                        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                                      MaxHeight="280">
+                            <Canvas x:Name="OverlayCanvas"
+                                    Width="500" Height="260"
+                                    Background="#1a1a2e"
+                                    ClipToBounds="True"/>
+                        </ScrollViewer>
+                    </StackPanel>
+                </Border>
+
+                <!-- Pin positions table -->
+                <Border Background="#252525" CornerRadius="4" Padding="10,8"
+                        IsVisible="{Binding SelectedComponent, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <StackPanel Spacing="6">
+                        <TextBlock Text="Pin Positions relative to Nazca Origin" FontWeight="Bold" Foreground="LightGray"/>
+                        <Grid ColumnDefinitions="80,90,90,90,90" Margin="0,4,0,2">
+                            <TextBlock Grid.Column="0" Text="Pin" Foreground="Gray" FontWeight="Bold"/>
+                            <TextBlock Grid.Column="1" Text="Local X" Foreground="Gray" FontWeight="Bold"/>
+                            <TextBlock Grid.Column="2" Text="Local Y" Foreground="Gray" FontWeight="Bold"/>
+                            <TextBlock Grid.Column="3" Text="Nazca X" Foreground="Cyan" FontWeight="Bold"/>
+                            <TextBlock Grid.Column="4" Text="Nazca Y" Foreground="Cyan" FontWeight="Bold"/>
+                        </Grid>
+                        <Rectangle Height="1" Fill="#3d3d3d"/>
+                        <ItemsControl ItemsSource="{Binding PinPositions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:PinPositionViewModel">
+                                    <Grid ColumnDefinitions="80,90,90,90,90" Margin="0,2">
+                                        <TextBlock Grid.Column="0" Text="{Binding PinName}" Foreground="White"/>
+                                        <TextBlock Grid.Column="1" Text="{Binding LocalXText}" Foreground="LightGray"/>
+                                        <TextBlock Grid.Column="2" Text="{Binding LocalYText}" Foreground="LightGray"/>
+                                        <TextBlock Grid.Column="3" Text="{Binding NazcaXText}" Foreground="Cyan"/>
+                                        <TextBlock Grid.Column="4" Text="{Binding NazcaYText}" Foreground="Cyan"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+
+                <!-- Save + status bar -->
+                <Border Background="#252526" CornerRadius="4" Padding="10,8">
+                    <DockPanel>
+                        <Button Content="💾 Save PDK" Command="{Binding SavePdkCommand}"
+                                DockPanel.Dock="Right" Padding="12,6" Background="#3d5d3d"
+                                ToolTip.Tip="Write all offset changes back to the PDK JSON file"/>
+                        <TextBlock Text="{Binding StatusText}"
+                                   Foreground="LightGray" VerticalAlignment="Center" TextWrapping="Wrap"/>
+                    </DockPanel>
+                </Border>
+
+            </StackPanel>
+        </ScrollViewer>
+
+    </Grid>
+</Window>

--- a/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml.cs
+++ b/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml.cs
@@ -11,8 +11,6 @@ namespace CAP.Avalonia.Views;
 /// </summary>
 public partial class PdkOffsetEditorWindow : Window
 {
-    private const double CanvasPadding = 20.0;
-    private const double CanvasScale = 2.0;
     private const double PinDotRadius = 5.0;
     private const double CrosshairLength = 12.0;
 
@@ -57,33 +55,36 @@ public partial class PdkOffsetEditorWindow : Window
 
     private void RedrawOverlay(PdkOffsetEditorViewModel vm)
     {
-        if (OverlayCanvas == null) return;
+        if (OverlayCanvas == null)
+        {
+            // Can happen when the DataContext is assigned before the XAML
+            // is fully loaded. The next redraw (triggered by a ViewModel
+            // change once the canvas exists) will render correctly.
+            System.Diagnostics.Debug.WriteLine(
+                "PdkOffsetEditorWindow.RedrawOverlay: OverlayCanvas not initialized — skipping redraw.");
+            return;
+        }
         OverlayCanvas.Children.Clear();
 
         if (vm.SelectedComponent == null) return;
 
-        var draft = vm.SelectedComponent.Draft;
-        double compW = draft.WidthMicrometers  * CanvasScale;
-        double compH = draft.HeightMicrometers * CanvasScale;
+        // All geometry comes from the ViewModel — the view only maps these
+        // pre-computed canvas pixel values onto Avalonia shapes.
+        OverlayCanvas.Width  = vm.CanvasTotalWidth;
+        OverlayCanvas.Height = vm.CanvasTotalHeight;
 
-        // Expand canvas if component is large
-        OverlayCanvas.Width  = compW + CanvasPadding * 2;
-        OverlayCanvas.Height = compH + CanvasPadding * 2;
-
-        // Component bounding box
         var box = new Rectangle
         {
-            Width  = compW,
-            Height = compH,
+            Width  = vm.CanvasComponentWidth,
+            Height = vm.CanvasComponentHeight,
             Fill   = ComponentBoxBrush,
             Stroke = ComponentBorderBrush,
             StrokeThickness = 1.5
         };
-        Canvas.SetLeft(box, CanvasPadding);
-        Canvas.SetTop(box, CanvasPadding);
+        Canvas.SetLeft(box, vm.CanvasComponentLeft);
+        Canvas.SetTop(box, vm.CanvasComponentTop);
         OverlayCanvas.Children.Add(box);
 
-        // Pin dots
         foreach (var pin in vm.PinMarkers)
         {
             var dot = new Ellipse
@@ -97,7 +98,6 @@ public partial class PdkOffsetEditorWindow : Window
             Canvas.SetTop(dot, pin.CanvasY - PinDotRadius);
             OverlayCanvas.Children.Add(dot);
 
-            // Pin label
             var label = new TextBlock
             {
                 Text       = pin.Name,
@@ -109,10 +109,7 @@ public partial class PdkOffsetEditorWindow : Window
             OverlayCanvas.Children.Add(label);
         }
 
-        // Nazca origin crosshair
-        double originX = CanvasPadding + vm.OffsetX * CanvasScale;
-        double originY = CanvasPadding + (draft.HeightMicrometers - vm.OffsetY) * CanvasScale;
-        DrawCrosshair(originX, originY);
+        DrawCrosshair(vm.CanvasOriginX, vm.CanvasOriginY);
 
         var originLabel = new TextBlock
         {
@@ -120,8 +117,8 @@ public partial class PdkOffsetEditorWindow : Window
             Foreground = OriginBrush,
             FontSize   = 9
         };
-        Canvas.SetLeft(originLabel, originX + CrosshairLength + 2);
-        Canvas.SetTop(originLabel, originY - 6);
+        Canvas.SetLeft(originLabel, vm.CanvasOriginX + CrosshairLength + 2);
+        Canvas.SetTop(originLabel, vm.CanvasOriginY - 6);
         OverlayCanvas.Children.Add(originLabel);
     }
 

--- a/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml.cs
+++ b/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml.cs
@@ -1,0 +1,147 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+using CAP.Avalonia.ViewModels.PdkOffset;
+
+namespace CAP.Avalonia.Views;
+
+/// <summary>
+/// Code-behind for the PDK Component Offset Editor window.
+/// Renders the visual pin overlay on the Canvas when the selected component changes.
+/// </summary>
+public partial class PdkOffsetEditorWindow : Window
+{
+    private const double CanvasPadding = 20.0;
+    private const double CanvasScale = 2.0;
+    private const double PinDotRadius = 5.0;
+    private const double CrosshairLength = 12.0;
+
+    private static readonly IBrush ComponentBoxBrush = new SolidColorBrush(Color.Parse("#1a3a6a"));
+    private static readonly IBrush ComponentBorderBrush = new SolidColorBrush(Color.Parse("#4080c0"));
+    private static readonly IBrush PinBrush = new SolidColorBrush(Colors.Cyan);
+    private static readonly IBrush OriginBrush = new SolidColorBrush(Colors.Orange);
+
+    /// <summary>
+    /// Initializes the window and subscribes to ViewModel property changes for canvas rendering.
+    /// </summary>
+    public PdkOffsetEditorWindow()
+    {
+        InitializeComponent();
+
+        DataContextChanged += (_, _) =>
+        {
+            if (DataContext is PdkOffsetEditorViewModel vm)
+            {
+                SubscribeToViewModel(vm);
+            }
+        };
+    }
+
+    private void SubscribeToViewModel(PdkOffsetEditorViewModel vm)
+    {
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is
+                nameof(vm.SelectedComponent) or
+                nameof(vm.OffsetX) or
+                nameof(vm.OffsetY) or
+                nameof(vm.CanvasComponentWidth) or
+                nameof(vm.CanvasComponentHeight))
+            {
+                RedrawOverlay(vm);
+            }
+        };
+
+        vm.PinMarkers.CollectionChanged += (_, _) => RedrawOverlay(vm);
+    }
+
+    private void RedrawOverlay(PdkOffsetEditorViewModel vm)
+    {
+        if (OverlayCanvas == null) return;
+        OverlayCanvas.Children.Clear();
+
+        if (vm.SelectedComponent == null) return;
+
+        var draft = vm.SelectedComponent.Draft;
+        double compW = draft.WidthMicrometers  * CanvasScale;
+        double compH = draft.HeightMicrometers * CanvasScale;
+
+        // Expand canvas if component is large
+        OverlayCanvas.Width  = compW + CanvasPadding * 2;
+        OverlayCanvas.Height = compH + CanvasPadding * 2;
+
+        // Component bounding box
+        var box = new Rectangle
+        {
+            Width  = compW,
+            Height = compH,
+            Fill   = ComponentBoxBrush,
+            Stroke = ComponentBorderBrush,
+            StrokeThickness = 1.5
+        };
+        Canvas.SetLeft(box, CanvasPadding);
+        Canvas.SetTop(box, CanvasPadding);
+        OverlayCanvas.Children.Add(box);
+
+        // Pin dots
+        foreach (var pin in vm.PinMarkers)
+        {
+            var dot = new Ellipse
+            {
+                Width  = PinDotRadius * 2,
+                Height = PinDotRadius * 2,
+                Fill   = PinBrush
+            };
+            ToolTip.SetTip(dot, pin.Name);
+            Canvas.SetLeft(dot, pin.CanvasX - PinDotRadius);
+            Canvas.SetTop(dot, pin.CanvasY - PinDotRadius);
+            OverlayCanvas.Children.Add(dot);
+
+            // Pin label
+            var label = new TextBlock
+            {
+                Text       = pin.Name,
+                Foreground = PinBrush,
+                FontSize   = 9
+            };
+            Canvas.SetLeft(label, pin.CanvasX + PinDotRadius + 1);
+            Canvas.SetTop(label, pin.CanvasY - 6);
+            OverlayCanvas.Children.Add(label);
+        }
+
+        // Nazca origin crosshair
+        double originX = CanvasPadding + vm.OffsetX * CanvasScale;
+        double originY = CanvasPadding + (draft.HeightMicrometers - vm.OffsetY) * CanvasScale;
+        DrawCrosshair(originX, originY);
+
+        var originLabel = new TextBlock
+        {
+            Text       = "origin",
+            Foreground = OriginBrush,
+            FontSize   = 9
+        };
+        Canvas.SetLeft(originLabel, originX + CrosshairLength + 2);
+        Canvas.SetTop(originLabel, originY - 6);
+        OverlayCanvas.Children.Add(originLabel);
+    }
+
+    private void DrawCrosshair(double cx, double cy)
+    {
+        var hLine = new Line
+        {
+            StartPoint = new global::Avalonia.Point(cx - CrosshairLength, cy),
+            EndPoint   = new global::Avalonia.Point(cx + CrosshairLength, cy),
+            Stroke     = OriginBrush,
+            StrokeThickness = 1.5
+        };
+        var vLine = new Line
+        {
+            StartPoint = new global::Avalonia.Point(cx, cy - CrosshairLength),
+            EndPoint   = new global::Avalonia.Point(cx, cy + CrosshairLength),
+            Stroke     = OriginBrush,
+            StrokeThickness = 1.5
+        };
+        OverlayCanvas.Children.Add(hLine);
+        OverlayCanvas.Children.Add(vLine);
+    }
+}

--- a/UnitTests/Components/PdkLoaderOffsetEditingTests.cs
+++ b/UnitTests/Components/PdkLoaderOffsetEditingTests.cs
@@ -1,0 +1,101 @@
+using System.IO;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Shouldly;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Verifies the editing-tolerant loader path used by the PDK Offset Editor:
+/// it must accept PDKs with null NazcaOriginOffsets (the tool fixes them),
+/// while the strict main path must keep rejecting them.
+/// </summary>
+public class PdkLoaderOffsetEditingTests
+{
+    private const string PdkWithNullOffsets = @"{
+        ""fileFormatVersion"": 1,
+        ""name"": ""Uncalibrated PDK"",
+        ""components"": [
+            {
+                ""name"": ""Raw Waveguide"",
+                ""category"": ""Waveguides"",
+                ""nazcaFunction"": ""raw.wg"",
+                ""widthMicrometers"": 100,
+                ""heightMicrometers"": 5,
+                ""pins"": [
+                    { ""name"": ""a0"", ""offsetXMicrometers"": 0,   ""offsetYMicrometers"": 2.5 },
+                    { ""name"": ""b0"", ""offsetXMicrometers"": 100, ""offsetYMicrometers"": 2.5 }
+                ]
+            }
+        ]
+    }";
+
+    [Fact]
+    public void LoadFromFileForEditing_WhenOffsetsNull_ReturnsPdkInsteadOfThrowing()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, PdkWithNullOffsets);
+            var loader = new PdkLoader();
+
+            var pdk = loader.LoadFromFileForEditing(tempFile);
+
+            pdk.ShouldNotBeNull();
+            pdk.Components.Count.ShouldBe(1);
+            pdk.Components[0].NazcaOriginOffsetX.ShouldBeNull();
+            pdk.Components[0].NazcaOriginOffsetY.ShouldBeNull();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void LoadFromFile_WhenOffsetsNull_StillThrowsValidationException()
+    {
+        // Regression guard: the strict path (used by simulation and GDS export)
+        // must keep rejecting PDKs with missing offsets — the editing-tolerant
+        // method must not have relaxed the strict one by accident.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, PdkWithNullOffsets);
+            var loader = new PdkLoader();
+
+            var ex = Should.Throw<PdkValidationException>(() => loader.LoadFromFile(tempFile));
+            ex.Errors.ShouldContain(e => e.Contains("nazcaOriginOffsetX"));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void LoadFromFileForEditing_StillRejectsStructuralErrors()
+    {
+        // Editing-tolerant must only relax the offset check — pins, dimensions,
+        // names still matter (otherwise the editor would silently load garbage).
+        const string brokenPdk = @"{
+            ""fileFormatVersion"": 1,
+            ""name"": ""Broken PDK"",
+            ""components"": [
+                { ""name"": ""NoPins"", ""nazcaFunction"": ""x"", ""widthMicrometers"": 10, ""heightMicrometers"": 5, ""pins"": [] }
+            ]
+        }";
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, brokenPdk);
+            var loader = new PdkLoader();
+
+            var ex = Should.Throw<PdkValidationException>(() => loader.LoadFromFileForEditing(tempFile));
+            ex.Errors.ShouldContain(e => e.Contains("pin"));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -11,6 +11,7 @@ using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.PdkOffset;
 using CAP_Core.Components.Creation;
 using CAP_Core.Export;
 using CAP_DataAccess.Components.ComponentDraftMapper;
@@ -59,7 +60,8 @@ public static class MainViewModelTestHelper
             leftPanel,
             rightPanel,
             bottomPanel,
-            new ViewportControlViewModel(canvas));
+            new ViewportControlViewModel(canvas),
+            new PdkOffsetEditorViewModel(pdkLoader, new PdkJsonSaver()));
     }
 
     /// <summary>

--- a/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
@@ -1,0 +1,277 @@
+using System.IO;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.PdkOffset;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Shouldly;
+
+namespace UnitTests.PdkOffset;
+
+/// <summary>
+/// Integration tests for the load-file and save-file paths of
+/// <see cref="PdkOffsetEditorViewModel"/>. These exercise the ViewModel
+/// through its public API (no reflection), including the failure
+/// branches that the per-VM unit tests cannot reach.
+/// </summary>
+public class PdkOffsetEditorLoadSaveTests
+{
+    private const string UncalibratedPdkJson = @"{
+        ""fileFormatVersion"": 1,
+        ""name"": ""Uncalibrated Demo"",
+        ""components"": [
+            {
+                ""name"": ""Raw Waveguide"",
+                ""category"": ""Waveguides"",
+                ""nazcaFunction"": ""demo.raw_wg"",
+                ""widthMicrometers"": 100,
+                ""heightMicrometers"": 5,
+                ""pins"": [
+                    { ""name"": ""a0"", ""offsetXMicrometers"": 0,   ""offsetYMicrometers"": 2.5 },
+                    { ""name"": ""b0"", ""offsetXMicrometers"": 100, ""offsetYMicrometers"": 2.5 }
+                ]
+            },
+            {
+                ""name"": ""Calibrated Splitter"",
+                ""category"": ""Splitters"",
+                ""nazcaFunction"": ""demo.splitter"",
+                ""widthMicrometers"": 40,
+                ""heightMicrometers"": 20,
+                ""nazcaOriginOffsetX"": 5.0,
+                ""nazcaOriginOffsetY"": 10.0,
+                ""pins"": [
+                    { ""name"": ""a0"", ""offsetXMicrometers"": 0,  ""offsetYMicrometers"": 10 }
+                ]
+            }
+        ]
+    }";
+
+    private static PdkOffsetEditorViewModel BuildViewModel() =>
+        new(new PdkLoader(), new PdkJsonSaver());
+
+    [Fact]
+    public async Task LoadPdkFile_WithMissingOffsets_LoadsAndReportsCounts()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, UncalibratedPdkJson);
+            var vm = BuildViewModel();
+            vm.FileDialogService = new StubFileDialogService(tempFile);
+
+            await vm.LoadPdkFileCommand.ExecuteAsync(null);
+
+            vm.Components.Count.ShouldBe(2);
+            vm.SelectedComponent.ShouldBeNull();
+            vm.HasUnsavedChanges.ShouldBeFalse();
+            vm.StatusText.ShouldContain("Uncalibrated Demo");
+            vm.StatusText.ShouldContain("1 missing offset");
+            vm.Components[0].Status.ShouldBe(OffsetStatus.Missing);
+            vm.Components[1].Status.ShouldBe(OffsetStatus.Set);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task LoadPdkFile_WhenCancelled_LeavesStateUntouched()
+    {
+        var vm = BuildViewModel();
+        vm.FileDialogService = new StubFileDialogService(null);
+
+        await vm.LoadPdkFileCommand.ExecuteAsync(null);
+
+        vm.Components.ShouldBeEmpty();
+        vm.SelectedComponent.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadPdkFile_Reload_ReplacesPreviousComponents()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, UncalibratedPdkJson);
+            var vm = BuildViewModel();
+            vm.FileDialogService = new StubFileDialogService(tempFile);
+
+            await vm.LoadPdkFileCommand.ExecuteAsync(null);
+            vm.SelectedComponent = vm.Components[0];
+            vm.Components.Count.ShouldBe(2);
+
+            // Re-load the same file — previous list must be cleared first,
+            // otherwise a reload would double each entry.
+            await vm.LoadPdkFileCommand.ExecuteAsync(null);
+
+            vm.Components.Count.ShouldBe(2);
+            vm.SelectedComponent.ShouldBeNull();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task SavePdk_FullLoadEditSaveRoundTrip_PreservesAllFieldsAndEditedOffset()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, UncalibratedPdkJson);
+            var vm = BuildViewModel();
+            vm.FileDialogService = new StubFileDialogService(tempFile);
+
+            await vm.LoadPdkFileCommand.ExecuteAsync(null);
+
+            vm.SelectedComponent = vm.Components[0]; // Raw Waveguide — Missing
+            vm.OffsetX = 12.5;
+            vm.OffsetY = 2.5;
+            vm.ApplyOffsetCommand.Execute(null);
+            vm.SavePdkCommand.Execute(null);
+
+            vm.HasUnsavedChanges.ShouldBeFalse();
+
+            // Reload via the strict loader — the file must now validate as a
+            // fully-calibrated PDK for the waveguide row.
+            var reloaded = new PdkLoader().LoadFromFileForEditing(tempFile);
+            reloaded.Name.ShouldBe("Uncalibrated Demo");
+            reloaded.Components.Count.ShouldBe(2);
+            reloaded.Components[0].NazcaOriginOffsetX.ShouldBe(12.5);
+            reloaded.Components[0].NazcaOriginOffsetY.ShouldBe(2.5);
+            reloaded.Components[0].Pins.Count.ShouldBe(2);
+            reloaded.Components[0].Pins[0].Name.ShouldBe("a0");
+            reloaded.Components[1].NazcaOriginOffsetX.ShouldBe(5.0);
+            reloaded.Components[1].Category.ShouldBe("Splitters");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task SavePdk_WhenSaveThrows_KeepsUnsavedChangesAndSurfacesError()
+    {
+        // If saving fails for any reason, the in-memory edits must remain
+        // pending — otherwise the user sees "no unsaved changes" and closes
+        // the window losing work. Trigger the failure by deleting the parent
+        // directory between load and save (PdkJsonSaver rejects a missing
+        // directory with InvalidOperationException).
+        var tempDir = Path.Combine(Path.GetTempPath(), "pdk-save-fail-" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDir);
+        var tempFile = Path.Combine(tempDir, "source.json");
+        File.WriteAllText(tempFile, UncalibratedPdkJson);
+
+        try
+        {
+            var vm = BuildViewModel();
+            vm.FileDialogService = new StubFileDialogService(tempFile);
+
+            await vm.LoadPdkFileCommand.ExecuteAsync(null);
+            vm.SelectedComponent = vm.Components[0];
+            vm.OffsetX = 1.0;
+            vm.OffsetY = 1.0;
+            vm.ApplyOffsetCommand.Execute(null);
+            vm.HasUnsavedChanges.ShouldBeTrue();
+
+            Directory.Delete(tempDir, recursive: true);
+
+            vm.SavePdkCommand.Execute(null);
+
+            vm.HasUnsavedChanges.ShouldBeTrue();
+            vm.StatusText.ShouldContain("Save failed");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DeselectComponent_ClearsPinPositionsAndMarkers()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, UncalibratedPdkJson);
+            var vm = BuildViewModel();
+            vm.FileDialogService = new StubFileDialogService(tempFile);
+            await vm.LoadPdkFileCommand.ExecuteAsync(null);
+
+            vm.SelectedComponent = vm.Components[0];
+            vm.PinPositions.Count.ShouldBe(2);
+            vm.PinMarkers.Count.ShouldBe(2);
+
+            vm.SelectedComponent = null;
+
+            vm.PinPositions.ShouldBeEmpty();
+            vm.PinMarkers.ShouldBeEmpty();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SaveToFile_LeavesNoTempFileOnSuccess()
+    {
+        // Atomic write: after a successful save there must be no leftover
+        // `<path>.tmp` on disk. Guards against a regression where the temp
+        // file rename step is skipped or the temp path naming drifts.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            new PdkJsonSaver().SaveToFile(BuildMinimalPdk(), tempFile);
+
+            File.Exists(tempFile).ShouldBeTrue();
+            File.Exists(tempFile + ".tmp").ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+            if (File.Exists(tempFile + ".tmp")) File.Delete(tempFile + ".tmp");
+        }
+    }
+
+    private static CAP_DataAccess.Components.ComponentDraftMapper.DTOs.PdkDraft BuildMinimalPdk() =>
+        new()
+        {
+            Name = "Minimal",
+            Components = new()
+            {
+                new()
+                {
+                    Name = "One",
+                    NazcaFunction = "x",
+                    WidthMicrometers = 10,
+                    HeightMicrometers = 5,
+                    NazcaOriginOffsetX = 0,
+                    NazcaOriginOffsetY = 0,
+                    Pins = new() { new() { Name = "a0", OffsetXMicrometers = 0, OffsetYMicrometers = 2.5 } }
+                }
+            }
+        };
+
+    /// <summary>
+    /// Minimal <see cref="IFileDialogService"/> that returns a pre-configured
+    /// path for open-file and throws for any other operation. Lets tests
+    /// drive the ViewModel's LoadPdkFile command without an Avalonia window.
+    /// </summary>
+    private sealed class StubFileDialogService : IFileDialogService
+    {
+        private readonly string? _pathToReturn;
+
+        public StubFileDialogService(string? pathToReturn)
+        {
+            _pathToReturn = pathToReturn;
+        }
+
+        public Task<string?> ShowOpenFileDialogAsync(string title, string filters)
+            => Task.FromResult(_pathToReturn);
+
+        public Task<string?> ShowSaveFileDialogAsync(string title, string defaultExtension, string filters)
+            => throw new NotSupportedException("Not used in these tests.");
+    }
+}

--- a/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
@@ -230,8 +230,32 @@ public class PdkOffsetEditorLoadSaveTests
         }
         finally
         {
-            File.Delete(tempFile);
-            if (File.Exists(tempFile + ".tmp")) File.Delete(tempFile + ".tmp");
+            if (File.Exists(tempFile))           File.Delete(tempFile);
+            if (File.Exists(tempFile + ".tmp"))  File.Delete(tempFile + ".tmp");
+        }
+    }
+
+    [Fact]
+    public void SaveToFile_WhenMoveFails_DoesNotLeaveOrphanTempFile()
+    {
+        // Atomic write should clean up its <path>.tmp sibling if the final
+        // rename step throws (target is a directory). Without the cleanup
+        // block we'd accumulate .tmp files on every failed save.
+        var tempDir = Path.Combine(Path.GetTempPath(), "pdk-saver-orphan-" + Guid.NewGuid());
+        Directory.CreateDirectory(tempDir);
+        var targetPath = Path.Combine(tempDir, "target");
+        Directory.CreateDirectory(targetPath); // target is a directory → File.Move throws
+
+        try
+        {
+            Should.Throw<Exception>(() =>
+                new PdkJsonSaver().SaveToFile(BuildMinimalPdk(), targetPath));
+
+            File.Exists(targetPath + ".tmp").ShouldBeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true);
         }
     }
 

--- a/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
@@ -110,6 +110,45 @@ public class PdkOffsetEditorViewModelTests
         vm.Status.ShouldBe(OffsetStatus.Set);
     }
 
+    [Fact]
+    public void OffsetItem_WhenOnlyOneFieldNull_HasMissingStatus()
+    {
+        // Guards against a `&&`-vs-`||` typo in RefreshStatus. One-null must be
+        // treated as Missing (can't GDS-export partial coordinates).
+        var draft = BuildTestPdk().Components[0];
+        draft.NazcaOriginOffsetX = 5.0;
+        draft.NazcaOriginOffsetY = null;
+        var vm = new PdkComponentOffsetItemViewModel(draft, "Test PDK");
+
+        vm.Status.ShouldBe(OffsetStatus.Missing);
+    }
+
+    [Fact]
+    public void OffsetItem_WhenFloatNoiseNearZero_StaysZeroOffset()
+    {
+        // Exact `== 0.0` comparison used to flip Status from ZeroOffset to Set
+        // on any floating-point noise (GUI round-trip, serializer fuzz).
+        var draft = BuildTestPdk().Components[2];
+        draft.NazcaOriginOffsetX = 1e-18;
+        draft.NazcaOriginOffsetY = -2e-18;
+        var vm = new PdkComponentOffsetItemViewModel(draft, "Test PDK");
+
+        vm.Status.ShouldBe(OffsetStatus.ZeroOffset);
+    }
+
+    [Fact]
+    public void OffsetItem_WhenOneFieldZeroOneNonzero_IsSet()
+    {
+        // Documents the boundary between ZeroOffset and Set: "both near-zero"
+        // is ZeroOffset, "any one non-zero" is Set.
+        var draft = BuildTestPdk().Components[0];
+        draft.NazcaOriginOffsetX = 0.0;
+        draft.NazcaOriginOffsetY = 10.0;
+        var vm = new PdkComponentOffsetItemViewModel(draft, "Test PDK");
+
+        vm.Status.ShouldBe(OffsetStatus.Set);
+    }
+
     // ─── PinPositionViewModel ──────────────────────────────────────────────────
 
     [Fact]
@@ -191,6 +230,60 @@ public class PdkOffsetEditorViewModelTests
         vm.SelectedComponent.Draft.NazcaOriginOffsetY.ShouldBe(4.0);
         vm.SelectedComponent.Status.ShouldBe(OffsetStatus.Set);
         vm.HasUnsavedChanges.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ViewModel_ApplyOffset_WithNoSelection_IsNoOpWithStatus()
+    {
+        var vm = CreateViewModel();
+        vm.OffsetX = 5.0;
+        vm.OffsetY = 2.0;
+
+        vm.ApplyOffsetCommand.Execute(null);
+
+        vm.HasUnsavedChanges.ShouldBeFalse();
+        vm.StatusText.ShouldContain("Select a component");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0.0)]
+    [InlineData(0.0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0.0)]
+    [InlineData(0.0, double.NegativeInfinity)]
+    public void ViewModel_ApplyOffset_RejectsNonFiniteValues(double badX, double badY)
+    {
+        var vm = CreateViewModel();
+        var pdk = BuildTestPdk();
+        foreach (var comp in pdk.Components)
+            vm.Components.Add(new PdkComponentOffsetItemViewModel(comp, pdk.Name));
+
+        vm.SelectedComponent = vm.Components[1]; // Waveguide — Missing
+        vm.OffsetX = badX;
+        vm.OffsetY = badY;
+
+        vm.ApplyOffsetCommand.Execute(null);
+
+        // Draft stays untouched — no silent propagation of NaN into the JSON.
+        vm.SelectedComponent.Draft.NazcaOriginOffsetX.ShouldBeNull();
+        vm.SelectedComponent.Draft.NazcaOriginOffsetY.ShouldBeNull();
+        vm.HasUnsavedChanges.ShouldBeFalse();
+        vm.StatusText.ShouldContain("finite");
+    }
+
+    [Fact]
+    public void ViewModel_SelectingMissingComponent_ShowsWarningInStatus()
+    {
+        // The edit fields default to 0/0 for a null-offset component. A user
+        // who clicks Apply without reading the warning would silently convert
+        // "no offset in JSON" into "offset = 0". Make the state visible.
+        var vm = CreateViewModel();
+        var pdk = BuildTestPdk();
+        foreach (var comp in pdk.Components)
+            vm.Components.Add(new PdkComponentOffsetItemViewModel(comp, pdk.Name));
+
+        vm.SelectedComponent = vm.Components[1]; // Waveguide — Missing
+
+        vm.StatusText.ShouldContain("no offset in the JSON");
     }
 
     [Fact]
@@ -276,17 +369,63 @@ public class PdkOffsetEditorViewModelTests
     }
 
     [Fact]
-    public void PdkJsonSaver_UpdateComponentOffset_ReturnsFalseForUnknownComponent()
+    public void PdkJsonSaver_PreservesFloatPrecisionInJson()
     {
+        // The existing round-trip test above only greps for "3.25". Protects
+        // against JsonSerializerOptions regressions on culture / precision.
+        // Deliberately checks values that would truncate with a naive F-format:
+        // 0.1+0.2 → 0.30000000000000004, and a value that needs ≥ 7 sig digits.
         var tempFile = Path.GetTempFileName();
         try
         {
             var pdk = BuildTestPdk();
+            pdk.Components[0].NazcaOriginOffsetX = 0.1 + 0.2;
+            pdk.Components[0].NazcaOriginOffsetY = 1234.5678901;
+
             new PdkJsonSaver().SaveToFile(pdk, tempFile);
+            var json = File.ReadAllText(tempFile);
 
-            var result = new PdkJsonSaver().UpdateComponentOffset(pdk, "NonExistent", 1, 2, tempFile);
+            json.ShouldContain("0.30000000000000004");
+            json.ShouldContain("1234.5678901");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
 
-            result.ShouldBeFalse();
+    [Fact]
+    public void PdkJsonSaver_WhenAllOffsetsNull_OmitsOffsetProperties()
+    {
+        // `DefaultIgnoreCondition.WhenWritingNull` on the saver's options is a
+        // contract: un-calibrated components must not flip to "0.0" in JSON.
+        // Otherwise the editor's missing-vs-zero-offset distinction collapses
+        // after one save and the user can never tell which components were
+        // actually calibrated.
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var pdk = new PdkDraft
+            {
+                Name = "Null-offsets",
+                Components = new List<PdkComponentDraft>
+                {
+                    new()
+                    {
+                        Name = "untouched",
+                        WidthMicrometers = 10,
+                        HeightMicrometers = 10,
+                        NazcaOriginOffsetX = null,
+                        NazcaOriginOffsetY = null,
+                    }
+                }
+            };
+
+            new PdkJsonSaver().SaveToFile(pdk, tempFile);
+            var json = File.ReadAllText(tempFile);
+
+            json.ShouldNotContain("nazcaOriginOffsetX");
+            json.ShouldNotContain("nazcaOriginOffsetY");
         }
         finally
         {

--- a/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
@@ -1,0 +1,305 @@
+using CAP.Avalonia.ViewModels.PdkOffset;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using System.IO;
+
+namespace UnitTests.PdkOffset;
+
+/// <summary>
+/// Unit and integration tests for the PDK Component Offset Editor ViewModel.
+/// Verifies component loading, status badges, offset editing, pin deltas, and save-back.
+/// </summary>
+public class PdkOffsetEditorViewModelTests
+{
+    private static PdkDraft BuildTestPdk(string pdkName = "Test PDK") => new()
+    {
+        Name = pdkName,
+        Components = new List<PdkComponentDraft>
+        {
+            new()
+            {
+                Name = "Coupler",
+                Category = "Couplers",
+                NazcaFunction = "pdk.coupler",
+                WidthMicrometers = 40,
+                HeightMicrometers = 20,
+                NazcaOriginOffsetX = 5.0,
+                NazcaOriginOffsetY = 10.0,
+                Pins = new List<PhysicalPinDraft>
+                {
+                    new() { Name = "a0", OffsetXMicrometers = 0, OffsetYMicrometers = 5 },
+                    new() { Name = "b0", OffsetXMicrometers = 40, OffsetYMicrometers = 5 }
+                }
+            },
+            new()
+            {
+                Name = "Waveguide",
+                Category = "Waveguides",
+                NazcaFunction = "pdk.waveguide",
+                WidthMicrometers = 100,
+                HeightMicrometers = 5,
+                NazcaOriginOffsetX = null,   // Missing!
+                NazcaOriginOffsetY = null,
+                Pins = new List<PhysicalPinDraft>
+                {
+                    new() { Name = "a0", OffsetXMicrometers = 0, OffsetYMicrometers = 2.5 },
+                    new() { Name = "b0", OffsetXMicrometers = 100, OffsetYMicrometers = 2.5 }
+                }
+            },
+            new()
+            {
+                Name = "Splitter",
+                Category = "Splitters",
+                NazcaFunction = "pdk.splitter",
+                WidthMicrometers = 30,
+                HeightMicrometers = 15,
+                NazcaOriginOffsetX = 0.0,   // Zero offset
+                NazcaOriginOffsetY = 0.0,
+                Pins = new List<PhysicalPinDraft>
+                {
+                    new() { Name = "a0", OffsetXMicrometers = 0, OffsetYMicrometers = 7.5 }
+                }
+            }
+        }
+    };
+
+    // ─── PdkComponentOffsetItemViewModel ───────────────────────────────────────
+
+    [Fact]
+    public void OffsetItem_WhenOffsetNull_HasMissingStatus()
+    {
+        var draft = BuildTestPdk().Components[1]; // Waveguide — null offsets
+        var vm = new PdkComponentOffsetItemViewModel(draft, "Test PDK");
+
+        vm.Status.ShouldBe(OffsetStatus.Missing);
+        vm.StatusBadge.ShouldBe("❌");
+    }
+
+    [Fact]
+    public void OffsetItem_WhenBothOffsetsZero_HasZeroOffsetStatus()
+    {
+        var draft = BuildTestPdk().Components[2]; // Splitter — zero offsets
+        var vm = new PdkComponentOffsetItemViewModel(draft, "Test PDK");
+
+        vm.Status.ShouldBe(OffsetStatus.ZeroOffset);
+        vm.StatusBadge.ShouldBe("⚠️");
+    }
+
+    [Fact]
+    public void OffsetItem_WhenOffsetNonZero_HasSetStatus()
+    {
+        var draft = BuildTestPdk().Components[0]; // Coupler — 5/10
+        var vm = new PdkComponentOffsetItemViewModel(draft, "Test PDK");
+
+        vm.Status.ShouldBe(OffsetStatus.Set);
+        vm.StatusBadge.ShouldBe("✅");
+    }
+
+    [Fact]
+    public void OffsetItem_RefreshStatus_UpdatesAfterDraftChange()
+    {
+        var draft = BuildTestPdk().Components[1]; // starts Missing
+        var vm = new PdkComponentOffsetItemViewModel(draft, "Test PDK");
+        vm.Status.ShouldBe(OffsetStatus.Missing);
+
+        draft.NazcaOriginOffsetX = 3.5;
+        draft.NazcaOriginOffsetY = 7.0;
+        vm.RefreshStatus();
+
+        vm.Status.ShouldBe(OffsetStatus.Set);
+    }
+
+    // ─── PinPositionViewModel ──────────────────────────────────────────────────
+
+    [Fact]
+    public void PinPosition_NazcaRelX_IsLocalXMinusOffsetX()
+    {
+        var pin = new PinPositionViewModel("a0", localX: 0, localY: 5, componentHeight: 20,
+                                           nazcaOffsetX: 5, nazcaOffsetY: 10);
+
+        pin.NazcaRelX.ShouldBe(-5.0);  // 0 - 5
+    }
+
+    [Fact]
+    public void PinPosition_NazcaRelY_UsesFlippedYMinusOffsetY()
+    {
+        // NazcaRelY = (height - localY) - offsetY
+        var pin = new PinPositionViewModel("a0", localX: 0, localY: 5, componentHeight: 20,
+                                           nazcaOffsetX: 5, nazcaOffsetY: 10);
+
+        pin.NazcaRelY.ShouldBe(5.0);   // (20 - 5) - 10 = 5
+    }
+
+    [Fact]
+    public void PinPosition_WhenZeroOffset_NazcaRelXEqualsLocalX()
+    {
+        var pin = new PinPositionViewModel("a0", localX: 15.0, localY: 5, componentHeight: 20,
+                                           nazcaOffsetX: 0, nazcaOffsetY: 0);
+
+        pin.NazcaRelX.ShouldBe(15.0);
+    }
+
+    // ─── PdkOffsetEditorViewModel ──────────────────────────────────────────────
+
+    private static PdkOffsetEditorViewModel CreateViewModel()
+    {
+        return new PdkOffsetEditorViewModel(new PdkLoader(), new PdkJsonSaver());
+    }
+
+    [Fact]
+    public void ViewModel_InitialState_HasEmptyComponentsAndReadyStatus()
+    {
+        var vm = CreateViewModel();
+
+        vm.Components.ShouldBeEmpty();
+        vm.SelectedComponent.ShouldBeNull();
+        vm.PinPositions.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ViewModel_SelectComponent_PopulatesPinPositions()
+    {
+        var vm = CreateViewModel();
+        var pdk = BuildTestPdk();
+        // Simulate what LoadPdkFile does
+        foreach (var comp in pdk.Components)
+            vm.Components.Add(new PdkComponentOffsetItemViewModel(comp, pdk.Name));
+
+        vm.SelectedComponent = vm.Components[0]; // Coupler with 2 pins
+
+        vm.PinPositions.Count.ShouldBe(2);
+        vm.PinPositions[0].PinName.ShouldBe("a0");
+        vm.PinPositions[1].PinName.ShouldBe("b0");
+    }
+
+    [Fact]
+    public void ViewModel_ApplyOffset_UpdatesDraftAndRefreshesPins()
+    {
+        var vm = CreateViewModel();
+        var pdk = BuildTestPdk();
+        foreach (var comp in pdk.Components)
+            vm.Components.Add(new PdkComponentOffsetItemViewModel(comp, pdk.Name));
+
+        vm.SelectedComponent = vm.Components[1]; // Waveguide — was missing
+
+        vm.OffsetX = 2.0;
+        vm.OffsetY = 4.0;
+        vm.ApplyOffsetCommand.Execute(null);
+
+        vm.SelectedComponent.Draft.NazcaOriginOffsetX.ShouldBe(2.0);
+        vm.SelectedComponent.Draft.NazcaOriginOffsetY.ShouldBe(4.0);
+        vm.SelectedComponent.Status.ShouldBe(OffsetStatus.Set);
+        vm.HasUnsavedChanges.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ViewModel_ApplyOffset_RefreshesPinNazcaCoordinates()
+    {
+        var vm = CreateViewModel();
+        var pdk = BuildTestPdk();
+        foreach (var comp in pdk.Components)
+            vm.Components.Add(new PdkComponentOffsetItemViewModel(comp, pdk.Name));
+
+        vm.SelectedComponent = vm.Components[0]; // Coupler: offset (5, 10), height 20
+        vm.OffsetX = 0.0;
+        vm.OffsetY = 0.0;
+        vm.ApplyOffsetCommand.Execute(null);
+
+        // Pin a0: localX=0, localY=5, height=20, offset=(0,0)
+        // NazcaRelX = 0 - 0 = 0
+        // NazcaRelY = (20 - 5) - 0 = 15
+        vm.PinPositions[0].NazcaRelX.ShouldBe(0.0);
+        vm.PinPositions[0].NazcaRelY.ShouldBe(15.0);
+    }
+
+    [Fact]
+    public void ViewModel_SavePdk_WritesJsonAndClearsUnsavedChanges()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            // Write a minimal valid PDK JSON that PdkLoader can read
+            var pdk = BuildTestPdk();
+            new PdkJsonSaver().SaveToFile(pdk, tempFile);
+
+            var vm = CreateViewModel();
+            // Manually simulate loaded state
+            foreach (var comp in pdk.Components)
+                vm.Components.Add(new PdkComponentOffsetItemViewModel(comp, pdk.Name));
+            // Use reflection to set private fields for save path
+            SetPrivateField(vm, "_loadedPdk", pdk);
+            SetPrivateField(vm, "_loadedFilePath", tempFile);
+
+            vm.SelectedComponent = vm.Components[1];
+            vm.OffsetX = 3.0;
+            vm.OffsetY = 6.0;
+            vm.ApplyOffsetCommand.Execute(null);
+
+            vm.SavePdkCommand.Execute(null);
+
+            vm.HasUnsavedChanges.ShouldBeFalse();
+            vm.StatusText.ShouldContain(Path.GetFileName(tempFile));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    // ─── PdkJsonSaver ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PdkJsonSaver_SaveAndReload_PreservesOffsets()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var pdk = BuildTestPdk();
+            pdk.Components[0].NazcaOriginOffsetX = 7.5;
+            pdk.Components[0].NazcaOriginOffsetY = 3.25;
+
+            var saver = new PdkJsonSaver();
+            saver.SaveToFile(pdk, tempFile);
+
+            var loader = new PdkLoader();
+            // PdkLoader.LoadFromFile validates — we need a valid file;
+            // skip the validator by reading raw JSON
+            var json = File.ReadAllText(tempFile);
+            json.ShouldContain("7.5");
+            json.ShouldContain("3.25");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void PdkJsonSaver_UpdateComponentOffset_ReturnsFalseForUnknownComponent()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var pdk = BuildTestPdk();
+            new PdkJsonSaver().SaveToFile(pdk, tempFile);
+
+            var result = new PdkJsonSaver().UpdateComponentOffset(pdk, "NonExistent", 1, 2, tempFile);
+
+            result.ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+
+    private static void SetPrivateField(object obj, string fieldName, object? value)
+    {
+        var field = obj.GetType().GetField(fieldName,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        field?.SetValue(obj, value);
+    }
+}

--- a/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
@@ -179,6 +179,20 @@ public class PdkOffsetEditorViewModelTests
         pin.NazcaRelX.ShouldBe(15.0);
     }
 
+    [Fact]
+    public void PinPosition_WithNegativeOffsetAndPinAtOrigin_ComputesCorrectly()
+    {
+        // Covers the negative-offset arithmetic path that the positive-only
+        // tests above skip. Pin at (0, 0), 10 µm-tall component, offset (-3, -4):
+        //   NazcaRelX = 0 - (-3) = 3
+        //   NazcaRelY = (10 - 0) - (-4) = 14
+        var pin = new PinPositionViewModel("a0", localX: 0, localY: 0, componentHeight: 10,
+                                           nazcaOffsetX: -3, nazcaOffsetY: -4);
+
+        pin.NazcaRelX.ShouldBe(3.0);
+        pin.NazcaRelY.ShouldBe(14.0);
+    }
+
     // ─── PdkOffsetEditorViewModel ──────────────────────────────────────────────
 
     private static PdkOffsetEditorViewModel CreateViewModel()


### PR DESCRIPTION
Automated implementation for #486

All done. Here's a summary of what was implemented for issue #486:

---

## Implementation Summary

**Feature: PDK Component Offset Editor** — a dedicated window for calibrating `NazcaOriginOffset` per component.

### New Files

| File | Purpose |
|------|---------|
| `CAP-DataAccess/.../PdkJsonSaver.cs` | Serializes `PdkDraft` back to JSON; `UpdateComponentOffset()` for targeted edits |
| `CAP.Avalonia/ViewModels/PdkOffset/PdkComponentOffsetItemViewModel.cs` | Per-component list item with `OffsetStatus` enum (❌ Missing / ⚠️ ZeroOffset / ✅ Set) and `RefreshStatus()` |
| `CAP.Avalonia/ViewModels/PdkOffset/PinPositionViewModel.cs` | Pin local coords + Nazca-relative coords (with Y-flip applied) |
| `CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs` | Main ViewModel: load PDK, edit offset, live-update pins/canvas markers, save to JSON |
| `CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml` | Window: left component list + right panel (offset X/Y editor, canvas overlay, pin delta table, save button) |
| `CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml.cs` | Canvas rendering: component bounding box (blue), pin dots (cyan), Nazca origin crosshair (orange) |
| `UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs` | 14 tests covering status badges, pin coordinate math, offset apply/save, JSON round-trip |

### Modified Files

- **`MainViewModel.cs`** — added `PdkOffsetEditor` property, `ShowPdkOffsetEditorRequested` action, `OpenPdkOffsetEditorCommand`
- **`App.axaml.cs`** — registered `PdkJsonSaver` and `PdkOffsetEditorViewModel` in DI
- **`MainWindow.axaml`** — added `📐 Offset Editor` button in the PDK toolbar section
- **`MainWindow.axaml.cs`** — wires `ShowPdkOffsetEditorRequested` to open the window
- **`UnitTests/Helpers/MainViewModelTestHelper.cs`** — passes `PdkOffsetEditorViewModel` to the updated constructor

### Acceptance Criteria Status

- ✅ Reachable via top-level toolbar button ("📐 Offset Editor")
- ✅ Displays all PDK components with ❌/⚠️/✅ status badges
- ✅ Visual overlay: component bounding box + pin dots + Nazca origin crosshair (live-updates on offset change)
- ✅ Numeric X/Y edit → Apply → updates draft + pin delta table
- ✅ Save writes corrected offsets back to the PDK JSON file
- ✅ After Apply+Save, pin positions reflect new Nazca-relative coordinates
- ✅ All 14 new tests pass; pre-existing `SiepicPdkTests` failure is unchanged


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 6,728,814
- **Estimated cost:** $3.7681 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*