### PR TITLE
Agent: Bug: NazcaExporter drops PDK parameters in generated Python code

### DIFF
--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -695,7 +695,8 @@ public class SimpleNazcaExporter
             // Keep dots (for module attribute access like demo.mmi2x2_dp), replace other invalid chars
             var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_.]", "_");
 
-            // Real PDK functions support arbitrary parameters — include them when present
+            // Forward stored parameters verbatim — the caller (component model)
+            // is responsible for ensuring they match the target PDK function's signature.
             var funcParams = comp.NazcaFunctionParameters;
             if (!string.IsNullOrEmpty(funcParams))
                 return $"{pythonFuncName}({funcParams})";

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -695,12 +695,9 @@ public class SimpleNazcaExporter
             // Keep dots (for module attribute access like demo.mmi2x2_dp), replace other invalid chars
             var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_.]", "_");
 
-            // Skip parameters for stub components - stubs don't support them
-            // Only include parameters for parametric straights (which do support length=)
+            // Real PDK functions support arbitrary parameters — include them when present
             var funcParams = comp.NazcaFunctionParameters;
-            bool isParametricStraight = IsParametricStraight(funcName, funcParams);
-
-            if (isParametricStraight && !string.IsNullOrEmpty(funcParams))
+            if (!string.IsNullOrEmpty(funcParams))
                 return $"{pythonFuncName}({funcParams})";
             else
                 return $"{pythonFuncName}()";


### PR DESCRIPTION
Automated implementation for #492

All 1794 tests pass, 17 skipped (pre-existing), 0 failures.

The fix was a one-liner in `GetNazcaFunction()` at line 703. The condition `isParametricStraight && !string.IsNullOrEmpty(funcParams)` was gating parameter inclusion to only "straight waveguide" components (those with `length=` params and "straight"/"strt" in the name). Real PDK components like `ebeam_dc_te1550(gap=200e-9)` aren't straight waveguides, so their parameters were silently dropped.

**Fix:** For real PDK functions (`IsPdkFunction()` returns true), include parameters whenever they're non-empty — no `isParametricStraight` restriction needed since these are actual PDK function calls, not stub-generated code.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 950,312
- **Estimated cost:** $0.5322 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*