### PR TITLE
Fix: PDK offset editor writes to repo source in dev builds

### DIFF
--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -168,11 +168,8 @@ public partial class LeftPanelViewModel : ObservableObject
 
     private void LoadBundledPdks()
     {
-        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
-        var pdkDir = Path.Combine(baseDir, "PDKs");
-
-        if (!Directory.Exists(pdkDir))
-            return;
+        var pdkDir = ResolveBundledPdkDirectory(AppDomain.CurrentDomain.BaseDirectory);
+        if (pdkDir == null) return;
 
         foreach (var pdkFile in Directory.GetFiles(pdkDir, "*.json"))
         {
@@ -202,6 +199,34 @@ public partial class LeftPanelViewModel : ObservableObject
                 _errorConsole?.LogError($"Failed to load PDK '{Path.GetFileName(pdkFile)}': {ex.Message}");
             }
         }
+    }
+
+    /// <summary>
+    /// Resolves which PDK directory to load and save against. In a dev build —
+    /// running from <c>bin/Debug</c> or <c>bin/Release</c> inside the source
+    /// tree — prefers the repo-tracked <c>CAP-DataAccess/PDKs</c> sibling so
+    /// the offset editor's saves land in the git working tree instead of the
+    /// build artefact (which the next build would silently overwrite and
+    /// which is never committed). Falls back to the bundled copy next to the
+    /// executable for deployed builds.
+    /// </summary>
+    /// <remarks>Internal so unit tests can drive it with a fake start dir.</remarks>
+    internal static string? ResolveBundledPdkDirectory(string baseDir)
+    {
+        var bundled = Path.Combine(baseDir, "PDKs");
+
+        // Walk up to the repo root looking for a CAP-DataAccess/PDKs sibling.
+        // 6 levels covers bin/<config>/<tfm>/<runtime>/ plus the project dir.
+        var dir = new DirectoryInfo(baseDir);
+        for (int i = 0; i < 6 && dir != null; i++, dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, "CAP-DataAccess", "PDKs");
+            if (Directory.Exists(candidate) &&
+                Directory.GetFiles(candidate, "*.json").Length > 0)
+                return candidate;
+        }
+
+        return Directory.Exists(bundled) ? bundled : null;
     }
 
     private void FilterComponents()

--- a/UnitTests/ViewModels/LeftPanelViewModelTests.cs
+++ b/UnitTests/ViewModels/LeftPanelViewModelTests.cs
@@ -154,4 +154,89 @@ public class LeftPanelViewModelTests : IDisposable
 
         vm.FilteredTemplates.Count.ShouldBe(initialCount);
     }
+
+    [Fact]
+    public void ResolveBundledPdkDirectory_PrefersRepoSourceWhenAvailable()
+    {
+        // Lay out the dev-build shape we want to detect:
+        //   <root>/CAP.Avalonia/bin/Debug/net8.0/        ← simulated baseDir
+        //   <root>/CAP-DataAccess/PDKs/demo.json         ← repo source we want
+        var root = Path.Combine(Path.GetTempPath(), $"cap_pdkdir_{Guid.NewGuid():N}");
+        var baseDir = Path.Combine(root, "CAP.Avalonia", "bin", "Debug", "net8.0");
+        var repoPdks = Path.Combine(root, "CAP-DataAccess", "PDKs");
+        var bundledPdks = Path.Combine(baseDir, "PDKs");
+        try
+        {
+            Directory.CreateDirectory(baseDir);
+            Directory.CreateDirectory(repoPdks);
+            Directory.CreateDirectory(bundledPdks);
+            File.WriteAllText(Path.Combine(repoPdks, "demo.json"), "{}");
+            File.WriteAllText(Path.Combine(bundledPdks, "demo.json"), "{}");
+
+            var resolved = LeftPanelViewModel.ResolveBundledPdkDirectory(baseDir);
+
+            // Edits saved through the editor must land in the repo copy so they
+            // get committed — the bundled-next-to-exe copy is a build artefact.
+            Path.GetFullPath(resolved!).ShouldBe(Path.GetFullPath(repoPdks));
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void ResolveBundledPdkDirectory_FallsBackToBundledWhenRepoMissing()
+    {
+        // Deployed-build shape: no CAP-DataAccess sibling exists, only the
+        // bundled PDKs folder next to the executable.
+        var root = Path.Combine(Path.GetTempPath(), $"cap_pdkdir_{Guid.NewGuid():N}");
+        var baseDir = Path.Combine(root, "app");
+        var bundledPdks = Path.Combine(baseDir, "PDKs");
+        try
+        {
+            Directory.CreateDirectory(bundledPdks);
+            File.WriteAllText(Path.Combine(bundledPdks, "demo.json"), "{}");
+
+            var resolved = LeftPanelViewModel.ResolveBundledPdkDirectory(baseDir);
+
+            Path.GetFullPath(resolved!).ShouldBe(Path.GetFullPath(bundledPdks));
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void ResolveBundledPdkDirectory_ReturnsNullWhenNothingExists()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"cap_pdkdir_{Guid.NewGuid():N}");
+        var baseDir = Path.Combine(root, "app");
+        try
+        {
+            Directory.CreateDirectory(baseDir);
+
+            LeftPanelViewModel.ResolveBundledPdkDirectory(baseDir).ShouldBeNull();
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void ResolveBundledPdkDirectory_IgnoresEmptyRepoFolder()
+    {
+        // A bare CAP-DataAccess/PDKs without any *.json must not be treated as
+        // the source of truth — it would mask the bundled copy and leave the
+        // editor with nothing to load.
+        var root = Path.Combine(Path.GetTempPath(), $"cap_pdkdir_{Guid.NewGuid():N}");
+        var baseDir = Path.Combine(root, "CAP.Avalonia", "bin", "Debug", "net8.0");
+        var emptyRepoPdks = Path.Combine(root, "CAP-DataAccess", "PDKs");
+        var bundledPdks = Path.Combine(baseDir, "PDKs");
+        try
+        {
+            Directory.CreateDirectory(baseDir);
+            Directory.CreateDirectory(emptyRepoPdks);
+            Directory.CreateDirectory(bundledPdks);
+            File.WriteAllText(Path.Combine(bundledPdks, "demo.json"), "{}");
+
+            var resolved = LeftPanelViewModel.ResolveBundledPdkDirectory(baseDir);
+
+            Path.GetFullPath(resolved!).ShouldBe(Path.GetFullPath(bundledPdks));
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
 }


### PR DESCRIPTION
## Summary

The offset editor in PR #511 saves correctly — but it saves to the **build artefact**, not the repo source. So calibration edits never landed in git, and pulling the branch on a different machine showed the components un-fixed again.

`LeftPanelViewModel.LoadBundledPdks` resolved the PDK directory via `AppDomain.CurrentDomain.BaseDirectory + "PDKs"`, which in dev points at `bin/Debug/<tfm>/PDKs/`. That path then propagates through `PdkInfoViewModel.FilePath` → `_loadedFilePath` → `SavePdk`, so the edits ended up in `bin/`. MSBuild's `CopyToOutputDirectory="PreserveNewest"` then either left the bin copy alone (because it was newer than the source) or overwrote it on a clean build — either way, the source file in `CAP-DataAccess/PDKs/` was never touched and never committed.

## Fix

`ResolveBundledPdkDirectory` walks up from `BaseDirectory` looking for a `CAP-DataAccess/PDKs` sibling with at least one `*.json`. When found (dev build inside the source tree), use it for both load and save. Otherwise (deployed build, no source tree) fall back to the bundled copy next to the executable.

## Test plan

- [x] 4 unit tests cover repo-found, bundled-fallback, nothing-found, and the empty-source-folder edge case
- [ ] Launch app from `bin/Debug/`, calibrate a component in the offset editor, hit Save, confirm `git diff CAP-DataAccess/PDKs/demo-pdk.json` shows the change
- [ ] Same test in a deployed build (or simulated by removing the source tree) — must save next to the executable, not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)