### PR TITLE
fix: preserve trailing .0 on whole-number doubles in PdkJsonSaver (#518)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/DoubleWithDecimalConverter.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/DoubleWithDecimalConverter.cs
@@ -1,0 +1,39 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CAP_DataAccess.Components.ComponentDraftMapper
+{
+    /// <summary>
+    /// Custom JSON converter for <see cref="double"/> values that always emits at
+    /// least one decimal place for whole-number values (e.g. <c>6.0</c> instead
+    /// of <c>6</c>). Non-integer values are written with their natural precision.
+    /// </summary>
+    /// <remarks>
+    /// Without this converter <c>System.Text.Json</c> serialises <c>6.0</c> as
+    /// <c>6</c>, which is semantically identical but differs textually from the
+    /// hand-authored PDK JSON files that use the <c>6.0</c> form. That mismatch
+    /// causes 200+ line diffs on every save even when only one value was edited
+    /// (issue #518).
+    /// </remarks>
+    public sealed class DoubleWithDecimalConverter : JsonConverter<double>
+    {
+        /// <inheritdoc/>
+        public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => reader.GetDouble();
+
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+        {
+            if (double.IsInteger(value) && !double.IsInfinity(value))
+            {
+                // Emit "6.0" so the output is round-trip stable with hand-authored PDK files.
+                writer.WriteRawValue(value.ToString("F1", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
+        }
+    }
+}

--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs
@@ -12,7 +12,8 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
         private static readonly JsonSerializerOptions WriteOptions = new()
         {
             WriteIndented = true,
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new DoubleWithDecimalConverter() }
         };
 
         /// <summary>

--- a/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorLoadSaveTests.cs
@@ -259,6 +259,58 @@ public class PdkOffsetEditorLoadSaveTests
         }
     }
 
+    /// <summary>
+    /// Regression test for issue #518: whole-number doubles (e.g. nazcaOriginOffsetY: 6)
+    /// must be written as "6.0" in the saved JSON, not "6", so that a round-trip through
+    /// PdkJsonSaver does not churn hand-authored PDK files with 200+ cosmetic diff lines.
+    /// </summary>
+    [Fact]
+    public void SaveToFile_WholeNumberDoubles_AreWrittenWithDecimalPoint()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var pdk = new CAP_DataAccess.Components.ComponentDraftMapper.DTOs.PdkDraft
+            {
+                Name = "TestPdk",
+                Components = new()
+                {
+                    new()
+                    {
+                        Name = "Comp",
+                        NazcaFunction = "f",
+                        WidthMicrometers = 100,   // whole number
+                        HeightMicrometers = 20,   // whole number
+                        NazcaOriginOffsetX = 6,   // whole number
+                        NazcaOriginOffsetY = 0,   // whole number (zero)
+                        Pins = new()
+                        {
+                            new() { Name = "a0", OffsetXMicrometers = 0, OffsetYMicrometers = 2.5 }
+                        }
+                    }
+                }
+            };
+
+            new PdkJsonSaver().SaveToFile(pdk, tempFile);
+            var json = File.ReadAllText(tempFile);
+
+            // Whole-number doubles must use the decimal form
+            json.ShouldContain("\"widthMicrometers\": 100.0");
+            json.ShouldContain("\"heightMicrometers\": 20.0");
+            json.ShouldContain("\"nazcaOriginOffsetX\": 6.0");
+            json.ShouldContain("\"nazcaOriginOffsetY\": 0.0");
+            // Non-integer values must keep their natural precision
+            json.ShouldContain("\"offsetYMicrometers\": 2.5");
+            // The plain integer form must NOT appear for any double field
+            json.ShouldNotContain("\"widthMicrometers\": 100,");
+            json.ShouldNotContain("\"heightMicrometers\": 20,");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
     private static CAP_DataAccess.Components.ComponentDraftMapper.DTOs.PdkDraft BuildMinimalPdk() =>
         new()
         {


### PR DESCRIPTION
## Summary

- Add `DoubleWithDecimalConverter` — a custom `JsonConverter<double>` that writes whole-number values as `6.0` instead of `6`, matching how PDK JSON files are hand-authored
- Register the converter in `PdkJsonSaver.WriteOptions` so all `double` fields in `PdkDraft` (widthMicrometers, heightMicrometers, nazcaOriginOffsetX/Y, pin offsets, S-matrix values) are handled automatically
- Add regression test `SaveToFile_WholeNumberDoubles_AreWrittenWithDecimalPoint` that asserts the saved JSON contains `"widthMicrometers": 100.0` (not `100`)

## Root cause

`System.Text.Json` serialises `double` value `6.0` as `6` (no decimal), while hand-authored PDK files use `6.0`. This caused ~200 cosmetic line-format changes per save, burying the real edit in diff noise.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~PdkOffset"` → 34/34 passed
- [x] New regression test explicitly asserts `"widthMicrometers": 100.0` and `"nazcaOriginOffsetX": 6.0` in saved JSON
- [x] Pre-existing test `SavePdk_FullLoadEditSaveRoundTrip_PreservesAllFieldsAndEditedOffset` still passes (round-trip stability confirmed)
- [x] Existing `NazcaExportAllComponentsTests` failure is pre-existing (present on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)