### PR TITLE
(+) PDK template S-matrix overrides persist user-globally across projects

### DIFF
--- a/CAP-DataAccess/Import/PortNameMapping.cs
+++ b/CAP-DataAccess/Import/PortNameMapping.cs
@@ -1,0 +1,100 @@
+namespace CAP_DataAccess.Import;
+
+/// <summary>
+/// Helpers for reconciling imported S-parameter port names (which often use
+/// generic labels like "port 1", "port 2", …) with the semantic pin names
+/// of a Lunima component (e.g. "in", "out1", "out2"). The applicator refuses
+/// to silently match across naming schemes — see
+/// <c>SMatrixOverrideApplicator.ResolvePins</c> — so the import flow has to
+/// resolve the names up front, either automatically when they happen to
+/// match or via a user dialog.
+/// </summary>
+public static class PortNameMapping
+{
+    /// <summary>
+    /// Returns true when every imported port name appears verbatim in
+    /// <paramref name="componentPinNames"/> (case-insensitive). When this
+    /// holds, the import data can flow straight into the override store —
+    /// no user mapping required.
+    /// </summary>
+    public static bool NamesAlignWithComponent(
+        IEnumerable<string> importedNames,
+        IEnumerable<string> componentPinNames)
+    {
+        var componentSet = new HashSet<string>(componentPinNames, StringComparer.OrdinalIgnoreCase);
+        return importedNames.All(componentSet.Contains);
+    }
+
+    /// <summary>
+    /// Builds a default mapping <c>imported name → component pin name</c> by
+    /// (a) keeping a name unchanged if the component already has a pin with
+    /// the same name, otherwise (b) falling back to positional pairing
+    /// (imported[i] → componentPinNames[i]). The user can override any row
+    /// in the mapping dialog before the result is applied.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the two lists have different lengths — a positional
+    /// fallback would be ambiguous and we'd rather fail loud than silently
+    /// drop or fabricate ports.
+    /// </exception>
+    public static Dictionary<string, string> BuildDefaultMapping(
+        IReadOnlyList<string> importedNames,
+        IReadOnlyList<string> componentPinNames)
+    {
+        if (importedNames.Count != componentPinNames.Count)
+            throw new ArgumentException(
+                $"Imported port count ({importedNames.Count}) must equal component pin count " +
+                $"({componentPinNames.Count}) before a positional fallback can be derived.");
+
+        var componentSet = new HashSet<string>(componentPinNames, StringComparer.OrdinalIgnoreCase);
+        var mapping = new Dictionary<string, string>(importedNames.Count, StringComparer.Ordinal);
+
+        for (int i = 0; i < importedNames.Count; i++)
+        {
+            var imported = importedNames[i];
+            mapping[imported] = componentSet.Contains(imported)
+                ? imported // already aligned — keep it
+                : componentPinNames[i]; // positional fallback
+        }
+
+        return mapping;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="imported"/> with port names rewritten
+    /// according to <paramref name="mapping"/>. The S-matrix data and indexing
+    /// stay untouched — relabelling alone is enough because the applicator
+    /// keys on names, not on the original Lumerical labels.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when an imported name has no entry in <paramref name="mapping"/>
+    /// — better to fail than silently drop one port and shift the rest.
+    /// </exception>
+    public static ImportedSParameters Remap(
+        ImportedSParameters imported,
+        IReadOnlyDictionary<string, string> mapping)
+    {
+        var renamed = new List<string>(imported.PortNames.Count);
+        foreach (var oldName in imported.PortNames)
+        {
+            if (!mapping.TryGetValue(oldName, out var newName))
+                throw new ArgumentException(
+                    $"Mapping does not cover imported port '{oldName}'. " +
+                    $"Provide a target for every imported name (got " +
+                    $"{string.Join(", ", mapping.Keys)}).");
+            renamed.Add(newName);
+        }
+
+        // SMatricesByWavelengthNm and PortCount are unchanged: we only
+        // rewrote the labels, not the matrix layout.
+        return new ImportedSParameters
+        {
+            SourceFormat = imported.SourceFormat,
+            SourceFilePath = imported.SourceFilePath,
+            PortCount = imported.PortCount,
+            PortNames = renamed,
+            SMatricesByWavelengthNm = imported.SMatricesByWavelengthNm,
+            Metadata = imported.Metadata,
+        };
+    }
+}

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -119,6 +119,11 @@ public partial class App : Application
         services.AddSingleton<Commands.CommandManager>();
         services.AddSingleton<UserPreferencesService>();
         services.AddSingleton<ProjectPersistenceService>();
+        // User-global PDK template S-matrix overrides — persists across projects
+        // so editing a template's S-matrix isn't silently confined to the .lun
+        // file the user happened to be in.
+        services.AddSingleton<UserSMatrixOverrideStore>(sp =>
+            new UserSMatrixOverrideStore(sp.GetService<CAP_Core.ErrorConsoleService>()));
         services.AddSingleton<Services.GroupPreviewGenerator>();
         services.AddSingleton<IInputDialogService, InputDialogService>();
 

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -126,6 +126,7 @@ public partial class App : Application
             new UserSMatrixOverrideStore(sp.GetService<CAP_Core.ErrorConsoleService>()));
         services.AddSingleton<Services.GroupPreviewGenerator>();
         services.AddSingleton<IInputDialogService, InputDialogService>();
+        services.AddSingleton<IPortMappingDialogService, PortMappingDialogService>();
 
         // Register DesignCanvasViewModel as singleton (shared across all panel VMs)
         services.AddSingleton<DesignCanvasViewModel>();

--- a/CAP.Avalonia/Services/IPortMappingDialogService.cs
+++ b/CAP.Avalonia/Services/IPortMappingDialogService.cs
@@ -1,0 +1,24 @@
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Shows a modal dialog letting the user reconcile imported S-parameter port
+/// names with the component's pin names. Abstracted as an interface so the
+/// import flow's tests can substitute a deterministic stub instead of having
+/// to instantiate an Avalonia Window.
+/// </summary>
+public interface IPortMappingDialogService
+{
+    /// <summary>
+    /// Displays the mapping dialog. Returns the user's chosen
+    /// <c>importedName → componentPinName</c> mapping on OK, or <c>null</c>
+    /// when the user cancels (in which case the caller should abort the
+    /// import rather than fall back to defaults).
+    /// </summary>
+    /// <param name="componentDisplayName">Human-readable name shown in the dialog title.</param>
+    /// <param name="importedNames">Port names as they appeared in the imported file, in matrix order.</param>
+    /// <param name="componentPinNames">Pin names available on the component, in physical-pin order.</param>
+    Task<IReadOnlyDictionary<string, string>?> ShowAsync(
+        string componentDisplayName,
+        IReadOnlyList<string> importedNames,
+        IReadOnlyList<string> componentPinNames);
+}

--- a/CAP.Avalonia/Services/PortMappingDialogService.cs
+++ b/CAP.Avalonia/Services/PortMappingDialogService.cs
@@ -1,0 +1,33 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using CAP.Avalonia.ViewModels.ComponentSettings;
+using CAP.Avalonia.Views;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Avalonia implementation of <see cref="IPortMappingDialogService"/>.
+/// Spins up a <see cref="PortMappingDialog"/> rooted at the application's
+/// main window and awaits its result.
+/// </summary>
+public class PortMappingDialogService : IPortMappingDialogService
+{
+    public async Task<IReadOnlyDictionary<string, string>?> ShowAsync(
+        string componentDisplayName,
+        IReadOnlyList<string> importedNames,
+        IReadOnlyList<string> componentPinNames)
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+            return null;
+        if (desktop.MainWindow is not { } owner)
+            return null;
+
+        var vm = new PortMappingDialogViewModel();
+        vm.Configure(importedNames, componentPinNames, componentDisplayName);
+
+        var dialog = new PortMappingDialog { DataContext = vm };
+        var result = await dialog.ShowDialog<IReadOnlyDictionary<string, string>?>(owner);
+        return result;
+    }
+}

--- a/CAP.Avalonia/Services/UserSMatrixOverrideStore.cs
+++ b/CAP.Avalonia/Services/UserSMatrixOverrideStore.cs
@@ -1,0 +1,157 @@
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using CAP_Core;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// User-global storage for PDK-template-scoped S-matrix overrides.
+/// Persists to a JSON file under the OS-standard application-data folder
+/// (<c>%APPDATA%/Lunima/sparam-overrides.json</c> on Windows, <c>~/.config/Lunima/...</c>
+/// on Linux). Overrides stored here apply to every project the user opens, mirroring
+/// the user's mental model when they edit a PDK template's S-matrix
+/// ("I just changed the 2x2 MMI Coupler — that should hold everywhere").
+///
+/// Per-instance overrides are NOT stored here; those remain in the project's .lun
+/// file because they are tied to a specific Canvas component instance and only make
+/// sense within that project.
+///
+/// Keys follow the same shape as the project-scoped store:
+/// <c>"{pdkSource}::{templateName}"</c>, e.g. <c>"siepic-ebeam-pdk::2x2 MMI Coupler"</c>.
+/// </summary>
+public class UserSMatrixOverrideStore
+{
+    private const string FileName = "sparam-overrides.json";
+    private const string AppFolderName = "Lunima";
+
+    private readonly string _filePath;
+    private readonly ErrorConsoleService? _errorConsole;
+    private readonly Dictionary<string, ComponentSMatrixData> _overrides = new();
+
+    /// <summary>
+    /// Live dictionary of user-global overrides. Mutated directly by the
+    /// <see cref="ComponentSettingsDialogViewModel"/> import path (which expects
+    /// a writable dictionary contract); call <see cref="Save"/> after any mutation
+    /// to flush to disk. Also consumed read-only by
+    /// <see cref="SMatrixOverrideApplicator.ApplyAll"/>.
+    /// </summary>
+    public Dictionary<string, ComponentSMatrixData> Overrides => _overrides;
+
+    /// <summary>
+    /// Absolute path to the on-disk file. Surfaced for diagnostics and for tests
+    /// that need to verify persistence.
+    /// </summary>
+    public string FilePath => _filePath;
+
+    /// <summary>
+    /// Creates a store backed by the standard application-data location.
+    /// Loads existing overrides from disk if the file is present.
+    /// </summary>
+    public UserSMatrixOverrideStore(ErrorConsoleService? errorConsole = null)
+        : this(BuildDefaultFilePath(), errorConsole)
+    {
+    }
+
+    /// <summary>
+    /// Test-friendly constructor that accepts an explicit file path.
+    /// </summary>
+    public UserSMatrixOverrideStore(string filePath, ErrorConsoleService? errorConsole = null)
+    {
+        _filePath = filePath;
+        _errorConsole = errorConsole;
+        Load();
+    }
+
+    /// <summary>
+    /// Stores or replaces the override for the given template key.
+    /// Does NOT auto-persist — call <see cref="Save"/> to flush to disk.
+    /// </summary>
+    public void Apply(string templateKey, ComponentSMatrixData data)
+    {
+        _overrides[templateKey] = data;
+    }
+
+    /// <summary>
+    /// Removes the override for the given template key. Returns true if an
+    /// entry was actually removed. Does NOT auto-persist.
+    /// </summary>
+    public bool Remove(string templateKey) => _overrides.Remove(templateKey);
+
+    /// <summary>
+    /// Persists the current in-memory state to <see cref="FilePath"/>.
+    /// Failures are surfaced via <see cref="ErrorConsoleService"/>; the
+    /// in-memory state is preserved so the caller can retry.
+    /// </summary>
+    public void Save()
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(_overrides, SerializerOptions);
+            File.WriteAllText(_filePath, json);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Loud failure to the user, but in-memory state survives so the
+            // session can keep working. Re-throwing would crash the dialog
+            // and lose the import the user just performed.
+            _errorConsole?.LogError(
+                $"Could not save user-global S-matrix overrides to '{_filePath}': {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Reloads from disk, discarding any unsaved in-memory mutations.
+    /// Useful primarily for tests; production code uses the constructor.
+    /// </summary>
+    public void Reload()
+    {
+        _overrides.Clear();
+        Load();
+    }
+
+    private void Load()
+    {
+        if (!File.Exists(_filePath))
+            return;
+
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            if (string.IsNullOrWhiteSpace(json))
+                return;
+
+            var loaded = JsonSerializer.Deserialize<Dictionary<string, ComponentSMatrixData>>(
+                json, SerializerOptions);
+            if (loaded == null) return;
+
+            foreach (var (key, value) in loaded)
+                _overrides[key] = value;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            // A corrupt file must not crash app startup. Surface it loudly so
+            // the user sees that their overrides aren't being applied; the
+            // store stays empty until the user fixes or deletes the file.
+            _errorConsole?.LogError(
+                $"Could not load user-global S-matrix overrides from '{_filePath}': {ex.Message}. " +
+                "PDK template overrides will not be applied this session.", ex);
+        }
+    }
+
+    private static string BuildDefaultFilePath()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        return Path.Combine(appData, AppFolderName, FileName);
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CAP_Core;
 using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
 using CAP_DataAccess.Import;
 using CAP_DataAccess.Persistence.PIR;
 using CAP.Avalonia.Services;
@@ -25,6 +26,8 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     private string _entityKey = string.Empty;
     private Action? _onChanged;
     private bool _isUserGlobalScope;
+    private Dictionary<int, SMatrix>? _effectiveSMatrices;
+    private IReadOnlyList<Pin>? _effectivePins;
 
     /// <summary>Dialog window title including the component name.</summary>
     [ObservableProperty]
@@ -42,8 +45,20 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     [ObservableProperty]
     private bool _hasSMatrices;
 
+    /// <summary>True when the "Currently effective S-matrix" section has rows.</summary>
+    [ObservableProperty]
+    private bool _hasEffectiveEntries;
+
     /// <summary>Per-wavelength S-matrix entries shown in the dialog list.</summary>
     public ObservableCollection<SMatrixEntryViewModel> SMatrixEntries { get; } = new();
+
+    /// <summary>
+    /// Read-only "currently effective" S-matrix entries — what the simulator
+    /// will use for each wavelength right now. Combines the PDK default with
+    /// any active override and tags each row accordingly so the user can see
+    /// the source without cross-referencing <see cref="SMatrixEntries"/>.
+    /// </summary>
+    public ObservableCollection<EffectiveSMatrixEntryViewModel> EffectiveEntries { get; } = new();
 
     /// <summary>
     /// Initialises a new instance with constructor-injected dependencies.
@@ -90,24 +105,42 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     /// rather than the project's <c>.lun</c>-backed store. Purely a UX hint;
     /// persistence behaviour is determined by the store the caller passes in.
     /// </param>
+    /// <param name="effectiveSMatrices">
+    /// Optional per-wavelength S-matrix map representing what the simulator
+    /// actually uses for this entity (PDK default merged with any active
+    /// override). When supplied alongside <paramref name="effectivePins"/>,
+    /// the dialog renders a read-only "Currently effective" section so the
+    /// user can see the source of truth without inferring it from the
+    /// override list.
+    /// </param>
+    /// <param name="effectivePins">
+    /// Pin order matching <paramref name="effectiveSMatrices"/>'s S-matrix
+    /// indexing. Required to read diagonal magnitudes from the SMatrix
+    /// (which is keyed by <see cref="Pin.IDInFlow"/> / <see cref="Pin.IDOutFlow"/>).
+    /// </param>
     public void Configure(
         string entityKey,
         string displayName,
         Dictionary<string, ComponentSMatrixData> storedSMatrices,
         Component? liveComponent = null,
         Action? onChanged = null,
-        bool isUserGlobalScope = false)
+        bool isUserGlobalScope = false,
+        Dictionary<int, SMatrix>? effectiveSMatrices = null,
+        IReadOnlyList<Pin>? effectivePins = null)
     {
         _entityKey = entityKey;
         _storedSMatrices = storedSMatrices;
         _liveComponent = liveComponent;
         _onChanged = onChanged;
         _isUserGlobalScope = isUserGlobalScope;
+        _effectiveSMatrices = effectiveSMatrices;
+        _effectivePins = effectivePins;
         Title = isUserGlobalScope
             ? $"Component Settings: {displayName} (applies to all projects)"
             : $"Component Settings: {displayName}";
         StatusText = string.Empty;
         RefreshEntries(notifyChanged: false);
+        RefreshEffectiveEntries();
     }
 
     /// <summary>
@@ -212,7 +245,11 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         if (_storedSMatrices == null || !_storedSMatrices.TryGetValue(_entityKey, out var data))
         {
             HasSMatrices = false;
-            if (notifyChanged) _onChanged?.Invoke();
+            if (notifyChanged)
+            {
+                RefreshEffectiveEntries();
+                _onChanged?.Invoke();
+            }
             return;
         }
 
@@ -220,7 +257,37 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
             SMatrixEntries.Add(new SMatrixEntryViewModel(kvp.Key, kvp.Value, data.SourceNote));
 
         HasSMatrices = SMatrixEntries.Count > 0;
-        if (notifyChanged) _onChanged?.Invoke();
+        if (notifyChanged)
+        {
+            RefreshEffectiveEntries();
+            _onChanged?.Invoke();
+        }
+    }
+
+    private void RefreshEffectiveEntries()
+    {
+        EffectiveEntries.Clear();
+        if (_effectiveSMatrices == null || _effectivePins == null)
+        {
+            HasEffectiveEntries = false;
+            return;
+        }
+
+        foreach (var kvp in _effectiveSMatrices.OrderBy(k => k.Key))
+        {
+            // A wavelength is "overridden" iff the active store has an entry
+            // with the same wavelength key — a wavelength present in the
+            // PDK default but not in the override is still PDK-driven.
+            bool isOverridden =
+                _storedSMatrices != null &&
+                _storedSMatrices.TryGetValue(_entityKey, out var data) &&
+                data.Wavelengths.ContainsKey(kvp.Key.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            EffectiveEntries.Add(new EffectiveSMatrixEntryViewModel(
+                kvp.Key, kvp.Value, _effectivePins, isOverridden));
+        }
+
+        HasEffectiveEntries = EffectiveEntries.Count > 0;
     }
 
     private ISParameterImporter? FindImporter(string path)

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -20,14 +20,17 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     private readonly IFileDialogService _fileDialogService;
     private readonly ErrorConsoleService? _errorConsole;
     private readonly IReadOnlyList<ISParameterImporter> _importers;
+    private readonly IPortMappingDialogService? _portMappingDialog;
 
     private Dictionary<string, ComponentSMatrixData>? _storedSMatrices;
     private Component? _liveComponent;
     private string _entityKey = string.Empty;
+    private string _displayName = string.Empty;
     private Action? _onChanged;
     private bool _isUserGlobalScope;
     private Dictionary<int, SMatrix>? _effectiveSMatrices;
     private IReadOnlyList<Pin>? _effectivePins;
+    private IReadOnlyList<string>? _availablePinNames;
 
     /// <summary>Dialog window title including the component name.</summary>
     [ObservableProperty]
@@ -66,13 +69,21 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     /// <param name="fileDialogService">Service used to open the file picker for imports.</param>
     /// <param name="errorConsole">Optional error console for surfacing import failures and partial overrides.</param>
     /// <param name="importers">Optional importer set; defaults to Lumerical + Touchstone.</param>
+    /// <param name="portMappingDialog">
+    /// Optional dialog service used when imported port names don't match the
+    /// component's pin names. Required for production use; tests can pass null
+    /// to skip the interactive step (which causes the import to abort with a
+    /// status-text explanation when names mismatch).
+    /// </param>
     public ComponentSettingsDialogViewModel(
         IFileDialogService fileDialogService,
         ErrorConsoleService? errorConsole = null,
-        IReadOnlyList<ISParameterImporter>? importers = null)
+        IReadOnlyList<ISParameterImporter>? importers = null,
+        IPortMappingDialogService? portMappingDialog = null)
     {
         _fileDialogService = fileDialogService;
         _errorConsole = errorConsole;
+        _portMappingDialog = portMappingDialog;
         _importers = importers ?? new ISParameterImporter[]
         {
             new LumericalSParameterImporter(),
@@ -126,15 +137,18 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         Action? onChanged = null,
         bool isUserGlobalScope = false,
         Dictionary<int, SMatrix>? effectiveSMatrices = null,
-        IReadOnlyList<Pin>? effectivePins = null)
+        IReadOnlyList<Pin>? effectivePins = null,
+        IReadOnlyList<string>? availablePinNames = null)
     {
         _entityKey = entityKey;
+        _displayName = displayName;
         _storedSMatrices = storedSMatrices;
         _liveComponent = liveComponent;
         _onChanged = onChanged;
         _isUserGlobalScope = isUserGlobalScope;
         _effectiveSMatrices = effectiveSMatrices;
         _effectivePins = effectivePins;
+        _availablePinNames = availablePinNames;
         Title = isUserGlobalScope
             ? $"Component Settings: {displayName} (applies to all projects)"
             : $"Component Settings: {displayName}";
@@ -174,14 +188,24 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         try
         {
             var imported = await importer.ImportAsync(path);
-            var smatrixData = SParameterConverter.ToComponentSMatrixData(imported);
+
+            // Reconcile imported port names with the component's pin names.
+            // If they don't already align and we have both the available pin
+            // names and a mapping-dialog service, ask the user up-front. This
+            // is much friendlier than letting SMatrixOverrideApplicator skip
+            // every wavelength later with a "port name X not found" warning.
+            var resolved = await ReconcilePortNamesAsync(imported);
+            if (resolved == null)
+                return; // user cancelled — StatusText already set
+
+            var smatrixData = SParameterConverter.ToComponentSMatrixData(resolved);
             _storedSMatrices[_entityKey] = smatrixData;
 
             ApplyResult? applyResult = null;
             if (_liveComponent != null)
                 applyResult = SMatrixOverrideApplicator.Apply(_liveComponent, smatrixData, _errorConsole);
 
-            StatusText = BuildImportStatus(path, imported, applyResult);
+            StatusText = BuildImportStatus(path, resolved, applyResult);
         }
         catch (Exception ex)
         {
@@ -193,6 +217,48 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
             IsImporting = false;
             RefreshEntries(notifyChanged: true);
         }
+    }
+
+    /// <summary>
+    /// Returns <paramref name="imported"/> unchanged when port names already
+    /// align, the result of <see cref="PortNameMapping.Remap"/> with a
+    /// user-supplied mapping when they don't, or <c>null</c> when the user
+    /// cancelled the mapping dialog (in which case <see cref="StatusText"/>
+    /// is set so the caller can return without storing anything).
+    /// </summary>
+    private async Task<ImportedSParameters?> ReconcilePortNamesAsync(ImportedSParameters imported)
+    {
+        if (_availablePinNames == null || _availablePinNames.Count == 0)
+            return imported; // caller didn't tell us the pin names — proceed and let Apply complain if anything's wrong
+
+        if (PortNameMapping.NamesAlignWithComponent(imported.PortNames, _availablePinNames))
+            return imported;
+
+        if (imported.PortNames.Count != _availablePinNames.Count)
+        {
+            // Different port counts is structurally unmappable — bail out
+            // loudly rather than open a dialog the user couldn't satisfy.
+            StatusText = $"Cannot import: file has {imported.PortNames.Count} port(s), " +
+                         $"but '{_displayName}' has {_availablePinNames.Count} pin(s).";
+            return null;
+        }
+
+        if (_portMappingDialog == null)
+        {
+            // No interactive surface available (typically test or headless).
+            StatusText = $"Imported port names don't match component pins on '{_displayName}'. " +
+                         $"Re-run with a port-mapping dialog wired up to resolve this interactively.";
+            return null;
+        }
+
+        var mapping = await _portMappingDialog.ShowAsync(_displayName, imported.PortNames, _availablePinNames);
+        if (mapping == null)
+        {
+            StatusText = "Import cancelled — no port mapping was confirmed.";
+            return null;
+        }
+
+        return PortNameMapping.Remap(imported, mapping);
     }
 
     private static string BuildImportStatus(

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -24,6 +24,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     private Component? _liveComponent;
     private string _entityKey = string.Empty;
     private Action? _onChanged;
+    private bool _isUserGlobalScope;
 
     /// <summary>Dialog window title including the component name.</summary>
     [ObservableProperty]
@@ -83,18 +84,28 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     /// Optional callback invoked after every successful import or delete so observers
     /// (e.g. the hierarchy panel) can refresh derived state such as override badges.
     /// </param>
+    /// <param name="isUserGlobalScope">
+    /// When true, the dialog title flags that the override applies to all projects
+    /// — used when <paramref name="storedSMatrices"/> is the user-global store
+    /// rather than the project's <c>.lun</c>-backed store. Purely a UX hint;
+    /// persistence behaviour is determined by the store the caller passes in.
+    /// </param>
     public void Configure(
         string entityKey,
         string displayName,
         Dictionary<string, ComponentSMatrixData> storedSMatrices,
         Component? liveComponent = null,
-        Action? onChanged = null)
+        Action? onChanged = null,
+        bool isUserGlobalScope = false)
     {
         _entityKey = entityKey;
         _storedSMatrices = storedSMatrices;
         _liveComponent = liveComponent;
         _onChanged = onChanged;
-        Title = $"Component Settings: {displayName}";
+        _isUserGlobalScope = isUserGlobalScope;
+        Title = isUserGlobalScope
+            ? $"Component Settings: {displayName} (applies to all projects)"
+            : $"Component Settings: {displayName}";
         StatusText = string.Empty;
         RefreshEntries(notifyChanged: false);
     }

--- a/CAP.Avalonia/ViewModels/ComponentSettings/EffectiveSMatrixEntryViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/EffectiveSMatrixEntryViewModel.cs
@@ -31,9 +31,11 @@ public class EffectiveSMatrixEntryViewModel
     public bool IsOverridden { get; }
 
     /// <summary>
-    /// Diagonal magnitudes preview (|S11|, |S22|, …) for the first four ports.
+    /// Strongest off-diagonal couplings (top 4) as "P_i→P_j=value". Skips the
+    /// diagonal because |S_ii| is the reflection at port i, which is ≈0 for
+    /// the passive photonic devices in our PDKs and so makes a useless preview.
     /// </summary>
-    public string DiagonalPreview { get; }
+    public string MagnitudePreview { get; }
 
     /// <summary>
     /// Builds an entry from a live <see cref="SMatrix"/> and the component's
@@ -52,35 +54,46 @@ public class EffectiveSMatrixEntryViewModel
         Dimensions = $"{pins.Count} × {pins.Count}";
         IsOverridden = isOverridden;
         SourceTag = isOverridden ? "Override active" : "PDK Default";
-        DiagonalPreview = BuildDiagonalPreview(sMatrix, pins);
+        MagnitudePreview = BuildMagnitudePreview(sMatrix, pins);
     }
 
-    private static string BuildDiagonalPreview(SMatrix sMatrix, IReadOnlyList<Pin> pins)
+    private static string BuildMagnitudePreview(SMatrix sMatrix, IReadOnlyList<Pin> pins)
     {
         if (pins.Count == 0)
             return string.Empty;
 
-        var parts = new List<string>();
-        int maxPreview = Math.Min(pins.Count, 4);
+        var couplings = new List<(int From, int To, double Magnitude)>();
 
-        for (int i = 0; i < maxPreview; i++)
+        // S[out, in] convention. We label pairs as "input → output" so the
+        // user reads them as "Port 1 input couples 70% into Port 3 output" etc.
+        for (int from = 0; from < pins.Count; from++)
         {
-            // S[out, in] convention — diagonal = |S(pin_i_out, pin_i_in)|.
-            // A missing pin id (rare but possible for unusual templates)
-            // skips that diagonal entry rather than failing the whole row.
-            if (!sMatrix.PinReference.TryGetValue(pins[i].IDOutFlow, out var outIdx))
-                continue;
-            if (!sMatrix.PinReference.TryGetValue(pins[i].IDInFlow, out var inIdx))
+            if (!sMatrix.PinReference.TryGetValue(pins[from].IDInFlow, out var inIdx))
                 continue;
 
-            var v = sMatrix.SMat[outIdx, inIdx];
-            double mag = Math.Sqrt(v.Real * v.Real + v.Imaginary * v.Imaginary);
-            // Invariant culture so the "0.950" form is stable on de-DE/fr-FR locales
-            // — those would otherwise render "0,950" and break round-trip / log parsing.
-            parts.Add($"|S{i + 1}{i + 1}|={mag.ToString("F3", CultureInfo.InvariantCulture)}");
+            for (int to = 0; to < pins.Count; to++)
+            {
+                if (from == to) continue; // skip reflection
+                if (!sMatrix.PinReference.TryGetValue(pins[to].IDOutFlow, out var outIdx))
+                    continue;
+
+                var v = sMatrix.SMat[outIdx, inIdx];
+                double mag = Math.Sqrt(v.Real * v.Real + v.Imaginary * v.Imaginary);
+                if (mag < 1e-6) continue; // hide noise-floor entries
+
+                couplings.Add((from, to, mag));
+            }
         }
 
-        var preview = string.Join("  ", parts);
-        return pins.Count > 4 ? preview + " …" : preview;
+        if (couplings.Count == 0)
+            return "(no significant couplings)";
+
+        couplings.Sort((a, b) => b.Magnitude.CompareTo(a.Magnitude));
+        var top = couplings.Take(4)
+            // InvariantCulture so "0.707" stays "0.707" on de-DE / fr-FR locales.
+            .Select(c => $"P{c.From + 1}→P{c.To + 1}={c.Magnitude.ToString("F3", CultureInfo.InvariantCulture)}");
+
+        var preview = string.Join("  ", top);
+        return couplings.Count > 4 ? preview + " …" : preview;
     }
 }

--- a/CAP.Avalonia/ViewModels/ComponentSettings/EffectiveSMatrixEntryViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/EffectiveSMatrixEntryViewModel.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+
+namespace CAP.Avalonia.ViewModels.ComponentSettings;
+
+/// <summary>
+/// Read-only display row for the "Currently effective S-matrix" section in the
+/// Component Settings dialog. Shows whatever S-matrix the simulator will use
+/// for a given wavelength right now — i.e. the PDK default unless an override
+/// has replaced it. Source-tagged so the user can tell which layer wins
+/// without cross-referencing the override list.
+/// </summary>
+public class EffectiveSMatrixEntryViewModel
+{
+    /// <summary>Wavelength label (e.g. "1550 nm").</summary>
+    public string WavelengthLabel { get; }
+
+    /// <summary>Matrix dimensions string (e.g. "4 × 4").</summary>
+    public string Dimensions { get; }
+
+    /// <summary>
+    /// Source-of-truth tag — "PDK Default" when no override is in play for this
+    /// wavelength, "Override active" otherwise. The dialog wraps the row in a
+    /// faintly tinted background based on this tag so the visual difference is
+    /// obvious at a glance.
+    /// </summary>
+    public string SourceTag { get; }
+
+    /// <summary>True when <see cref="SourceTag"/> is "Override active".</summary>
+    public bool IsOverridden { get; }
+
+    /// <summary>
+    /// Diagonal magnitudes preview (|S11|, |S22|, …) for the first four ports.
+    /// </summary>
+    public string DiagonalPreview { get; }
+
+    /// <summary>
+    /// Builds an entry from a live <see cref="SMatrix"/> and the component's
+    /// physical pin list. Reads the pin-keyed transfer values via the
+    /// SMatrix.PinReference index map; if any expected pin id is missing the
+    /// preview falls back to the empty string rather than throwing — the
+    /// dialog should never crash because of an unusual S-matrix shape.
+    /// </summary>
+    public EffectiveSMatrixEntryViewModel(
+        int wavelengthNm,
+        SMatrix sMatrix,
+        IReadOnlyList<Pin> pins,
+        bool isOverridden)
+    {
+        WavelengthLabel = $"{wavelengthNm} nm";
+        Dimensions = $"{pins.Count} × {pins.Count}";
+        IsOverridden = isOverridden;
+        SourceTag = isOverridden ? "Override active" : "PDK Default";
+        DiagonalPreview = BuildDiagonalPreview(sMatrix, pins);
+    }
+
+    private static string BuildDiagonalPreview(SMatrix sMatrix, IReadOnlyList<Pin> pins)
+    {
+        if (pins.Count == 0)
+            return string.Empty;
+
+        var parts = new List<string>();
+        int maxPreview = Math.Min(pins.Count, 4);
+
+        for (int i = 0; i < maxPreview; i++)
+        {
+            // S[out, in] convention — diagonal = |S(pin_i_out, pin_i_in)|.
+            // A missing pin id (rare but possible for unusual templates)
+            // skips that diagonal entry rather than failing the whole row.
+            if (!sMatrix.PinReference.TryGetValue(pins[i].IDOutFlow, out var outIdx))
+                continue;
+            if (!sMatrix.PinReference.TryGetValue(pins[i].IDInFlow, out var inIdx))
+                continue;
+
+            var v = sMatrix.SMat[outIdx, inIdx];
+            double mag = Math.Sqrt(v.Real * v.Real + v.Imaginary * v.Imaginary);
+            // Invariant culture so the "0.950" form is stable on de-DE/fr-FR locales
+            // — those would otherwise render "0,950" and break round-trip / log parsing.
+            parts.Add($"|S{i + 1}{i + 1}|={mag.ToString("F3", CultureInfo.InvariantCulture)}");
+        }
+
+        var preview = string.Join("  ", parts);
+        return pins.Count > 4 ? preview + " …" : preview;
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/PortMappingDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/PortMappingDialogViewModel.cs
@@ -1,0 +1,95 @@
+using System.Collections.ObjectModel;
+using CAP_DataAccess.Import;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CAP.Avalonia.ViewModels.ComponentSettings;
+
+/// <summary>
+/// ViewModel backing the port-mapping dialog. Built when an imported S-parameter
+/// file's port names ("port 1", "port 2", …) don't match the component's pin
+/// names ("in", "out1", …), so the user can disambiguate the assignment before
+/// the override is stored.
+///
+/// Defaults follow <see cref="PortNameMapping.BuildDefaultMapping"/>: imported
+/// names that already match a component pin keep their target; the rest fall
+/// back to positional pairing. The user can re-pick any row.
+/// </summary>
+public partial class PortMappingDialogViewModel : ObservableObject
+{
+    /// <summary>Title shown in the window header.</summary>
+    [ObservableProperty]
+    private string _title = "Map imported ports to component pins";
+
+    /// <summary>One-line summary of why the dialog appeared, surfaced above the rows.</summary>
+    [ObservableProperty]
+    private string _explanation = "";
+
+    /// <summary>Per-imported-port editable rows.</summary>
+    public ObservableCollection<PortMappingRowViewModel> Rows { get; } = new();
+
+    /// <summary>Pin names the dropdowns are populated with — shared across rows.</summary>
+    public ObservableCollection<string> AvailablePins { get; } = new();
+
+    /// <summary>
+    /// Configures the dialog with the imported names and the component's pin names.
+    /// Builds default mappings via <see cref="PortNameMapping.BuildDefaultMapping"/>;
+    /// the user can edit each row before confirming.
+    /// </summary>
+    public void Configure(
+        IReadOnlyList<string> importedNames,
+        IReadOnlyList<string> componentPinNames,
+        string componentDisplayName)
+    {
+        AvailablePins.Clear();
+        foreach (var name in componentPinNames)
+            AvailablePins.Add(name);
+
+        Title = $"Map ports for '{componentDisplayName}'";
+        Explanation = $"The imported file uses port names that don't match this component's pins. " +
+                      $"Pick the component pin each imported port represents. " +
+                      $"Defaults are kept-on-match-or-positional; correct any row that's wrong.";
+
+        var defaults = PortNameMapping.BuildDefaultMapping(importedNames, componentPinNames);
+
+        Rows.Clear();
+        foreach (var imported in importedNames)
+        {
+            Rows.Add(new PortMappingRowViewModel(
+                imported,
+                AvailablePins,
+                defaults[imported]));
+        }
+    }
+
+    /// <summary>
+    /// Snapshots the user's selections as an imported→component mapping suitable
+    /// for <see cref="PortNameMapping.Remap"/>. Returns null when the user has
+    /// duplicated a target pin across rows — the caller surfaces that as an
+    /// error rather than letting two ports collapse silently into one.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? BuildResultOrNull(out string? errorReason)
+    {
+        var mapping = new Dictionary<string, string>(Rows.Count, StringComparer.Ordinal);
+        var usedTargets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var row in Rows)
+        {
+            if (string.IsNullOrEmpty(row.SelectedPin))
+            {
+                errorReason = $"No target pin selected for imported port '{row.ImportedName}'.";
+                return null;
+            }
+            if (!usedTargets.Add(row.SelectedPin))
+            {
+                errorReason = $"Component pin '{row.SelectedPin}' is mapped to more than one " +
+                              $"imported port. Each component pin can only receive data from one " +
+                              $"imported port.";
+                return null;
+            }
+            mapping[row.ImportedName] = row.SelectedPin;
+        }
+
+        errorReason = null;
+        return mapping;
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/PortMappingRowViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/PortMappingRowViewModel.cs
@@ -1,0 +1,31 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CAP.Avalonia.ViewModels.ComponentSettings;
+
+/// <summary>
+/// One row in the port-mapping dialog: the imported port name (read-only)
+/// plus a ComboBox-bound selection from the component's available pin names.
+/// </summary>
+public partial class PortMappingRowViewModel : ObservableObject
+{
+    /// <summary>The original name as it appeared in the imported file.</summary>
+    public string ImportedName { get; }
+
+    /// <summary>Component pin names the user can pick from for this row.</summary>
+    public ObservableCollection<string> AvailablePins { get; }
+
+    /// <summary>The pin currently selected as the target for <see cref="ImportedName"/>.</summary>
+    [ObservableProperty]
+    private string _selectedPin;
+
+    public PortMappingRowViewModel(
+        string importedName,
+        ObservableCollection<string> availablePins,
+        string selectedPin)
+    {
+        ImportedName = importedName;
+        AvailablePins = availablePins;
+        _selectedPin = selectedPin;
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/SMatrixEntryViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/SMatrixEntryViewModel.cs
@@ -25,9 +25,14 @@ public class SMatrixEntryViewModel
     public string? SourceNote { get; }
 
     /// <summary>
-    /// Short preview of the diagonal magnitudes (|S11|, |S22|, …) truncated at 4 entries.
+    /// Short preview of the strongest off-diagonal couplings — i.e. the largest
+    /// |S_ij| transmissions between distinct ports, formatted as "P_i→P_j=value".
+    /// We deliberately skip the diagonal: |S_ii| is the reflection at port i,
+    /// which is engineered to be ≈0 for passive photonic devices (couplers,
+    /// splitters, MMIs) and so was the least informative thing to preview.
+    /// Top 4 couplings shown, sorted by magnitude desc.
     /// </summary>
-    public string DiagonalPreview { get; }
+    public string MagnitudePreview { get; }
 
     /// <summary>
     /// Initialises the entry from the raw DTO and optional source note.
@@ -43,34 +48,45 @@ public class SMatrixEntryViewModel
             ? string.Join(", ", entry.PortNames)
             : "(no port names)";
 
-        DiagonalPreview = BuildDiagonalPreview(entry);
+        MagnitudePreview = BuildMagnitudePreview(entry);
     }
 
-    private static string BuildDiagonalPreview(SMatrixWavelengthEntry entry)
+    private static string BuildMagnitudePreview(SMatrixWavelengthEntry entry)
     {
         if (entry.Rows == 0 || entry.Real.Count == 0)
             return string.Empty;
 
         int n = entry.Rows;
-        var parts = new List<string>();
-        int maxPreview = Math.Min(n, 4);
+        var couplings = new List<(int From, int To, double Magnitude)>();
 
-        for (int i = 0; i < maxPreview; i++)
+        // Convention: entry.Real[r*n + c] = S[r=out, c=in]. We want
+        // "input port from → output port to" labels, so iterate (in=from, out=to).
+        for (int from = 0; from < n; from++)
         {
-            int idx = i * n + i;
-            if (idx >= entry.Real.Count)
-                break;
+            for (int to = 0; to < n; to++)
+            {
+                if (from == to) continue; // skip reflection (always ≈0 for passive devices)
+                int idx = to * n + from;
+                if (idx >= entry.Real.Count) continue;
 
-            double mag = Math.Sqrt(
-                entry.Real[idx] * entry.Real[idx] +
-                entry.Imag[idx] * entry.Imag[idx]);
+                double mag = Math.Sqrt(
+                    entry.Real[idx] * entry.Real[idx] +
+                    entry.Imag[idx] * entry.Imag[idx]);
+                if (mag < 1e-6) continue; // hide noise floor
 
-            // InvariantCulture so the "0.950" form is stable on de-DE / fr-FR locales
-            // (which would otherwise render "0,950" and break log parsing & screenshots).
-            parts.Add($"|S{i + 1}{i + 1}|={mag.ToString("F3", CultureInfo.InvariantCulture)}");
+                couplings.Add((from, to, mag));
+            }
         }
 
-        var preview = string.Join("  ", parts);
-        return n > 4 ? preview + " …" : preview;
+        if (couplings.Count == 0)
+            return "(no significant couplings)";
+
+        couplings.Sort((a, b) => b.Magnitude.CompareTo(a.Magnitude));
+        var top = couplings.Take(4)
+            // InvariantCulture so the "0.707" form is stable on de-DE / fr-FR locales.
+            .Select(c => $"P{c.From + 1}→P{c.To + 1}={c.Magnitude.ToString("F3", CultureInfo.InvariantCulture)}");
+
+        var preview = string.Join("  ", top);
+        return couplings.Count > 4 ? preview + " …" : preview;
     }
 }

--- a/CAP.Avalonia/ViewModels/ComponentSettings/SMatrixEntryViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/SMatrixEntryViewModel.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.ViewModels.ComponentSettings;
@@ -64,7 +65,9 @@ public class SMatrixEntryViewModel
                 entry.Real[idx] * entry.Real[idx] +
                 entry.Imag[idx] * entry.Imag[idx]);
 
-            parts.Add($"|S{i + 1}{i + 1}|={mag:F3}");
+            // InvariantCulture so the "0.950" form is stable on de-DE / fr-FR locales
+            // (which would otherwise render "0,950" and break log parsing & screenshots).
+            parts.Add($"|S{i + 1}{i + 1}|={mag.ToString("F3", CultureInfo.InvariantCulture)}");
         }
 
         var preview = string.Join("  ", parts);

--- a/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
@@ -2,6 +2,7 @@ using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.LightCalculation;
 using CAP_Core.Tiles;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace CAP.Avalonia.ViewModels.Library;
 
@@ -129,7 +130,7 @@ public static class ComponentTemplates
 
 }
 
-public class ComponentTemplate
+public partial class ComponentTemplate : ObservableObject
 {
     public string Name { get; set; } = "";
     public string Category { get; set; } = "";
@@ -139,6 +140,17 @@ public class ComponentTemplate
     public bool HasSlider { get; set; }
     public double SliderMin { get; set; }
     public double SliderMax { get; set; }
+
+    /// <summary>
+    /// True when the user-global <see cref="Services.UserSMatrixOverrideStore"/>
+    /// holds an entry under this template's <c>"{PdkSource}::{Name}"</c> key —
+    /// drives the 📊 badge in the PDK library list. Refreshed by
+    /// <see cref="ComponentLibraryViewModel.RefreshUserGlobalOverrideBadges"/>
+    /// after any import or delete in the Component Settings dialog and after
+    /// project load (which can migrate template overrides from .lun files).
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasUserGlobalSMatrixOverride;
     public Func<List<Pin>, SMatrix>? CreateSMatrix { get; set; }
     public Func<List<Pin>, List<Slider>, SMatrix>? CreateSMatrixWithSliders { get; set; }
 

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -151,7 +151,8 @@ public partial class MainViewModel : ObservableObject
         PdkOffsetEditorViewModel pdkOffsetEditor,
         ViewModels.Export.PhotonTorchExportViewModel photonTorchExport,
         ViewModels.Export.VerilogAExportViewModel verilogAExport,
-        ViewModels.Canvas.ChipSizeViewModel chipSize)
+        ViewModels.Canvas.ChipSizeViewModel chipSize,
+        Services.UserSMatrixOverrideStore userSMatrixOverrideStore)
     {
         Simulation = simulationService;
         CommandManager = commandManager;
@@ -169,7 +170,7 @@ public partial class MainViewModel : ObservableObject
 
         CanvasInteraction = new CanvasInteractionViewModel(_canvas, commandManager, LeftPanel.ComponentLibrary, previewGenerator, inputDialogService);
 
-        FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, saxExporter, LeftPanel.AllTemplates, gdsExportViewModel, photonTorchExport, verilogAExport, errorConsoleService);
+        FileOperations = new FileOperationsViewModel(_canvas, commandManager, nazcaExporter, saxExporter, LeftPanel.AllTemplates, gdsExportViewModel, photonTorchExport, verilogAExport, errorConsoleService, userSMatrixOverrideStore);
         ViewportControl = viewportControl;
 
         // Build the unified Export menu (add new IExportFormat here for new formats)

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -30,6 +30,7 @@ public partial class FileOperationsViewModel : ObservableObject
     private readonly SaxExporter _saxExporter;
     private readonly ObservableCollection<ComponentTemplate> _componentLibrary;
     private readonly ErrorConsoleService? _errorConsole;
+    private readonly UserSMatrixOverrideStore? _userSMatrixOverrideStore;
 
     /// <summary>
     /// Current .lun format version this build reads and writes. Files with any other value are rejected at load time.
@@ -112,7 +113,8 @@ public partial class FileOperationsViewModel : ObservableObject
         GdsExportViewModel gdsExport,
         PhotonTorchExportViewModel photonTorchExport,
         VerilogAExportViewModel verilogAExport,
-        ErrorConsoleService? errorConsole = null)
+        ErrorConsoleService? errorConsole = null,
+        UserSMatrixOverrideStore? userSMatrixOverrideStore = null)
     {
         _canvas = canvas;
         _commandManager = commandManager;
@@ -123,6 +125,7 @@ public partial class FileOperationsViewModel : ObservableObject
         PhotonTorchExport = photonTorchExport;
         VerilogAExport = verilogAExport;
         _errorConsole = errorConsole;
+        _userSMatrixOverrideStore = userSMatrixOverrideStore;
 
         // Track changes to mark project as unsaved
         _canvas.Components.CollectionChanged += (s, e) => HasUnsavedChanges = true;
@@ -141,19 +144,57 @@ public partial class FileOperationsViewModel : ObservableObject
     private void OnComponentsChangedApplyStoredOverrides(object? sender,
         System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
-        if (StoredSMatrices.Count == 0 || e.NewItems == null) return;
+        if (e.NewItems == null) return;
+
+        var addedComponents = e.NewItems
+            .OfType<ComponentViewModel>()
+            .Select(vm => vm.Component)
+            .ToList();
+        if (addedComponents.Count == 0) return;
 
         // Reuse ApplyAll with a single-component view so the identifier /
         // template-key lookup logic stays in one place. Re-applying the
         // same matrix to an already-up-to-date component is a no-op.
-        var addedComponents = e.NewItems
-            .OfType<ComponentViewModel>()
-            .Select(vm => vm.Component);
+        if (StoredSMatrices.Count > 0)
+        {
+            Services.SMatrixOverrideApplicator.ApplyAll(
+                addedComponents,
+                StoredSMatrices,
+                templateKeyResolver: ResolveTemplateKey,
+                errorConsole: _errorConsole);
+        }
+
+        ApplyUserGlobalOverrides(addedComponents);
+    }
+
+    /// <summary>
+    /// Applies the user-global PDK template S-matrix overrides to a set of
+    /// components. Project-local instance overrides (in <see cref="StoredSMatrices"/>)
+    /// take precedence and are intentionally applied first; this fills the
+    /// gap for components that don't have a project-local override.
+    /// </summary>
+    private void ApplyUserGlobalOverrides(IEnumerable<Component> components)
+    {
+        if (_userSMatrixOverrideStore == null ||
+            _userSMatrixOverrideStore.Overrides.Count == 0)
+            return;
+
         Services.SMatrixOverrideApplicator.ApplyAll(
-            addedComponents,
-            StoredSMatrices,
+            components,
+            _userSMatrixOverrideStore.Overrides,
             templateKeyResolver: ResolveTemplateKey,
             errorConsole: _errorConsole);
+    }
+
+    /// <summary>
+    /// Re-applies all user-global PDK template overrides to every live canvas
+    /// component. Called by the Component Settings dialog after a successful
+    /// import or delete in Per-Template mode so the change propagates to
+    /// existing instances without requiring a project reload.
+    /// </summary>
+    public void ReapplyTemplateOverrides()
+    {
+        ApplyUserGlobalOverrides(_canvas.Components.Select(vm => vm.Component));
     }
 
     [RelayCommand]
@@ -299,6 +340,14 @@ public partial class FileOperationsViewModel : ObservableObject
             HumanReadableName = c.Component.HumanReadableName
         };
     }
+
+    /// <summary>
+    /// Returns true when the given store key is shaped like a PDK-template-scoped
+    /// key (<c>"{pdkSource}::{templateName}"</c>) rather than a per-instance key
+    /// (a bare <c>component.Identifier</c> with no <c>::</c> separator). Used during
+    /// project load to migrate template-scoped entries to the user-global store.
+    /// </summary>
+    private static bool IsTemplateScopedKey(string key) => key.Contains("::", StringComparison.Ordinal);
 
     /// <summary>
     /// Builds the PDK-template-scoped store key (<c>"{pdkSource}::{templateName}"</c>) for a component,
@@ -648,19 +697,51 @@ public partial class FileOperationsViewModel : ObservableObject
                 StoredSMatrices.Clear();
                 if (designData.SMatrices != null)
                 {
+                    int migratedCount = 0;
                     foreach (var kv in designData.SMatrices)
-                        StoredSMatrices[kv.Key] = kv.Value;
+                    {
+                        // Migration: PDK-template-scoped keys ("{pdkSource}::{templateName}")
+                        // used to live in the project file. They now belong to the user-global
+                        // store so the override applies to every project the user opens.
+                        // Move them out so a subsequent save writes a clean project file.
+                        if (_userSMatrixOverrideStore != null && IsTemplateScopedKey(kv.Key))
+                        {
+                            _userSMatrixOverrideStore.Overrides[kv.Key] = kv.Value;
+                            migratedCount++;
+                        }
+                        else
+                        {
+                            StoredSMatrices[kv.Key] = kv.Value;
+                        }
+                    }
+
+                    if (migratedCount > 0)
+                    {
+                        _userSMatrixOverrideStore!.Save();
+                        _errorConsole?.LogWarning(
+                            $"Migrated {migratedCount} PDK template S-matrix override(s) from project file to user-global storage. " +
+                            "These now apply to all projects. Save this project to finalise the migration.");
+                        HasUnsavedChanges = true;
+                    }
 
                     // Apply per-instance overrides to live components so the
                     // next simulation run picks up the stored S-matrices.
                     // Falls back to "{pdkSource}::{templateName}" so PDK-template-scoped
                     // overrides reach every instance of the template, not just renamed instances.
-                    var allComponents = _canvas.Components.Select(vm => vm.Component);
+                    var allComponents = _canvas.Components.Select(vm => vm.Component).ToList();
                     Services.SMatrixOverrideApplicator.ApplyAll(
                         allComponents,
                         StoredSMatrices,
                         templateKeyResolver: ResolveTemplateKey,
                         errorConsole: _errorConsole);
+                    ApplyUserGlobalOverrides(allComponents);
+                }
+                else
+                {
+                    // No project overrides — still apply user-global ones so the
+                    // user's PDK template edits show up in projects that never
+                    // had any project-scoped overrides of their own.
+                    ApplyUserGlobalOverrides(_canvas.Components.Select(vm => vm.Component));
                 }
 
                 _currentFilePath = filePath;

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -255,6 +255,22 @@ public partial class LeftPanelViewModel : ObservableObject
             || t.PdkSource.Contains(query, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Updates the <see cref="ComponentTemplate.HasUserGlobalSMatrixOverride"/> flag on
+    /// every template, so the 📊 badge in the PDK list reflects the current state of
+    /// the user-global override store. The lookup uses the same key shape the dialog
+    /// writes (<c>"{PdkSource}::{Name}"</c>); callers pass that as a predicate so this
+    /// VM stays unaware of the store implementation.
+    /// </summary>
+    public void RefreshUserGlobalOverrideBadges(Func<string, bool> hasUserOverride)
+    {
+        foreach (var t in AllTemplates)
+        {
+            var key = $"{t.PdkSource}::{t.Name}";
+            t.HasUserGlobalSMatrixOverride = hasUserOverride(key);
+        }
+    }
+
     private void RestorePdkFilterState()
     {
         var enabledPdks = _preferencesService.GetEnabledPdks();

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -87,7 +87,7 @@
                                            FontSize="10"
                                            VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="2"
-                                           Text="{Binding DiagonalPreview}"
+                                           Text="{Binding MagnitudePreview}"
                                            Foreground="#88ccaa"
                                            FontFamily="Consolas, Courier New, monospace"
                                            FontSize="10"
@@ -128,7 +128,8 @@
               IsVisible="{Binding HasSMatrices}">
             <TextBlock Grid.Column="0" Text="Wavelength" Foreground="#888888" FontSize="10" FontWeight="SemiBold"/>
             <TextBlock Grid.Column="1" Text="Size" Foreground="#888888" FontSize="10" FontWeight="SemiBold"/>
-            <TextBlock Grid.Column="2" Text="Diagonal magnitudes" Foreground="#888888" FontSize="10" FontWeight="SemiBold"/>
+            <TextBlock Grid.Column="2" Text="Strongest couplings" Foreground="#888888" FontSize="10" FontWeight="SemiBold"
+                       ToolTip.Tip="Top off-diagonal magnitudes |S_ij| in the form input port → output port. Diagonal entries (reflections) are skipped because they're ≈0 for passive devices."/>
             <TextBlock Grid.Column="3" Text="" Foreground="#888888" FontSize="10" FontWeight="SemiBold"/>
         </Grid>
 
@@ -163,9 +164,9 @@
                                            FontSize="11"
                                            VerticalAlignment="Center"/>
 
-                                <!-- Diagonal preview -->
+                                <!-- Strongest couplings preview -->
                                 <StackPanel Grid.Column="2" VerticalAlignment="Center">
-                                    <TextBlock Text="{Binding DiagonalPreview}"
+                                    <TextBlock Text="{Binding MagnitudePreview}"
                                                Foreground="#88ccaa"
                                                FontFamily="Consolas, Courier New, monospace"
                                                FontSize="10"

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -52,6 +52,75 @@
                    TextWrapping="Wrap"
                    IsVisible="{Binding HasSMatrices, Converter={x:Static BoolConverters.Not}}"/>
 
+        <!-- Currently effective S-matrix (read-only): shows what the simulator
+             actually uses for this entity right now, with a per-row tag that
+             distinguishes "PDK Default" from "Override active" so the user can
+             see the source of truth without inferring it from the override list. -->
+        <TextBlock DockPanel.Dock="Top"
+                   Text="Currently effective S-matrix"
+                   Foreground="#aaaacc"
+                   FontSize="11"
+                   FontWeight="SemiBold"
+                   Margin="0,0,0,4"
+                   IsVisible="{Binding HasEffectiveEntries}"/>
+        <Border DockPanel.Dock="Top"
+                Background="#161616"
+                CornerRadius="4"
+                Padding="6"
+                Margin="0,0,0,10"
+                MaxHeight="140"
+                IsVisible="{Binding HasEffectiveEntries}">
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <ItemsControl ItemsSource="{Binding EffectiveEntries}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:EffectiveSMatrixEntryViewModel">
+                            <Grid ColumnDefinitions="80,60,*,90" Margin="0,1">
+                                <TextBlock Grid.Column="0"
+                                           Text="{Binding WavelengthLabel}"
+                                           Foreground="White"
+                                           FontSize="11"
+                                           VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding Dimensions}"
+                                           Foreground="#aaaaaa"
+                                           FontSize="10"
+                                           VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2"
+                                           Text="{Binding DiagonalPreview}"
+                                           Foreground="#88ccaa"
+                                           FontFamily="Consolas, Courier New, monospace"
+                                           FontSize="10"
+                                           TextTrimming="CharacterEllipsis"
+                                           VerticalAlignment="Center"/>
+                                <!-- Source tag: orange when override active, dim when PDK default.
+                                     Uses two overlapping TextBlocks toggled by IsOverridden — Avalonia
+                                     compiled bindings can't take a foreground brush from a binding
+                                     in this scope, so two pre-coloured rows is the cleanest path. -->
+                                <TextBlock Grid.Column="3"
+                                           Text="{Binding SourceTag}"
+                                           Foreground="#FFA500"
+                                           FontSize="10"
+                                           FontWeight="SemiBold"
+                                           VerticalAlignment="Center"
+                                           HorizontalAlignment="Right"
+                                           IsVisible="{Binding IsOverridden}"
+                                           ToolTip.Tip="A user import has replaced the PDK default for this wavelength"/>
+                                <TextBlock Grid.Column="3"
+                                           Text="{Binding SourceTag}"
+                                           Foreground="#777777"
+                                           FontSize="10"
+                                           VerticalAlignment="Center"
+                                           HorizontalAlignment="Right"
+                                           IsVisible="{Binding !IsOverridden}"
+                                           ToolTip.Tip="Comes from the PDK definition; no user override"/>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
         <!-- S-matrix list header -->
         <Grid DockPanel.Dock="Top"
               ColumnDefinitions="110,80,*,80"

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -503,7 +503,18 @@
                                             PinDefinitions="{Binding PinDefinitions}"
                                             Margin="0,0,6,0"/>
                                         <StackPanel VerticalAlignment="Center">
-                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="11"/>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="11"/>
+                                                <!-- User-global S-matrix override badge: signals that this template's
+                                                     S-matrix has been replaced by an imported override that applies
+                                                     to every project the user opens. -->
+                                                <TextBlock Text="📊"
+                                                           FontSize="11"
+                                                           VerticalAlignment="Center"
+                                                           Margin="4,0,0,0"
+                                                           IsVisible="{Binding HasUserGlobalSMatrixOverride}"
+                                                           ToolTip.Tip="User-global S-matrix override active — applies to all projects"/>
+                                            </StackPanel>
                                             <TextBlock Text="{Binding Category}" FontSize="9" Foreground="Gray"/>
                                         </StackPanel>
                                     </StackPanel>

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -124,6 +124,11 @@ public partial class MainWindow : Window
                 vm.LeftPanel.HierarchyPanel.CheckHasSMatrixOverride =
                     id => vm.FileOperations.StoredSMatrices.ContainsKey(id);
 
+                // Initial badge population for PDK templates (covers user-global
+                // overrides loaded from disk on app start). Updated again every
+                // time the dialog mutates the user store, see ShowComponentSettingsDialog.
+                RefreshTemplateOverrideBadges(vm);
+
                 // Wire up GridSplitter resize events
                 SetupPanelResizing(vm);
 
@@ -450,6 +455,20 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Refreshes the 📊 user-global-override badges on every PDK template in the
+    /// library list. Called on initial wire-up and after every dialog mutation in
+    /// template mode so the badge tracks the on-disk store without manual reloads.
+    /// </summary>
+    private static void RefreshTemplateOverrideBadges(MainViewModel vm)
+    {
+        var userStore = App.Services.GetService(typeof(UserSMatrixOverrideStore))
+            as UserSMatrixOverrideStore;
+        if (userStore == null) return;
+
+        vm.LeftPanel.RefreshUserGlobalOverrideBadges(userStore.Overrides.ContainsKey);
+    }
+
+    /// <summary>
     /// Handles "Component Settings…" click in the PDK template list context menu.
     /// </summary>
     private void TemplateComponentSettings_Click(object? sender, RoutedEventArgs e)
@@ -460,7 +479,7 @@ public partial class MainWindow : Window
         if (sender is MenuItem { DataContext: ComponentTemplate template })
         {
             var key = $"{template.PdkSource}::{template.Name}";
-            ShowComponentSettingsDialog(key, template.Name, null, vm);
+            ShowComponentSettingsDialog(key, template.Name, null, vm, template);
         }
     }
 
@@ -482,7 +501,8 @@ public partial class MainWindow : Window
         string entityKey,
         string displayName,
         CAP_Core.Components.Core.Component? liveComponent,
-        MainViewModel vm)
+        MainViewModel vm,
+        ComponentTemplate? templateForDefaults = null)
     {
         var errorConsole = App.Services.GetService(typeof(CAP_Core.ErrorConsoleService))
             as CAP_Core.ErrorConsoleService;
@@ -503,8 +523,34 @@ public partial class MainWindow : Window
                   userStore!.Save();
                   vm.FileOperations.ReapplyTemplateOverrides();
                   vm.LeftPanel.HierarchyPanel.RefreshOverrideMarkers();
+                  RefreshTemplateOverrideBadges(vm);
               }
             : () => vm.LeftPanel.HierarchyPanel.RefreshOverrideMarkers();
+
+        // Effective S-matrix data feeds the read-only "Currently effective" section.
+        // Per-Instance: read straight off the live component (its WaveLengthToSMatrixMap
+        // is exactly what the simulator will use, including any override already applied).
+        // Per-Template: build a throwaway component from the template so we can show
+        // the PDK default without requiring a canvas instance.
+        Dictionary<int, CAP_Core.LightCalculation.SMatrix>? effectiveSMatrices = null;
+        IReadOnlyList<CAP_Core.Components.Core.Pin>? effectivePins = null;
+        if (liveComponent != null)
+        {
+            effectiveSMatrices = liveComponent.WaveLengthToSMatrixMap;
+            effectivePins = liveComponent.PhysicalPins
+                .Where(pp => pp.LogicalPin != null)
+                .Select(pp => pp.LogicalPin!)
+                .ToList();
+        }
+        else if (templateForDefaults != null)
+        {
+            var tempInstance = ComponentTemplates.CreateFromTemplate(templateForDefaults, 0, 0);
+            effectiveSMatrices = tempInstance.WaveLengthToSMatrixMap;
+            effectivePins = tempInstance.PhysicalPins
+                .Where(pp => pp.LogicalPin != null)
+                .Select(pp => pp.LogicalPin!)
+                .ToList();
+        }
 
         dialogVm.Configure(
             entityKey,
@@ -512,7 +558,9 @@ public partial class MainWindow : Window
             store,
             liveComponent,
             onChanged: onChanged,
-            isUserGlobalScope: isTemplateMode);
+            isUserGlobalScope: isTemplateMode,
+            effectiveSMatrices: effectiveSMatrices,
+            effectivePins: effectivePins);
 
         var dialog = new ComponentSettingsDialog { DataContext = dialogVm };
         dialog.Show(this);

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -508,9 +508,13 @@ public partial class MainWindow : Window
             as CAP_Core.ErrorConsoleService;
         var userStore = App.Services.GetService(typeof(UserSMatrixOverrideStore))
             as UserSMatrixOverrideStore;
+        var portMappingDialog = App.Services.GetService(typeof(IPortMappingDialogService))
+            as IPortMappingDialogService;
         var dialogVm = new ComponentSettingsDialogViewModel(
             new FileDialogService(this),
-            errorConsole);
+            errorConsole,
+            importers: null,
+            portMappingDialog: portMappingDialog);
 
         bool isTemplateMode = liveComponent == null && userStore != null;
         var store = isTemplateMode
@@ -534,12 +538,20 @@ public partial class MainWindow : Window
         // the PDK default without requiring a canvas instance.
         Dictionary<int, CAP_Core.LightCalculation.SMatrix>? effectiveSMatrices = null;
         IReadOnlyList<CAP_Core.Components.Core.Pin>? effectivePins = null;
+        IReadOnlyList<string>? availablePinNames = null;
         if (liveComponent != null)
         {
             effectiveSMatrices = liveComponent.WaveLengthToSMatrixMap;
             effectivePins = liveComponent.PhysicalPins
                 .Where(pp => pp.LogicalPin != null)
                 .Select(pp => pp.LogicalPin!)
+                .ToList();
+            // Pin-name list drives the port-mapping dialog. Use PhysicalPin
+            // names (what the user sees in the UI), not the LogicalPin's
+            // internal id, so the dialog matches the rest of the dialog.
+            availablePinNames = liveComponent.PhysicalPins
+                .Where(pp => pp.LogicalPin != null)
+                .Select(pp => pp.Name)
                 .ToList();
         }
         else if (templateForDefaults != null)
@@ -549,6 +561,9 @@ public partial class MainWindow : Window
             effectivePins = tempInstance.PhysicalPins
                 .Where(pp => pp.LogicalPin != null)
                 .Select(pp => pp.LogicalPin!)
+                .ToList();
+            availablePinNames = templateForDefaults.PinDefinitions
+                .Select(pd => pd.Name)
                 .ToList();
         }
 
@@ -560,7 +575,8 @@ public partial class MainWindow : Window
             onChanged: onChanged,
             isUserGlobalScope: isTemplateMode,
             effectiveSMatrices: effectiveSMatrices,
-            effectivePins: effectivePins);
+            effectivePins: effectivePins,
+            availablePinNames: availablePinNames);
 
         var dialog = new ComponentSettingsDialog { DataContext = dialogVm };
         dialog.Show(this);

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -466,9 +466,17 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Creates and shows the Component Settings dialog for the given entity.
-    /// The dialog's <see cref="ComponentSettingsDialogViewModel.Configure"/>
-    /// onChanged callback refreshes the hierarchy panel's 📊 override badges
-    /// after every import or delete.
+    ///
+    /// Per-Instance mode (<paramref name="liveComponent"/> non-null): the dialog
+    /// reads/writes <c>FileOperations.StoredSMatrices</c>, so the override is
+    /// scoped to this canvas instance and persisted in the .lun file.
+    ///
+    /// Per-Template mode (<paramref name="liveComponent"/> null): the dialog
+    /// reads/writes the user-global <see cref="UserSMatrixOverrideStore"/>, so
+    /// the override applies to every instance of that template across every
+    /// project the user opens. After a successful import/delete the store is
+    /// flushed to disk and live components matching the template are
+    /// re-applied so the change takes effect immediately without reloading.
     /// </summary>
     private void ShowComponentSettingsDialog(
         string entityKey,
@@ -478,15 +486,33 @@ public partial class MainWindow : Window
     {
         var errorConsole = App.Services.GetService(typeof(CAP_Core.ErrorConsoleService))
             as CAP_Core.ErrorConsoleService;
+        var userStore = App.Services.GetService(typeof(UserSMatrixOverrideStore))
+            as UserSMatrixOverrideStore;
         var dialogVm = new ComponentSettingsDialogViewModel(
             new FileDialogService(this),
             errorConsole);
+
+        bool isTemplateMode = liveComponent == null && userStore != null;
+        var store = isTemplateMode
+            ? userStore!.Overrides
+            : vm.FileOperations.StoredSMatrices;
+
+        Action onChanged = isTemplateMode
+            ? () =>
+              {
+                  userStore!.Save();
+                  vm.FileOperations.ReapplyTemplateOverrides();
+                  vm.LeftPanel.HierarchyPanel.RefreshOverrideMarkers();
+              }
+            : () => vm.LeftPanel.HierarchyPanel.RefreshOverrideMarkers();
+
         dialogVm.Configure(
             entityKey,
             displayName,
-            vm.FileOperations.StoredSMatrices,
+            store,
             liveComponent,
-            onChanged: () => vm.LeftPanel.HierarchyPanel.RefreshOverrideMarkers());
+            onChanged: onChanged,
+            isUserGlobalScope: isTemplateMode);
 
         var dialog = new ComponentSettingsDialog { DataContext = dialogVm };
         dialog.Show(this);

--- a/CAP.Avalonia/Views/PortMappingDialog.axaml
+++ b/CAP.Avalonia/Views/PortMappingDialog.axaml
@@ -1,0 +1,104 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:CAP.Avalonia.ViewModels.ComponentSettings"
+        x:Class="CAP.Avalonia.Views.PortMappingDialog"
+        x:Name="DialogRoot"
+        x:DataType="vm:PortMappingDialogViewModel"
+        Title="{Binding Title}"
+        Width="540" Height="420"
+        MinWidth="420" MinHeight="320"
+        Background="#1e1e1e"
+        WindowStartupLocation="CenterOwner">
+
+    <DockPanel Margin="16">
+
+        <!-- Title -->
+        <TextBlock DockPanel.Dock="Top"
+                   Text="{Binding Title}"
+                   FontWeight="SemiBold"
+                   FontSize="15"
+                   Foreground="LightBlue"
+                   Margin="0,0,0,8"/>
+
+        <!-- Explanation -->
+        <TextBlock DockPanel.Dock="Top"
+                   Text="{Binding Explanation}"
+                   Foreground="#bbbbbb"
+                   FontSize="11"
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,12"/>
+
+        <!-- Buttons -->
+        <StackPanel DockPanel.Dock="Bottom"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,12,0,0"
+                    Spacing="8">
+            <Button Content="Cancel"
+                    Click="OnCancelClick"
+                    Width="80"
+                    Background="#3d3d3d"
+                    Foreground="White"/>
+            <Button Content="OK"
+                    Click="OnOkClick"
+                    Width="80"
+                    Background="#0d6efd"
+                    Foreground="White"
+                    IsDefault="True"/>
+        </StackPanel>
+
+        <!-- Validation error (set when OK is pressed but mapping is invalid) -->
+        <Border DockPanel.Dock="Bottom"
+                Background="#3a1f1f"
+                CornerRadius="4"
+                Padding="8,6"
+                Margin="0,8,0,0"
+                IsVisible="{Binding #ErrorText.Text, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <TextBlock x:Name="ErrorText"
+                       Foreground="#ff8888"
+                       FontSize="11"
+                       TextWrapping="Wrap"/>
+        </Border>
+
+        <!-- Header row -->
+        <Grid DockPanel.Dock="Top"
+              ColumnDefinitions="*,16,*"
+              Margin="4,0,4,4">
+            <TextBlock Grid.Column="0" Text="Imported port"
+                       Foreground="#888888" FontSize="10" FontWeight="SemiBold"/>
+            <TextBlock Grid.Column="2" Text="Map to component pin"
+                       Foreground="#888888" FontSize="10" FontWeight="SemiBold"/>
+        </Grid>
+
+        <!-- Mapping rows -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled">
+            <ItemsControl ItemsSource="{Binding Rows}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:PortMappingRowViewModel">
+                        <Border Background="#252526"
+                                CornerRadius="4"
+                                Padding="8,6"
+                                Margin="0,2">
+                            <Grid ColumnDefinitions="*,16,*">
+                                <TextBlock Grid.Column="0"
+                                           Text="{Binding ImportedName}"
+                                           Foreground="White"
+                                           FontFamily="Consolas, Courier New, monospace"
+                                           FontSize="12"
+                                           VerticalAlignment="Center"/>
+                                <ComboBox Grid.Column="2"
+                                          ItemsSource="{Binding AvailablePins}"
+                                          SelectedItem="{Binding SelectedPin, Mode=TwoWay}"
+                                          MinWidth="180"
+                                          Background="#1e1e1e"
+                                          Foreground="White"/>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+    </DockPanel>
+</Window>

--- a/CAP.Avalonia/Views/PortMappingDialog.axaml.cs
+++ b/CAP.Avalonia/Views/PortMappingDialog.axaml.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using CAP.Avalonia.ViewModels.ComponentSettings;
+
+namespace CAP.Avalonia.Views;
+
+/// <summary>
+/// Modal dialog asking the user to map imported S-parameter port names onto
+/// the component's pin names. Returns the selected mapping via
+/// <see cref="ShowDialog"/>; null on Cancel.
+/// </summary>
+public partial class PortMappingDialog : Window
+{
+    public PortMappingDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void OnOkClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not PortMappingDialogViewModel vm)
+        {
+            Close(null);
+            return;
+        }
+
+        var mapping = vm.BuildResultOrNull(out var error);
+        if (mapping == null)
+        {
+            // Surface the validation reason in-dialog rather than closing
+            // with an inscrutable null result. The error TextBlock binding
+            // takes care of showing/hiding the panel.
+            if (this.FindControl<TextBlock>("ErrorText") is { } errorBlock)
+                errorBlock.Text = error;
+            return;
+        }
+
+        Close(mapping);
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e)
+    {
+        Close(null);
+    }
+}

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogEffectiveDisplayTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogEffectiveDisplayTests.cs
@@ -1,0 +1,184 @@
+using System.Numerics;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.ComponentSettings;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
+using CAP_DataAccess.Persistence.PIR;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ComponentSettings;
+
+/// <summary>
+/// Tests for the dialog's "Currently effective S-matrix" read-only section
+/// and the per-row source tag (PDK Default vs Override active). The display
+/// logic answers "what does the simulator actually use right now?" so a user
+/// can audit the source of the S-matrix without inferring it from the
+/// override list.
+/// </summary>
+public class ComponentSettingsDialogEffectiveDisplayTests
+{
+    private static (SMatrix matrix, List<Pin> pins) BuildSimple2PortSMatrix(double diag = 0.95)
+    {
+        var pin1 = new Pin("port 1", 0, MatterType.Light, RectSide.Left);
+        var pin2 = new Pin("port 2", 1, MatterType.Light, RectSide.Right);
+        var pins = new List<Pin> { pin1, pin2 };
+        var allIds = new List<Guid>
+        {
+            pin1.IDInFlow, pin1.IDOutFlow,
+            pin2.IDInFlow, pin2.IDOutFlow
+        };
+
+        var sm = new SMatrix(allIds, new List<(Guid, double)>());
+        sm.SetValues(new Dictionary<(Guid, Guid), Complex>
+        {
+            // S(out, in) — diagonal magnitudes the dialog displays.
+            [(pin1.IDInFlow, pin1.IDOutFlow)] = new Complex(diag, 0),
+            [(pin2.IDInFlow, pin2.IDOutFlow)] = new Complex(diag, 0)
+        });
+        return (sm, pins);
+    }
+
+    [Fact]
+    public void Configure_NoEffectiveData_HidesSection()
+    {
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+        vm.Configure("comp_1", "MyComp", new Dictionary<string, ComponentSMatrixData>());
+
+        vm.HasEffectiveEntries.ShouldBeFalse();
+        vm.EffectiveEntries.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Configure_EffectiveDataNoOverride_TagsAllAsPdkDefault()
+    {
+        var (sm, pins) = BuildSimple2PortSMatrix();
+        var effective = new Dictionary<int, SMatrix> { [1550] = sm };
+
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+        vm.Configure(
+            "comp_1",
+            "MyComp",
+            new Dictionary<string, ComponentSMatrixData>(),
+            effectiveSMatrices: effective,
+            effectivePins: pins);
+
+        vm.HasEffectiveEntries.ShouldBeTrue();
+        vm.EffectiveEntries.Count.ShouldBe(1);
+        vm.EffectiveEntries[0].SourceTag.ShouldBe("PDK Default");
+        vm.EffectiveEntries[0].IsOverridden.ShouldBeFalse();
+        vm.EffectiveEntries[0].WavelengthLabel.ShouldBe("1550 nm");
+        vm.EffectiveEntries[0].Dimensions.ShouldBe("2 × 2");
+        vm.EffectiveEntries[0].DiagonalPreview.ShouldContain("|S11|=0.950");
+    }
+
+    [Fact]
+    public void Configure_OverrideMatchingWavelength_TagsOnlyThatRow()
+    {
+        // Pinning the per-row tag logic: a wavelength gets "Override active"
+        // only when the active store has an entry under the same wavelength
+        // key. Other wavelengths in the effective map stay PDK-driven.
+        var (sm, pins) = BuildSimple2PortSMatrix();
+        var effective = new Dictionary<int, SMatrix> { [1550] = sm, [1310] = sm };
+
+        var store = new Dictionary<string, ComponentSMatrixData>
+        {
+            ["comp_1"] = new ComponentSMatrixData
+            {
+                SourceNote = "imported",
+                Wavelengths =
+                {
+                    ["1550"] = new SMatrixWavelengthEntry
+                    {
+                        Rows = 2, Cols = 2,
+                        Real = new List<double> { 0.5, 0, 0, 0.5 },
+                        Imag = new List<double> { 0, 0, 0, 0 }
+                    }
+                }
+            }
+        };
+
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+        vm.Configure(
+            "comp_1",
+            "MyComp",
+            store,
+            effectiveSMatrices: effective,
+            effectivePins: pins);
+
+        var byWavelength = vm.EffectiveEntries.ToDictionary(e => e.WavelengthLabel);
+        byWavelength["1550 nm"].IsOverridden.ShouldBeTrue();
+        byWavelength["1550 nm"].SourceTag.ShouldBe("Override active");
+        byWavelength["1310 nm"].IsOverridden.ShouldBeFalse();
+        byWavelength["1310 nm"].SourceTag.ShouldBe("PDK Default");
+    }
+
+    [Fact]
+    public void DeleteEntry_RefreshesEffectiveSourceTagToPdkDefault()
+    {
+        // After a user deletes their override the corresponding effective row
+        // must flip back to "PDK Default". Without the refresh the user would
+        // see stale "Override active" labels on a row they just unset.
+        var (sm, pins) = BuildSimple2PortSMatrix();
+        var effective = new Dictionary<int, SMatrix> { [1550] = sm };
+
+        var store = new Dictionary<string, ComponentSMatrixData>
+        {
+            ["comp_1"] = new ComponentSMatrixData
+            {
+                Wavelengths =
+                {
+                    ["1550"] = new SMatrixWavelengthEntry
+                    {
+                        Rows = 2, Cols = 2,
+                        Real = new List<double> { 0.5, 0, 0, 0.5 },
+                        Imag = new List<double> { 0, 0, 0, 0 }
+                    }
+                }
+            }
+        };
+
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+        vm.Configure(
+            "comp_1",
+            "MyComp",
+            store,
+            effectiveSMatrices: effective,
+            effectivePins: pins);
+
+        vm.EffectiveEntries[0].IsOverridden.ShouldBeTrue();
+
+        vm.DeleteEntryCommand.Execute(vm.SMatrixEntries[0]);
+
+        vm.EffectiveEntries.Count.ShouldBe(1);
+        vm.EffectiveEntries[0].IsOverridden.ShouldBeFalse();
+        vm.EffectiveEntries[0].SourceTag.ShouldBe("PDK Default");
+    }
+
+    [Fact]
+    public void ComponentTemplate_HasUserGlobalSMatrixOverride_IsObservable()
+    {
+        // The badge property must fire PropertyChanged so the ListBox
+        // re-renders when the user edits an override; otherwise the user
+        // would have to scroll or close/open the panel to see the badge.
+        var template = new ComponentTemplate
+        {
+            Name = "2x2 MMI Coupler",
+            PdkSource = "siepic-ebeam-pdk"
+        };
+
+        bool propertyChangedFired = false;
+        template.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(ComponentTemplate.HasUserGlobalSMatrixOverride))
+                propertyChangedFired = true;
+        };
+
+        template.HasUserGlobalSMatrixOverride = true;
+
+        propertyChangedFired.ShouldBeTrue();
+    }
+}

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogEffectiveDisplayTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogEffectiveDisplayTests.cs
@@ -21,7 +21,13 @@ namespace UnitTests.ComponentSettings;
 /// </summary>
 public class ComponentSettingsDialogEffectiveDisplayTests
 {
-    private static (SMatrix matrix, List<Pin> pins) BuildSimple2PortSMatrix(double diag = 0.95)
+    /// <summary>
+    /// 2-port S-matrix with strong P1↔P2 cross-coupling — what a 50:50 splitter
+    /// or directional coupler looks like. The preview ignores diagonals
+    /// (reflections), so this builds the off-diagonal entries the preview
+    /// actually surfaces.
+    /// </summary>
+    private static (SMatrix matrix, List<Pin> pins) BuildSimple2PortCoupling(double transmission = 0.7)
     {
         var pin1 = new Pin("port 1", 0, MatterType.Light, RectSide.Left);
         var pin2 = new Pin("port 2", 1, MatterType.Light, RectSide.Right);
@@ -35,9 +41,11 @@ public class ComponentSettingsDialogEffectiveDisplayTests
         var sm = new SMatrix(allIds, new List<(Guid, double)>());
         sm.SetValues(new Dictionary<(Guid, Guid), Complex>
         {
-            // S(out, in) — diagonal magnitudes the dialog displays.
-            [(pin1.IDInFlow, pin1.IDOutFlow)] = new Complex(diag, 0),
-            [(pin2.IDInFlow, pin2.IDOutFlow)] = new Complex(diag, 0)
+            // S(out, in) keyed via (input.IDInFlow, output.IDOutFlow).
+            // P1 → P2 transmission and P2 → P1 transmission — the values the
+            // strongest-couplings preview will show.
+            [(pin1.IDInFlow, pin2.IDOutFlow)] = new Complex(transmission, 0),
+            [(pin2.IDInFlow, pin1.IDOutFlow)] = new Complex(transmission, 0)
         });
         return (sm, pins);
     }
@@ -55,7 +63,9 @@ public class ComponentSettingsDialogEffectiveDisplayTests
     [Fact]
     public void Configure_EffectiveDataNoOverride_TagsAllAsPdkDefault()
     {
-        var (sm, pins) = BuildSimple2PortSMatrix();
+        // Build a 2-port SMatrix with strong cross-coupling so the preview has
+        // something to show — diagonals (reflections) are intentionally skipped.
+        var (sm, pins) = BuildSimple2PortCoupling(transmission: 0.7);
         var effective = new Dictionary<int, SMatrix> { [1550] = sm };
 
         var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
@@ -72,7 +82,8 @@ public class ComponentSettingsDialogEffectiveDisplayTests
         vm.EffectiveEntries[0].IsOverridden.ShouldBeFalse();
         vm.EffectiveEntries[0].WavelengthLabel.ShouldBe("1550 nm");
         vm.EffectiveEntries[0].Dimensions.ShouldBe("2 × 2");
-        vm.EffectiveEntries[0].DiagonalPreview.ShouldContain("|S11|=0.950");
+        vm.EffectiveEntries[0].MagnitudePreview.ShouldContain("P1→P2=0.700");
+        vm.EffectiveEntries[0].MagnitudePreview.ShouldNotContain("|S11|");
     }
 
     [Fact]
@@ -81,7 +92,7 @@ public class ComponentSettingsDialogEffectiveDisplayTests
         // Pinning the per-row tag logic: a wavelength gets "Override active"
         // only when the active store has an entry under the same wavelength
         // key. Other wavelengths in the effective map stay PDK-driven.
-        var (sm, pins) = BuildSimple2PortSMatrix();
+        var (sm, pins) = BuildSimple2PortCoupling();
         var effective = new Dictionary<int, SMatrix> { [1550] = sm, [1310] = sm };
 
         var store = new Dictionary<string, ComponentSMatrixData>
@@ -122,7 +133,7 @@ public class ComponentSettingsDialogEffectiveDisplayTests
         // After a user deletes their override the corresponding effective row
         // must flip back to "PDK Default". Without the refresh the user would
         // see stale "Override active" labels on a row they just unset.
-        var (sm, pins) = BuildSimple2PortSMatrix();
+        var (sm, pins) = BuildSimple2PortCoupling();
         var effective = new Dictionary<int, SMatrix> { [1550] = sm };
 
         var store = new Dictionary<string, ComponentSMatrixData>

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogImportIntegrationTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogImportIntegrationTests.cs
@@ -73,14 +73,14 @@ public class ComponentSettingsDialogImportIntegrationTests
         vm.StatusText.ShouldContain("Imported");
 
         // Each entry must carry the data the delete-button row renders so the
-        // AXAML binding paths (Dimensions, DiagonalPreview, PortNamesDisplay)
+        // AXAML binding paths (Dimensions, MagnitudePreview, PortNamesDisplay)
         // never hit nulls and the deferred DataTemplate build can complete.
         foreach (var entryVm in vm.SMatrixEntries)
         {
             entryVm.WavelengthLabel.ShouldNotBeNullOrEmpty();
             entryVm.Dimensions.ShouldBe("4 × 4");
             entryVm.PortNamesDisplay.ShouldNotBeNullOrEmpty();
-            entryVm.DiagonalPreview.ShouldNotBeNullOrEmpty();
+            entryVm.MagnitudePreview.ShouldNotBeNullOrEmpty();
         }
     }
 

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogUserGlobalScopeTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogUserGlobalScopeTests.cs
@@ -1,0 +1,151 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.ComponentSettings;
+using CAP_DataAccess.Persistence.PIR;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ComponentSettings;
+
+/// <summary>
+/// Tests that the Component Settings dialog VM behaves correctly when wired
+/// against the user-global <see cref="UserSMatrixOverrideStore"/> instead of
+/// the project's <c>StoredSMatrices</c>. The wiring lives in
+/// <c>MainWindow.axaml.cs::ShowComponentSettingsDialog</c>; these tests pin
+/// the contract the wiring depends on so that path can be refactored without
+/// silently breaking PDK-template-scoped imports.
+/// </summary>
+public class ComponentSettingsDialogUserGlobalScopeTests : IDisposable
+{
+    private readonly string _tempStorePath;
+    private readonly string _tempSparamPath;
+
+    public ComponentSettingsDialogUserGlobalScopeTests()
+    {
+        _tempStorePath = Path.Combine(Path.GetTempPath(), $"sparam-overrides-{Guid.NewGuid()}.json");
+        _tempSparamPath = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid()}.sparam");
+        WriteMinimalSparamFile(_tempSparamPath);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempStorePath)) File.Delete(_tempStorePath);
+        if (File.Exists(_tempSparamPath)) File.Delete(_tempSparamPath);
+    }
+
+    private static void WriteMinimalSparamFile(string path)
+    {
+        // 2-port single-wavelength Lumerical-format file just large enough
+        // to drive the importer. Two transmission blocks (1→1 and 2→1).
+        File.WriteAllText(path,
+            "('port 1','TE',1,'port 1',1,'transmission')\n" +
+            "(1,3)\n" +
+            "1.93414e+14\t0.05\t0.0\n" +
+            "('port 2','TE',1,'port 1',1,'transmission')\n" +
+            "(1,3)\n" +
+            "1.93414e+14\t0.95\t0.0\n");
+    }
+
+    [Fact]
+    public async Task LoadFromFile_PdkTemplateScope_PersistsToUserStoreOnSave()
+    {
+        var userStore = new UserSMatrixOverrideStore(_tempStorePath);
+        var fileDialog = new Mock<IFileDialogService>();
+        fileDialog
+            .Setup(s => s.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_tempSparamPath);
+
+        var vm = new ComponentSettingsDialogViewModel(fileDialog.Object);
+        bool onChangedFired = false;
+        vm.Configure(
+            entityKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
+            displayName: "2x2 MMI Coupler",
+            storedSMatrices: userStore.Overrides,
+            liveComponent: null,
+            onChanged: () => { onChangedFired = true; userStore.Save(); },
+            isUserGlobalScope: true);
+
+        await vm.LoadFromFileCommand.ExecuteAsync(null);
+
+        // Dialog ran the onChanged callback so the user-global store persisted.
+        onChangedFired.ShouldBeTrue();
+        userStore.Overrides.ShouldContainKey("siepic-ebeam-pdk::2x2 MMI Coupler");
+
+        // Reload from disk: a fresh process picking up the same file would
+        // see the same override. This is the cross-project guarantee.
+        var fresh = new UserSMatrixOverrideStore(_tempStorePath);
+        fresh.Overrides.ShouldContainKey("siepic-ebeam-pdk::2x2 MMI Coupler");
+        fresh.Overrides["siepic-ebeam-pdk::2x2 MMI Coupler"].Wavelengths.Count.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Configure_UserGlobalScope_AnnouncesScopeInTitle()
+    {
+        // The dialog title is the only piece of the dialog that distinguishes
+        // user-global from project scope, so a future UI change that drops
+        // the suffix would silently confuse the user. Pin the suffix.
+        var userStore = new UserSMatrixOverrideStore(_tempStorePath);
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+
+        vm.Configure(
+            entityKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
+            displayName: "2x2 MMI Coupler",
+            storedSMatrices: userStore.Overrides,
+            isUserGlobalScope: true);
+
+        vm.Title.ShouldContain("applies to all projects");
+    }
+
+    [Fact]
+    public void Configure_ProjectScope_DoesNotAnnounceUserScope()
+    {
+        var store = new Dictionary<string, ComponentSMatrixData>();
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+
+        vm.Configure(
+            entityKey: "comp_1",
+            displayName: "MyComponent_1",
+            storedSMatrices: store,
+            isUserGlobalScope: false);
+
+        vm.Title.ShouldNotContain("applies to all projects");
+    }
+
+    [Fact]
+    public void DeleteEntry_UserGlobalScope_RemovesFromUserStoreOnSave()
+    {
+        var userStore = new UserSMatrixOverrideStore(_tempStorePath);
+        userStore.Apply(
+            "siepic-ebeam-pdk::2x2 MMI Coupler",
+            new ComponentSMatrixData
+            {
+                SourceNote = "test",
+                Wavelengths =
+                {
+                    ["1550"] = new SMatrixWavelengthEntry
+                    {
+                        Rows = 2, Cols = 2,
+                        Real = new List<double> { 1, 0, 0, 1 },
+                        Imag = new List<double> { 0, 0, 0, 0 }
+                    }
+                }
+            });
+        userStore.Save();
+
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+        vm.Configure(
+            entityKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
+            displayName: "2x2 MMI Coupler",
+            storedSMatrices: userStore.Overrides,
+            onChanged: userStore.Save,
+            isUserGlobalScope: true);
+
+        vm.SMatrixEntries.Count.ShouldBe(1);
+        vm.DeleteEntryCommand.Execute(vm.SMatrixEntries[0]);
+
+        userStore.Overrides.ShouldNotContainKey("siepic-ebeam-pdk::2x2 MMI Coupler");
+
+        var fresh = new UserSMatrixOverrideStore(_tempStorePath);
+        fresh.Overrides.ShouldNotContainKey("siepic-ebeam-pdk::2x2 MMI Coupler");
+    }
+}

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogViewModelTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogViewModelTests.cs
@@ -151,13 +151,20 @@ public class ComponentSettingsDialogViewModelTests
     }
 
     [Fact]
-    public void SMatrixEntryViewModel_DiagonalPreview_ShowsMagnitudes()
+    public void SMatrixEntryViewModel_MagnitudePreview_ShowsStrongestCouplings()
     {
+        // Off-diagonal couplings (the engineering-meaningful values) — diagonals
+        // are reflections ≈0 for passive devices, which is why we don't preview them.
+        // Real layout: row-major, S[r=out, c=in].
+        // S(out=0, in=0) = 0.05 reflection at port 1
+        // S(out=0, in=1) = 0.95 transmission Port 2 → Port 1
+        // S(out=1, in=0) = 0.95 transmission Port 1 → Port 2
+        // S(out=1, in=1) = 0.05 reflection at port 2
         var entry = new SMatrixWavelengthEntry
         {
             Rows = 2,
             Cols = 2,
-            Real = new List<double> { 0.9, 0.1, 0.1, 0.9 },
+            Real = new List<double> { 0.05, 0.95, 0.95, 0.05 },
             Imag = new List<double> { 0, 0, 0, 0 },
             PortNames = new List<string> { "port1", "port2" }
         };
@@ -167,7 +174,9 @@ public class ComponentSettingsDialogViewModelTests
         vm.WavelengthLabel.ShouldBe("1550 nm");
         vm.Dimensions.ShouldBe("2 × 2");
         vm.PortNamesDisplay.ShouldBe("port1, port2");
-        vm.DiagonalPreview.ShouldContain("|S11|=");
+        vm.MagnitudePreview.ShouldContain("P1→P2=0.950");
+        vm.MagnitudePreview.ShouldContain("P2→P1=0.950");
+        vm.MagnitudePreview.ShouldNotContain("|S11|");
         vm.SourceNote.ShouldBe("TestSource");
     }
 

--- a/UnitTests/ComponentSettings/PortMappingDialogIntegrationTests.cs
+++ b/UnitTests/ComponentSettings/PortMappingDialogIntegrationTests.cs
@@ -1,0 +1,198 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.ComponentSettings;
+using CAP_DataAccess.Persistence.PIR;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ComponentSettings;
+
+/// <summary>
+/// Tests for the dialog VM's port-mapping integration in the LoadFromFile flow.
+/// Each test feeds a hand-crafted Lumerical-style file with generic port names
+/// (<c>port 1, port 2, …</c>) and verifies the mapping path resolves correctly
+/// against a component whose pins use semantic names (<c>in, out1, …</c>).
+/// </summary>
+public class PortMappingDialogIntegrationTests : IDisposable
+{
+    private readonly string _tempSparamPath;
+
+    public PortMappingDialogIntegrationTests()
+    {
+        _tempSparamPath = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid()}.sparam");
+        WriteThreePortSplitterFile(_tempSparamPath);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempSparamPath)) File.Delete(_tempSparamPath);
+    }
+
+    private static void WriteThreePortSplitterFile(string path)
+    {
+        // 1×2 splitter: ports 1, 2, 3. Generic names like a real Lumerical file.
+        // Single wavelength is enough to exercise the mapping path.
+        File.WriteAllText(path, string.Join("\n", new[]
+        {
+            "('port 1','TE',1,'port 1',1,'transmission')", "(1,3)", "1.93414e+14\t0.05\t0.0",
+            "('port 2','TE',1,'port 1',1,'transmission')", "(1,3)", "1.93414e+14\t0.7\t0.0",
+            "('port 3','TE',1,'port 1',1,'transmission')", "(1,3)", "1.93414e+14\t0.7\t0.0",
+            "('port 1','TE',1,'port 2',1,'transmission')", "(1,3)", "1.93414e+14\t0.7\t0.0",
+            "('port 2','TE',1,'port 2',1,'transmission')", "(1,3)", "1.93414e+14\t0.0\t0.0",
+            "('port 3','TE',1,'port 2',1,'transmission')", "(1,3)", "1.93414e+14\t0.0\t0.0",
+            "('port 1','TE',1,'port 3',1,'transmission')", "(1,3)", "1.93414e+14\t0.7\t0.0",
+            "('port 2','TE',1,'port 3',1,'transmission')", "(1,3)", "1.93414e+14\t0.0\t0.0",
+            "('port 3','TE',1,'port 3',1,'transmission')", "(1,3)", "1.93414e+14\t0.0\t0.0",
+        }));
+    }
+
+    [Fact]
+    public async Task LoadFromFile_ImportedNamesMatchPins_NoMappingDialogShown()
+    {
+        // Negative case — when the file's port names already match the pin
+        // names (test fixture won't, but we simulate with a custom pin list),
+        // the dialog service must not be invoked at all.
+        var dialogService = new Mock<IPortMappingDialogService>(MockBehavior.Strict);
+
+        var fileDialog = new Mock<IFileDialogService>();
+        fileDialog
+            .Setup(s => s.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_tempSparamPath);
+
+        var vm = new ComponentSettingsDialogViewModel(
+            fileDialog.Object,
+            errorConsole: null,
+            importers: null,
+            portMappingDialog: dialogService.Object);
+
+        var store = new Dictionary<string, ComponentSMatrixData>();
+        // Pin list intentionally matches the imported names — no dialog needed.
+        vm.Configure(
+            "comp_1", "MyComp", store,
+            availablePinNames: new[] { "port 1", "port 2", "port 3" });
+
+        await vm.LoadFromFileCommand.ExecuteAsync(null);
+
+        store.ShouldContainKey("comp_1");
+        dialogService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task LoadFromFile_ImportedNamesDontMatch_DialogReturnsMapping_AppliesIt()
+    {
+        // The realistic case from the bug report: a 3-port splitter file with
+        // generic "port 1/2/3" names imported against a component with
+        // semantic "in/out1/out2" pins. Dialog stub returns the user's mapping;
+        // the resulting override must use the semantic names.
+        var dialogService = new Mock<IPortMappingDialogService>();
+        dialogService
+            .Setup(s => s.ShowAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IReadOnlyList<string>>()))
+            .ReturnsAsync(new Dictionary<string, string>
+            {
+                ["port 1"] = "in",
+                ["port 2"] = "out1",
+                ["port 3"] = "out2",
+            });
+
+        var fileDialog = new Mock<IFileDialogService>();
+        fileDialog
+            .Setup(s => s.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_tempSparamPath);
+
+        var vm = new ComponentSettingsDialogViewModel(
+            fileDialog.Object,
+            errorConsole: null,
+            importers: null,
+            portMappingDialog: dialogService.Object);
+
+        var store = new Dictionary<string, ComponentSMatrixData>();
+        vm.Configure(
+            "comp_1", "1×2 Splitter", store,
+            availablePinNames: new[] { "in", "out1", "out2" });
+
+        await vm.LoadFromFileCommand.ExecuteAsync(null);
+
+        store.ShouldContainKey("comp_1");
+        var data = store["comp_1"];
+        data.Wavelengths.ShouldNotBeEmpty();
+
+        // Stored entries carry the semantic pin names — the SMatrixOverrideApplicator
+        // can now resolve these against the component without skipping wavelengths.
+        foreach (var (_, entry) in data.Wavelengths)
+        {
+            entry.PortNames.ShouldNotBeNull();
+            entry.PortNames!.ShouldBe(new[] { "in", "out1", "out2" });
+        }
+    }
+
+    [Fact]
+    public async Task LoadFromFile_DialogCancelled_NoOverrideStored_StatusExplains()
+    {
+        // Cancel must abort cleanly — no half-stored data, no crash, and a
+        // status message that tells the user why nothing happened.
+        var dialogService = new Mock<IPortMappingDialogService>();
+        dialogService
+            .Setup(s => s.ShowAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<IReadOnlyList<string>>()))
+            .ReturnsAsync((IReadOnlyDictionary<string, string>?)null);
+
+        var fileDialog = new Mock<IFileDialogService>();
+        fileDialog
+            .Setup(s => s.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_tempSparamPath);
+
+        var vm = new ComponentSettingsDialogViewModel(
+            fileDialog.Object,
+            errorConsole: null,
+            importers: null,
+            portMappingDialog: dialogService.Object);
+
+        var store = new Dictionary<string, ComponentSMatrixData>();
+        vm.Configure(
+            "comp_1", "1×2 Splitter", store,
+            availablePinNames: new[] { "in", "out1", "out2" });
+
+        await vm.LoadFromFileCommand.ExecuteAsync(null);
+
+        store.ShouldNotContainKey("comp_1");
+        vm.StatusText.ShouldContain("cancelled", Case.Insensitive);
+    }
+
+    [Fact]
+    public async Task LoadFromFile_PortCountMismatch_FailsLoud_NoDialog()
+    {
+        // Structurally impossible — the dialog can't help. Bail out with a
+        // clear status message instead of opening a dialog the user can't
+        // satisfy.
+        var dialogService = new Mock<IPortMappingDialogService>(MockBehavior.Strict);
+
+        var fileDialog = new Mock<IFileDialogService>();
+        fileDialog
+            .Setup(s => s.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_tempSparamPath);
+
+        var vm = new ComponentSettingsDialogViewModel(
+            fileDialog.Object,
+            errorConsole: null,
+            importers: null,
+            portMappingDialog: dialogService.Object);
+
+        var store = new Dictionary<string, ComponentSMatrixData>();
+        // 2-port pin list against a 3-port file: structurally unmappable.
+        vm.Configure(
+            "comp_1", "MyComp", store,
+            availablePinNames: new[] { "in", "out" });
+
+        await vm.LoadFromFileCommand.ExecuteAsync(null);
+
+        store.ShouldNotContainKey("comp_1");
+        vm.StatusText.ShouldContain("3 port");
+        vm.StatusText.ShouldContain("2 pin");
+        dialogService.VerifyNoOtherCalls();
+    }
+}

--- a/UnitTests/ComponentSettings/UserGlobalOverrideOnPlacementTests.cs
+++ b/UnitTests/ComponentSettings/UserGlobalOverrideOnPlacementTests.cs
@@ -1,0 +1,194 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ComponentSettings;
+
+/// <summary>
+/// Pins the placement-time application of user-global PDK template overrides.
+///
+/// Bug history: <see cref="MainViewModel"/> instantiated <see cref="FileOperationsViewModel"/>
+/// without forwarding the <see cref="UserSMatrixOverrideStore"/> dependency, so
+/// the optional parameter defaulted to <c>null</c> and
+/// <see cref="FileOperationsViewModel.ApplyUserGlobalOverrides"/> early-returned
+/// on every component placement. The user saw their template override take
+/// effect on existing instances (via dialog-triggered re-apply) but NOT on
+/// newly placed instances — exactly the silent failure
+/// <see cref="UserSMatrixOverrideStore"/> was meant to prevent.
+///
+/// These tests exercise the placement path with the store actually wired so
+/// we'd catch a regression of that wiring at unit-test time instead of at
+/// "drag a component onto the canvas and run a sim" time.
+/// </summary>
+public class UserGlobalOverrideOnPlacementTests : IDisposable
+{
+    private readonly string _tempStorePath;
+
+    public UserGlobalOverrideOnPlacementTests()
+    {
+        _tempStorePath = Path.Combine(Path.GetTempPath(), $"sparam-overrides-{Guid.NewGuid()}.json");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempStorePath)) File.Delete(_tempStorePath);
+    }
+
+    private static FileOperationsViewModel BuildFileOps(
+        DesignCanvasViewModel canvas,
+        ObservableCollection<ComponentTemplate> library,
+        UserSMatrixOverrideStore? userStore)
+    {
+        return new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!, // verilogAExport — not exercised here
+            errorConsole: null,
+            userSMatrixOverrideStore: userStore);
+    }
+
+    /// <summary>
+    /// Builds a minimal 2-port template that pretends to be a PDK template:
+    /// matching NazcaFunctionName so ResolveTemplateKey can find it, identity
+    /// PDK default S-matrix so the override path is the only thing that can
+    /// produce the test's expected 0.7 transmission.
+    /// </summary>
+    private static ComponentTemplate BuildTwoPortTemplate()
+    {
+        return new ComponentTemplate
+        {
+            Name = "TestCoupler",
+            Category = "Test",
+            PdkSource = "test-pdk",
+            NazcaFunctionName = "nazca_testcoupler",
+            WidthMicrometers = 10,
+            HeightMicrometers = 1,
+            PinDefinitions = new[]
+            {
+                new PinDefinition("in", 0, 0.5, 180),
+                new PinDefinition("out", 10, 0.5, 0)
+            },
+            CreateSMatrix = pins =>
+            {
+                // Identity default — picked so any non-identity transmission
+                // in the assertion comes from the override, not the PDK.
+                var allIds = pins.SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+                var sm = new CAP_Core.LightCalculation.SMatrix(allIds, new List<(Guid, double)>());
+                return sm;
+            }
+        };
+    }
+
+    [Fact]
+    public void Placement_WithUserGlobalOverrideForTemplate_AppliesOverrideToNewComponent()
+    {
+        // Set up a template the user-global store has an override for. The
+        // template-key shape is "{PdkSource}::{Name}", same shape the dialog
+        // writes — see FileOperationsViewModel.ResolveTemplateKey.
+        var template = BuildTwoPortTemplate();
+        var library = new ObservableCollection<ComponentTemplate> { template };
+
+        var userStore = new UserSMatrixOverrideStore(_tempStorePath);
+        var overrideKey = $"{template.PdkSource}::{template.Name}";
+        userStore.Apply(overrideKey, BuildOverrideData());
+
+        var canvas = new DesignCanvasViewModel();
+        _ = BuildFileOps(canvas, library, userStore);
+
+        // Place a fresh instance: the placement handler should apply the
+        // user-global override via the template-key resolver.
+        var instance = ComponentTemplates.CreateFromTemplate(template, x: 0, y: 0);
+        var instanceVm = new ComponentViewModel(instance);
+        canvas.Components.Add(instanceVm);
+
+        // After the CollectionChanged handler runs, the live component's
+        // wavelength map for 1550 nm must have been replaced with the
+        // override matrix — same behaviour as the project-load path.
+        instance.WaveLengthToSMatrixMap.ShouldContainKey(1550);
+        var sMatrix = instance.WaveLengthToSMatrixMap[1550];
+        sMatrix.ShouldNotBeNull();
+
+        // Sanity-check the actual values came from our override (transmission
+        // 0.7 between port 1 and port 2). Diagonal entries can stay 0.
+        bool foundOverrideTransmission = false;
+        foreach (var (key, value) in EnumerateNonZero(sMatrix))
+        {
+            if (Math.Abs(value.Magnitude - 0.7) < 1e-3)
+            {
+                foundOverrideTransmission = true;
+                break;
+            }
+        }
+        foundOverrideTransmission.ShouldBeTrue(
+            "the placement handler must have copied the user-store override " +
+            "into Component.WaveLengthToSMatrixMap; if not, ApplyUserGlobalOverrides " +
+            "is being skipped (likely the store wasn't injected into FileOperationsViewModel)");
+    }
+
+    [Fact]
+    public void Placement_WithoutUserGlobalOverride_KeepsPdkDefault()
+    {
+        // Negative case: with no override in the user store, placement leaves
+        // the PDK-default matrix untouched. Locks in that the override path
+        // doesn't bleed into projects that haven't opted in.
+        var template = BuildTwoPortTemplate();
+        var library = new ObservableCollection<ComponentTemplate> { template };
+
+        var userStore = new UserSMatrixOverrideStore(_tempStorePath);
+        var canvas = new DesignCanvasViewModel();
+        _ = BuildFileOps(canvas, library, userStore);
+
+        var instance = ComponentTemplates.CreateFromTemplate(template, x: 0, y: 0);
+        var defaultMatrix = instance.WaveLengthToSMatrixMap[1550];
+        canvas.Components.Add(new ComponentViewModel(instance));
+
+        // Same instance reference, same matrix object — placement was a no-op
+        // for the override path.
+        instance.WaveLengthToSMatrixMap[1550].ShouldBeSameAs(defaultMatrix);
+    }
+
+    private static ComponentSMatrixData BuildOverrideData()
+    {
+        // 2-port override with strong cross-coupling — the value 0.7 is what
+        // the test asserts came through to the live component.
+        var data = new ComponentSMatrixData { SourceNote = "Test override" };
+        data.Wavelengths["1550"] = new SMatrixWavelengthEntry
+        {
+            Rows = 2,
+            Cols = 2,
+            // S[r=out, c=in] row-major. Cross-coupling at S[0,1] and S[1,0].
+            Real = new List<double> { 0.0, 0.7, 0.7, 0.0 },
+            Imag = new List<double> { 0, 0, 0, 0 },
+            PortNames = new List<string> { "in", "out" }
+        };
+        return data;
+    }
+
+    private static IEnumerable<(string Key, System.Numerics.Complex Value)> EnumerateNonZero(
+        CAP_Core.LightCalculation.SMatrix sMatrix)
+    {
+        for (int r = 0; r < sMatrix.SMat.RowCount; r++)
+        {
+            for (int c = 0; c < sMatrix.SMat.ColumnCount; c++)
+            {
+                var v = sMatrix.SMat[r, c];
+                if (v.Magnitude > 1e-6)
+                    yield return ($"[{r},{c}]", v);
+            }
+        }
+    }
+}

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -79,7 +79,11 @@ public static class MainViewModelTestHelper
             new PdkOffsetEditorViewModel(pdkLoader, new PdkJsonSaver(), new PdkManagerViewModel()),
             photonTorchVm,
             verilogAVm,
-            new CAP.Avalonia.ViewModels.Canvas.ChipSizeViewModel(preferencesService, canvas));
+            new CAP.Avalonia.ViewModels.Canvas.ChipSizeViewModel(preferencesService, canvas),
+            // Test-isolated user S-matrix store: a unique temp path per call so
+            // tests don't contaminate each other or the developer's real file.
+            new CAP.Avalonia.Services.UserSMatrixOverrideStore(
+                Path.Combine(Path.GetTempPath(), $"sparam-overrides-test-{Guid.NewGuid()}.json")));
     }
 
     /// <summary>

--- a/UnitTests/Import/PortNameMappingTests.cs
+++ b/UnitTests/Import/PortNameMappingTests.cs
@@ -1,0 +1,121 @@
+using System.Numerics;
+using CAP_DataAccess.Import;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Import;
+
+/// <summary>
+/// Unit tests for the pure port-name reconciliation helpers
+/// (<see cref="PortNameMapping"/>). Drives the import flow's decision
+/// "do we need a mapping dialog?" and the subsequent relabel.
+/// </summary>
+public class PortNameMappingTests
+{
+    [Fact]
+    public void NamesAlignWithComponent_AllImportedNamesPresent_True()
+    {
+        var imported = new[] { "in", "out1", "out2" };
+        var component = new[] { "in", "out1", "out2", "extra" }; // extras allowed
+
+        PortNameMapping.NamesAlignWithComponent(imported, component).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void NamesAlignWithComponent_GenericLumericalNames_False()
+    {
+        var imported = new[] { "port 1", "port 2", "port 3" };
+        var component = new[] { "in", "out1", "out2" };
+
+        PortNameMapping.NamesAlignWithComponent(imported, component).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void NamesAlignWithComponent_CaseInsensitive_True()
+    {
+        // Lumerical occasionally capitalises; we don't want to spuriously
+        // trigger the mapping dialog over a casing difference.
+        var imported = new[] { "IN", "OUT1" };
+        var component = new[] { "in", "out1" };
+
+        PortNameMapping.NamesAlignWithComponent(imported, component).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildDefaultMapping_KeepsMatchingNames_PositionalForOthers()
+    {
+        // Mixed case: one name already matches a component pin, the other
+        // doesn't — the matching one stays put, the rest fall back positionally.
+        var imported = new[] { "in", "port 2", "port 3" };
+        var component = new[] { "in", "out1", "out2" };
+
+        var mapping = PortNameMapping.BuildDefaultMapping(imported, component);
+
+        mapping["in"].ShouldBe("in");           // matched
+        mapping["port 2"].ShouldBe("out1");     // positional (index 1)
+        mapping["port 3"].ShouldBe("out2");     // positional (index 2)
+    }
+
+    [Fact]
+    public void BuildDefaultMapping_PortCountMismatch_Throws()
+    {
+        // A positional fallback would silently drop or fabricate a port
+        // — fail loud instead so the import flow can surface a clear error.
+        var imported = new[] { "port 1", "port 2" };
+        var component = new[] { "in", "out1", "out2" };
+
+        Should.Throw<ArgumentException>(() =>
+            PortNameMapping.BuildDefaultMapping(imported, component));
+    }
+
+    [Fact]
+    public void Remap_RewritesPortNames_KeepsDataAndOrderingIntact()
+    {
+        var imported = new ImportedSParameters
+        {
+            PortCount = 3,
+            PortNames = new List<string> { "port 1", "port 2", "port 3" },
+            SMatricesByWavelengthNm =
+            {
+                [1550] = new Complex[3, 3]
+                {
+                    { new(0.1, 0), new(0.7, 0), new(0.7, 0) },
+                    { new(0.7, 0), new(0.0, 0), new(0.0, 0) },
+                    { new(0.7, 0), new(0.0, 0), new(0.0, 0) }
+                }
+            }
+        };
+
+        var mapping = new Dictionary<string, string>
+        {
+            ["port 1"] = "in",
+            ["port 2"] = "out1",
+            ["port 3"] = "out2"
+        };
+
+        var result = PortNameMapping.Remap(imported, mapping);
+
+        result.PortNames.ShouldBe(new[] { "in", "out1", "out2" });
+        result.PortCount.ShouldBe(3);
+        // The matrix data points to the same array — relabelling alone is
+        // enough; we don't permute rows/columns because the applicator keys
+        // on names, not positions.
+        result.SMatricesByWavelengthNm[1550].ShouldBeSameAs(imported.SMatricesByWavelengthNm[1550]);
+    }
+
+    [Fact]
+    public void Remap_MissingTargetForOneName_Throws()
+    {
+        // Any imported name without a mapping entry is a contract violation:
+        // we'd otherwise drop it on the floor and shift the matrix indexing
+        // by one, producing physically wrong S-matrices in subtle silence.
+        var imported = new ImportedSParameters
+        {
+            PortCount = 2,
+            PortNames = new List<string> { "port 1", "port 2" },
+        };
+        var mapping = new Dictionary<string, string> { ["port 1"] = "in" };
+
+        Should.Throw<ArgumentException>(() => PortNameMapping.Remap(imported, mapping));
+    }
+}

--- a/UnitTests/Services/UserSMatrixOverrideStoreTests.cs
+++ b/UnitTests/Services/UserSMatrixOverrideStoreTests.cs
@@ -1,0 +1,138 @@
+using CAP.Avalonia.Services;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Services;
+
+/// <summary>
+/// Tests for <see cref="UserSMatrixOverrideStore"/>: round-trip persistence,
+/// graceful behaviour on missing/corrupt files, and re-load semantics.
+/// Each test uses an isolated temp file so tests run in parallel without
+/// interfering with each other or with the real user-global store.
+/// </summary>
+public class UserSMatrixOverrideStoreTests : IDisposable
+{
+    private readonly string _tempPath;
+
+    public UserSMatrixOverrideStoreTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"sparam-overrides-{Guid.NewGuid()}.json");
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempPath)) File.Delete(_tempPath);
+    }
+
+    private static ComponentSMatrixData MakeSimple2x2(string sourceNote = "Test")
+    {
+        var data = new ComponentSMatrixData { SourceNote = sourceNote };
+        data.Wavelengths["1550"] = new SMatrixWavelengthEntry
+        {
+            Rows = 2,
+            Cols = 2,
+            Real = new List<double> { 0.9, 0.1, 0.1, 0.9 },
+            Imag = new List<double> { 0, 0, 0, 0 },
+            PortNames = new List<string> { "in", "out" }
+        };
+        return data;
+    }
+
+    [Fact]
+    public void Constructor_NoExistingFile_StartsEmpty()
+    {
+        var store = new UserSMatrixOverrideStore(_tempPath);
+
+        store.Overrides.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Save_ThenReload_RestoresOverrides()
+    {
+        var store = new UserSMatrixOverrideStore(_tempPath);
+        store.Apply("siepic-ebeam-pdk::2x2 MMI Coupler", MakeSimple2x2("Lumerical bdc_te1550.sparam"));
+        store.Save();
+
+        File.Exists(_tempPath).ShouldBeTrue();
+
+        var fresh = new UserSMatrixOverrideStore(_tempPath);
+        fresh.Overrides.Count.ShouldBe(1);
+        fresh.Overrides.ShouldContainKey("siepic-ebeam-pdk::2x2 MMI Coupler");
+        fresh.Overrides["siepic-ebeam-pdk::2x2 MMI Coupler"].SourceNote.ShouldBe("Lumerical bdc_te1550.sparam");
+        fresh.Overrides["siepic-ebeam-pdk::2x2 MMI Coupler"].Wavelengths["1550"].Rows.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Save_CreatesParentDirectoryWhenMissing()
+    {
+        var nestedPath = Path.Combine(
+            Path.GetTempPath(),
+            $"sparam-test-{Guid.NewGuid()}",
+            "deep",
+            "sparam-overrides.json");
+        try
+        {
+            var store = new UserSMatrixOverrideStore(nestedPath);
+            store.Apply("any::key", MakeSimple2x2());
+            store.Save();
+
+            File.Exists(nestedPath).ShouldBeTrue();
+        }
+        finally
+        {
+            var rootDir = Path.GetDirectoryName(Path.GetDirectoryName(nestedPath));
+            if (rootDir != null && Directory.Exists(rootDir))
+                Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Remove_DeletesFromMemory_NotPersistedUntilSave()
+    {
+        var store = new UserSMatrixOverrideStore(_tempPath);
+        store.Apply("k1", MakeSimple2x2());
+        store.Apply("k2", MakeSimple2x2());
+        store.Save();
+
+        store.Remove("k1").ShouldBeTrue();
+        store.Overrides.Count.ShouldBe(1);
+
+        // On disk still has both — Remove without Save shouldn't persist.
+        var diskState = new UserSMatrixOverrideStore(_tempPath);
+        diskState.Overrides.Count.ShouldBe(2);
+
+        store.Save();
+        var afterSave = new UserSMatrixOverrideStore(_tempPath);
+        afterSave.Overrides.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Load_CorruptJsonFile_LeavesStoreEmpty_DoesNotThrow()
+    {
+        // A corrupt file must not crash app startup. Surface via ErrorConsoleService.
+        File.WriteAllText(_tempPath, "{ this is not valid json");
+
+        var store = new UserSMatrixOverrideStore(_tempPath);
+
+        // Constructor must not throw; store stays empty.
+        store.Overrides.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Reload_DiscardsUnsavedMutations()
+    {
+        var store = new UserSMatrixOverrideStore(_tempPath);
+        store.Apply("persisted", MakeSimple2x2("on disk"));
+        store.Save();
+
+        store.Apply("ephemeral", MakeSimple2x2("not saved"));
+        store.Overrides.Count.ShouldBe(2);
+
+        store.Reload();
+
+        store.Overrides.Count.ShouldBe(1);
+        store.Overrides.ShouldContainKey("persisted");
+        store.Overrides.ShouldNotContainKey("ephemeral");
+    }
+}


### PR DESCRIPTION
## Summary

When a user edits a PDK template's S-matrix via *Component Settings…*, the override now persists in a user-global store (`%APPDATA%/Lunima/sparam-overrides.json`) and is applied to every project on the same PDK — matching the user's mental model that editing a template scopes to the template, not the project.

Per-instance overrides (right-click on a canvas instance) still live in the `.lun` because they're tied to a specific component and only make sense inside that project.

## Behaviour

| Scope | Key shape | Storage | Survives across projects? |
|-------|-----------|---------|---------------------------|
| Per-Instance (canvas right-click) | `component.Identifier` | `.lun` PIR section | no — by design |
| **Per-Template (PDK library right-click)** | `{pdkSource}::{templateName}` | `~/AppData/.../Lunima/sparam-overrides.json` | **yes** |
| PDK Default | (in PDK JSON) | unchanged | unchanged |

Lookup precedence on load and on component placement:
**Per-Instance → Per-Template (user-global) → PDK Default**

## Migration

Old `.lun` files that already contain `{pdk}::{template}` keys (from before this change) are migrated transparently on load:

1. The keys move into the user-global store
2. A one-time warning is logged via the Error Console so the user knows what happened
3. `HasUnsavedChanges = true` so re-saving finalises the migration in the project file

No data loss; lossless round-trip via the existing `ComponentSMatrixData` schema.

## UX

The dialog title gains the suffix \"(applies to all projects)\" in template mode so scope is self-documenting. Per-instance dialogs are unchanged.

## Test plan

- [x] `UserSMatrixOverrideStoreTests` — round-trip JSON, missing-file, corrupt-file recovery, parent-dir auto-create, Reload semantics
- [x] `ComponentSettingsDialogUserGlobalScopeTests` — template-scope import persists to user store, delete removes from user store, title flag pinned
- [x] All 2099 tests pass; 0 failures
- [ ] Manual: import `bdc_te1550.sparam` against the *2x2 MMI Coupler* template via PDK library context menu; reopen Lunima with a different project and verify the override is applied
- [ ] Manual: load an existing `.lun` containing a `{pdk}::{template}` key and confirm the migration warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)