### PR TITLE
Agent: Extract settings from right panel into dedicated Settings window (registry pattern)

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -15,6 +15,7 @@ using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.ViewModels.PdkOffset;
+using CAP.Avalonia.ViewModels.Settings;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP.Avalonia.Views;
 using CAP.Avalonia.Services.AiTools;
@@ -53,7 +54,7 @@ public partial class App : Application
         services.AddSingleton(sp => new UpdateDownloader(
             sp.GetRequiredService<HttpClient>()));
         services.AddSingleton<IUrlLauncher, SystemUrlLauncher>();
-        services.AddTransient<UpdateViewModel>();
+        services.AddSingleton<UpdateViewModel>();
 
         // Register AI assistant services
         services.AddSingleton<IAiService, AiService>(sp => new AiService(sp.GetRequiredService<HttpClient>()));
@@ -78,10 +79,22 @@ public partial class App : Application
         services.AddTransient<IAiTool, FitToViewTool>();
         services.AddSingleton<IAiToolRegistry, AiToolRegistry>();
 
-        services.AddTransient<AiAssistantViewModel>(sp => new AiAssistantViewModel(
+        services.AddSingleton<AiAssistantViewModel>(sp => new AiAssistantViewModel(
             sp.GetRequiredService<IAiService>(),
             sp.GetRequiredService<UserPreferencesService>(),
             sp.GetRequiredService<IAiToolRegistry>()));
+
+        // Register GdsExportViewModel as singleton so both FileOperations and PythonEnvironmentSettingsPage share the same instance
+        services.AddSingleton<GdsExportViewModel>(sp =>
+        {
+            var vm = new GdsExportViewModel(
+                sp.GetRequiredService<GdsExportService>(),
+                sp.GetRequiredService<CAP_Core.ErrorConsoleService>());
+            var prefs = sp.GetRequiredService<UserPreferencesService>();
+            vm.Initialize(prefs.GetCustomPythonPath());
+            vm.OnPythonPathChanged = path => prefs.SetCustomPythonPath(path);
+            return vm;
+        });
 
         // Register core services
         services.AddSingleton<IDataAccessor, FileDataAccessor>();
@@ -130,6 +143,15 @@ public partial class App : Application
         services.AddTransient<WaveguideLengthViewModel>();
         services.AddTransient<ElementLockViewModel>();
         services.AddTransient<ErrorConsoleViewModel>();
+
+        // Register settings pages — each implements ISettingsPage; SettingsWindowViewModel enumerates them all.
+        // To add a new settings page: add one line here + create the page class. Nothing else changes.
+        services.AddTransient<ISettingsPage, GeneralSettingsPage>();
+        services.AddTransient<ISettingsPage, GridSnapSettingsPage>();
+        services.AddTransient<ISettingsPage, UpdateSettingsPage>();
+        services.AddTransient<ISettingsPage, PythonEnvironmentSettingsPage>();
+        services.AddTransient<ISettingsPage, AiAssistantSettingsPage>();
+        services.AddTransient<SettingsWindowViewModel>();
 
         // Register panel ViewModels as singletons
         services.AddSingleton<LeftPanelViewModel>();

--- a/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
@@ -85,7 +85,10 @@ public partial class GdsExportViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Checks the Python/Nazca environment and updates status.
+    /// Checks the Python/Nazca environment and updates status. Exceptions
+    /// are surfaced on the status strings and logged to the ErrorConsole —
+    /// this method is also invoked fire-and-forget from MainViewModel wiring,
+    /// where an unobserved task exception would crash silently.
     /// </summary>
     [RelayCommand]
     public async Task CheckEnvironmentAsync()
@@ -123,6 +126,15 @@ public partial class GdsExportViewModel : ObservableObject
                 NazcaStatus = "N/A (Python not found)";
             }
 
+            OnPropertyChanged(nameof(IsEnvironmentReady));
+        }
+        catch (Exception ex)
+        {
+            PythonAvailable = false;
+            NazcaAvailable = false;
+            PythonStatus = $"✗ Check failed: {ex.Message}";
+            NazcaStatus = "✗ Check failed";
+            _errorConsole?.LogError($"Python environment check failed: {ex.Message}", ex);
             OnPropertyChanged(nameof(IsEnvironmentReady));
         }
         finally

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -13,6 +13,7 @@ using CAP.Avalonia.ViewModels.Simulation;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Update;
 using CAP_Core.Export;
 using CAP.Avalonia.ViewModels.PdkOffset;
 using CAP_DataAccess.Persistence.PIR;
@@ -65,6 +66,16 @@ public partial class MainViewModel : ObservableObject
     /// </summary>
     public BottomPanelViewModel BottomPanel { get; }
 
+    /// <summary>
+    /// ViewModel for software update checking. Shared with the Settings window.
+    /// The update banner in the main window binds to this property.
+    /// </summary>
+    public UpdateViewModel Update { get; }
+
+    /// <summary>
+    /// Delegate wired by <see cref="CAP.Avalonia.Views.MainWindow"/> to open the Settings window.
+    /// </summary>
+    public Func<Task>? ShowSettingsWindowAsync { get; set; }
 
     /// <summary>
     /// Available wavelength options for the laser configuration dropdown.
@@ -99,8 +110,9 @@ public partial class MainViewModel : ObservableObject
         UserPreferencesService preferencesService,
         Services.GroupPreviewGenerator previewGenerator,
         Services.IInputDialogService inputDialogService,
-        CAP_Core.Export.GdsExportService gdsExportService,
         ErrorConsoleService errorConsoleService,
+        GdsExportViewModel gdsExportViewModel,
+        UpdateViewModel updateViewModel,
         LeftPanelViewModel leftPanel,
         RightPanelViewModel rightPanel,
         BottomPanelViewModel bottomPanel,
@@ -112,6 +124,7 @@ public partial class MainViewModel : ObservableObject
         _canvas = canvas;
         PdkOffsetEditor = pdkOffsetEditor;
         _canvas.SimulationRequested = async () => await ExecuteSimulation();
+        Update = updateViewModel;
 
         // Wire panel ViewModels (injected via DI)
         LeftPanel = leftPanel;
@@ -119,14 +132,11 @@ public partial class MainViewModel : ObservableObject
         BottomPanel = bottomPanel;
 
         CanvasInteraction = new CanvasInteractionViewModel(_canvas, commandManager, LeftPanel.ComponentLibrary, previewGenerator, inputDialogService);
-        var gdsExportVm = new ViewModels.Export.GdsExportViewModel(gdsExportService, errorConsoleService);
-        gdsExportVm.Initialize(preferencesService.GetCustomPythonPath());
-        gdsExportVm.OnPythonPathChanged = path => preferencesService.SetCustomPythonPath(path);
 
         var photonTorchVm = new ViewModels.Export.PhotonTorchExportViewModel(
             new CAP_Core.Export.PhotonTorchExporter(), _canvas);
 
-        FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, picWaveExporter, LeftPanel.AllTemplates, gdsExportVm, photonTorchVm, errorConsoleService);
+        FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, picWaveExporter, LeftPanel.AllTemplates, gdsExportViewModel, photonTorchVm, errorConsoleService);
         ViewportControl = viewportControl;
 
         // Wire up status callbacks
@@ -261,7 +271,7 @@ public partial class MainViewModel : ObservableObject
     private async Task TriggerStartupUpdateCheckAsync()
     {
         await Task.Delay(2000);
-        await RightPanel.Update.CheckForUpdatesOnStartupAsync();
+        await Update.CheckForUpdatesOnStartupAsync();
     }
 
     private void WireCommandManager()
@@ -431,6 +441,17 @@ public partial class MainViewModel : ObservableObject
         {
             StatusText = $"Could not open browser: {ex.Message}";
         }
+    }
+
+    /// <summary>
+    /// Opens the application Settings window.
+    /// The actual window creation is wired by <see cref="CAP.Avalonia.Views.MainWindow"/>.
+    /// </summary>
+    [RelayCommand]
+    private async Task OpenSettingsWindow()
+    {
+        if (ShowSettingsWindowAsync != null)
+            await ShowSettingsWindowAsync();
     }
 
     [RelayCommand(CanExecute = nameof(CanUndo))]

--- a/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
@@ -5,7 +5,6 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Converters;
 using CAP.Avalonia.ViewModels.Export;
-using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.Services;
 
@@ -97,11 +96,6 @@ public partial class RightPanelViewModel : ObservableObject
     public PdkConsistencyViewModel PdkConsistency { get; }
 
     /// <summary>
-    /// ViewModel for the software update panel (check for updates, download, install).
-    /// </summary>
-    public UpdateViewModel Update { get; }
-
-    /// <summary>
     /// ViewModel for the in-app AI Design Assistant chat panel.
     /// </summary>
     public AiAssistantViewModel AiAssistant { get; }
@@ -126,7 +120,6 @@ public partial class RightPanelViewModel : ObservableObject
         GroupSMatrixViewModel groupSMatrix,
         ArchitectureReportViewModel architectureReport,
         PdkConsistencyViewModel pdkConsistency,
-        UpdateViewModel update,
         AiAssistantViewModel aiAssistant,
         VerilogAExportViewModel verilogAExport)
     {
@@ -143,7 +136,6 @@ public partial class RightPanelViewModel : ObservableObject
         GroupSMatrix = groupSMatrix;
         ArchitectureReport = architectureReport;
         PdkConsistency = pdkConsistency;
-        Update = update;
         AiAssistant = aiAssistant;
         VerilogAExport = verilogAExport;
 

--- a/CAP.Avalonia/ViewModels/Settings/AiAssistantSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/AiAssistantSettingsPage.cs
@@ -1,0 +1,31 @@
+using CAP.Avalonia.ViewModels.AI;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Settings page for AI Design Assistant configuration (API key and model selection).
+/// Shares the singleton <see cref="AiAssistantViewModel"/> so the key entered here
+/// is immediately available to the chat panel in the right sidebar.
+/// </summary>
+public class AiAssistantSettingsPage : ISettingsPage
+{
+    /// <inheritdoc/>
+    public string Title => "AI Assistant";
+
+    /// <inheritdoc/>
+    public string Icon => "🤖";
+
+    /// <inheritdoc/>
+    public string? Category => null;
+
+    /// <inheritdoc/>
+    public object ViewModel { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="AiAssistantSettingsPage"/>.
+    /// </summary>
+    public AiAssistantSettingsPage(AiAssistantViewModel aiAssistantViewModel)
+    {
+        ViewModel = aiAssistantViewModel;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/GeneralSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GeneralSettingsPage.cs
@@ -1,10 +1,8 @@
-using CAP.Avalonia.Services;
-
 namespace CAP.Avalonia.ViewModels.Settings;
 
 /// <summary>
-/// Settings page for general application preferences backed by
-/// <see cref="UserPreferencesService"/> that do not belong to a dedicated category.
+/// Settings page for general application preferences that do not belong to a
+/// dedicated category. Acts as an anchor point for future general preferences.
 /// </summary>
 public class GeneralSettingsPage : ISettingsPage
 {
@@ -18,13 +16,5 @@ public class GeneralSettingsPage : ISettingsPage
     public string? Category => null;
 
     /// <inheritdoc/>
-    public object ViewModel { get; }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="GeneralSettingsPage"/>.
-    /// </summary>
-    public GeneralSettingsPage(UserPreferencesService preferences)
-    {
-        ViewModel = new GeneralSettingsViewModel(preferences);
-    }
+    public object ViewModel { get; } = new GeneralSettingsViewModel();
 }

--- a/CAP.Avalonia/ViewModels/Settings/GeneralSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GeneralSettingsPage.cs
@@ -1,0 +1,30 @@
+using CAP.Avalonia.Services;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Settings page for general application preferences backed by
+/// <see cref="UserPreferencesService"/> that do not belong to a dedicated category.
+/// </summary>
+public class GeneralSettingsPage : ISettingsPage
+{
+    /// <inheritdoc/>
+    public string Title => "General";
+
+    /// <inheritdoc/>
+    public string Icon => "⚙";
+
+    /// <inheritdoc/>
+    public string? Category => null;
+
+    /// <inheritdoc/>
+    public object ViewModel { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="GeneralSettingsPage"/>.
+    /// </summary>
+    public GeneralSettingsPage(UserPreferencesService preferences)
+    {
+        ViewModel = new GeneralSettingsViewModel(preferences);
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/GeneralSettingsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GeneralSettingsViewModel.cs
@@ -1,0 +1,40 @@
+using CAP.Avalonia.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// ViewModel for general application preferences backed by
+/// <see cref="UserPreferencesService"/>.
+/// Currently exposes the custom Python path as a convenience;
+/// additional preferences can be surfaced here without new pages.
+/// </summary>
+public partial class GeneralSettingsViewModel : ObservableObject
+{
+    private readonly UserPreferencesService _preferences;
+
+    [ObservableProperty]
+    private string _customPythonPath;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="GeneralSettingsViewModel"/>.
+    /// </summary>
+    public GeneralSettingsViewModel(UserPreferencesService preferences)
+    {
+        _preferences = preferences;
+        _customPythonPath = preferences.GetCustomPythonPath() ?? string.Empty;
+    }
+
+    partial void OnCustomPythonPathChanged(string value)
+    {
+        _preferences.SetCustomPythonPath(string.IsNullOrWhiteSpace(value) ? null : value);
+    }
+
+    /// <summary>Clears the stored custom Python path so auto-detection is used.</summary>
+    [RelayCommand]
+    private void ClearPythonPath()
+    {
+        CustomPythonPath = string.Empty;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/GeneralSettingsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GeneralSettingsViewModel.cs
@@ -1,40 +1,14 @@
-using CAP.Avalonia.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
 
 namespace CAP.Avalonia.ViewModels.Settings;
 
 /// <summary>
-/// ViewModel for general application preferences backed by
-/// <see cref="UserPreferencesService"/>.
-/// Currently exposes the custom Python path as a convenience;
-/// additional preferences can be surfaced here without new pages.
+/// ViewModel for general application preferences that do not belong to a
+/// dedicated category. Currently a placeholder — the custom Python path lives
+/// on the dedicated Python Environment page to avoid a dual-write / desync
+/// hazard with <see cref="Export.GdsExportViewModel"/>. Additional general
+/// preferences can be surfaced here as they come up.
 /// </summary>
 public partial class GeneralSettingsViewModel : ObservableObject
 {
-    private readonly UserPreferencesService _preferences;
-
-    [ObservableProperty]
-    private string _customPythonPath;
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="GeneralSettingsViewModel"/>.
-    /// </summary>
-    public GeneralSettingsViewModel(UserPreferencesService preferences)
-    {
-        _preferences = preferences;
-        _customPythonPath = preferences.GetCustomPythonPath() ?? string.Empty;
-    }
-
-    partial void OnCustomPythonPathChanged(string value)
-    {
-        _preferences.SetCustomPythonPath(string.IsNullOrWhiteSpace(value) ? null : value);
-    }
-
-    /// <summary>Clears the stored custom Python path so auto-detection is used.</summary>
-    [RelayCommand]
-    private void ClearPythonPath()
-    {
-        CustomPythonPath = string.Empty;
-    }
 }

--- a/CAP.Avalonia/ViewModels/Settings/GridSnapSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GridSnapSettingsPage.cs
@@ -10,7 +10,7 @@ namespace CAP.Avalonia.ViewModels.Settings;
 public class GridSnapSettingsPage : ISettingsPage
 {
     /// <inheritdoc/>
-    public string Title => "Grid &amp; Alignment";
+    public string Title => "Grid & Alignment";
 
     /// <inheritdoc/>
     public string Icon => "⊞";

--- a/CAP.Avalonia/ViewModels/Settings/GridSnapSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GridSnapSettingsPage.cs
@@ -1,0 +1,31 @@
+using CAP.Avalonia.ViewModels.Canvas;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Settings page for grid-snapping and pin-alignment guide preferences.
+/// Wraps the canvas-owned <see cref="GridSnapSettings"/> and
+/// <see cref="AlignmentGuideViewModel"/> so changes are live.
+/// </summary>
+public class GridSnapSettingsPage : ISettingsPage
+{
+    /// <inheritdoc/>
+    public string Title => "Grid &amp; Alignment";
+
+    /// <inheritdoc/>
+    public string Icon => "⊞";
+
+    /// <inheritdoc/>
+    public string? Category => "Canvas";
+
+    /// <inheritdoc/>
+    public object ViewModel { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="GridSnapSettingsPage"/>.
+    /// </summary>
+    public GridSnapSettingsPage(DesignCanvasViewModel canvas)
+    {
+        ViewModel = new GridSnapSettingsViewModel(canvas.GridSnap, canvas.AlignmentGuide);
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/GridSnapSettingsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GridSnapSettingsViewModel.cs
@@ -1,0 +1,27 @@
+using CAP.Avalonia.ViewModels.Canvas;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// ViewModel for the Grid Snap settings page.
+/// Wraps the existing <see cref="GridSnapSettings"/> and
+/// <see cref="AlignmentGuideViewModel"/> instances from the canvas,
+/// so changes take effect immediately on the canvas without copying state.
+/// </summary>
+public class GridSnapSettingsViewModel
+{
+    /// <summary>Grid-snapping settings (enabled state and snap size).</summary>
+    public GridSnapSettings GridSnap { get; }
+
+    /// <summary>Pin-alignment guide settings (show guides, snap-to-align).</summary>
+    public AlignmentGuideViewModel AlignmentGuide { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="GridSnapSettingsViewModel"/>.
+    /// </summary>
+    public GridSnapSettingsViewModel(GridSnapSettings gridSnap, AlignmentGuideViewModel alignmentGuide)
+    {
+        GridSnap = gridSnap;
+        AlignmentGuide = alignmentGuide;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/ISettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/ISettingsPage.cs
@@ -1,0 +1,22 @@
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Contract for a settings page in the Settings window.
+/// Implement this interface to add a new settings category without modifying
+/// <see cref="SettingsWindowViewModel"/>. Register via DI as
+/// <c>services.AddTransient&lt;ISettingsPage, MyPage&gt;()</c>.
+/// </summary>
+public interface ISettingsPage
+{
+    /// <summary>Display name shown in the navigation list.</summary>
+    string Title { get; }
+
+    /// <summary>Emoji or icon character displayed next to the title.</summary>
+    string Icon { get; }
+
+    /// <summary>Optional category header for grouping pages (e.g. "Canvas", "Export").</summary>
+    string? Category { get; }
+
+    /// <summary>The ViewModel rendered inside the content area when this page is selected.</summary>
+    object ViewModel { get; }
+}

--- a/CAP.Avalonia/ViewModels/Settings/PythonEnvironmentSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/PythonEnvironmentSettingsPage.cs
@@ -1,0 +1,31 @@
+using CAP.Avalonia.ViewModels.Export;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Settings page for Python interpreter discovery and environment validation.
+/// Reuses the existing <see cref="GdsExportViewModel"/> which owns the Python-path
+/// property and Nazca availability check — changes apply immediately to GDS export.
+/// </summary>
+public class PythonEnvironmentSettingsPage : ISettingsPage
+{
+    /// <inheritdoc/>
+    public string Title => "Python Environment";
+
+    /// <inheritdoc/>
+    public string Icon => "🐍";
+
+    /// <inheritdoc/>
+    public string? Category => "Export";
+
+    /// <inheritdoc/>
+    public object ViewModel { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PythonEnvironmentSettingsPage"/>.
+    /// </summary>
+    public PythonEnvironmentSettingsPage(GdsExportViewModel gdsExportViewModel)
+    {
+        ViewModel = gdsExportViewModel;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// ViewModel for the application Settings window.
+/// Enumerates all registered <see cref="ISettingsPage"/> implementations
+/// and tracks which page is currently selected.
+/// Adding a new settings page requires only a new class + one DI registration.
+/// </summary>
+public partial class SettingsWindowViewModel : ObservableObject
+{
+    /// <summary>All settings pages, ordered as registered in DI.</summary>
+    public IReadOnlyList<ISettingsPage> Pages { get; }
+
+    /// <summary>The currently selected settings page.</summary>
+    [ObservableProperty]
+    private ISettingsPage? _selectedPage;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="SettingsWindowViewModel"/>.
+    /// </summary>
+    /// <param name="pages">All registered settings page implementations (injected by DI).</param>
+    public SettingsWindowViewModel(IEnumerable<ISettingsPage> pages)
+    {
+        Pages = pages.ToList();
+        SelectedPage = Pages.FirstOrDefault();
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/UpdateSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/UpdateSettingsPage.cs
@@ -1,0 +1,31 @@
+using CAP.Avalonia.ViewModels.Update;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Settings page for software update configuration.
+/// Delegates to the shared <see cref="UpdateViewModel"/> so
+/// startup-check state is shared with the main-window update banner.
+/// </summary>
+public class UpdateSettingsPage : ISettingsPage
+{
+    /// <inheritdoc/>
+    public string Title => "Software Updates";
+
+    /// <inheritdoc/>
+    public string Icon => "🔄";
+
+    /// <inheritdoc/>
+    public string? Category => null;
+
+    /// <inheritdoc/>
+    public object ViewModel { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="UpdateSettingsPage"/>.
+    /// </summary>
+    public UpdateSettingsPage(UpdateViewModel updateViewModel)
+    {
+        ViewModel = updateViewModel;
+    }
+}

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -114,6 +114,14 @@
                 <!-- Simulation -->
                 <Button Content="[L] Simulate" Command="{Binding RunSimulationCommand}"
                         Width="90" Margin="2" Background="#3d5d3d" ToolTip.Tip="Run light simulation (L). Press P to toggle power overlay. Overlay auto-updates on circuit changes."/>
+
+                <Separator Width="1" Background="Gray" Margin="10,5"/>
+
+                <!-- Settings -->
+                <Button Command="{Binding OpenSettingsWindowCommand}"
+                        Width="36" Margin="2" Background="#3d3d3d" ToolTip.Tip="Open Settings (grid snap, updates, Python environment, AI key)">
+                    <TextBlock Text="⚙" FontSize="16" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                </Button>
             </StackPanel>
         </ScrollViewer>
 
@@ -703,78 +711,6 @@
                                Foreground="LightGreen" FontSize="10" Margin="0,0,0,5"
                                IsVisible="{Binding BottomPanel.ElementLock.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
-                    <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
-
-                    <TextBlock Text="Grid Snap [G Key]:" Foreground="Gray" Margin="0,0,0,5"/>
-                    <CheckBox Content="Enable Grid Snapping"
-                              IsChecked="{Binding Canvas.GridSnap.IsEnabled}"
-                              Foreground="White" Margin="0,0,0,10"/>
-                    <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                        <TextBlock Text="Grid Size: " Foreground="Gray" VerticalAlignment="Center" Width="70"/>
-                        <NumericUpDown Value="{Binding Canvas.GridSnap.GridSizeMicrometers}"
-                                       Minimum="1" Maximum="1000" Increment="10"
-                                       Width="120" Margin="5,0,5,0"
-                                       FormatString="F0"/>
-                        <TextBlock Text="µm" Foreground="Gray" VerticalAlignment="Center"/>
-                    </StackPanel>
-
-                    <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
-
-                    <TextBlock Text="Alignment Guides:" Foreground="Cyan" Margin="0,0,0,5" FontWeight="SemiBold"/>
-                    <CheckBox Content="Show Pin Alignment"
-                              IsChecked="{Binding Canvas.AlignmentGuide.IsEnabled}"
-                              Foreground="White" Margin="0,0,0,5"/>
-                    <TextBlock Text="Shows cyan guide lines when pins align on same X or Y axis during dragging."
-                               Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="0,0,0,10"/>
-
-                    <!-- Check for Updates -->
-                    <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
-                    <TextBlock Text="Software Updates:" Foreground="SkyBlue" Margin="0,0,0,5" FontWeight="SemiBold"/>
-                    <TextBlock Text="{Binding RightPanel.Update.CurrentVersionText}"
-                               Foreground="Gray" FontSize="10" Margin="0,0,0,8"/>
-
-                    <Button Content="Check for Updates"
-                            Command="{Binding RightPanel.Update.CheckForUpdatesCommand}"
-                            Width="150" Margin="0,0,0,5" Background="#3d4d5d"
-                            IsEnabled="{Binding RightPanel.Update.IsChecking, Converter={x:Static BoolConverters.Not}}"/>
-
-                    <TextBlock Text="{Binding RightPanel.Update.StatusText}"
-                               Foreground="Gray" FontSize="10" Margin="0,0,0,5" TextWrapping="Wrap"
-                               IsVisible="{Binding RightPanel.Update.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-
-                    <!-- Update available panel -->
-                    <StackPanel IsVisible="{Binding RightPanel.Update.UpdateAvailable}">
-                        <TextBlock Text="{Binding RightPanel.Update.LatestVersionText}"
-                                   Foreground="LightGreen" FontWeight="SemiBold" Margin="0,5,0,5"/>
-
-                        <ScrollViewer MaxHeight="120" Margin="0,0,0,8"
-                                      IsVisible="{Binding RightPanel.Update.ReleaseNotes, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                            <TextBlock Text="{Binding RightPanel.Update.ReleaseNotes}"
-                                       Foreground="#aaaaaa" FontSize="10" TextWrapping="Wrap"/>
-                        </ScrollViewer>
-
-                        <!-- Download progress -->
-                        <ProgressBar Value="{Binding RightPanel.Update.DownloadProgress}"
-                                     Minimum="0" Maximum="1"
-                                     Height="6" Margin="0,0,0,5"
-                                     IsVisible="{Binding RightPanel.Update.IsDownloading}"/>
-
-                        <StackPanel Orientation="Horizontal" Spacing="5">
-                            <Button Content="Download"
-                                    Command="{Binding RightPanel.Update.InstallUpdateCommand}"
-                                    Width="90" Background="#3d5d3d"
-                                    IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
-                            <Button Content="Skip"
-                                    Command="{Binding RightPanel.Update.RemindLaterCommand}"
-                                    Width="55" Background="#3d3d3d"
-                                    IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
-                            <Button Content="Skip Version"
-                                    Command="{Binding RightPanel.Update.SkipThisVersionCommand}"
-                                    Width="95" Background="#5d4330"
-                                    IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
-                        </StackPanel>
-                    </StackPanel>
-
                     <!-- GDS Export Configuration -->
                     <panels:GdsExportPanel/>
 
@@ -792,22 +728,22 @@
             <!-- Update Banner -->
             <Border DockPanel.Dock="Top"
                     Background="#21463A"
-                    IsVisible="{Binding RightPanel.Update.UpdateAvailable}"
+                    IsVisible="{Binding Update.UpdateAvailable}"
                     Padding="14,10"
                     BorderBrush="#3F8F73"
                     BorderThickness="0,0,0,2">
                 <Grid ColumnDefinitions="*,Auto"
                       RowDefinitions="Auto,Auto,Auto">
                     <StackPanel Grid.Row="0" Grid.Column="0" Spacing="2">
-                        <TextBlock Text="{Binding RightPanel.Update.LatestVersionText}"
+                        <TextBlock Text="{Binding Update.LatestVersionText}"
                                    Foreground="White"
                                    FontWeight="Bold"
                                    FontSize="14"/>
-                        <TextBlock Text="{Binding RightPanel.Update.StatusText}"
+                        <TextBlock Text="{Binding Update.StatusText}"
                                    Foreground="#D4F2E6"
                                    FontSize="11"
                                    TextWrapping="Wrap"
-                                   IsVisible="{Binding RightPanel.Update.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                                   IsVisible="{Binding Update.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                     </StackPanel>
 
                     <StackPanel Grid.Row="0" Grid.Column="1"
@@ -815,42 +751,42 @@
                                 Spacing="8"
                                 HorizontalAlignment="Right">
                         <Button Content="Skip Version"
-                                Command="{Binding RightPanel.Update.SkipThisVersionCommand}"
+                                Command="{Binding Update.SkipThisVersionCommand}"
                                 Background="#6A4A32"
                                 Foreground="White"
                                 Padding="14,6"
-                                IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                                IsEnabled="{Binding Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
                         <Button Content="Skip"
-                                Command="{Binding RightPanel.Update.RemindLaterCommand}"
+                                Command="{Binding Update.RemindLaterCommand}"
                                 Background="#355248"
                                 Foreground="White"
                                 Padding="14,6"
-                                IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                                IsEnabled="{Binding Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
                         <Button Content="Download"
-                                Command="{Binding RightPanel.Update.InstallUpdateCommand}"
+                                Command="{Binding Update.InstallUpdateCommand}"
                                 Background="#8FD3A7"
                                 Foreground="#163227"
                                 FontWeight="SemiBold"
                                 Padding="16,6"
-                                IsEnabled="{Binding RightPanel.Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                                IsEnabled="{Binding Update.IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
                     </StackPanel>
 
                     <TextBlock Grid.Row="1" Grid.ColumnSpan="2"
                                Margin="0,8,0,0"
-                               Text="{Binding RightPanel.Update.ReleaseNotes}"
+                               Text="{Binding Update.ReleaseNotes}"
                                Foreground="#C5E8DB"
                                FontSize="11"
                                TextWrapping="Wrap"
                                MaxHeight="72"
-                               IsVisible="{Binding RightPanel.Update.ReleaseNotes, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                               IsVisible="{Binding Update.ReleaseNotes, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
                     <ProgressBar Grid.Row="2" Grid.ColumnSpan="2"
                                  Margin="0,10,0,0"
-                                 Value="{Binding RightPanel.Update.DownloadProgress}"
+                                 Value="{Binding Update.DownloadProgress}"
                                  Minimum="0"
                                  Maximum="1"
                                  Height="6"
-                                 IsVisible="{Binding RightPanel.Update.IsDownloading}"/>
+                                 IsVisible="{Binding Update.IsDownloading}"/>
                 </Grid>
             </Border>
 

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -6,6 +6,8 @@ using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.PdkImport;
 using CAP.Avalonia.Views.PdkImport;
+using CAP.Avalonia.ViewModels.Settings;
+using Microsoft.Extensions.DependencyInjection;
 using System.ComponentModel;
 using System.Linq;
 
@@ -13,6 +15,8 @@ namespace CAP.Avalonia.Views;
 
 public partial class MainWindow : Window
 {
+    private SettingsWindow? _settingsWindow;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -22,6 +26,20 @@ public partial class MainWindow : Window
         {
             if (DataContext is MainViewModel vm)
             {
+                // Wire up Settings window opener
+                vm.ShowSettingsWindowAsync = async () =>
+                {
+                    if (_settingsWindow != null && _settingsWindow.IsVisible)
+                    {
+                        _settingsWindow.Activate();
+                        return;
+                    }
+                    var settingsVm = App.Services.GetRequiredService<SettingsWindowViewModel>();
+                    _settingsWindow = new SettingsWindow { DataContext = settingsVm };
+                    _settingsWindow.Show(this);
+                    await Task.CompletedTask;
+                };
+
                 vm.FileDialogService = new FileDialogService(this);
                 vm.FileOperations.MessageBoxService = new MessageBoxService();
                 vm.RightPanel.Sweep.FileDialogService = vm.FileDialogService;

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -26,17 +26,27 @@ public partial class MainWindow : Window
         {
             if (DataContext is MainViewModel vm)
             {
-                // Wire up Settings window opener
+                // Wire up Settings window opener. Any failure resolving a
+                // page would otherwise crash the UI thread silently (this
+                // lambda is reached from an async-void event handler); we
+                // surface the error on the status bar instead.
                 vm.ShowSettingsWindowAsync = async () =>
                 {
-                    if (_settingsWindow != null && _settingsWindow.IsVisible)
+                    try
                     {
-                        _settingsWindow.Activate();
-                        return;
+                        if (_settingsWindow != null && _settingsWindow.IsVisible)
+                        {
+                            _settingsWindow.Activate();
+                            return;
+                        }
+                        var settingsVm = App.Services.GetRequiredService<SettingsWindowViewModel>();
+                        _settingsWindow = new SettingsWindow { DataContext = settingsVm };
+                        _settingsWindow.Show(this);
                     }
-                    var settingsVm = App.Services.GetRequiredService<SettingsWindowViewModel>();
-                    _settingsWindow = new SettingsWindow { DataContext = settingsVm };
-                    _settingsWindow.Show(this);
+                    catch (System.Exception ex)
+                    {
+                        vm.StatusText = $"Failed to open Settings: {ex.Message}";
+                    }
                     await Task.CompletedTask;
                 };
 

--- a/CAP.Avalonia/Views/SettingsWindow.axaml
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml
@@ -212,29 +212,14 @@
                         </StackPanel>
                     </DataTemplate>
 
-                    <!-- General -->
+                    <!-- General (placeholder — Python path lives on Python Environment) -->
                     <DataTemplate DataType="{x:Type settings:GeneralSettingsViewModel}">
                         <StackPanel Spacing="8">
                             <TextBlock Text="General" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,8"/>
-                            <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,8">
+                            <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap">
                                 General application preferences. Additional settings will appear here
                                 as new features are added.
                             </TextBlock>
-
-                            <TextBlock Text="Custom Python Path:" Foreground="Gray" FontSize="12" Margin="0,8,0,3"/>
-                            <TextBlock Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="0,0,0,4">
-                                Override the Python interpreter used for GDS and export scripts.
-                                Leave blank to rely on auto-detection (preferred).
-                            </TextBlock>
-                            <Grid ColumnDefinitions="*,Auto">
-                                <TextBox Grid.Column="0"
-                                         Text="{Binding CustomPythonPath}"
-                                         Watermark="Auto-detect (recommended)"
-                                         Margin="0,0,6,0"/>
-                                <Button Grid.Column="1" Content="Clear"
-                                        Command="{Binding ClearPythonPathCommand}"
-                                        Padding="8,4"/>
-                            </Grid>
                         </StackPanel>
                     </DataTemplate>
 

--- a/CAP.Avalonia/Views/SettingsWindow.axaml
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml
@@ -1,0 +1,246 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:settings="using:CAP.Avalonia.ViewModels.Settings"
+        xmlns:vmUpdate="using:CAP.Avalonia.ViewModels.Update"
+        xmlns:vmExport="using:CAP.Avalonia.ViewModels.Export"
+        xmlns:vmAi="using:CAP.Avalonia.ViewModels.AI"
+        x:Class="CAP.Avalonia.Views.SettingsWindow"
+        x:DataType="settings:SettingsWindowViewModel"
+        Title="Settings"
+        Width="820" Height="560"
+        WindowStartupLocation="CenterOwner"
+        Background="#1e1e1e"
+        Foreground="White">
+
+    <Grid ColumnDefinitions="200,1,*">
+
+        <!-- Navigation sidebar -->
+        <DockPanel Grid.Column="0" Background="#252525">
+            <TextBlock DockPanel.Dock="Top"
+                       Text="Settings"
+                       FontSize="16" FontWeight="SemiBold"
+                       Foreground="White"
+                       Margin="15,15,15,12"/>
+            <ListBox ItemsSource="{Binding Pages}"
+                     SelectedItem="{Binding SelectedPage}"
+                     Background="Transparent"
+                     BorderThickness="0">
+                <ListBox.ItemTemplate>
+                    <DataTemplate DataType="{x:Type settings:ISettingsPage}">
+                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="5,2">
+                            <TextBlock Text="{Binding Icon}" VerticalAlignment="Center" FontSize="14"/>
+                            <TextBlock Text="{Binding Title}" VerticalAlignment="Center" FontSize="13"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <ListBox.Styles>
+                    <Style Selector="ListBoxItem">
+                        <Setter Property="Padding" Value="10,6"/>
+                        <Setter Property="Foreground" Value="#cccccc"/>
+                    </Style>
+                    <Style Selector="ListBoxItem:selected">
+                        <Setter Property="Background" Value="#3a3a3a"/>
+                        <Setter Property="Foreground" Value="White"/>
+                    </Style>
+                    <Style Selector="ListBoxItem:pointerover">
+                        <Setter Property="Background" Value="#333333"/>
+                    </Style>
+                </ListBox.Styles>
+            </ListBox>
+        </DockPanel>
+
+        <!-- Divider -->
+        <Rectangle Grid.Column="1" Fill="#3d3d3d"/>
+
+        <!-- Content area -->
+        <ScrollViewer Grid.Column="2" Padding="24,20">
+            <ContentControl Content="{Binding SelectedPage.ViewModel}">
+                <ContentControl.DataTemplates>
+
+                    <!-- Grid Snap & Alignment -->
+                    <DataTemplate DataType="{x:Type settings:GridSnapSettingsViewModel}">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="Grid Snap" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,8"/>
+                            <CheckBox Content="Enable Grid Snapping  [G Key]"
+                                      IsChecked="{Binding GridSnap.IsEnabled}"
+                                      Foreground="White"/>
+                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                <TextBlock Text="Grid Size:" Foreground="Gray" VerticalAlignment="Center" Width="80"/>
+                                <NumericUpDown Value="{Binding GridSnap.GridSizeMicrometers}"
+                                               Minimum="1" Maximum="1000" Increment="10"
+                                               Width="130" FormatString="F0"/>
+                                <TextBlock Text="µm" Foreground="Gray" VerticalAlignment="Center" Margin="6,0,0,0"/>
+                            </StackPanel>
+
+                            <Separator Margin="0,16,0,8" Background="#3d3d3d"/>
+                            <TextBlock Text="Alignment Guides" FontSize="16" FontWeight="SemiBold" Foreground="Cyan" Margin="0,0,0,4"/>
+                            <CheckBox Content="Show Pin Alignment Guides during dragging"
+                                      IsChecked="{Binding AlignmentGuide.IsEnabled}"
+                                      Foreground="White"/>
+                            <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,4,0,0">
+                                Displays cyan guide lines when component pins share an X or Y axis.
+                                The component snaps to alignment when released nearby.
+                            </TextBlock>
+                        </StackPanel>
+                    </DataTemplate>
+
+                    <!-- Software Updates -->
+                    <DataTemplate DataType="{x:Type vmUpdate:UpdateViewModel}">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="Software Updates" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,8"/>
+                            <TextBlock Text="{Binding CurrentVersionText}" Foreground="Gray" FontSize="11"/>
+
+                            <Button Content="Check for Updates"
+                                    Command="{Binding CheckForUpdatesCommand}"
+                                    Width="150" Margin="0,8,0,0" Background="#3d4d5d"
+                                    HorizontalAlignment="Left"
+                                    IsEnabled="{Binding IsChecking, Converter={x:Static BoolConverters.Not}}"/>
+
+                            <TextBlock Text="{Binding StatusText}"
+                                       Foreground="Gray" FontSize="11" TextWrapping="Wrap"
+                                       IsVisible="{Binding StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
+                            <StackPanel IsVisible="{Binding UpdateAvailable}" Spacing="6" Margin="0,8,0,0">
+                                <TextBlock Text="{Binding LatestVersionText}"
+                                           Foreground="LightGreen" FontWeight="SemiBold"/>
+
+                                <ScrollViewer MaxHeight="120"
+                                              IsVisible="{Binding ReleaseNotes, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                                    <TextBlock Text="{Binding ReleaseNotes}"
+                                               Foreground="#aaaaaa" FontSize="11" TextWrapping="Wrap"/>
+                                </ScrollViewer>
+
+                                <ProgressBar Value="{Binding DownloadProgress}"
+                                             Minimum="0" Maximum="1"
+                                             Height="6"
+                                             IsVisible="{Binding IsDownloading}"/>
+
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Button Content="Download &amp; Install"
+                                            Command="{Binding InstallUpdateCommand}"
+                                            Background="#3d5d3d"
+                                            IsEnabled="{Binding IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                                    <Button Content="Remind Later"
+                                            Command="{Binding RemindLaterCommand}"
+                                            Background="#3d3d3d"
+                                            IsEnabled="{Binding IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                                    <Button Content="Skip Version"
+                                            Command="{Binding SkipThisVersionCommand}"
+                                            Background="#5d4330"
+                                            IsEnabled="{Binding IsDownloading, Converter={x:Static BoolConverters.Not}}"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </StackPanel>
+                    </DataTemplate>
+
+                    <!-- Python Environment -->
+                    <DataTemplate DataType="{x:Type vmExport:GdsExportViewModel}">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="Python Environment" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,8"/>
+                            <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,4">
+                                Configures the Python interpreter used for GDS export via Nazca.
+                                Leave blank to use auto-detection.
+                            </TextBlock>
+
+                            <TextBlock Text="Python Path:" Foreground="Gray" FontSize="12" Margin="0,8,0,3"/>
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBox Grid.Column="0"
+                                         Text="{Binding CustomPythonPath}"
+                                         Watermark="Auto-detect or enter path..."
+                                         Margin="0,0,6,0"/>
+                                <Button Grid.Column="1" Content="🔍" Width="32" Padding="4"
+                                        Command="{Binding SearchForPythonCommand}"
+                                        ToolTip.Tip="Search for Python with Nazca"
+                                        IsEnabled="{Binding IsSearching, Converter={x:Static BoolConverters.Not}}"/>
+                            </Grid>
+
+                            <TextBlock Text="{Binding PythonPathSource}"
+                                       Foreground="Gray" FontSize="10"
+                                       IsVisible="{Binding PythonPathSource, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
+                            <Button Content="Check Environment"
+                                    Command="{Binding CheckEnvironmentCommand}"
+                                    Width="150" Margin="0,8,0,0" Background="#3d5d5d"
+                                    HorizontalAlignment="Left"
+                                    IsEnabled="{Binding IsChecking, Converter={x:Static BoolConverters.Not}}"/>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                <TextBlock Text="Python: " Foreground="Gray" Width="70"/>
+                                <TextBlock Text="{Binding PythonStatus}" Foreground="White"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="Nazca: " Foreground="Gray" Width="70"/>
+                                <TextBlock Text="{Binding NazcaStatus}" Foreground="White"/>
+                            </StackPanel>
+
+                            <ItemsControl ItemsSource="{Binding AvailablePythons}"
+                                          Margin="0,6,0,0"
+                                          x:Name="AvailablePythonsList"
+                                          IsVisible="{Binding AvailablePythons.Count}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Button Content="{Binding DisplayText}"
+                                                Command="{Binding #AvailablePythonsList.DataContext.SelectPythonCommand}"
+                                                CommandParameter="{Binding}"
+                                                HorizontalAlignment="Stretch"
+                                                HorizontalContentAlignment="Left"
+                                                Margin="0,2,0,0" Padding="6,4"
+                                                Background="#2d2d2d" FontSize="11"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </DataTemplate>
+
+                    <!-- AI Assistant -->
+                    <DataTemplate DataType="{x:Type vmAi:AiAssistantViewModel}">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="AI Assistant" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,8"/>
+                            <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,8">
+                                Configure the Anthropic Claude API key used by the AI Design Assistant
+                                in the right panel. The key is stored locally and never transmitted elsewhere.
+                            </TextBlock>
+
+                            <TextBlock Text="API Key:" Foreground="Gray" FontSize="12" Margin="0,0,0,3"/>
+                            <TextBox Text="{Binding ApiKey}"
+                                     Watermark="sk-ant-..."
+                                     PasswordChar="•"/>
+
+                            <TextBlock Text="{Binding StatusText}"
+                                       Foreground="Gray" FontSize="11"
+                                       IsVisible="{Binding StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                        </StackPanel>
+                    </DataTemplate>
+
+                    <!-- General -->
+                    <DataTemplate DataType="{x:Type settings:GeneralSettingsViewModel}">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="General" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,8"/>
+                            <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,8">
+                                General application preferences. Additional settings will appear here
+                                as new features are added.
+                            </TextBlock>
+
+                            <TextBlock Text="Custom Python Path:" Foreground="Gray" FontSize="12" Margin="0,8,0,3"/>
+                            <TextBlock Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="0,0,0,4">
+                                Override the Python interpreter used for GDS and export scripts.
+                                Leave blank to rely on auto-detection (preferred).
+                            </TextBlock>
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBox Grid.Column="0"
+                                         Text="{Binding CustomPythonPath}"
+                                         Watermark="Auto-detect (recommended)"
+                                         Margin="0,0,6,0"/>
+                                <Button Grid.Column="1" Content="Clear"
+                                        Command="{Binding ClearPythonPathCommand}"
+                                        Padding="8,4"/>
+                            </Grid>
+                        </StackPanel>
+                    </DataTemplate>
+
+                </ContentControl.DataTemplates>
+            </ContentControl>
+        </ScrollViewer>
+
+    </Grid>
+</Window>

--- a/CAP.Avalonia/Views/SettingsWindow.axaml.cs
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using CAP.Avalonia.ViewModels.Settings;
+
+namespace CAP.Avalonia.Views;
+
+/// <summary>
+/// Settings window that hosts the settings registry navigation panel
+/// and renders the selected <see cref="ISettingsPage"/> content area.
+/// </summary>
+public partial class SettingsWindow : Window
+{
+    /// <summary>Initializes a new instance of <see cref="SettingsWindow"/>.</summary>
+    public SettingsWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -46,6 +46,14 @@ public static class MainViewModelTestHelper
         var rightPanel = CreateRightPanelViewModel(canvas, preferencesService);
         var bottomPanel = CreateBottomPanelViewModel(canvas, commandManager);
 
+        var errorConsoleService = new CAP_Core.ErrorConsoleService();
+        var gdsExportVm = new GdsExportViewModel(new GdsExportService(), errorConsoleService);
+        var updateVm = new UpdateViewModel(
+            new UpdateChecker(new HttpClient(), "aignermax", "Connect-A-PIC-Pro"),
+            new UpdateDownloader(new HttpClient()),
+            preferencesService,
+            Mock.Of<IUrlLauncher>());
+
         return new MainViewModel(
             canvas,
             simulationService,
@@ -55,8 +63,9 @@ public static class MainViewModelTestHelper
             preferencesService,
             new GroupPreviewGenerator(),
             Mock.Of<IInputDialogService>(),
-            new GdsExportService(),
-            new CAP_Core.ErrorConsoleService(),
+            errorConsoleService,
+            gdsExportVm,
+            updateVm,
             leftPanel,
             rightPanel,
             bottomPanel,
@@ -99,15 +108,6 @@ public static class MainViewModelTestHelper
         canvas ??= new DesignCanvasViewModel();
         preferencesService ??= new UserPreferencesService();
 
-        var httpClient = new HttpClient();
-        var updateChecker = new UpdateChecker(httpClient, "aignermax", "Connect-A-PIC-Pro");
-        var updateDownloader = new UpdateDownloader(httpClient);
-        var updateVm = new UpdateViewModel(
-            updateChecker,
-            updateDownloader,
-            preferencesService,
-            Mock.Of<IUrlLauncher>());
-
         return new RightPanelViewModel(
             canvas,
             preferencesService,
@@ -122,7 +122,6 @@ public static class MainViewModelTestHelper
             new GroupSMatrixViewModel(),
             new ArchitectureReportViewModel(),
             new PdkConsistencyViewModel(),
-            updateVm,
             new AiAssistantViewModel(Mock.Of<IAiService>(), preferencesService),
             new VerilogAExportViewModel(new VerilogAExporter(), new VerilogAFileWriter(), canvas));
     }

--- a/UnitTests/Settings/SettingsRegistryTests.cs
+++ b/UnitTests/Settings/SettingsRegistryTests.cs
@@ -1,0 +1,135 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Settings;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Settings;
+
+/// <summary>
+/// Unit tests for the settings registry pattern.
+/// Verifies that <see cref="SettingsWindowViewModel"/> correctly enumerates pages
+/// and that individual page implementations meet the contract.
+/// </summary>
+public class SettingsRegistryTests
+{
+    // -----------------------------------------------------------------------
+    // SettingsWindowViewModel — registry contract
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SettingsWindowViewModel_SelectsFirstPageByDefault()
+    {
+        // Arrange
+        var pages = new List<ISettingsPage>
+        {
+            new StubSettingsPage("Alpha"),
+            new StubSettingsPage("Beta"),
+        };
+
+        // Act
+        var vm = new SettingsWindowViewModel(pages);
+
+        // Assert
+        vm.SelectedPage.ShouldNotBeNull();
+        vm.SelectedPage!.Title.ShouldBe("Alpha");
+    }
+
+    [Fact]
+    public void SettingsWindowViewModel_ExposesAllRegisteredPages()
+    {
+        // Arrange
+        var pages = new List<ISettingsPage>
+        {
+            new StubSettingsPage("A"),
+            new StubSettingsPage("B"),
+            new StubSettingsPage("C"),
+        };
+
+        // Act
+        var vm = new SettingsWindowViewModel(pages);
+
+        // Assert
+        vm.Pages.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void SettingsWindowViewModel_WithNoPages_HasNullSelectedPage()
+    {
+        var vm = new SettingsWindowViewModel(Enumerable.Empty<ISettingsPage>());
+        vm.SelectedPage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void SettingsWindowViewModel_ChangingSelectedPage_UpdatesProperty()
+    {
+        // Arrange
+        var page1 = new StubSettingsPage("Page1");
+        var page2 = new StubSettingsPage("Page2");
+        var vm = new SettingsWindowViewModel(new[] { page1, page2 });
+
+        // Act
+        vm.SelectedPage = page2;
+
+        // Assert
+        vm.SelectedPage!.Title.ShouldBe("Page2");
+    }
+
+    // -----------------------------------------------------------------------
+    // GridSnapSettingsPage
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GridSnapSettingsPage_ContractIsSatisfied()
+    {
+        var canvas = new DesignCanvasViewModel();
+        ISettingsPage page = new GridSnapSettingsPage(canvas);
+
+        page.Title.ShouldNotBeNullOrEmpty();
+        page.Icon.ShouldNotBeNullOrEmpty();
+        page.ViewModel.ShouldNotBeNull();
+        page.ViewModel.ShouldBeOfType<GridSnapSettingsViewModel>();
+    }
+
+    [Fact]
+    public void GridSnapSettingsPage_ViewModelWrapsCanvasGridSnap()
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.GridSnap.IsEnabled = true;
+        canvas.GridSnap.GridSizeMicrometers = 25.0;
+
+        var page = new GridSnapSettingsPage(canvas);
+        var vm = (GridSnapSettingsViewModel)page.ViewModel;
+
+        vm.GridSnap.IsEnabled.ShouldBeTrue();
+        vm.GridSnap.GridSizeMicrometers.ShouldBe(25.0);
+    }
+
+    [Fact]
+    public void GridSnapSettingsPage_ViewModelChange_AffectsCanvas()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var page = new GridSnapSettingsPage(canvas);
+        var vm = (GridSnapSettingsViewModel)page.ViewModel;
+
+        // Act: change via settings ViewModel
+        vm.GridSnap.IsEnabled = true;
+        vm.GridSnap.GridSizeMicrometers = 100.0;
+
+        // Assert: same objects — canvas reflects the change immediately
+        canvas.GridSnap.IsEnabled.ShouldBeTrue();
+        canvas.GridSnap.GridSizeMicrometers.ShouldBe(100.0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private sealed class StubSettingsPage : ISettingsPage
+    {
+        public StubSettingsPage(string title) { Title = title; }
+        public string Title { get; }
+        public string Icon => "⚙";
+        public string? Category => null;
+        public object ViewModel => new object();
+    }
+}

--- a/UnitTests/Settings/SettingsRegistryTests.cs
+++ b/UnitTests/Settings/SettingsRegistryTests.cs
@@ -120,6 +120,81 @@ public class SettingsRegistryTests
         canvas.GridSnap.GridSizeMicrometers.ShouldBe(100.0);
     }
 
+    [Fact]
+    public void GridSnapSettingsPage_AlignmentGuideChange_AffectsCanvas()
+    {
+        // Mirrors the GridSnap test for the second wrapped property — a
+        // regression in the AlignmentGuide wiring (e.g. a local copy instead
+        // of the canvas reference) would otherwise slip through.
+        var canvas = new DesignCanvasViewModel();
+        var page = new GridSnapSettingsPage(canvas);
+        var vm = (GridSnapSettingsViewModel)page.ViewModel;
+
+        vm.AlignmentGuide.IsEnabled = true;
+
+        canvas.AlignmentGuide.IsEnabled.ShouldBeTrue();
+    }
+
+    // -----------------------------------------------------------------------
+    // Page contract — title, icon, category stability
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GeneralSettingsPage_StableContract()
+    {
+        ISettingsPage page = new GeneralSettingsPage();
+
+        page.Title.ShouldBe("General");
+        page.Icon.ShouldBe("⚙");
+        page.Category.ShouldBeNull();
+        page.ViewModel.ShouldBeOfType<GeneralSettingsViewModel>();
+    }
+
+    [Fact]
+    public void GridSnapSettingsPage_StableContract()
+    {
+        // Guards the display string — a refactor silently turning
+        // "Grid & Alignment" into "Grid" would otherwise ship.
+        ISettingsPage page = new GridSnapSettingsPage(new DesignCanvasViewModel());
+
+        page.Title.ShouldBe("Grid & Alignment");
+        page.Icon.ShouldBe("⊞");
+        page.Category.ShouldBe("Canvas");
+    }
+
+    [Fact]
+    public void UpdateSettingsPage_StableContract()
+    {
+        // The page reads only its own Title/Icon/Category — the VM is passed
+        // through untouched — so a null VM is fine for verifying the contract
+        // and avoids pulling HttpClient / UpdateChecker into the test rig.
+        ISettingsPage page = new UpdateSettingsPage(null!);
+
+        page.Title.ShouldBe("Software Updates");
+        page.Icon.ShouldBe("🔄");
+        page.Category.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PythonEnvironmentSettingsPage_StableContract()
+    {
+        ISettingsPage page = new PythonEnvironmentSettingsPage(null!);
+
+        page.Title.ShouldBe("Python Environment");
+        page.Icon.ShouldBe("🐍");
+        page.Category.ShouldBe("Export");
+    }
+
+    [Fact]
+    public void AiAssistantSettingsPage_StableContract()
+    {
+        ISettingsPage page = new AiAssistantSettingsPage(null!);
+
+        page.Title.ShouldBe("AI Assistant");
+        page.Icon.ShouldBe("🤖");
+        page.Category.ShouldBeNull();
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------

--- a/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
+++ b/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
@@ -1,11 +1,9 @@
-using System.Net.Http;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Analysis;
 using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Library;
-using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.ViewModels.Export;
 using CAP_Core.Export;
@@ -58,15 +56,8 @@ public class PanelWidthPersistenceTests : IDisposable
             new ComponentLibraryViewModel(_libraryManager));
 
     /// <summary>Creates a RightPanelViewModel with all required sub-VM dependencies.</summary>
-    private RightPanelViewModel CreateRightPanelViewModel()
-    {
-        var httpClient = new HttpClient();
-        var updateVm = new UpdateViewModel(
-            new UpdateChecker(httpClient, "aignermax", "Connect-A-PIC-Pro"),
-            new UpdateDownloader(httpClient),
-            _preferencesService,
-            new NoOpUrlLauncher());
-        return new(_canvas, _preferencesService,
+    private RightPanelViewModel CreateRightPanelViewModel() =>
+        new(_canvas, _preferencesService,
             new ParameterSweepViewModel(),
             new RoutingDiagnosticsViewModel(),
             new DesignValidationViewModel(),
@@ -78,17 +69,8 @@ public class PanelWidthPersistenceTests : IDisposable
             new GroupSMatrixViewModel(),
             new ArchitectureReportViewModel(),
             new PdkConsistencyViewModel(),
-            updateVm,
             new AiAssistantViewModel(Mock.Of<IAiService>(), _preferencesService),
             new VerilogAExportViewModel(new VerilogAExporter(), new VerilogAFileWriter(), _canvas));
-    }
-
-    private sealed class NoOpUrlLauncher : IUrlLauncher
-    {
-        public void Open(string url)
-        {
-        }
-    }
 
     [Fact]
     public void LeftPanelWidth_DefaultsTo220()


### PR DESCRIPTION
Automated implementation for #495

Both test runs passed. The implementation is complete.

**Tools used:** `smart_test.py` equivalent via direct `dotnet test` (~saved context vs 1000+ raw test lines).


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 150,739
- **Estimated cost:** $0.0844 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*