### PR TITLE
PIR Phase 2: Import S-parameters from Lumerical/Tidy3D (#471)

### DIFF
--- a/CAP-DataAccess/Import/ISParameterImporter.cs
+++ b/CAP-DataAccess/Import/ISParameterImporter.cs
@@ -1,0 +1,31 @@
+namespace CAP_DataAccess.Import;
+
+/// <summary>
+/// Parses S-parameter data from an external simulation file into <see cref="ImportedSParameters"/>.
+/// </summary>
+public interface ISParameterImporter
+{
+    /// <summary>
+    /// File extensions this importer handles (lower-case, with dot, e.g. ".sparam").
+    /// </summary>
+    IReadOnlyList<string> SupportedExtensions { get; }
+
+    /// <summary>
+    /// Parse the given file and return structured S-parameter data.
+    /// </summary>
+    /// <param name="filePath">Absolute path to the source file.</param>
+    /// <returns>Parsed S-parameters, or throws <see cref="SParameterImportException"/> on format errors.</returns>
+    Task<ImportedSParameters> ImportAsync(string filePath);
+}
+
+/// <summary>
+/// Thrown when an S-parameter file cannot be parsed due to format errors.
+/// </summary>
+public class SParameterImportException : Exception
+{
+    /// <inheritdoc/>
+    public SParameterImportException(string message) : base(message) { }
+
+    /// <inheritdoc/>
+    public SParameterImportException(string message, Exception inner) : base(message, inner) { }
+}

--- a/CAP-DataAccess/Import/ImportedSParameters.cs
+++ b/CAP-DataAccess/Import/ImportedSParameters.cs
@@ -1,0 +1,31 @@
+using System.Numerics;
+
+namespace CAP_DataAccess.Import;
+
+/// <summary>
+/// Result of parsing an external S-parameter file (Lumerical, Touchstone, etc.).
+/// Wavelengths are stored in nanometers; S-matrix entries are complex numbers.
+/// </summary>
+public class ImportedSParameters
+{
+    /// <summary>Detected tool/format used to produce this data (e.g. "Lumerical SiEPIC", "Touchstone S2P").</summary>
+    public string SourceFormat { get; set; } = string.Empty;
+
+    /// <summary>Absolute path to the source file.</summary>
+    public string SourceFilePath { get; set; } = string.Empty;
+
+    /// <summary>Number of ports in the S-matrix.</summary>
+    public int PortCount { get; set; }
+
+    /// <summary>Ordered list of port names matching matrix row/column indices.</summary>
+    public List<string> PortNames { get; set; } = new();
+
+    /// <summary>
+    /// S-matrix at each wavelength (nm).
+    /// Key = wavelength in nm; Value = PortCount×PortCount complex matrix in row-major order.
+    /// </summary>
+    public Dictionary<int, Complex[,]> SMatricesByWavelengthNm { get; set; } = new();
+
+    /// <summary>Optional metadata (polarization, simulation settings, etc.).</summary>
+    public Dictionary<string, string> Metadata { get; set; } = new();
+}

--- a/CAP-DataAccess/Import/LumericalSParameterImporter.cs
+++ b/CAP-DataAccess/Import/LumericalSParameterImporter.cs
@@ -33,11 +33,45 @@ public class LumericalSParameterImporter : ISParameterImporter
         var lines = await File.ReadAllLinesAsync(filePath);
         var ext = Path.GetExtension(filePath).ToLowerInvariant();
 
-        var blocks = ext == ".txt"
-            ? ParseGcTxtFormat(lines)
-            : ParseSparamFormat(lines);
+        // Format routing by extension alone is not enough: both `.dat` and `.txt`
+        // are used in the wild for the GC-packed layout (9 numeric columns per
+        // row, no header), and `.dat` is ALSO used for the blocked SiEPIC
+        // format. Try blocked first (it's unambiguous — starts with `(`), and
+        // fall back to the packed parser if no blocks are found.
+        bool forcedPacked = ext == ".txt" && LooksLikePacked(lines);
+
+        List<SparamBlock> blocks;
+        if (forcedPacked)
+        {
+            blocks = ParseGcTxtFormat(lines);
+        }
+        else
+        {
+            blocks = ParseSparamFormat(lines);
+            if (blocks.Count == 0 && LooksLikePacked(lines))
+                blocks = ParseGcTxtFormat(lines);
+        }
 
         return BuildResult(blocks, filePath, ext);
+    }
+
+    /// <summary>
+    /// GC-packed layout heuristic: first non-blank, non-comment line has 9+
+    /// numeric tokens (freq + 4×(mag, phase) for 2-port) and no leading `(`.
+    /// </summary>
+    private static bool LooksLikePacked(string[] lines)
+    {
+        foreach (var line in lines)
+        {
+            var t = line.TrimStart();
+            if (t.Length == 0 || t.StartsWith('#') || t.StartsWith('!') || t.StartsWith('['))
+                continue;
+            if (t.StartsWith('(')) return false;
+            var tokens = t.Split(new[] { '\t', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            return tokens.Length >= 9 &&
+                   double.TryParse(tokens[0], NumberStyles.Float, CultureInfo.InvariantCulture, out _);
+        }
+        return false;
     }
 
     // ── Blocked (.sparam / .dat) parser ──────────────────────────────────────
@@ -196,6 +230,11 @@ public class LumericalSParameterImporter : ISParameterImporter
             PortNames = portNames,
         };
 
+        // Dense sweeps in frequency don't stay distinct when rounded to nm:
+        // 101 equally-spaced Hz samples around 1550 nm collapse to ~99 nm
+        // keys. Count collisions so they're visible via Metadata instead of
+        // the dict silently dropping data points.
+        int wavelengthCollisions = 0;
         for (int wIdx = 0; wIdx < wavelengthsNm.Length; wIdx++)
         {
             var matrix = new Complex[n, n];
@@ -209,8 +248,13 @@ public class LumericalSParameterImporter : ISParameterImporter
                 matrix[outIdx, inIdx] = Complex.FromPolarCoordinates(mag, phase);
             }
 
+            if (result.SMatricesByWavelengthNm.ContainsKey(wavelengthsNm[wIdx]))
+                wavelengthCollisions++;
             result.SMatricesByWavelengthNm[wavelengthsNm[wIdx]] = matrix;
         }
+
+        if (wavelengthCollisions > 0)
+            result.Metadata["wavelengthCollisions"] = wavelengthCollisions.ToString(CultureInfo.InvariantCulture);
 
         result.Metadata["polarization"] = "TE";
         result.Metadata["tool"] = "Lumerical INTERCONNECT";

--- a/CAP-DataAccess/Import/LumericalSParameterImporter.cs
+++ b/CAP-DataAccess/Import/LumericalSParameterImporter.cs
@@ -1,0 +1,209 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text.RegularExpressions;
+
+namespace CAP_DataAccess.Import;
+
+/// <summary>
+/// Parses Lumerical INTERCONNECT S-parameter files in SiEPIC/EBeam PDK format.
+///
+/// Supported file formats:
+/// <list type="bullet">
+///   <item><description>.sparam – Blocked format: header line, shape line, frequency/magnitude/phase data</description></item>
+///   <item><description>.dat – Same blocked format with .dat extension</description></item>
+///   <item><description>.txt – GC packed format: one row per frequency with all Sij columns</description></item>
+/// </list>
+///
+/// The blocked format header: ('port X','MODE',mode_id,'port Y',mode_id,'transmission')
+/// The data columns are: frequency_Hz  magnitude  phase_radians
+/// </summary>
+public class LumericalSParameterImporter : ISParameterImporter
+{
+    private const double SpeedOfLightMs = 299_792_458.0;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<string> SupportedExtensions { get; } = new[] { ".sparam", ".dat", ".txt" };
+
+    /// <inheritdoc/>
+    public async Task<ImportedSParameters> ImportAsync(string filePath)
+    {
+        if (!File.Exists(filePath))
+            throw new SParameterImportException($"File not found: {filePath}");
+
+        var lines = await File.ReadAllLinesAsync(filePath);
+        var ext = Path.GetExtension(filePath).ToLowerInvariant();
+
+        var blocks = ext == ".txt"
+            ? ParseGcTxtFormat(lines)
+            : ParseSparamFormat(lines);
+
+        return BuildResult(blocks, filePath, ext);
+    }
+
+    // ── Blocked (.sparam / .dat) parser ──────────────────────────────────────
+
+    private static List<SparamBlock> ParseSparamFormat(string[] lines)
+    {
+        var blocks = new List<SparamBlock>();
+        int i = 0;
+
+        while (i < lines.Length)
+        {
+            var line = lines[i].Trim();
+            if (line.StartsWith('(') && line.Contains("transmission", StringComparison.OrdinalIgnoreCase))
+            {
+                var (outPort, inPort, mode, ok) = ParseBlockHeader(line);
+                if (!ok) { i++; continue; }
+
+                i++;
+                if (i >= lines.Length) break;
+
+                var shapeMatch = Regex.Match(lines[i].Trim(), @"\((\d+)\s*,\s*3\)");
+                int numPoints = shapeMatch.Success ? int.Parse(shapeMatch.Groups[1].Value, CultureInfo.InvariantCulture) : 0;
+
+                var data = new List<(double FreqHz, double Mag, double PhaseRad)>(numPoints);
+                for (int j = 0; j < numPoints && i + 1 + j < lines.Length; j++)
+                {
+                    var parts = lines[i + 1 + j].Trim().Split(new[] { '\t', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 3 &&
+                        double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var freq) &&
+                        double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var mag) &&
+                        double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var phase))
+                    {
+                        data.Add((freq, mag, phase));
+                    }
+                }
+
+                blocks.Add(new SparamBlock(outPort, inPort, mode, data));
+                i += 1 + numPoints;
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return blocks;
+    }
+
+    private static (string outPort, string inPort, string mode, bool ok) ParseBlockHeader(string line)
+    {
+        // Single-quote variant: ('port 1','TE',0,'port 2',0,'transmission')
+        var m = Regex.Match(line, @"\('([^']+)','?(\w+)'?,\d+,'([^']+)',\d+,'transmission'\)");
+        if (!m.Success)
+            m = Regex.Match(line, @"\(""([^""]+)"",""?([^"",]+)""?,\d+,""([^""]+)"",\d+,""transmission""\)");
+
+        if (!m.Success)
+            return (string.Empty, string.Empty, string.Empty, false);
+
+        return (m.Groups[1].Value, m.Groups[3].Value, m.Groups[2].Value, true);
+    }
+
+    // ── GC packed .txt parser ────────────────────────────────────────────────
+    // Row format: freq |S11| ang(S11) |S21| ang(S21) |S12| ang(S12) |S22| ang(S22)
+
+    private static List<SparamBlock> ParseGcTxtFormat(string[] lines)
+    {
+        var s11 = new List<(double, double, double)>();
+        var s21 = new List<(double, double, double)>();
+        var s12 = new List<(double, double, double)>();
+        var s22 = new List<(double, double, double)>();
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith('#'))
+                continue;
+
+            var parts = line.Trim().Split(new[] { '\t', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 9) continue;
+
+            if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var freq)) continue;
+
+            static bool TryPair(string[] p, int idx, out double mag, out double phase)
+            {
+                mag = phase = 0;
+                return double.TryParse(p[idx], NumberStyles.Float, CultureInfo.InvariantCulture, out mag)
+                    && double.TryParse(p[idx + 1], NumberStyles.Float, CultureInfo.InvariantCulture, out phase);
+            }
+
+            if (TryPair(parts, 1, out var m11, out var p11)) s11.Add((freq, m11, p11 * Math.PI / 180));
+            if (TryPair(parts, 3, out var m21, out var p21)) s21.Add((freq, m21, p21 * Math.PI / 180));
+            if (TryPair(parts, 5, out var m12, out var p12)) s12.Add((freq, m12, p12 * Math.PI / 180));
+            if (TryPair(parts, 7, out var m22, out var p22)) s22.Add((freq, m22, p22 * Math.PI / 180));
+        }
+
+        return new List<SparamBlock>
+        {
+            new("port 1", "port 1", "TE", s11),
+            new("port 2", "port 1", "TE", s21),
+            new("port 1", "port 2", "TE", s12),
+            new("port 2", "port 2", "TE", s22)
+        };
+    }
+
+    // ── Result assembly ──────────────────────────────────────────────────────
+
+    private static ImportedSParameters BuildResult(List<SparamBlock> blocks, string filePath, string ext)
+    {
+        if (blocks.Count == 0)
+            throw new SParameterImportException("No S-parameter blocks found in file.");
+
+        // Filter to TE mode (or take all if no TE found)
+        var teBlocks = blocks.Where(b => b.Mode.Equals("TE", StringComparison.OrdinalIgnoreCase)).ToList();
+        var useBlocks = teBlocks.Count > 0 ? teBlocks : blocks;
+
+        // Collect all unique port names
+        var portNames = useBlocks
+            .SelectMany(b => new[] { b.InPort, b.OutPort })
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(p => p)
+            .ToList();
+
+        int n = portNames.Count;
+
+        // Get all wavelengths from first block
+        var refBlock = useBlocks[0];
+        var wavelengthsNm = refBlock.Data
+            .Select(d => FreqToWavelengthNm(d.FreqHz))
+            .ToArray();
+
+        // Build S-matrix for each wavelength index
+        var result = new ImportedSParameters
+        {
+            SourceFormat = ext == ".txt" ? "Lumerical GC TXT" : "Lumerical SiEPIC",
+            SourceFilePath = filePath,
+            PortCount = n,
+            PortNames = portNames,
+        };
+
+        for (int wIdx = 0; wIdx < wavelengthsNm.Length; wIdx++)
+        {
+            var matrix = new Complex[n, n];
+            foreach (var block in useBlocks)
+            {
+                int outIdx = portNames.IndexOf(portNames.FirstOrDefault(p => string.Equals(p, block.OutPort, StringComparison.OrdinalIgnoreCase)) ?? "");
+                int inIdx = portNames.IndexOf(portNames.FirstOrDefault(p => string.Equals(p, block.InPort, StringComparison.OrdinalIgnoreCase)) ?? "");
+                if (outIdx < 0 || inIdx < 0 || wIdx >= block.Data.Count) continue;
+
+                var (_, mag, phase) = block.Data[wIdx];
+                matrix[outIdx, inIdx] = Complex.FromPolarCoordinates(mag, phase);
+            }
+
+            result.SMatricesByWavelengthNm[wavelengthsNm[wIdx]] = matrix;
+        }
+
+        result.Metadata["polarization"] = "TE";
+        result.Metadata["tool"] = "Lumerical INTERCONNECT";
+
+        return result;
+    }
+
+    private static int FreqToWavelengthNm(double freqHz) =>
+        (int)Math.Round(SpeedOfLightMs / freqHz * 1e9);
+
+    private record SparamBlock(
+        string OutPort,
+        string InPort,
+        string Mode,
+        List<(double FreqHz, double Mag, double PhaseRad)> Data);
+}

--- a/CAP-DataAccess/Import/LumericalSParameterImporter.cs
+++ b/CAP-DataAccess/Import/LumericalSParameterImporter.cs
@@ -45,6 +45,7 @@ public class LumericalSParameterImporter : ISParameterImporter
     private static List<SparamBlock> ParseSparamFormat(string[] lines)
     {
         var blocks = new List<SparamBlock>();
+        int malformedRows = 0;
         int i = 0;
 
         while (i < lines.Length)
@@ -70,7 +71,16 @@ public class LumericalSParameterImporter : ISParameterImporter
                         double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var mag) &&
                         double.TryParse(parts[2], NumberStyles.Float, CultureInfo.InvariantCulture, out var phase))
                     {
+                        if (!double.IsFinite(freq) || freq <= 0 || !double.IsFinite(mag) || !double.IsFinite(phase))
+                        {
+                            malformedRows++;
+                            continue;
+                        }
                         data.Add((freq, mag, phase));
+                    }
+                    else
+                    {
+                        malformedRows++;
                     }
                 }
 
@@ -82,6 +92,9 @@ public class LumericalSParameterImporter : ISParameterImporter
                 i++;
             }
         }
+
+        if (malformedRows > 0 && blocks.Count > 0)
+            blocks[0] = blocks[0] with { MalformedRowsWarning = malformedRows };
 
         return blocks;
     }
@@ -152,14 +165,21 @@ public class LumericalSParameterImporter : ISParameterImporter
         var teBlocks = blocks.Where(b => b.Mode.Equals("TE", StringComparison.OrdinalIgnoreCase)).ToList();
         var useBlocks = teBlocks.Count > 0 ? teBlocks : blocks;
 
-        // Collect all unique port names
+        // Collect all unique port names, ordered numerically so "port 10"
+        // follows "port 9" instead of "port 1" (lexicographic breaks past 10).
         var portNames = useBlocks
             .SelectMany(b => new[] { b.InPort, b.OutPort })
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(p => p)
+            .OrderBy(NaturalSortKey, StringComparer.Ordinal)
             .ToList();
 
         int n = portNames.Count;
+
+        // Build a case-insensitive port-name → index map once, instead of
+        // the O(n²) IndexOf+FirstOrDefault inside the per-wavelength loop.
+        var portIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (int idx = 0; idx < portNames.Count; idx++)
+            portIndex[portNames[idx]] = idx;
 
         // Get all wavelengths from first block
         var refBlock = useBlocks[0];
@@ -181,9 +201,9 @@ public class LumericalSParameterImporter : ISParameterImporter
             var matrix = new Complex[n, n];
             foreach (var block in useBlocks)
             {
-                int outIdx = portNames.IndexOf(portNames.FirstOrDefault(p => string.Equals(p, block.OutPort, StringComparison.OrdinalIgnoreCase)) ?? "");
-                int inIdx = portNames.IndexOf(portNames.FirstOrDefault(p => string.Equals(p, block.InPort, StringComparison.OrdinalIgnoreCase)) ?? "");
-                if (outIdx < 0 || inIdx < 0 || wIdx >= block.Data.Count) continue;
+                if (!portIndex.TryGetValue(block.OutPort, out var outIdx)) continue;
+                if (!portIndex.TryGetValue(block.InPort, out var inIdx)) continue;
+                if (wIdx >= block.Data.Count) continue;
 
                 var (_, mag, phase) = block.Data[wIdx];
                 matrix[outIdx, inIdx] = Complex.FromPolarCoordinates(mag, phase);
@@ -195,15 +215,40 @@ public class LumericalSParameterImporter : ISParameterImporter
         result.Metadata["polarization"] = "TE";
         result.Metadata["tool"] = "Lumerical INTERCONNECT";
 
+        var totalMalformed = blocks.Sum(b => b.MalformedRowsWarning);
+        if (totalMalformed > 0)
+            result.Metadata["malformedRows"] = totalMalformed.ToString(CultureInfo.InvariantCulture);
+
         return result;
     }
 
-    private static int FreqToWavelengthNm(double freqHz) =>
-        (int)Math.Round(SpeedOfLightMs / freqHz * 1e9);
+    private static int FreqToWavelengthNm(double freqHz)
+    {
+        if (!double.IsFinite(freqHz) || freqHz <= 0)
+            throw new SParameterImportException(
+                $"Invalid frequency {freqHz} Hz — must be finite and positive for wavelength conversion.");
+        return (int)Math.Round(SpeedOfLightMs / freqHz * 1e9);
+    }
+
+    /// <summary>
+    /// Returns a natural-sort key so port names like "port 2" precede "port 10".
+    /// Falls back to the original string if no numeric suffix is found.
+    /// </summary>
+    private static string NaturalSortKey(string s)
+    {
+        var m = Regex.Match(s, @"^(?<prefix>.*?)(?<num>\d+)(?<suffix>.*)$");
+        if (!m.Success) return s;
+        var padded = m.Groups["num"].Value.PadLeft(10, '0');
+        return m.Groups["prefix"].Value + padded + m.Groups["suffix"].Value;
+    }
 
     private record SparamBlock(
         string OutPort,
         string InPort,
         string Mode,
-        List<(double FreqHz, double Mag, double PhaseRad)> Data);
+        List<(double FreqHz, double Mag, double PhaseRad)> Data)
+    {
+        /// <summary>Count of rows that failed to parse in this block; exposed via Metadata on the result.</summary>
+        public int MalformedRowsWarning { get; init; }
+    }
 }

--- a/CAP-DataAccess/Import/SParameterConverter.cs
+++ b/CAP-DataAccess/Import/SParameterConverter.cs
@@ -1,0 +1,52 @@
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP_DataAccess.Import;
+
+/// <summary>
+/// Converts <see cref="ImportedSParameters"/> to <see cref="ComponentSMatrixData"/>
+/// for storage in the .lun PIR section.
+/// </summary>
+public static class SParameterConverter
+{
+    /// <summary>
+    /// Converts parsed S-parameter data to the PIR storage format.
+    /// </summary>
+    /// <param name="imported">Parsed S-parameters from an importer.</param>
+    /// <param name="sourceNote">Optional note to embed (defaults to format + filename).</param>
+    /// <returns>A <see cref="ComponentSMatrixData"/> ready for <c>DesignFileData.SMatrices</c>.</returns>
+    public static ComponentSMatrixData ToComponentSMatrixData(
+        ImportedSParameters imported,
+        string? sourceNote = null)
+    {
+        var data = new ComponentSMatrixData
+        {
+            SourceNote = sourceNote
+                ?? $"{imported.SourceFormat} — {Path.GetFileName(imported.SourceFilePath)}"
+        };
+
+        foreach (var (wavelengthNm, matrix) in imported.SMatricesByWavelengthNm)
+        {
+            int n = imported.PortCount;
+            var entry = new SMatrixWavelengthEntry
+            {
+                Rows = n,
+                Cols = n,
+                PortNames = new List<string>(imported.PortNames),
+            };
+
+            for (int r = 0; r < n; r++)
+            {
+                for (int c = 0; c < n; c++)
+                {
+                    var v = matrix[r, c];
+                    entry.Real.Add(v.Real);
+                    entry.Imag.Add(v.Imaginary);
+                }
+            }
+
+            data.Wavelengths[wavelengthNm.ToString()] = entry;
+        }
+
+        return data;
+    }
+}

--- a/CAP-DataAccess/Import/SParameterConverter.cs
+++ b/CAP-DataAccess/Import/SParameterConverter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP_DataAccess.Import;
@@ -44,7 +45,10 @@ public static class SParameterConverter
                 }
             }
 
-            data.Wavelengths[wavelengthNm.ToString()] = entry;
+            // InvariantCulture: wavelength keys round-trip through JSON save/load;
+            // a culture-dependent ToString() would write "1.550e+3" on fr-FR and
+            // silently break the reload.
+            data.Wavelengths[wavelengthNm.ToString(CultureInfo.InvariantCulture)] = entry;
         }
 
         return data;

--- a/CAP-DataAccess/Import/TouchstoneImporter.cs
+++ b/CAP-DataAccess/Import/TouchstoneImporter.cs
@@ -1,0 +1,162 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text.RegularExpressions;
+
+namespace CAP_DataAccess.Import;
+
+/// <summary>
+/// Parses Touchstone S-parameter files (.sNp where N is the port count).
+///
+/// Supports:
+/// <list type="bullet">
+///   <item><description>Frequency units: Hz, KHz, MHz, GHz (case-insensitive)</description></item>
+///   <item><description>Data formats: MA (magnitude-angle°), DB (dB-angle°), RI (real-imaginary)</description></item>
+///   <item><description>Parameter type: S (S-parameters only; Y and Z are rejected)</description></item>
+/// </list>
+///
+/// Reference impedance (R line) is parsed but not used in conversion.
+/// </summary>
+public class TouchstoneImporter : ISParameterImporter
+{
+    /// <inheritdoc/>
+    public IReadOnlyList<string> SupportedExtensions { get; } = BuildExtensions();
+
+    /// <inheritdoc/>
+    public async Task<ImportedSParameters> ImportAsync(string filePath)
+    {
+        if (!File.Exists(filePath))
+            throw new SParameterImportException($"File not found: {filePath}");
+
+        int portCount = DetectPortCount(filePath);
+        var lines = await File.ReadAllLinesAsync(filePath);
+        return Parse(lines, portCount, filePath);
+    }
+
+    // ── Port count from extension (.s2p → 2, .s4p → 4) ──────────────────────
+
+    private static int DetectPortCount(string filePath)
+    {
+        var m = Regex.Match(Path.GetExtension(filePath), @"\.s(\d+)p", RegexOptions.IgnoreCase);
+        return m.Success ? int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture) : 2;
+    }
+
+    // ── Main parser ──────────────────────────────────────────────────────────
+
+    private static ImportedSParameters Parse(string[] lines, int portCount, string filePath)
+    {
+        double freqMultiplier = 1.0;
+        string dataFormat = "MA";
+
+        var dataRows = new List<double[]>();
+        var currentRow = new List<double>();
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+
+            // Strip inline comment
+            var bangIdx = line.IndexOf('!');
+            if (bangIdx >= 0)
+                line = line[..bangIdx].Trim();
+
+            if (string.IsNullOrEmpty(line)) continue;
+
+            if (line.StartsWith('#'))
+            {
+                // Option line: # <FreqUnit> <ParamType> <DataFormat> R <Impedance>
+                var parts = line[1..].Trim().Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 1) freqMultiplier = FreqUnitMultiplier(parts[0]);
+                // parts[1] = S/Y/Z — we only handle S, but read all anyway
+                if (parts.Length >= 3) dataFormat = parts[2].ToUpperInvariant();
+                continue;
+            }
+
+            // Data line — may span multiple lines for large matrices
+            var nums = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var num in nums)
+            {
+                if (double.TryParse(num, NumberStyles.Float, CultureInfo.InvariantCulture, out var v))
+                    currentRow.Add(v);
+            }
+
+            // A complete row has 1 (freq) + 2*N*N values
+            int expectedPerRow = 1 + 2 * portCount * portCount;
+            if (currentRow.Count >= expectedPerRow)
+            {
+                dataRows.Add(currentRow.Take(expectedPerRow).ToArray());
+                currentRow = new List<double>(currentRow.Skip(expectedPerRow));
+            }
+        }
+
+        if (dataRows.Count == 0)
+            throw new SParameterImportException("No data rows found in Touchstone file.");
+
+        return BuildResult(dataRows, portCount, freqMultiplier, dataFormat, filePath);
+    }
+
+    private static ImportedSParameters BuildResult(
+        List<double[]> dataRows, int n, double freqMult, string format, string filePath)
+    {
+        var portNames = Enumerable.Range(1, n).Select(i => $"port {i}").ToList();
+
+        var result = new ImportedSParameters
+        {
+            SourceFormat = $"Touchstone S{n}P",
+            SourceFilePath = filePath,
+            PortCount = n,
+            PortNames = portNames,
+        };
+
+        result.Metadata["tool"] = "Touchstone";
+        result.Metadata["dataFormat"] = format;
+
+        foreach (var row in dataRows)
+        {
+            double freqHz = row[0] * freqMult;
+            int wavelengthNm = (int)Math.Round(299_792_458.0 / freqHz * 1e9);
+
+            var matrix = new Complex[n, n];
+
+            // Touchstone v1 ordering: S11, S21, S31... S12, S22, S32... (column-major)
+            for (int col = 0; col < n; col++)
+            {
+                for (int row2 = 0; row2 < n; row2++)
+                {
+                    int pairIdx = col * n + row2;
+                    int baseIdx = 1 + pairIdx * 2;
+                    double a = row[baseIdx];
+                    double b = row[baseIdx + 1];
+
+                    matrix[row2, col] = ToComplex(a, b, format);
+                }
+            }
+
+            result.SMatricesByWavelengthNm[wavelengthNm] = matrix;
+        }
+
+        return result;
+    }
+
+    private static Complex ToComplex(double a, double b, string format) => format switch
+    {
+        "MA" => Complex.FromPolarCoordinates(a, b * Math.PI / 180.0),
+        "DB" => Complex.FromPolarCoordinates(Math.Pow(10, a / 20.0), b * Math.PI / 180.0),
+        "RI" => new Complex(a, b),
+        _ => new Complex(a, b)
+    };
+
+    private static double FreqUnitMultiplier(string unit) => unit.ToUpperInvariant() switch
+    {
+        "HZ"  => 1.0,
+        "KHZ" => 1e3,
+        "MHZ" => 1e6,
+        "GHZ" => 1e9,
+        _ => 1.0
+    };
+
+    private static IReadOnlyList<string> BuildExtensions()
+    {
+        // .s1p through .s9p are the common ones; .s1p and .s2p most frequent
+        return Enumerable.Range(1, 9).Select(i => $".s{i}p").ToList();
+    }
+}

--- a/CAP-DataAccess/Import/TouchstoneImporter.cs
+++ b/CAP-DataAccess/Import/TouchstoneImporter.cs
@@ -66,8 +66,17 @@ public class TouchstoneImporter : ISParameterImporter
                 // Option line: # <FreqUnit> <ParamType> <DataFormat> R <Impedance>
                 var parts = line[1..].Trim().Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length >= 1) freqMultiplier = FreqUnitMultiplier(parts[0]);
-                // parts[1] = S/Y/Z — we only handle S, but read all anyway
-                if (parts.Length >= 3) dataFormat = parts[2].ToUpperInvariant();
+                if (parts.Length >= 2)
+                {
+                    // Only S parameters are supported. Silently accepting Y/Z
+                    // would produce physically wrong simulation (admittance or
+                    // impedance treated as scattering) — reject explicitly.
+                    var paramType = parts[1].ToUpperInvariant();
+                    if (paramType != "S")
+                        throw new SParameterImportException(
+                            $"Unsupported parameter type '{parts[1]}'. Only S-parameters are supported; Y and Z must be converted before import.");
+                }
+                if (parts.Length >= 3) dataFormat = ValidateDataFormat(parts[2]);
                 continue;
             }
 
@@ -83,7 +92,18 @@ public class TouchstoneImporter : ISParameterImporter
             int expectedPerRow = 1 + 2 * portCount * portCount;
             if (currentRow.Count >= expectedPerRow)
             {
-                dataRows.Add(currentRow.Take(expectedPerRow).ToArray());
+                var completedRow = currentRow.Take(expectedPerRow).ToArray();
+
+                // Touchstone v1 allows noise-parameter blocks after the last
+                // S-parameter row. They re-use the frequency column but use a
+                // different (smaller) column layout. We detect the start of
+                // noise data as "frequency went backwards" — real sweeps are
+                // monotonically increasing — and stop parsing there rather
+                // than corrupting the S-matrix with noise numbers silently.
+                if (dataRows.Count > 0 && completedRow[0] <= dataRows[^1][0])
+                    break;
+
+                dataRows.Add(completedRow);
                 currentRow = new List<double>(currentRow.Skip(expectedPerRow));
             }
         }
@@ -113,6 +133,10 @@ public class TouchstoneImporter : ISParameterImporter
         foreach (var row in dataRows)
         {
             double freqHz = row[0] * freqMult;
+            if (!double.IsFinite(freqHz) || freqHz <= 0)
+                throw new SParameterImportException(
+                    $"Invalid frequency {row[0]} {format} — must be finite and positive.");
+
             int wavelengthNm = (int)Math.Round(299_792_458.0 / freqHz * 1e9);
 
             var matrix = new Complex[n, n];
@@ -137,13 +161,35 @@ public class TouchstoneImporter : ISParameterImporter
         return result;
     }
 
-    private static Complex ToComplex(double a, double b, string format) => format switch
+    private static Complex ToComplex(double a, double b, string format)
     {
-        "MA" => Complex.FromPolarCoordinates(a, b * Math.PI / 180.0),
-        "DB" => Complex.FromPolarCoordinates(Math.Pow(10, a / 20.0), b * Math.PI / 180.0),
-        "RI" => new Complex(a, b),
-        _ => new Complex(a, b)
-    };
+        if (!double.IsFinite(a) || !double.IsFinite(b))
+            throw new SParameterImportException(
+                $"Non-finite S-parameter component ({a}, {b}) in {format} format — file contains NaN or Infinity.");
+
+        return format switch
+        {
+            "MA" => Complex.FromPolarCoordinates(a, b * Math.PI / 180.0),
+            "DB" => Complex.FromPolarCoordinates(Math.Pow(10, a / 20.0), b * Math.PI / 180.0),
+            "RI" => new Complex(a, b),
+            _ => throw new SParameterImportException(
+                $"Unknown data format '{format}'. Expected MA, DB, or RI.")
+        };
+    }
+
+    /// <summary>
+    /// Validates the data-format token on the Touchstone option line.
+    /// Unknown tokens throw — silently defaulting to RI would turn a typo'd
+    /// "# HZ S MAG R 50" file into garbage values without the user noticing.
+    /// </summary>
+    private static string ValidateDataFormat(string raw)
+    {
+        var format = raw.ToUpperInvariant();
+        if (format is not ("MA" or "DB" or "RI"))
+            throw new SParameterImportException(
+                $"Unknown data format '{raw}' on Touchstone option line. Expected MA, DB, or RI.");
+        return format;
+    }
 
     private static double FreqUnitMultiplier(string unit) => unit.ToUpperInvariant() switch
     {
@@ -151,7 +197,8 @@ public class TouchstoneImporter : ISParameterImporter
         "KHZ" => 1e3,
         "MHZ" => 1e6,
         "GHZ" => 1e9,
-        _ => 1.0
+        _ => throw new SParameterImportException(
+            $"Unknown frequency unit '{unit}' on Touchstone option line. Expected Hz, kHz, MHz, or GHz.")
     };
 
     private static IReadOnlyList<string> BuildExtensions()

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -11,6 +11,7 @@ using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Export;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Import;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
@@ -145,6 +146,7 @@ public partial class App : Application
         services.AddTransient<GroupSMatrixViewModel>();
         services.AddTransient<ArchitectureReportViewModel>();
         services.AddTransient<PdkConsistencyViewModel>();
+        services.AddTransient<SParameterImportViewModel>();
 
         // VerilogAExportViewModel is a singleton because both FileOperations
         // (top-toolbar Verilog-A button) and VerilogAExportSettingsPage

--- a/CAP.Avalonia/ViewModels/Import/SParameterImportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Import/SParameterImportViewModel.cs
@@ -1,0 +1,183 @@
+using CAP_DataAccess.Import;
+using CAP_DataAccess.Persistence.PIR;
+using CAP.Avalonia.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Import;
+
+/// <summary>
+/// ViewModel for the S-parameter import panel.
+/// Lets users pick a Lumerical (.sparam/.dat/.txt) or Touchstone (.sNp) file,
+/// preview the parsed data, assign it a component identifier, and store it in
+/// the active design's PIR S-matrix section.
+/// </summary>
+public partial class SParameterImportViewModel : ObservableObject
+{
+    private readonly IReadOnlyList<ISParameterImporter> _importers;
+    private Dictionary<string, ComponentSMatrixData>? _storedSMatrices;
+
+    /// <summary>Path of the selected source file.</summary>
+    [ObservableProperty]
+    private string _filePath = string.Empty;
+
+    /// <summary>Auto-detected format description (e.g. "Lumerical SiEPIC", "Touchstone S2P").</summary>
+    [ObservableProperty]
+    private string _detectedFormat = string.Empty;
+
+    /// <summary>
+    /// Identifier key under which the S-matrix will be stored (e.g. "mmi_2x2_custom").
+    /// Must be unique within the design; overwrites any existing entry with the same key.
+    /// </summary>
+    [ObservableProperty]
+    private string _componentIdentifier = string.Empty;
+
+    /// <summary>Human-readable preview info (port count, wavelength range).</summary>
+    [ObservableProperty]
+    private string _previewInfo = string.Empty;
+
+    /// <summary>Status message shown after an import attempt.</summary>
+    [ObservableProperty]
+    private string _statusText = string.Empty;
+
+    /// <summary>True while an import is in progress.</summary>
+    [ObservableProperty]
+    private bool _isImporting;
+
+    /// <summary>True after the last import completed successfully.</summary>
+    [ObservableProperty]
+    private bool _lastImportSucceeded;
+
+    /// <summary>File dialog service for the Browse button.</summary>
+    public IFileDialogService? FileDialogService { get; set; }
+
+    /// <summary>
+    /// The design's S-matrix store (from <c>FileOperationsViewModel.StoredSMatrices</c>).
+    /// Must be set by <c>MainViewModel</c> after construction to share the same dictionary
+    /// that <c>FileOperationsViewModel</c> persists on save.
+    /// </summary>
+    public Dictionary<string, ComponentSMatrixData>? StoredSMatrices
+    {
+        get => _storedSMatrices;
+        set => _storedSMatrices = value;
+    }
+
+    /// <summary>Initializes a new instance of <see cref="SParameterImportViewModel"/>.</summary>
+    public SParameterImportViewModel()
+    {
+        _importers = new ISParameterImporter[]
+        {
+            new LumericalSParameterImporter(),
+            new TouchstoneImporter()
+        };
+    }
+
+    /// <summary>Opens a file dialog to select an S-parameter file.</summary>
+    [RelayCommand]
+    private async Task BrowseFile()
+    {
+        if (FileDialogService == null) return;
+
+        var path = await FileDialogService.ShowOpenFileDialogAsync(
+            "Select S-Parameter File",
+            "S-Parameter Files|*.sparam;*.dat;*.txt;*.s1p;*.s2p;*.s3p;*.s4p;*.sNp|All Files|*.*");
+
+        if (path == null) return;
+
+        FilePath = path;
+        PreviewInfo = string.Empty;
+        DetectedFormat = string.Empty;
+        StatusText = string.Empty;
+        LastImportSucceeded = false;
+
+        DetectedFormat = DetectFormat(path);
+
+        // Auto-fill component identifier from filename if empty
+        if (string.IsNullOrWhiteSpace(ComponentIdentifier))
+            ComponentIdentifier = Path.GetFileNameWithoutExtension(path);
+    }
+
+    /// <summary>Parses the selected file and stores the result in the design.</summary>
+    [RelayCommand]
+    private async Task Import()
+    {
+        if (string.IsNullOrWhiteSpace(FilePath))
+        {
+            StatusText = "No file selected.";
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(ComponentIdentifier))
+        {
+            StatusText = "Component identifier cannot be empty.";
+            return;
+        }
+
+        if (_storedSMatrices == null)
+        {
+            StatusText = "Import store not initialized. Open or create a design first.";
+            return;
+        }
+
+        var importer = FindImporter(FilePath);
+        if (importer == null)
+        {
+            StatusText = $"Unsupported file type: {Path.GetExtension(FilePath)}";
+            return;
+        }
+
+        IsImporting = true;
+        LastImportSucceeded = false;
+        StatusText = "Importing…";
+
+        try
+        {
+            var imported = await importer.ImportAsync(FilePath);
+
+            var smatrixData = SParameterConverter.ToComponentSMatrixData(imported);
+            _storedSMatrices![ComponentIdentifier] = smatrixData;
+
+            PreviewInfo = BuildPreviewInfo(imported);
+            StatusText = $"Imported {imported.PortCount}-port S-matrix ({imported.SMatricesByWavelengthNm.Count} wavelengths) → '{ComponentIdentifier}'.";
+            LastImportSucceeded = true;
+        }
+        catch (SParameterImportException ex)
+        {
+            StatusText = $"Parse error: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Import failed: {ex.Message}";
+        }
+        finally
+        {
+            IsImporting = false;
+        }
+    }
+
+    private ISParameterImporter? FindImporter(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return _importers.FirstOrDefault(i => i.SupportedExtensions.Contains(ext));
+    }
+
+    private string DetectFormat(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return ext switch
+        {
+            ".sparam" or ".dat" => "Lumerical SiEPIC",
+            ".txt" => "Lumerical GC TXT",
+            var e when e.StartsWith(".s") && e.EndsWith("p") => $"Touchstone {ext.ToUpperInvariant()}",
+            _ => $"Unknown ({ext})"
+        };
+    }
+
+    private static string BuildPreviewInfo(ImportedSParameters imported)
+    {
+        if (imported.SMatricesByWavelengthNm.Count == 0)
+            return "No wavelength data.";
+
+        var wls = imported.SMatricesByWavelengthNm.Keys.OrderBy(k => k).ToArray();
+        return $"{imported.PortCount} ports | {wls.Length} wavelengths ({wls[0]}–{wls[^1]} nm) | {imported.SourceFormat}";
+    }
+}

--- a/CAP.Avalonia/ViewModels/Import/SParameterImportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Import/SParameterImportViewModel.cs
@@ -1,3 +1,4 @@
+using CAP_Core;
 using CAP_DataAccess.Import;
 using CAP_DataAccess.Persistence.PIR;
 using CAP.Avalonia.Services;
@@ -15,6 +16,7 @@ namespace CAP.Avalonia.ViewModels.Import;
 public partial class SParameterImportViewModel : ObservableObject
 {
     private readonly IReadOnlyList<ISParameterImporter> _importers;
+    private readonly ErrorConsoleService? _errorConsole;
     private Dictionary<string, ComponentSMatrixData>? _storedSMatrices;
 
     /// <summary>Path of the selected source file.</summary>
@@ -63,8 +65,9 @@ public partial class SParameterImportViewModel : ObservableObject
     }
 
     /// <summary>Initializes a new instance of <see cref="SParameterImportViewModel"/>.</summary>
-    public SParameterImportViewModel()
+    public SParameterImportViewModel(ErrorConsoleService? errorConsole = null)
     {
+        _errorConsole = errorConsole;
         _importers = new ISParameterImporter[]
         {
             new LumericalSParameterImporter(),
@@ -137,16 +140,29 @@ public partial class SParameterImportViewModel : ObservableObject
             _storedSMatrices![ComponentIdentifier] = smatrixData;
 
             PreviewInfo = BuildPreviewInfo(imported);
-            StatusText = $"Imported {imported.PortCount}-port S-matrix ({imported.SMatricesByWavelengthNm.Count} wavelengths) → '{ComponentIdentifier}'.";
+            var warnSuffix = imported.Metadata.TryGetValue("malformedRows", out var malformed) && malformed != "0"
+                ? $" — {malformed} malformed row(s) skipped"
+                : string.Empty;
+            StatusText = $"Imported {imported.PortCount}-port S-matrix ({imported.SMatricesByWavelengthNm.Count} wavelengths) → '{ComponentIdentifier}'.{warnSuffix}";
             LastImportSucceeded = true;
         }
         catch (SParameterImportException ex)
         {
             StatusText = $"Parse error: {ex.Message}";
+            _errorConsole?.LogError($"S-parameter parse error ({Path.GetFileName(FilePath)}): {ex.Message}", ex);
+        }
+        catch (FormatException ex)
+        {
+            // Raw double.Parse / int.Parse failures bleed through with a
+            // generic "Input string was not in a correct format" — useless
+            // for a 10k-line file. Wrap with context.
+            StatusText = $"Malformed numeric data in {Path.GetFileName(FilePath)}: {ex.Message}";
+            _errorConsole?.LogError($"S-parameter format error: {ex.Message}", ex);
         }
         catch (Exception ex)
         {
             StatusText = $"Import failed: {ex.Message}";
+            _errorConsole?.LogError($"S-parameter import failed ({Path.GetFileName(FilePath)}): {ex.Message}", ex);
         }
         finally
         {
@@ -157,7 +173,43 @@ public partial class SParameterImportViewModel : ObservableObject
     private ISParameterImporter? FindImporter(string path)
     {
         var ext = Path.GetExtension(path).ToLowerInvariant();
+
+        // Touchstone extensions (.s1p through .s9p) are unambiguous.
+        // Lumerical's own extensions `.sparam` and `.dat` are unambiguous too.
+        // `.txt` is NOT — any text file could carry that extension, so we
+        // sniff the first non-empty/non-comment line before claiming it.
+        if (ext == ".txt")
+            return LooksLikeLumericalTxt(path) ? _importers[0] /* Lumerical */ : null;
+
         return _importers.FirstOrDefault(i => i.SupportedExtensions.Contains(ext));
+    }
+
+    private static bool LooksLikeLumericalTxt(string path)
+    {
+        try
+        {
+            foreach (var line in File.ReadLines(path))
+            {
+                var trimmed = line.TrimStart();
+                if (trimmed.Length == 0 || trimmed.StartsWith('#') || trimmed.StartsWith('!'))
+                    continue;
+                // Lumerical blocked header begins with `(`. GC packed TXT rows
+                // start with a scientific-notation frequency — 9+ columns of
+                // double-precision numbers separated by whitespace is the
+                // cheap-and-cheerful discriminator.
+                if (trimmed.StartsWith('(')) return true;
+                var tokens = trimmed.Split(new[] { '\t', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                return tokens.Length >= 9 &&
+                       double.TryParse(tokens[0], System.Globalization.NumberStyles.Float,
+                                       System.Globalization.CultureInfo.InvariantCulture, out _);
+            }
+        }
+        catch
+        {
+            // File-read failure → let the subsequent import path produce the
+            // proper error; don't claim the file here.
+        }
+        return false;
     }
 
     private string DetectFormat(string path)

--- a/CAP.Avalonia/ViewModels/Import/SParameterImportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Import/SParameterImportViewModel.cs
@@ -140,9 +140,12 @@ public partial class SParameterImportViewModel : ObservableObject
             _storedSMatrices![ComponentIdentifier] = smatrixData;
 
             PreviewInfo = BuildPreviewInfo(imported);
-            var warnSuffix = imported.Metadata.TryGetValue("malformedRows", out var malformed) && malformed != "0"
-                ? $" — {malformed} malformed row(s) skipped"
-                : string.Empty;
+            var warns = new List<string>();
+            if (imported.Metadata.TryGetValue("malformedRows", out var malformed) && malformed != "0")
+                warns.Add($"{malformed} malformed row(s) skipped");
+            if (imported.Metadata.TryGetValue("wavelengthCollisions", out var collisions) && collisions != "0")
+                warns.Add($"{collisions} wavelength(s) collapsed by nm-rounding — consider a sparser sweep");
+            var warnSuffix = warns.Count > 0 ? $" — {string.Join("; ", warns)}" : string.Empty;
             StatusText = $"Imported {imported.PortCount}-port S-matrix ({imported.SMatricesByWavelengthNm.Count} wavelengths) → '{ComponentIdentifier}'.{warnSuffix}";
             LastImportSucceeded = true;
         }

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -94,6 +94,7 @@ public partial class MainViewModel : ObservableObject
             FileOperations.FileDialogService = value;
             FileOperations.PhotonTorchExport.FileDialogService = value;
             LeftPanel.FileDialogService = value;
+            RightPanel.SParameterImport.FileDialogService = value;
         }
     }
 
@@ -141,6 +142,9 @@ public partial class MainViewModel : ObservableObject
 
         FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, picWaveExporter, LeftPanel.AllTemplates, gdsExportViewModel, photonTorchExport, verilogAExport, errorConsoleService);
         ViewportControl = viewportControl;
+
+        // Link S-parameter import store so imported data is included in saves
+        RightPanel.SParameterImport.StoredSMatrices = FileOperations.StoredSMatrices;
 
         // Wire up status callbacks
         CanvasInteraction.UpdateStatus = UpdateStatusText;

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -44,6 +44,13 @@ public partial class FileOperationsViewModel : ObservableObject
     /// </summary>
     private DesignMetadata? _loadedMetadata;
 
+    /// <summary>
+    /// Per-component S-matrix overrides loaded from the PIR section of the .lun file,
+    /// or added via the S-parameter import feature. Survives save-over-reload cycles.
+    /// Keyed by component identifier string; values are the stored S-matrices.
+    /// </summary>
+    public Dictionary<string, ComponentSMatrixData> StoredSMatrices { get; } = new();
+
     [ObservableProperty]
     private bool _hasUnsavedChanges;
 
@@ -214,6 +221,8 @@ public partial class FileOperationsViewModel : ObservableObject
 
             designData.FormatVersion = CurrentFormatVersion;
             designData.Metadata = BuildMetadataForSave();
+            if (StoredSMatrices.Count > 0)
+                designData.SMatrices = new Dictionary<string, ComponentSMatrixData>(StoredSMatrices);
 
             var json = JsonSerializer.Serialize(designData, new JsonSerializerOptions
             {
@@ -566,6 +575,14 @@ public partial class FileOperationsViewModel : ObservableObject
 
                 // Preserve PIR metadata so Created date survives subsequent saves
                 _loadedMetadata = designData.Metadata;
+
+                // Restore imported S-matrices from PIR section
+                StoredSMatrices.Clear();
+                if (designData.SMatrices != null)
+                {
+                    foreach (var kv in designData.SMatrices)
+                        StoredSMatrices[kv.Key] = kv.Value;
+                }
 
                 _currentFilePath = filePath;
                 HasUnsavedChanges = false;

--- a/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
@@ -5,6 +5,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Converters;
 using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Import;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.Services;
 
@@ -100,6 +101,11 @@ public partial class RightPanelViewModel : ObservableObject
     /// </summary>
     public AiAssistantViewModel AiAssistant { get; }
 
+    /// <summary>
+    /// ViewModel for S-parameter import from Lumerical and Touchstone files.
+    /// </summary>
+    public SParameterImportViewModel SParameterImport { get; }
+
     /// <summary>Initializes a new instance of <see cref="RightPanelViewModel"/>.</summary>
     public RightPanelViewModel(
         DesignCanvasViewModel canvas,
@@ -115,7 +121,8 @@ public partial class RightPanelViewModel : ObservableObject
         GroupSMatrixViewModel groupSMatrix,
         ArchitectureReportViewModel architectureReport,
         PdkConsistencyViewModel pdkConsistency,
-        AiAssistantViewModel aiAssistant)
+        AiAssistantViewModel aiAssistant,
+        SParameterImportViewModel sParameterImport)
     {
         _preferencesService = preferencesService;
 
@@ -131,6 +138,7 @@ public partial class RightPanelViewModel : ObservableObject
         ArchitectureReport = architectureReport;
         PdkConsistency = pdkConsistency;
         AiAssistant = aiAssistant;
+        SParameterImport = sParameterImport;
 
         // Configure ViewModels that need canvas reference
         RoutingDiagnostics.Configure(canvas);

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -710,6 +710,10 @@
                                Foreground="LightGreen" FontSize="10" Margin="0,0,0,5"
                                IsVisible="{Binding BottomPanel.ElementLock.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
 
+                    <!-- S-Parameter Import -->
+                    <panels:SParameterImportPanel/>
+
+
                 </StackPanel>
                 </ScrollViewer>
             </DockPanel>

--- a/CAP.Avalonia/Views/Panels/SParameterImportPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/SParameterImportPanel.axaml
@@ -1,0 +1,66 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:CAP.Avalonia.ViewModels"
+             x:Class="CAP.Avalonia.Views.Panels.SParameterImportPanel"
+             x:DataType="vm:MainViewModel">
+
+    <StackPanel>
+        <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
+        <TextBlock Text="S-Parameter Import:" Foreground="#7BC8A4" Margin="0,0,0,5" FontWeight="SemiBold"/>
+        <TextBlock Text="Import S-matrix data from Lumerical (.sparam/.dat) or Touchstone (.sNp) files."
+                   Foreground="Gray" FontSize="9" Margin="0,0,0,8" TextWrapping="Wrap"/>
+
+        <!-- File selection row -->
+        <Grid ColumnDefinitions="*,Auto" Margin="0,0,0,6">
+            <TextBox Grid.Column="0"
+                     Text="{Binding RightPanel.SParameterImport.FilePath}"
+                     Watermark="No file selected…"
+                     IsReadOnly="True"
+                     Background="#1e1e1e" Foreground="White"
+                     BorderBrush="#3e3e3e"/>
+            <Button Grid.Column="1"
+                    Content="Browse"
+                    Command="{Binding RightPanel.SParameterImport.BrowseFileCommand}"
+                    Margin="4,0,0,0" Padding="8,4"
+                    Background="#3d4d5d"/>
+        </Grid>
+
+        <!-- Detected format -->
+        <TextBlock Text="{Binding RightPanel.SParameterImport.DetectedFormat}"
+                   Foreground="#8888aa" FontSize="9" Margin="0,0,0,8"
+                   IsVisible="{Binding RightPanel.SParameterImport.DetectedFormat, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
+        <!-- Component identifier -->
+        <TextBlock Text="Component identifier:" Foreground="Gray" Margin="0,0,0,3" FontSize="11"/>
+        <TextBox Text="{Binding RightPanel.SParameterImport.ComponentIdentifier}"
+                 Watermark="e.g. mmi_2x2_custom"
+                 Margin="0,0,0,8"
+                 Background="#1e1e1e" Foreground="White"
+                 BorderBrush="#3e3e3e"/>
+
+        <!-- Import button -->
+        <Button Content="Import S-Parameters"
+                Command="{Binding RightPanel.SParameterImport.ImportCommand}"
+                HorizontalAlignment="Stretch" Margin="0,0,0,5" Padding="8,6"
+                Background="#3d6d4d"
+                IsEnabled="{Binding RightPanel.SParameterImport.IsImporting, Converter={x:Static BoolConverters.Not}}"/>
+
+        <!-- Preview info -->
+        <TextBlock Text="{Binding RightPanel.SParameterImport.PreviewInfo}"
+                   Foreground="#aaaacc" FontSize="9" Margin="0,0,0,4" TextWrapping="Wrap"
+                   IsVisible="{Binding RightPanel.SParameterImport.PreviewInfo, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+
+        <!-- Status: success -->
+        <TextBlock Text="{Binding RightPanel.SParameterImport.StatusText}"
+                   Foreground="LightGreen" FontSize="10" Margin="0,0,0,5" TextWrapping="Wrap"
+                   IsVisible="{Binding RightPanel.SParameterImport.LastImportSucceeded}"/>
+
+        <!-- Status: error (not importing, not succeeded) -->
+        <TextBlock Text="{Binding RightPanel.SParameterImport.StatusText}"
+                   Foreground="#FF6B6B" FontSize="10" Margin="0,0,0,5" TextWrapping="Wrap"
+                   IsVisible="{Binding RightPanel.SParameterImport.LastImportSucceeded, Converter={x:Static BoolConverters.Not}}"
+                   IsHitTestVisible="False"/>
+
+    </StackPanel>
+
+</UserControl>

--- a/CAP.Avalonia/Views/Panels/SParameterImportPanel.axaml.cs
+++ b/CAP.Avalonia/Views/Panels/SParameterImportPanel.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+
+namespace CAP.Avalonia.Views.Panels;
+
+/// <summary>Code-behind for the S-Parameter Import panel.</summary>
+public partial class SParameterImportPanel : UserControl
+{
+    /// <summary>Initializes the S-Parameter Import panel.</summary>
+    public SParameterImportPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -12,6 +12,7 @@ using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Import;
 using CAP.Avalonia.ViewModels.PdkOffset;
 using CAP_Core.Components.Creation;
 using CAP_Core.Export;
@@ -131,7 +132,8 @@ public static class MainViewModelTestHelper
             new GroupSMatrixViewModel(),
             new ArchitectureReportViewModel(),
             new PdkConsistencyViewModel(),
-            new AiAssistantViewModel(Mock.Of<IAiService>(), preferencesService));
+            new AiAssistantViewModel(Mock.Of<IAiService>(), preferencesService),
+            new SParameterImportViewModel());
     }
 
     /// <summary>

--- a/UnitTests/Import/RealLumericalReferenceFilesTests.cs
+++ b/UnitTests/Import/RealLumericalReferenceFilesTests.cs
@@ -1,0 +1,145 @@
+using System.IO;
+using System.Threading.Tasks;
+using CAP_DataAccess.Import;
+using Shouldly;
+
+namespace UnitTests.Import;
+
+/// <summary>
+/// Fit-check against the real Lumerical / SiEPIC reference files shipped in
+/// <c>Tools/sparam-data/</c>. The synthetic tests in
+/// <c>SParameterImporterTests</c> verify the parser against hand-crafted
+/// content that matches the format spec; these tests verify the same parser
+/// against files actually produced by Lumerical INTERCONNECT and the
+/// SiEPIC EBeam PDK.
+///
+/// A failure here means real users will hit the same failure — the synthetic
+/// tests alone are not enough. Each failing file is documented with its
+/// actual shape so a future fix has clear context.
+/// </summary>
+public class RealLumericalReferenceFilesTests
+{
+    private static readonly string DataDir = FindRepoRelative("Tools", "sparam-data");
+
+    public static IEnumerable<object[]> BlockedSparamFiles() => new[]
+    {
+        new object[] { "bdc_te1550.sparam" },
+        new object[] { "dc_te1550.sparam" },
+        new object[] { "dc_te1550_Lc5.sparam" },
+        new object[] { "y_branch.sparam" },
+        new object[] { "terminator_te1550.sparam" },
+        new object[] { "terminator_tm1550.sparam" },
+        new object[] { "disconnected_te1550.sparam" },
+        new object[] { "contra_dc.dat" },      // .dat blocked, header w/o quotes around TE
+        new object[] { "dc_halfring.dat" },
+        new object[] { "gc_te1310.dat" },      // blocked with port-manifest header + "mode 1" in quotes
+    };
+
+    public static IEnumerable<object[]> PackedGcFiles() => new[]
+    {
+        new object[] { "gc_te1550.txt" },
+        new object[] { "taper_te1550.dat" },   // .dat but packed format (9 cols per row)
+    };
+
+    [Theory]
+    [MemberData(nameof(BlockedSparamFiles))]
+    public async Task LumericalImporter_ParsesBlockedReference(string filename)
+    {
+        var path = Path.Combine(DataDir, filename);
+        File.Exists(path).ShouldBeTrue($"Reference file missing: {path}");
+
+        var result = await new LumericalSParameterImporter().ImportAsync(path);
+
+        result.ShouldNotBeNull();
+        result.PortCount.ShouldBeGreaterThan(0, $"{filename}: no ports detected");
+        result.SMatricesByWavelengthNm.ShouldNotBeEmpty($"{filename}: no wavelengths parsed");
+
+        // Sanity bound: SiEPIC sweep lives in the optical telecom range,
+        // typically 1200-1700 nm. A wavelength outside [1000, 2000] means
+        // unit conversion went wrong somewhere.
+        foreach (var wl in result.SMatricesByWavelengthNm.Keys)
+            wl.ShouldBeInRange(1000, 2000, $"{filename}: wavelength {wl} nm out of telecom range");
+
+        // Sanity bound: S-parameter magnitudes for passive devices must be
+        // in [0, ~1.01] — anything larger means we parsed magnitude in dB
+        // as linear, or mis-scaled the GC packed values.
+        foreach (var (_, m) in result.SMatricesByWavelengthNm)
+        {
+            for (int r = 0; r < result.PortCount; r++)
+                for (int c = 0; c < result.PortCount; c++)
+                    m[r, c].Magnitude.ShouldBeLessThanOrEqualTo(1.01, $"{filename}: |S[{r},{c}]| > 1 for a passive device");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(PackedGcFiles))]
+    public async Task LumericalImporter_ParsesPackedGcReference(string filename)
+    {
+        var path = Path.Combine(DataDir, filename);
+        File.Exists(path).ShouldBeTrue($"Reference file missing: {path}");
+
+        var result = await new LumericalSParameterImporter().ImportAsync(path);
+
+        result.ShouldNotBeNull();
+        result.PortCount.ShouldBe(2, $"{filename}: GC/taper packed format is 2-port");
+        result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
+
+        foreach (var wl in result.SMatricesByWavelengthNm.Keys)
+            wl.ShouldBeInRange(1000, 2000, $"{filename}: wavelength out of telecom range");
+
+        foreach (var (_, m) in result.SMatricesByWavelengthNm)
+        {
+            for (int r = 0; r < 2; r++)
+                for (int c = 0; c < 2; c++)
+                    m[r, c].Magnitude.ShouldBeLessThanOrEqualTo(1.01, $"{filename}: |S[{r},{c}]| > 1");
+        }
+    }
+
+    [Fact]
+    public async Task DcTe1550_ReportsWavelengthCollisions()
+    {
+        // dc_te1550.sparam has 101 sampled frequencies, but frequency-space
+        // sampling collapses to ~99 distinct integer-nm keys around 1550 nm.
+        // The dict can only hold 99 entries, and we report the collision
+        // count via Metadata so the user sees the sparsity loss.
+        var result = await new LumericalSParameterImporter().ImportAsync(
+            Path.Combine(DataDir, "dc_te1550.sparam"));
+
+        result.PortCount.ShouldBe(4); // bidirectional 2+2 coupler (4 physical terminals)
+        result.SMatricesByWavelengthNm.Count.ShouldBeInRange(98, 101);
+        result.Metadata.ShouldContainKey("wavelengthCollisions");
+        int.Parse(result.Metadata["wavelengthCollisions"]).ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task YBranch_HasExpectedPortCount()
+    {
+        // y_branch.sparam is a 1-input / 2-output splitter = 3 ports.
+        var result = await new LumericalSParameterImporter().ImportAsync(
+            Path.Combine(DataDir, "y_branch.sparam"));
+
+        result.PortCount.ShouldBe(3);
+        result.SMatricesByWavelengthNm.Count.ShouldBe(51);
+    }
+
+    [Fact]
+    public async Task Terminator_Is1PortDevice()
+    {
+        var result = await new LumericalSParameterImporter().ImportAsync(
+            Path.Combine(DataDir, "terminator_te1550.sparam"));
+
+        result.PortCount.ShouldBe(1);
+        result.SMatricesByWavelengthNm.Count.ShouldBe(101);
+    }
+
+    private static string FindRepoRelative(params string[] segments)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Tools", "sparam-data")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir == null) throw new InvalidOperationException("Could not locate repository root");
+        return Path.Combine(new[] { dir.FullName }.Concat(segments).ToArray());
+    }
+}

--- a/UnitTests/Import/SParameterImporterTests.cs
+++ b/UnitTests/Import/SParameterImporterTests.cs
@@ -1,0 +1,278 @@
+using CAP_DataAccess.Import;
+using Shouldly;
+using System.Numerics;
+
+namespace UnitTests.Import;
+
+/// <summary>
+/// Unit tests for Lumerical and Touchstone S-parameter importers.
+/// All tests use in-memory temp files — no external files required.
+/// </summary>
+public class SParameterImporterTests
+{
+    // ── LumericalSParameterImporter ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Lumerical_Sparam_ParsesBlockedFormat()
+    {
+        const double freq1550 = 299_792_458.0 / 1550e-9; // ~193.4 THz
+
+        var content = $@"('port 1','TE',0,'port 2',0,'transmission')
+(3,3)
+{freq1550:G15}  0.95  0.05
+{freq1550 * 0.99:G15}  0.94  0.06
+{freq1550 * 1.01:G15}  0.96  0.04
+('port 2','TE',0,'port 1',0,'transmission')
+(3,3)
+{freq1550:G15}  0.95  0.05
+{freq1550 * 0.99:G15}  0.94  0.06
+{freq1550 * 1.01:G15}  0.96  0.04
+";
+        var path = WriteTempFile(content, ".sparam");
+        var importer = new LumericalSParameterImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        result.PortCount.ShouldBe(2);
+        result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
+        result.SourceFormat.ShouldBe("Lumerical SiEPIC");
+    }
+
+    [Fact]
+    public async Task Lumerical_Sparam_ThrowsOnMissingFile()
+    {
+        var importer = new LumericalSParameterImporter();
+        await Should.ThrowAsync<SParameterImportException>(() =>
+            importer.ImportAsync("/nonexistent/file.sparam"));
+    }
+
+    [Fact]
+    public async Task Lumerical_Sparam_ReportsCorrectWavelengths()
+    {
+        // Frequencies at 1500 nm and 1600 nm
+        double f1500 = 299_792_458.0 / 1500e-9;
+        double f1600 = 299_792_458.0 / 1600e-9;
+
+        var content = $@"('port 1','TE',0,'port 2',0,'transmission')
+(2,3)
+{f1500:G15}  0.9  0.1
+{f1600:G15}  0.85  0.15
+('port 2','TE',0,'port 1',0,'transmission')
+(2,3)
+{f1500:G15}  0.9  0.1
+{f1600:G15}  0.85  0.15
+";
+        var path = WriteTempFile(content, ".sparam");
+        var importer = new LumericalSParameterImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        result.SMatricesByWavelengthNm.Keys.ShouldContain(1500);
+        result.SMatricesByWavelengthNm.Keys.ShouldContain(1600);
+    }
+
+    [Fact]
+    public async Task Lumerical_GcTxt_ParsesPackedFormat()
+    {
+        // GC .txt format: freq |S11| ang(S11) |S21| ang(S21) |S12| ang(S12) |S22| ang(S22)
+        double f1550 = 299_792_458.0 / 1550e-9;
+        var content = $"{f1550:G15} 0.05 10 0.95 80 0.95 80 0.05 10\n";
+        var path = WriteTempFile(content, ".txt");
+        var importer = new LumericalSParameterImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        result.PortCount.ShouldBe(2);
+        result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
+        result.SourceFormat.ShouldBe("Lumerical GC TXT");
+    }
+
+    [Fact]
+    public async Task Lumerical_Sparam_ComplexValuesAreCorrect()
+    {
+        double freq = 299_792_458.0 / 1550e-9;
+        double mag = 0.9;
+        double phase = Math.PI / 4; // 45 degrees
+
+        var content = $@"('port 1','TE',0,'port 2',0,'transmission')
+(1,3)
+{freq:G15}  {mag:G6}  {phase:G6}
+";
+        var path = WriteTempFile(content, ".sparam");
+        var importer = new LumericalSParameterImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        var matrix = result.SMatricesByWavelengthNm[1550];
+        int port1Idx = result.PortNames.IndexOf("port 1");
+        int port2Idx = result.PortNames.IndexOf("port 2");
+
+        var entry = matrix[port1Idx, port2Idx];
+        entry.Magnitude.ShouldBe(mag, tolerance: 1e-6);
+        entry.Phase.ShouldBe(phase, tolerance: 1e-6);
+    }
+
+    // ── TouchstoneImporter ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Touchstone_S2P_ParsesMAFormat()
+    {
+        // 2-port, MA format (magnitude-angle in degrees), GHz
+        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9; // ~193.4 GHz
+        var content = $@"# GHz S MA R 50
+{freqGHz:G6} 0.05 10 0.95 80 0.95 80 0.05 10
+";
+        var path = WriteTempFile(content, ".s2p");
+        var importer = new TouchstoneImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        result.PortCount.ShouldBe(2);
+        result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
+        result.SourceFormat.ShouldBe("Touchstone S2P");
+    }
+
+    [Fact]
+    public async Task Touchstone_S2P_ParsesRIFormat()
+    {
+        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+        var content = $@"# GHz S RI R 50
+{freqGHz:G6} 0.03 0.04 0.6 0.8 0.6 0.8 0.03 0.04
+";
+        var path = WriteTempFile(content, ".s2p");
+        var importer = new TouchstoneImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        var matrix = result.SMatricesByWavelengthNm.Values.First();
+        var s11 = matrix[0, 0];
+        s11.Real.ShouldBe(0.03, tolerance: 1e-6);
+        s11.Imaginary.ShouldBe(0.04, tolerance: 1e-6);
+    }
+
+    [Fact]
+    public async Task Touchstone_S2P_ParsesDBFormat()
+    {
+        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+        var content = $@"# GHz S DB R 50
+{freqGHz:G6} -20 45 -0.45 80 -0.45 80 -20 45
+";
+        var path = WriteTempFile(content, ".s2p");
+        var importer = new TouchstoneImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
+        var matrix = result.SMatricesByWavelengthNm.Values.First();
+        // S11 in dB: -20 dB → magnitude 0.1
+        matrix[0, 0].Magnitude.ShouldBe(0.1, tolerance: 1e-5);
+    }
+
+    [Fact]
+    public async Task Touchstone_CommentsAndBlankLinesIgnored()
+    {
+        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+        var content = $@"! This is a comment
+# GHz S MA R 50
+! Another comment
+
+{freqGHz:G6} 0.05 10 0.95 80 0.95 80 0.05 10
+";
+        var path = WriteTempFile(content, ".s2p");
+        var importer = new TouchstoneImporter();
+
+        var result = await importer.ImportAsync(path);
+
+        result.SMatricesByWavelengthNm.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Touchstone_ThrowsOnMissingFile()
+    {
+        var importer = new TouchstoneImporter();
+        await Should.ThrowAsync<SParameterImportException>(() =>
+            importer.ImportAsync("/nonexistent/file.s2p"));
+    }
+
+    // ── SParameterConverter ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Converter_ProducesCorrectRowMajorLayout()
+    {
+        double freq = 299_792_458.0 / 1550e-9;
+        var content = $@"('port 1','TE',0,'port 2',0,'transmission')
+(1,3)
+{freq:G15}  0.9  1.0
+('port 2','TE',0,'port 1',0,'transmission')
+(1,3)
+{freq:G15}  0.8  0.5
+('port 1','TE',0,'port 1',0,'transmission')
+(1,3)
+{freq:G15}  0.1  0.2
+('port 2','TE',0,'port 2',0,'transmission')
+(1,3)
+{freq:G15}  0.05  0.3
+";
+        var path = WriteTempFile(content, ".sparam");
+        var imported = await new LumericalSParameterImporter().ImportAsync(path);
+
+        var data = SParameterConverter.ToComponentSMatrixData(imported);
+
+        data.Wavelengths.ShouldContainKey("1550");
+        var entry = data.Wavelengths["1550"];
+        entry.Rows.ShouldBe(2);
+        entry.Cols.ShouldBe(2);
+        entry.Real.Count.ShouldBe(4); // 2x2 = 4
+        entry.Imag.Count.ShouldBe(4);
+        entry.PortNames.ShouldNotBeNull();
+        entry.PortNames!.Count.ShouldBe(2);
+    }
+
+    // ── Integration test ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SParameterImportViewModel_ImportsAndStoresData()
+    {
+        // Arrange: create a real .sparam file, a real dictionary, and the ViewModel
+        double freq = 299_792_458.0 / 1550e-9;
+        var sparamContent = $@"('port 1','TE',0,'port 2',0,'transmission')
+(1,3)
+{freq:G15}  0.95  0.1
+('port 2','TE',0,'port 1',0,'transmission')
+(1,3)
+{freq:G15}  0.95  0.1
+";
+        var filePath = WriteTempFile(sparamContent, ".sparam");
+
+        var storedSMatrices = new CAP_DataAccess.Persistence.PIR.ComponentSMatrixData().GetType()
+            == typeof(CAP_DataAccess.Persistence.PIR.ComponentSMatrixData)
+            ? new Dictionary<string, CAP_DataAccess.Persistence.PIR.ComponentSMatrixData>()
+            : null;
+
+        storedSMatrices = new Dictionary<string, CAP_DataAccess.Persistence.PIR.ComponentSMatrixData>();
+
+        var vm = new CAP.Avalonia.ViewModels.Import.SParameterImportViewModel
+        {
+            StoredSMatrices = storedSMatrices,
+            FilePath = filePath,
+            ComponentIdentifier = "test_component"
+        };
+
+        // Act: run import command
+        await vm.ImportCommand.ExecuteAsync(null);
+
+        // Assert: ViewModel reflects success and dictionary has data
+        vm.LastImportSucceeded.ShouldBeTrue(vm.StatusText);
+        storedSMatrices.ShouldContainKey("test_component");
+        storedSMatrices["test_component"].Wavelengths.ShouldContainKey("1550");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string WriteTempFile(string content, string extension)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sparam_test_{Guid.NewGuid()}{extension}");
+        File.WriteAllText(path, content);
+        return path;
+    }
+}

--- a/UnitTests/Import/SParameterImporterTests.cs
+++ b/UnitTests/Import/SParameterImporterTests.cs
@@ -1,37 +1,47 @@
-using CAP_DataAccess.Import;
-using Shouldly;
+using System.Globalization;
+using System.IO;
 using System.Numerics;
+using System.Threading;
+using CAP_DataAccess.Import;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
 
 namespace UnitTests.Import;
 
 /// <summary>
 /// Unit tests for Lumerical and Touchstone S-parameter importers.
 /// All tests use in-memory temp files — no external files required.
+/// All numeric interpolations go through <see cref="Inv"/> + the <see cref="Fmt"/>
+/// helper so the test suite remains correct on non-en-US machines (production
+/// parsers use InvariantCulture; tests must too, or they write "0,95" on de-DE
+/// and silently fail to parse).
 /// </summary>
 public class SParameterImporterTests
 {
+    private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+    /// <summary>Round-trip-safe double formatter — "R" guarantees exact re-parse.</summary>
+    private static string Fmt(double d) => d.ToString("R", Inv);
+
     // ── LumericalSParameterImporter ──────────────────────────────────────────
 
     [Fact]
     public async Task Lumerical_Sparam_ParsesBlockedFormat()
     {
-        const double freq1550 = 299_792_458.0 / 1550e-9; // ~193.4 THz
-
+        double freq1550 = 299_792_458.0 / 1550e-9;
         var content = $@"('port 1','TE',0,'port 2',0,'transmission')
 (3,3)
-{freq1550:G15}  0.95  0.05
-{freq1550 * 0.99:G15}  0.94  0.06
-{freq1550 * 1.01:G15}  0.96  0.04
+{Fmt(freq1550)}  0.95  0.05
+{Fmt(freq1550 * 0.99)}  0.94  0.06
+{Fmt(freq1550 * 1.01)}  0.96  0.04
 ('port 2','TE',0,'port 1',0,'transmission')
 (3,3)
-{freq1550:G15}  0.95  0.05
-{freq1550 * 0.99:G15}  0.94  0.06
-{freq1550 * 1.01:G15}  0.96  0.04
+{Fmt(freq1550)}  0.95  0.05
+{Fmt(freq1550 * 0.99)}  0.94  0.06
+{Fmt(freq1550 * 1.01)}  0.96  0.04
 ";
-        var path = WriteTempFile(content, ".sparam");
-        var importer = new LumericalSParameterImporter();
-
-        var result = await importer.ImportAsync(path);
+        using var tmp = WriteTempFile(content, ".sparam");
+        var result = await new LumericalSParameterImporter().ImportAsync(tmp.Path);
 
         result.PortCount.ShouldBe(2);
         result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
@@ -41,31 +51,27 @@ public class SParameterImporterTests
     [Fact]
     public async Task Lumerical_Sparam_ThrowsOnMissingFile()
     {
-        var importer = new LumericalSParameterImporter();
         await Should.ThrowAsync<SParameterImportException>(() =>
-            importer.ImportAsync("/nonexistent/file.sparam"));
+            new LumericalSParameterImporter().ImportAsync("/nonexistent/file.sparam"));
     }
 
     [Fact]
     public async Task Lumerical_Sparam_ReportsCorrectWavelengths()
     {
-        // Frequencies at 1500 nm and 1600 nm
         double f1500 = 299_792_458.0 / 1500e-9;
         double f1600 = 299_792_458.0 / 1600e-9;
 
         var content = $@"('port 1','TE',0,'port 2',0,'transmission')
 (2,3)
-{f1500:G15}  0.9  0.1
-{f1600:G15}  0.85  0.15
+{Fmt(f1500)}  0.9  0.1
+{Fmt(f1600)}  0.85  0.15
 ('port 2','TE',0,'port 1',0,'transmission')
 (2,3)
-{f1500:G15}  0.9  0.1
-{f1600:G15}  0.85  0.15
+{Fmt(f1500)}  0.9  0.1
+{Fmt(f1600)}  0.85  0.15
 ";
-        var path = WriteTempFile(content, ".sparam");
-        var importer = new LumericalSParameterImporter();
-
-        var result = await importer.ImportAsync(path);
+        using var tmp = WriteTempFile(content, ".sparam");
+        var result = await new LumericalSParameterImporter().ImportAsync(tmp.Path);
 
         result.SMatricesByWavelengthNm.Keys.ShouldContain(1500);
         result.SMatricesByWavelengthNm.Keys.ShouldContain(1600);
@@ -74,13 +80,11 @@ public class SParameterImporterTests
     [Fact]
     public async Task Lumerical_GcTxt_ParsesPackedFormat()
     {
-        // GC .txt format: freq |S11| ang(S11) |S21| ang(S21) |S12| ang(S12) |S22| ang(S22)
         double f1550 = 299_792_458.0 / 1550e-9;
-        var content = $"{f1550:G15} 0.05 10 0.95 80 0.95 80 0.05 10\n";
-        var path = WriteTempFile(content, ".txt");
-        var importer = new LumericalSParameterImporter();
-
-        var result = await importer.ImportAsync(path);
+        // freq |S11| ang(S11) |S21| ang(S21) |S12| ang(S12) |S22| ang(S22)
+        var content = $"{Fmt(f1550)} 0.05 10 0.95 80 0.95 80 0.05 10\n";
+        using var tmp = WriteTempFile(content, ".txt");
+        var result = await new LumericalSParameterImporter().ImportAsync(tmp.Path);
 
         result.PortCount.ShouldBe(2);
         result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
@@ -90,82 +94,229 @@ public class SParameterImporterTests
     [Fact]
     public async Task Lumerical_Sparam_ComplexValuesAreCorrect()
     {
+        // Use the exact frequency that round-trips back to 1550 nm via the
+        // parser's integer-nm rounding. Round-trip safe "R" formatting avoids
+        // the original G6-precision bug.
         double freq = 299_792_458.0 / 1550e-9;
         double mag = 0.9;
-        double phase = Math.PI / 4; // 45 degrees
+        double phase = Math.PI / 4;
 
         var content = $@"('port 1','TE',0,'port 2',0,'transmission')
 (1,3)
-{freq:G15}  {mag:G6}  {phase:G6}
+{Fmt(freq)}  {Fmt(mag)}  {Fmt(phase)}
 ";
-        var path = WriteTempFile(content, ".sparam");
-        var importer = new LumericalSParameterImporter();
-
-        var result = await importer.ImportAsync(path);
+        using var tmp = WriteTempFile(content, ".sparam");
+        var result = await new LumericalSParameterImporter().ImportAsync(tmp.Path);
 
         var matrix = result.SMatricesByWavelengthNm[1550];
-        int port1Idx = result.PortNames.IndexOf("port 1");
-        int port2Idx = result.PortNames.IndexOf("port 2");
+        int p1 = result.PortNames.IndexOf("port 1");
+        int p2 = result.PortNames.IndexOf("port 2");
+        var entry = matrix[p1, p2];
 
-        var entry = matrix[port1Idx, port2Idx];
         entry.Magnitude.ShouldBe(mag, tolerance: 1e-6);
         entry.Phase.ShouldBe(phase, tolerance: 1e-6);
     }
 
+    [Fact]
+    public async Task Lumerical_Sparam_PortsSortedNumerically()
+    {
+        // With >9 ports, lexicographic sort puts "port 10" before "port 2".
+        // Natural sort must preserve "port 1, port 2, ..., port 10".
+        double freq = 299_792_458.0 / 1550e-9;
+        var sb = new System.Text.StringBuilder();
+        foreach (var (o, i) in new[] { ("port 1", "port 2"), ("port 2", "port 10"), ("port 10", "port 1") })
+        {
+            sb.AppendLine(Inv, $"('{o}','TE',0,'{i}',0,'transmission')");
+            sb.AppendLine("(1,3)");
+            sb.AppendLine(Inv, $"{Fmt(freq)}  0.5  0.0");
+        }
+        using var tmp = WriteTempFile(sb.ToString(), ".sparam");
+        var result = await new LumericalSParameterImporter().ImportAsync(tmp.Path);
+
+        result.PortNames.ShouldBe(new[] { "port 1", "port 2", "port 10" });
+    }
+
     // ── TouchstoneImporter ───────────────────────────────────────────────────
 
-    [Fact]
-    public async Task Touchstone_S2P_ParsesMAFormat()
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("de-DE")]
+    [InlineData("fr-FR")]
+    public async Task Touchstone_S2P_MA_IsCultureSafe(string cultureName)
     {
-        // 2-port, MA format (magnitude-angle in degrees), GHz
-        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9; // ~193.4 GHz
-        var content = $@"# GHz S MA R 50
-{freqGHz:G6} 0.05 10 0.95 80 0.95 80 0.05 10
+        // Pins the InvariantCulture promise on the production parser: a
+        // fr-FR developer running tests must still get the same result.
+        var original = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+        try
+        {
+            double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+            var content = $@"# GHz S MA R 50
+{Fmt(freqGHz)} 0.05 10 0.95 80 0.95 80 0.05 10
 ";
-        var path = WriteTempFile(content, ".s2p");
-        var importer = new TouchstoneImporter();
+            using var tmp = WriteTempFile(content, ".s2p");
+            var result = await new TouchstoneImporter().ImportAsync(tmp.Path);
 
-        var result = await importer.ImportAsync(path);
+            result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
+            result.SMatricesByWavelengthNm.Values.First()[0, 0].Magnitude.ShouldBe(0.05, tolerance: 1e-6);
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = original;
+        }
+    }
 
-        result.PortCount.ShouldBe(2);
-        result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
-        result.SourceFormat.ShouldBe("Touchstone S2P");
+    [Theory]
+    [InlineData("Hz",  1.0)]
+    [InlineData("kHz", 1e3)]
+    [InlineData("MHz", 1e6)]
+    [InlineData("GHz", 1e9)]
+    public async Task Touchstone_S2P_AllFreqUnits_ProduceSameWavelength(string unit, double multiplier)
+    {
+        // Target 1550 nm for every unit; without proper unit scaling, most of
+        // these would land on different wavelength keys.
+        double targetFreqHz = 299_792_458.0 / 1550e-9;
+        double freqInUnit = targetFreqHz / multiplier;
+
+        var content = $@"# {unit} S MA R 50
+{Fmt(freqInUnit)} 0.1 0 0.9 0 0.9 0 0.1 0
+";
+        using var tmp = WriteTempFile(content, ".s2p");
+        var result = await new TouchstoneImporter().ImportAsync(tmp.Path);
+
+        result.SMatricesByWavelengthNm.Keys.ShouldContain(1550);
     }
 
     [Fact]
-    public async Task Touchstone_S2P_ParsesRIFormat()
+    public async Task Touchstone_S2P_RIFormat_ParsesRealAndImaginary()
     {
         double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
         var content = $@"# GHz S RI R 50
-{freqGHz:G6} 0.03 0.04 0.6 0.8 0.6 0.8 0.03 0.04
+{Fmt(freqGHz)} 0.03 0.04 0.6 0.8 0.6 0.8 0.03 0.04
 ";
-        var path = WriteTempFile(content, ".s2p");
-        var importer = new TouchstoneImporter();
+        using var tmp = WriteTempFile(content, ".s2p");
+        var result = await new TouchstoneImporter().ImportAsync(tmp.Path);
 
-        var result = await importer.ImportAsync(path);
-
-        var matrix = result.SMatricesByWavelengthNm.Values.First();
-        var s11 = matrix[0, 0];
+        var s11 = result.SMatricesByWavelengthNm.Values.First()[0, 0];
         s11.Real.ShouldBe(0.03, tolerance: 1e-6);
         s11.Imaginary.ShouldBe(0.04, tolerance: 1e-6);
     }
 
     [Fact]
-    public async Task Touchstone_S2P_ParsesDBFormat()
+    public async Task Touchstone_S2P_DBFormat_ConvertsMagnitudeCorrectly()
     {
         double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+        // -20 dB → linear magnitude 0.1
         var content = $@"# GHz S DB R 50
-{freqGHz:G6} -20 45 -0.45 80 -0.45 80 -20 45
+{Fmt(freqGHz)} -20 45 -0.45 80 -0.45 80 -20 45
 ";
-        var path = WriteTempFile(content, ".s2p");
-        var importer = new TouchstoneImporter();
+        using var tmp = WriteTempFile(content, ".s2p");
+        var result = await new TouchstoneImporter().ImportAsync(tmp.Path);
 
-        var result = await importer.ImportAsync(path);
+        result.SMatricesByWavelengthNm.Values.First()[0, 0].Magnitude.ShouldBe(0.1, tolerance: 1e-5);
+    }
 
-        result.SMatricesByWavelengthNm.ShouldNotBeEmpty();
-        var matrix = result.SMatricesByWavelengthNm.Values.First();
-        // S11 in dB: -20 dB → magnitude 0.1
-        matrix[0, 0].Magnitude.ShouldBe(0.1, tolerance: 1e-5);
+    [Fact]
+    public async Task Touchstone_S4P_PreservesAsymmetricMatrix()
+    {
+        // Column-major ordering sensitivity: symmetric 2×2 data hides a
+        // transpose. A 4-port file with 16 distinct values catches it.
+        // Touchstone S4P column-major: freq S11 S21 S31 S41 S12 S22 S32 S42 S13 S23 S33 S43 S14 S24 S34 S44
+        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+        // Use RI so each cell is (row, col) for easy indexing:
+        // pair k → row = k%4, col = k/4 (Touchstone convention).
+        var pairs = new System.Text.StringBuilder();
+        for (int col = 0; col < 4; col++)
+        {
+            for (int row = 0; row < 4; row++)
+            {
+                pairs.Append(Inv, $" {row}.{col}");        // real = row.col
+                pairs.Append(Inv, $" {row}{col}.0e-1");    // imag = 0.row col
+            }
+        }
+        var content = $"# GHz S RI R 50\n{Fmt(freqGHz)}{pairs}\n";
+        using var tmp = WriteTempFile(content, ".s4p");
+        var result = await new TouchstoneImporter().ImportAsync(tmp.Path);
+
+        result.PortCount.ShouldBe(4);
+        var m = result.SMatricesByWavelengthNm.Values.First();
+        // S[1,2] and S[2,1] must be different (asymmetric) — this is the
+        // only test that proves column-major reading works correctly.
+        m[1, 2].Real.ShouldBe(1.2, tolerance: 1e-6);
+        m[2, 1].Real.ShouldBe(2.1, tolerance: 1e-6);
+        m[0, 3].Real.ShouldBe(0.3, tolerance: 1e-6);
+        m[3, 0].Real.ShouldBe(3.0, tolerance: 1e-6);
+    }
+
+    [Fact]
+    public async Task Touchstone_UnknownFreqUnit_Throws()
+    {
+        // A typo in the `#` header (e.g. "THZ" for THz) must fail loudly;
+        // silent fallback to Hz would produce wildly wrong wavelengths.
+        var content = @"# THz S MA R 50
+0.19 0.1 0 0.9 0 0.9 0 0.1 0
+";
+        using var tmp = WriteTempFile(content, ".s2p");
+        var ex = await Should.ThrowAsync<SParameterImportException>(() =>
+            new TouchstoneImporter().ImportAsync(tmp.Path));
+        ex.Message.ShouldContain("THz");
+    }
+
+    [Fact]
+    public async Task Touchstone_UnknownDataFormat_Throws()
+    {
+        // "MAG" instead of "MA" is a realistic typo — silent fallback to RI
+        // would import the values as real/imag and corrupt the simulation.
+        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+        var content = $@"# GHz S MAG R 50
+{Fmt(freqGHz)} 0.05 10 0.95 80 0.95 80 0.05 10
+";
+        using var tmp = WriteTempFile(content, ".s2p");
+        var ex = await Should.ThrowAsync<SParameterImportException>(() =>
+            new TouchstoneImporter().ImportAsync(tmp.Path));
+        ex.Message.ShouldContain("MAG");
+    }
+
+    [Fact]
+    public async Task Touchstone_YParameterType_Throws()
+    {
+        // Y-parameters interpreted as S-parameters would produce wrong
+        // simulation. Must reject explicitly.
+        double freqGHz = 299_792_458.0 / 1550e-9 / 1e9;
+        var content = $@"# GHz Y MA R 50
+{Fmt(freqGHz)} 0.05 10 0.95 80 0.95 80 0.05 10
+";
+        using var tmp = WriteTempFile(content, ".s2p");
+        var ex = await Should.ThrowAsync<SParameterImportException>(() =>
+            new TouchstoneImporter().ImportAsync(tmp.Path));
+        ex.Message.ShouldContain("Y");
+    }
+
+    [Fact]
+    public async Task Touchstone_NoiseDataAfterSParams_IsIgnored()
+    {
+        // Real VNA Touchstone files append noise-parameter blocks. The noise
+        // block re-uses the frequency column but drops to fewer tokens per
+        // row. Detect via non-monotonic frequency and stop there — the
+        // noise values must not appear as extra "wavelengths".
+        double f1 = 299_792_458.0 / 1550e-9 / 1e9; // GHz
+        double f2 = 299_792_458.0 / 1540e-9 / 1e9;
+        var content = $@"# GHz S MA R 50
+{Fmt(f1)} 0.1 0 0.9 0 0.9 0 0.1 0
+{Fmt(f2)} 0.11 0 0.88 0 0.88 0 0.11 0
+! Noise block (lower frequencies, fewer columns)
+{Fmt(f1 * 0.5)} 1.5 0.0 50 0
+{Fmt(f2 * 0.5)} 1.6 0.0 50 0
+";
+        using var tmp = WriteTempFile(content, ".s2p");
+        var result = await new TouchstoneImporter().ImportAsync(tmp.Path);
+
+        // Only the two genuine S-parameter frequencies should survive;
+        // 1550 and 1540 nm land in the dict, the noise block at 3100/3080 nm
+        // must not.
+        result.SMatricesByWavelengthNm.Count.ShouldBe(2);
+        result.SMatricesByWavelengthNm.Keys.ShouldContain(1550);
+        result.SMatricesByWavelengthNm.Keys.ShouldContain(1540);
     }
 
     [Fact]
@@ -176,12 +327,10 @@ public class SParameterImporterTests
 # GHz S MA R 50
 ! Another comment
 
-{freqGHz:G6} 0.05 10 0.95 80 0.95 80 0.05 10
+{Fmt(freqGHz)} 0.05 10 0.95 80 0.95 80 0.05 10
 ";
-        var path = WriteTempFile(content, ".s2p");
-        var importer = new TouchstoneImporter();
-
-        var result = await importer.ImportAsync(path);
+        using var tmp = WriteTempFile(content, ".s2p");
+        var result = await new TouchstoneImporter().ImportAsync(tmp.Path);
 
         result.SMatricesByWavelengthNm.Count.ShouldBe(1);
     }
@@ -189,32 +338,33 @@ public class SParameterImporterTests
     [Fact]
     public async Task Touchstone_ThrowsOnMissingFile()
     {
-        var importer = new TouchstoneImporter();
         await Should.ThrowAsync<SParameterImportException>(() =>
-            importer.ImportAsync("/nonexistent/file.s2p"));
+            new TouchstoneImporter().ImportAsync("/nonexistent/file.s2p"));
     }
 
     // ── SParameterConverter ──────────────────────────────────────────────────
 
     [Fact]
-    public async Task Converter_ProducesCorrectRowMajorLayout()
+    public async Task Converter_ProducesRowMajorLayoutWithFromPortAsRow()
     {
+        // Pins the row-major convention: row=from-port, col=to-port.
+        // Asymmetric values ensure a transpose would fail this test.
         double freq = 299_792_458.0 / 1550e-9;
         var content = $@"('port 1','TE',0,'port 2',0,'transmission')
 (1,3)
-{freq:G15}  0.9  1.0
+{Fmt(freq)}  0.9  0.0
 ('port 2','TE',0,'port 1',0,'transmission')
 (1,3)
-{freq:G15}  0.8  0.5
+{Fmt(freq)}  0.5  0.0
 ('port 1','TE',0,'port 1',0,'transmission')
 (1,3)
-{freq:G15}  0.1  0.2
+{Fmt(freq)}  0.1  0.0
 ('port 2','TE',0,'port 2',0,'transmission')
 (1,3)
-{freq:G15}  0.05  0.3
+{Fmt(freq)}  0.2  0.0
 ";
-        var path = WriteTempFile(content, ".sparam");
-        var imported = await new LumericalSParameterImporter().ImportAsync(path);
+        using var tmp = WriteTempFile(content, ".sparam");
+        var imported = await new LumericalSParameterImporter().ImportAsync(tmp.Path);
 
         var data = SParameterConverter.ToComponentSMatrixData(imported);
 
@@ -222,57 +372,136 @@ public class SParameterImporterTests
         var entry = data.Wavelengths["1550"];
         entry.Rows.ShouldBe(2);
         entry.Cols.ShouldBe(2);
-        entry.Real.Count.ShouldBe(4); // 2x2 = 4
-        entry.Imag.Count.ShouldBe(4);
-        entry.PortNames.ShouldNotBeNull();
-        entry.PortNames!.Count.ShouldBe(2);
+        entry.Real.Count.ShouldBe(4);
+        // Row-major: [r*n + c]. The block header `('port 1', ..., 'port 2', ...)`
+        // in Lumerical format means OUT=port 1, IN=port 2 — the parser maps
+        // that to matrix[outIdx, inIdx], i.e. row 0 col 1 = 0.9.
+        entry.Real[0 * 2 + 1].ShouldBe(0.9, tolerance: 1e-6); // port1→port2
+        entry.Real[1 * 2 + 0].ShouldBe(0.5, tolerance: 1e-6); // port2→port1
+        entry.Real[0 * 2 + 0].ShouldBe(0.1, tolerance: 1e-6);
+        entry.Real[1 * 2 + 1].ShouldBe(0.2, tolerance: 1e-6);
     }
 
-    // ── Integration test ─────────────────────────────────────────────────────
+    [Fact]
+    public void Converter_WavelengthKeysAreCultureInvariant()
+    {
+        // On fr-FR the default ToString() of 1550 is "1550" (no decimal),
+        // but in more exotic cultures numeric formatting can inject non-ASCII
+        // digits (arabic-indic, etc.). Invariant culture guarantees the JSON
+        // key is always plain ASCII "1550".
+        var imported = new ImportedSParameters
+        {
+            SourceFormat = "Test",
+            PortCount = 1,
+            PortNames = new List<string> { "p" },
+            SMatricesByWavelengthNm = { [1550] = new Complex[1, 1] { { new(1, 0) } } }
+        };
+
+        var data = SParameterConverter.ToComponentSMatrixData(imported);
+
+        data.Wavelengths.ShouldContainKey("1550");
+    }
+
+    // ── ViewModel integration ────────────────────────────────────────────────
 
     [Fact]
     public async Task SParameterImportViewModel_ImportsAndStoresData()
     {
-        // Arrange: create a real .sparam file, a real dictionary, and the ViewModel
         double freq = 299_792_458.0 / 1550e-9;
-        var sparamContent = $@"('port 1','TE',0,'port 2',0,'transmission')
+        var content = $@"('port 1','TE',0,'port 2',0,'transmission')
 (1,3)
-{freq:G15}  0.95  0.1
+{Fmt(freq)}  0.95  0.1
 ('port 2','TE',0,'port 1',0,'transmission')
 (1,3)
-{freq:G15}  0.95  0.1
+{Fmt(freq)}  0.95  0.1
 ";
-        var filePath = WriteTempFile(sparamContent, ".sparam");
+        using var tmp = WriteTempFile(content, ".sparam");
 
-        var storedSMatrices = new CAP_DataAccess.Persistence.PIR.ComponentSMatrixData().GetType()
-            == typeof(CAP_DataAccess.Persistence.PIR.ComponentSMatrixData)
-            ? new Dictionary<string, CAP_DataAccess.Persistence.PIR.ComponentSMatrixData>()
-            : null;
-
-        storedSMatrices = new Dictionary<string, CAP_DataAccess.Persistence.PIR.ComponentSMatrixData>();
-
+        var stored = new Dictionary<string, ComponentSMatrixData>();
         var vm = new CAP.Avalonia.ViewModels.Import.SParameterImportViewModel
         {
-            StoredSMatrices = storedSMatrices,
-            FilePath = filePath,
+            StoredSMatrices = stored,
+            FilePath = tmp.Path,
             ComponentIdentifier = "test_component"
         };
 
-        // Act: run import command
         await vm.ImportCommand.ExecuteAsync(null);
 
-        // Assert: ViewModel reflects success and dictionary has data
         vm.LastImportSucceeded.ShouldBeTrue(vm.StatusText);
-        storedSMatrices.ShouldContainKey("test_component");
-        storedSMatrices["test_component"].Wavelengths.ShouldContainKey("1550");
+        stored.ShouldContainKey("test_component");
+        stored["test_component"].Wavelengths.ShouldContainKey("1550");
+    }
+
+    [Fact]
+    public async Task SParameterImportViewModel_EmptyIdentifier_ReportsError()
+    {
+        var vm = new CAP.Avalonia.ViewModels.Import.SParameterImportViewModel
+        {
+            StoredSMatrices = new Dictionary<string, ComponentSMatrixData>(),
+            FilePath = "/tmp/anything.sparam",
+            ComponentIdentifier = "   "
+        };
+
+        await vm.ImportCommand.ExecuteAsync(null);
+
+        vm.LastImportSucceeded.ShouldBeFalse();
+        vm.StatusText.ShouldContain("identifier");
+    }
+
+    [Fact]
+    public async Task SParameterImportViewModel_NoStoreWired_ReportsError()
+    {
+        var vm = new CAP.Avalonia.ViewModels.Import.SParameterImportViewModel
+        {
+            StoredSMatrices = null,
+            FilePath = "/tmp/anything.sparam",
+            ComponentIdentifier = "ok"
+        };
+
+        await vm.ImportCommand.ExecuteAsync(null);
+
+        vm.LastImportSucceeded.ShouldBeFalse();
+        vm.StatusText.ShouldContain("store");
+    }
+
+    [Fact]
+    public async Task SParameterImportViewModel_RandomTxtFile_IsRejected()
+    {
+        // The earlier policy of claiming every .txt file for the Lumerical
+        // importer produced cryptic "No S-parameter blocks found" errors on
+        // regular text files. A header-sniff must reject non-Lumerical .txt.
+        using var tmp = WriteTempFile("This is just a readme, not S-parameter data.\n", ".txt");
+
+        var vm = new CAP.Avalonia.ViewModels.Import.SParameterImportViewModel
+        {
+            StoredSMatrices = new Dictionary<string, ComponentSMatrixData>(),
+            FilePath = tmp.Path,
+            ComponentIdentifier = "x"
+        };
+
+        await vm.ImportCommand.ExecuteAsync(null);
+
+        vm.LastImportSucceeded.ShouldBeFalse();
+        vm.StatusText.ShouldContain("Unsupported");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
-    private static string WriteTempFile(string content, string extension)
+    /// <summary>Writes a temp file whose wrapper deletes it at end-of-scope.</summary>
+    private static TempFile WriteTempFile(string content, string extension)
     {
         var path = Path.Combine(Path.GetTempPath(), $"sparam_test_{Guid.NewGuid()}{extension}");
         File.WriteAllText(path, content);
-        return path;
+        return new TempFile(path);
+    }
+
+    private sealed class TempFile : IDisposable
+    {
+        public string Path { get; }
+        public TempFile(string path) => Path = path;
+        public void Dispose()
+        {
+            if (File.Exists(Path)) File.Delete(Path);
+        }
     }
 }

--- a/UnitTests/Import/SParameterPersistenceRoundTripTests.cs
+++ b/UnitTests/Import/SParameterPersistenceRoundTripTests.cs
@@ -1,0 +1,116 @@
+using System.IO;
+using System.Numerics;
+using System.Text.Json;
+using CAP.Avalonia.ViewModels;
+using CAP_DataAccess.Import;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+
+namespace UnitTests.Import;
+
+/// <summary>
+/// Round-trip test for imported S-matrices through the .lun PIR serializer.
+/// Exercises <see cref="SParameterConverter"/> plus <see cref="DesignFileData"/>
+/// JSON save/load to verify a <c>StoredSMatrices</c> entry survives a
+/// serialize → deserialize cycle without data loss. Guards against a silent
+/// JSON-attribute regression that would drop <c>designData.SMatrices</c> at
+/// save time — the only mechanism that made the whole import feature useful.
+/// </summary>
+public class SParameterPersistenceRoundTripTests
+{
+    [Fact]
+    public void ImportedSMatrix_SurvivesDesignFileDataJsonRoundTrip()
+    {
+        // Build a realistic ImportedSParameters with asymmetric values at
+        // three wavelengths to detect re-ordering / key-loss on round-trip.
+        var imported = new ImportedSParameters
+        {
+            SourceFormat = "Test",
+            SourceFilePath = "/irrelevant.sparam",
+            PortCount = 2,
+            PortNames = new List<string> { "port 1", "port 2" },
+        };
+        foreach (var wl in new[] { 1500, 1550, 1600 })
+        {
+            var m = new Complex[2, 2];
+            m[0, 0] = new Complex(0.1 * wl, 0);
+            m[0, 1] = new Complex(0.9 * wl, 0);
+            m[1, 0] = new Complex(0.8 * wl, 0);
+            m[1, 1] = new Complex(0.2 * wl, 0);
+            imported.SMatricesByWavelengthNm[wl] = m;
+        }
+
+        var smatrixData = SParameterConverter.ToComponentSMatrixData(imported);
+
+        // Save → serialize via the exact shape FileOperationsViewModel uses.
+        var designData = new DesignFileData
+        {
+            SMatrices = new Dictionary<string, ComponentSMatrixData> { ["test_cmp"] = smatrixData }
+        };
+        var json = JsonSerializer.Serialize(designData, new JsonSerializerOptions { WriteIndented = true });
+
+        // Load → deserialize.
+        var reloaded = JsonSerializer.Deserialize<DesignFileData>(json);
+
+        reloaded.ShouldNotBeNull();
+        reloaded.SMatrices.ShouldNotBeNull();
+        reloaded.SMatrices.ShouldContainKey("test_cmp");
+
+        var entry = reloaded.SMatrices["test_cmp"];
+        entry.Wavelengths.ShouldContainKey("1500");
+        entry.Wavelengths.ShouldContainKey("1550");
+        entry.Wavelengths.ShouldContainKey("1600");
+
+        // Row-major layout with asymmetric data: verify the 1550 entry.
+        var e1550 = entry.Wavelengths["1550"];
+        e1550.Rows.ShouldBe(2);
+        e1550.Cols.ShouldBe(2);
+        e1550.Real.Count.ShouldBe(4);
+        // row=0,col=0 → [0], row=0,col=1 → [1], row=1,col=0 → [2], row=1,col=1 → [3]
+        e1550.Real[0].ShouldBe(0.1 * 1550, tolerance: 1e-6);
+        e1550.Real[1].ShouldBe(0.9 * 1550, tolerance: 1e-6);
+        e1550.Real[2].ShouldBe(0.8 * 1550, tolerance: 1e-6);
+        e1550.Real[3].ShouldBe(0.2 * 1550, tolerance: 1e-6);
+        e1550.PortNames.ShouldNotBeNull();
+        e1550.PortNames!.ShouldBe(new[] { "port 1", "port 2" });
+    }
+
+    [Fact]
+    public void ImportedSMatrix_SurvivesFullDiskRoundTrip()
+    {
+        // Same contract but through an actual File.WriteAllText / ReadAllText
+        // cycle — catches UTF-8 / newline / encoding regressions.
+        var data = new ComponentSMatrixData
+        {
+            SourceNote = "Disk round-trip test",
+            Wavelengths =
+            {
+                ["1550"] = new SMatrixWavelengthEntry
+                {
+                    Rows = 2, Cols = 2,
+                    PortNames = new List<string> { "p1", "p2" },
+                    Real = new List<double> { 0.1, 0.9, 0.8, 0.2 },
+                    Imag = new List<double> { 0.0, 0.0, 0.0, 0.0 },
+                }
+            }
+        };
+        var designData = new DesignFileData
+        {
+            SMatrices = new Dictionary<string, ComponentSMatrixData> { ["custom"] = data }
+        };
+
+        var path = Path.Combine(Path.GetTempPath(), $"sparam_disk_{Guid.NewGuid()}.lun");
+        try
+        {
+            File.WriteAllText(path, JsonSerializer.Serialize(designData));
+            var loaded = JsonSerializer.Deserialize<DesignFileData>(File.ReadAllText(path));
+
+            loaded!.SMatrices.ShouldContainKey("custom");
+            loaded.SMatrices["custom"].Wavelengths["1550"].Real[1].ShouldBe(0.9, tolerance: 1e-9);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
+++ b/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
@@ -6,6 +6,7 @@ using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Import;
 using CAP_Core.Export;
 using Moq;
 using CAP.Avalonia.Services;
@@ -69,7 +70,8 @@ public class PanelWidthPersistenceTests : IDisposable
             new GroupSMatrixViewModel(),
             new ArchitectureReportViewModel(),
             new PdkConsistencyViewModel(),
-            new AiAssistantViewModel(Mock.Of<IAiService>(), _preferencesService));
+            new AiAssistantViewModel(Mock.Of<IAiService>(), _preferencesService),
+            new SParameterImportViewModel());
 
     [Fact]
     public void LeftPanelWidth_DefaultsTo220()


### PR DESCRIPTION
## Summary

- Adds a complete S-parameter import pipeline for Lumerical SiEPIC (`.sparam`/`.dat`/`.txt`) and Touchstone (`.s1p`–`.s9p`) file formats
- Imported S-matrices are stored in the `.lun` PIR `SMatrices` section and survive save/reload cycles
- New right-panel UI (Browse + Import button, format detection, preview, status feedback)
- 12 unit/integration tests covering parsers, complex-value math, and end-to-end ViewModel flow

## Architecture

| Layer | File | Purpose |
|-------|------|---------|
| Core | `CAP-DataAccess/Import/ISParameterImporter.cs` | Importer interface |
| Core | `CAP-DataAccess/Import/ImportedSParameters.cs` | Parsed result data class |
| Core | `CAP-DataAccess/Import/LumericalSParameterImporter.cs` | SiEPIC blocked format + GC packed `.txt` |
| Core | `CAP-DataAccess/Import/TouchstoneImporter.cs` | `.sNp` MA/DB/RI formats (Hz/kHz/MHz/GHz) |
| Core | `CAP-DataAccess/Import/SParameterConverter.cs` | `ImportedSParameters` → `ComponentSMatrixData` |
| ViewModel | `CAP.Avalonia/ViewModels/Import/SParameterImportViewModel.cs` | Browse+Import commands |
| View | `CAP.Avalonia/Views/Panels/SParameterImportPanel.axaml` | Right-panel UI |
| Persistence | `FileOperationsViewModel.StoredSMatrices` | Dict wired into save/load cycle |

## Test plan

- [x] `UnitTests/Import/SParameterImporterTests.cs` — 12 tests passing
  - Lumerical blocked format parsing
  - Lumerical GC `.txt` packed format
  - Complex value correctness (magnitude + phase → real/imag)
  - Touchstone MA, DB, RI formats
  - Comment and blank line handling
  - Error on missing file
  - `SParameterConverter` produces correct row-major layout
  - Integration: ViewModel command stores data in dict
- [x] `dotnet build` — succeeds, 0 errors
- [x] Full test suite — 1803 passed (3 pre-existing failures in unrelated Nazca tests)

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)