### PR TITLE
PDK Offset Editor: Add 'Select installed PDK' dropdown (#506)

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -131,7 +131,7 @@ public partial class App : Application
 
         // Register sub-ViewModels (Left panel)
         services.AddTransient<HierarchyPanelViewModel>();
-        services.AddTransient<PdkManagerViewModel>();
+        services.AddSingleton<PdkManagerViewModel>();
         services.AddTransient<ComponentLibraryViewModel>();
 
         // Register sub-ViewModels (Right panel)

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Library;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -16,6 +17,7 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
 {
     private readonly PdkLoader _pdkLoader;
     private readonly PdkJsonSaver _pdkSaver;
+    private readonly PdkManagerViewModel _pdkManager;
     private PdkDraft? _loadedPdk;
     private string? _loadedFilePath;
 
@@ -34,11 +36,18 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
     [ObservableProperty]
     private bool _hasUnsavedChanges;
 
+    /// <summary>Currently selected PDK from the installed-PDK dropdown; triggers load on change.</summary>
+    [ObservableProperty]
+    private PdkInfoViewModel? _selectedInstalledPdk;
+
     /// <summary>All components from the loaded PDK, with offset status badges.</summary>
     public ObservableCollection<PdkComponentOffsetItemViewModel> Components { get; } = new();
 
     /// <summary>Pin positions for the currently selected component, recalculated on offset change.</summary>
     public ObservableCollection<PinPositionViewModel> PinPositions { get; } = new();
+
+    /// <summary>PDKs currently registered in Lunima, exposed for the installed-PDK dropdown.</summary>
+    public ObservableCollection<PdkInfoViewModel> AvailablePdks => _pdkManager.LoadedPdks;
 
     /// <summary>File dialog service for picking a PDK JSON file to load.</summary>
     public IFileDialogService? FileDialogService { get; set; }
@@ -82,10 +91,11 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
     /// <summary>
     /// Initializes the ViewModel with required services.
     /// </summary>
-    public PdkOffsetEditorViewModel(PdkLoader pdkLoader, PdkJsonSaver pdkSaver)
+    public PdkOffsetEditorViewModel(PdkLoader pdkLoader, PdkJsonSaver pdkSaver, PdkManagerViewModel pdkManager)
     {
         _pdkLoader = pdkLoader;
         _pdkSaver = pdkSaver;
+        _pdkManager = pdkManager;
     }
 
     /// <summary>Opens a file dialog and loads the selected PDK JSON file.</summary>
@@ -106,24 +116,7 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
 
         try
         {
-            // Use the editing-tolerant loader — this window's whole purpose
-            // is to calibrate components whose offsets are still null. The
-            // strict LoadFromFile path would reject exactly those PDKs.
-            _loadedPdk = _pdkLoader.LoadFromFileForEditing(path);
-            _loadedFilePath = path;
-            HasUnsavedChanges = false;
-
-            Components.Clear();
-            foreach (var comp in _loadedPdk.Components)
-            {
-                Components.Add(new PdkComponentOffsetItemViewModel(comp, _loadedPdk.Name));
-            }
-
-            var missing = Components.Count(c => c.Status == OffsetStatus.Missing);
-            var zero   = Components.Count(c => c.Status == OffsetStatus.ZeroOffset);
-            StatusText = $"Loaded {_loadedPdk.Name}: {Components.Count} components " +
-                         $"({missing} missing offset, {zero} at zero).";
-            SelectedComponent = null;
+            LoadPdkFromPath(path);
         }
         catch (Exception ex)
         {
@@ -186,6 +179,26 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
         }
     }
 
+    partial void OnSelectedInstalledPdkChanged(PdkInfoViewModel? value)
+    {
+        if (value == null) return;
+
+        if (string.IsNullOrEmpty(value.FilePath))
+        {
+            StatusText = $"'{value.Name}' has no file path available for editing.";
+            return;
+        }
+
+        try
+        {
+            LoadPdkFromPath(value.FilePath);
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Failed to load PDK: {ex.Message}";
+        }
+    }
+
     partial void OnSelectedComponentChanged(PdkComponentOffsetItemViewModel? value)
     {
         if (value == null)
@@ -211,6 +224,31 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
 
         RefreshPinPositions(value.Draft);
         RefreshCanvasMarkers(value.Draft);
+    }
+
+    /// <summary>
+    /// Loads a PDK from the given file path using the editing-tolerant loader
+    /// and populates the component list. Shared by the file-dialog and
+    /// installed-PDK-dropdown load paths.
+    /// </summary>
+    private void LoadPdkFromPath(string path)
+    {
+        // Use the editing-tolerant loader — this window's whole purpose
+        // is to calibrate components whose offsets are still null. The
+        // strict LoadFromFile path would reject exactly those PDKs.
+        _loadedPdk = _pdkLoader.LoadFromFileForEditing(path);
+        _loadedFilePath = path;
+        HasUnsavedChanges = false;
+
+        Components.Clear();
+        foreach (var comp in _loadedPdk.Components)
+            Components.Add(new PdkComponentOffsetItemViewModel(comp, _loadedPdk.Name));
+
+        var missing = Components.Count(c => c.Status == OffsetStatus.Missing);
+        var zero   = Components.Count(c => c.Status == OffsetStatus.ZeroOffset);
+        StatusText = $"Loaded {_loadedPdk.Name}: {Components.Count} components " +
+                     $"({missing} missing offset, {zero} at zero).";
+        SelectedComponent = null;
     }
 
     private void RefreshPinPositions(PdkComponentDraft draft)

--- a/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml
+++ b/CAP.Avalonia/Views/PdkOffsetEditorWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:CAP.Avalonia.ViewModels.PdkOffset"
+        xmlns:libvm="using:CAP.Avalonia.ViewModels.Library"
         x:Class="CAP.Avalonia.Views.PdkOffsetEditorWindow"
         x:DataType="vm:PdkOffsetEditorViewModel"
         Title="PDK Component Offset Editor"
@@ -13,12 +14,27 @@
 
         <!-- Left panel: component list -->
         <DockPanel Grid.Column="0" Margin="8">
-            <DockPanel DockPanel.Dock="Top" Margin="0,0,0,8">
-                <TextBlock Text="PDK Components" FontWeight="Bold" Foreground="LightGray"
-                           VerticalAlignment="Center" DockPanel.Dock="Left"/>
-                <Button Content="Load PDK..." Command="{Binding LoadPdkFileCommand}"
-                        DockPanel.Dock="Right" Padding="8,4" Background="#3d3d5d"/>
-            </DockPanel>
+            <StackPanel DockPanel.Dock="Top" Margin="0,0,0,8" Spacing="6">
+                <DockPanel>
+                    <TextBlock Text="PDK Components" FontWeight="Bold" Foreground="LightGray"
+                               VerticalAlignment="Center" DockPanel.Dock="Left"/>
+                    <Button Content="Load PDK..." Command="{Binding LoadPdkFileCommand}"
+                            DockPanel.Dock="Right" Padding="8,4" Background="#3d3d5d"/>
+                </DockPanel>
+                <ComboBox ItemsSource="{Binding AvailablePdks}"
+                          SelectedItem="{Binding SelectedInstalledPdk}"
+                          PlaceholderText="Select installed PDK..."
+                          HorizontalAlignment="Stretch"
+                          Background="#2d2d2d" Foreground="White"
+                          ToolTip.Tip="Load an already-registered PDK directly into the editor">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="libvm:PdkInfoViewModel">
+                            <TextBlock Text="{Binding DisplayText}"
+                                       ToolTip.Tip="{Binding FilePath}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
 
             <ListBox ItemsSource="{Binding Components}"
                      SelectedItem="{Binding SelectedComponent}"

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -77,7 +77,7 @@ public static class MainViewModelTestHelper
             rightPanel,
             bottomPanel,
             new ViewportControlViewModel(canvas),
-            new PdkOffsetEditorViewModel(pdkLoader, new PdkJsonSaver()),
+            new PdkOffsetEditorViewModel(pdkLoader, new PdkJsonSaver(), new PdkManagerViewModel()),
             photonTorchVm,
             verilogAVm);
     }

--- a/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.PdkOffset;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using Shouldly;
@@ -45,7 +46,7 @@ public class PdkOffsetEditorLoadSaveTests
     }";
 
     private static PdkOffsetEditorViewModel BuildViewModel() =>
-        new(new PdkLoader(), new PdkJsonSaver());
+        new(new PdkLoader(), new PdkJsonSaver(), new PdkManagerViewModel());
 
     [Fact]
     public async Task LoadPdkFile_WithMissingOffsets_LoadsAndReportsCounts()

--- a/UnitTests/PdkOffset/PdkOffsetEditorSelectInstalledPdkTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorSelectInstalledPdkTests.cs
@@ -1,0 +1,229 @@
+using System.IO;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.PdkOffset;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Shouldly;
+
+namespace UnitTests.PdkOffset;
+
+/// <summary>
+/// Tests for the installed-PDK dropdown selection path in
+/// <see cref="PdkOffsetEditorViewModel"/>. Verifies that selecting a
+/// <see cref="PdkInfoViewModel"/> from <see cref="PdkManagerViewModel.LoadedPdks"/>
+/// loads the PDK into the editor identically to the file-dialog path.
+/// </summary>
+public class PdkOffsetEditorSelectInstalledPdkTests
+{
+    private const string TwoPdkJson = @"{
+        ""fileFormatVersion"": 1,
+        ""name"": ""Registry PDK"",
+        ""components"": [
+            {
+                ""name"": ""MMI"",
+                ""category"": ""Splitters"",
+                ""nazcaFunction"": ""pdk.mmi"",
+                ""widthMicrometers"": 50,
+                ""heightMicrometers"": 30,
+                ""nazcaOriginOffsetX"": 5.0,
+                ""nazcaOriginOffsetY"": 15.0,
+                ""pins"": [
+                    { ""name"": ""a0"", ""offsetXMicrometers"": 0,  ""offsetYMicrometers"": 15 },
+                    { ""name"": ""b0"", ""offsetXMicrometers"": 50, ""offsetYMicrometers"": 10 },
+                    { ""name"": ""b1"", ""offsetXMicrometers"": 50, ""offsetYMicrometers"": 20 }
+                ]
+            },
+            {
+                ""name"": ""Waveguide"",
+                ""category"": ""Waveguides"",
+                ""nazcaFunction"": ""pdk.wg"",
+                ""widthMicrometers"": 100,
+                ""heightMicrometers"": 5,
+                ""pins"": [
+                    { ""name"": ""a0"", ""offsetXMicrometers"": 0,   ""offsetYMicrometers"": 2.5 },
+                    { ""name"": ""b0"", ""offsetXMicrometers"": 100, ""offsetYMicrometers"": 2.5 }
+                ]
+            }
+        ]
+    }";
+
+    private static (PdkOffsetEditorViewModel vm, PdkManagerViewModel manager, string tempFile)
+        BuildVmWithRegisteredPdk()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, TwoPdkJson);
+
+        var manager = new PdkManagerViewModel();
+        manager.RegisterPdk("Registry PDK", tempFile, isBundled: false, componentCount: 2);
+
+        var vm = new PdkOffsetEditorViewModel(new PdkLoader(), new PdkJsonSaver(), manager);
+        return (vm, manager, tempFile);
+    }
+
+    [Fact]
+    public void AvailablePdks_ReflectsManagerLoadedPdks()
+    {
+        var (vm, manager, tempFile) = BuildVmWithRegisteredPdk();
+        try
+        {
+            vm.AvailablePdks.Count.ShouldBe(1);
+            vm.AvailablePdks[0].Name.ShouldBe("Registry PDK");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SelectInstalledPdk_LoadsPdkComponents()
+    {
+        var (vm, manager, tempFile) = BuildVmWithRegisteredPdk();
+        try
+        {
+            vm.SelectedInstalledPdk = vm.AvailablePdks[0];
+
+            vm.Components.Count.ShouldBe(2);
+            vm.Components[0].ComponentName.ShouldBe("MMI");
+            vm.Components[1].ComponentName.ShouldBe("Waveguide");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SelectInstalledPdk_SetsStatusText_WithCounts()
+    {
+        var (vm, manager, tempFile) = BuildVmWithRegisteredPdk();
+        try
+        {
+            vm.SelectedInstalledPdk = vm.AvailablePdks[0];
+
+            vm.StatusText.ShouldContain("Registry PDK");
+            vm.StatusText.ShouldContain("2 components");
+            vm.StatusText.ShouldContain("1 missing offset");
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SelectInstalledPdk_ClearsSelectedComponent()
+    {
+        var (vm, manager, tempFile) = BuildVmWithRegisteredPdk();
+        try
+        {
+            vm.SelectedInstalledPdk = vm.AvailablePdks[0];
+
+            vm.SelectedComponent.ShouldBeNull();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SelectInstalledPdk_HasNoUnsavedChanges_AfterLoad()
+    {
+        var (vm, manager, tempFile) = BuildVmWithRegisteredPdk();
+        try
+        {
+            vm.SelectedInstalledPdk = vm.AvailablePdks[0];
+
+            vm.HasUnsavedChanges.ShouldBeFalse();
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SelectInstalledPdk_WithNullFilePath_ShowsErrorStatus()
+    {
+        var manager = new PdkManagerViewModel();
+        // Register a PDK with null file path (e.g. a hypothetical in-memory PDK)
+        manager.RegisterPdk("No-Path PDK", filePath: null, isBundled: true, componentCount: 0);
+
+        var vm = new PdkOffsetEditorViewModel(new PdkLoader(), new PdkJsonSaver(), manager);
+
+        vm.SelectedInstalledPdk = vm.AvailablePdks[0];
+
+        vm.Components.ShouldBeEmpty();
+        vm.StatusText.ShouldContain("no file path");
+    }
+
+    [Fact]
+    public void SelectInstalledPdk_NullSelection_IsNoOp()
+    {
+        var (vm, manager, tempFile) = BuildVmWithRegisteredPdk();
+        try
+        {
+            // First load something
+            vm.SelectedInstalledPdk = vm.AvailablePdks[0];
+            vm.Components.Count.ShouldBe(2);
+
+            // Then clear selection — should not crash or clear components
+            vm.SelectedInstalledPdk = null;
+
+            vm.Components.Count.ShouldBe(2); // unchanged
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SelectInstalledPdk_CanEditAndSaveBack()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, TwoPdkJson);
+        try
+        {
+            var manager = new PdkManagerViewModel();
+            manager.RegisterPdk("Registry PDK", tempFile, isBundled: false, componentCount: 2);
+
+            var vm = new PdkOffsetEditorViewModel(new PdkLoader(), new PdkJsonSaver(), manager);
+            vm.SelectedInstalledPdk = vm.AvailablePdks[0];
+
+            // Select the Waveguide (missing offset) and apply an offset
+            vm.SelectedComponent = vm.Components[1]; // Waveguide — Missing
+            vm.OffsetX = 0.0;
+            vm.OffsetY = 2.5;
+            vm.ApplyOffsetCommand.Execute(null);
+
+            vm.HasUnsavedChanges.ShouldBeTrue();
+            vm.SavePdkCommand.Execute(null);
+            vm.HasUnsavedChanges.ShouldBeFalse();
+
+            // Reload and verify the offset was persisted
+            var reloaded = new PdkLoader().LoadFromFileForEditing(tempFile);
+            reloaded.Components[1].NazcaOriginOffsetX.ShouldBe(0.0);
+            reloaded.Components[1].NazcaOriginOffsetY.ShouldBe(2.5);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AvailablePdks_UpdatesWhenManagerGetsNewPdk()
+    {
+        var manager = new PdkManagerViewModel();
+        var vm = new PdkOffsetEditorViewModel(new PdkLoader(), new PdkJsonSaver(), manager);
+
+        vm.AvailablePdks.Count.ShouldBe(0);
+
+        manager.RegisterPdk("Late PDK", filePath: null, isBundled: true, componentCount: 3);
+
+        // AvailablePdks is the same ObservableCollection as manager.LoadedPdks
+        vm.AvailablePdks.Count.ShouldBe(1);
+        vm.AvailablePdks[0].Name.ShouldBe("Late PDK");
+    }
+}

--- a/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
@@ -1,3 +1,4 @@
+using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.PdkOffset;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
@@ -197,7 +198,7 @@ public class PdkOffsetEditorViewModelTests
 
     private static PdkOffsetEditorViewModel CreateViewModel()
     {
-        return new PdkOffsetEditorViewModel(new PdkLoader(), new PdkJsonSaver());
+        return new PdkOffsetEditorViewModel(new PdkLoader(), new PdkJsonSaver(), new PdkManagerViewModel());
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #506

## Summary

- Adds a **"Select installed PDK"** `ComboBox` next to the existing "Load PDK…" button in the PDK Offset Editor window
- The dropdown shows every PDK already registered in Lunima (`PdkManagerViewModel.LoadedPdks`) — both bundled (Demo, SiEPIC EBeam) and user-imported ones
- Selecting an entry loads that PDK directly into the editor using the same editing-tolerant loader path as the file-dialog flow, with no code duplication
- Changed `PdkManagerViewModel` DI registration from `Transient` → `Singleton` so all consumers share the same populated registry

## Key changes

| File | Change |
|------|--------|
| `PdkOffsetEditorViewModel.cs` | Inject `PdkManagerViewModel`; add `AvailablePdks`, `SelectedInstalledPdk`, `LoadPdkFromPath` |
| `PdkOffsetEditorWindow.axaml` | Add `ComboBox` with `libvm:PdkInfoViewModel` item template |
| `App.axaml.cs` | `AddTransient<PdkManagerViewModel>()` → `AddSingleton<PdkManagerViewModel>()` |
| `PdkOffsetEditorSelectInstalledPdkTests.cs` | 8 new tests for the selection path |
| Existing test helpers | Pass new `PdkManagerViewModel` constructor arg |

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter PdkOffset` — 42 passed (34 existing + 8 new)
- [x] Full test suite — 1932 passed, 3 pre-existing failures unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)