### PR TITLE
Architecture: adopt vertical-slice convention formally (no Prism) #530

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- 1–3 bullet points describing what this PR does -->
+
+## Related issue
+
+Closes #
+
+## Test plan
+
+<!-- How was this tested? -->
+
+- [ ] Build passes (`dotnet build` / `build_errors.py`)
+- [ ] All tests pass (`python3 ~/.cap-tools/smart_test.py`)
+- [ ] No new warnings introduced
+
+## Architecture checklist
+
+- [ ] Follows vertical-slice convention: new feature code lives in mirrored subfolders across layers (see CLAUDE.md §1.1)
+- [ ] No cross-feature reach-in: feature code only references its own namespace or the shared kernel
+- [ ] New DI registrations added to the feature's extension method in `CAP.Avalonia/DI/` (not directly in `App.axaml.cs`)
+- [ ] No new file exceeds 250 lines (or grandfathered in `FileSizeLimitTests.cs` with an issue reference)
+
+## Notes for reviewer
+
+<!-- Anything else the reviewer should know: tricky edge cases, follow-up issues, etc. -->

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -1,28 +1,9 @@
-using System.Net.Http;
-using System.Net.Http.Headers;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-using CAP.Avalonia.Services;
+using CAP.Avalonia.DI;
 using CAP.Avalonia.ViewModels;
-using CAP.Avalonia.ViewModels.Analysis;
-using CAP.Avalonia.ViewModels.Canvas;
-using CAP.Avalonia.ViewModels.Diagnostics;
-using CAP.Avalonia.ViewModels.Export;
-using CAP.Avalonia.ViewModels.Hierarchy;
-using CAP.Avalonia.ViewModels.Library;
-using CAP.Avalonia.ViewModels.Panels;
-using CAP.Avalonia.ViewModels.Update;
-using CAP.Avalonia.ViewModels.AI;
-using CAP.Avalonia.ViewModels.PdkOffset;
-using CAP.Avalonia.ViewModels.Settings;
-using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP.Avalonia.Views;
-using CAP.Avalonia.Services.AiTools;
-using CAP.Avalonia.Services.AiTools.GridTools;
-using CAP_Contracts;
-using CAP_Core.Helpers;
-using CAP_Core.Export;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CAP.Avalonia;
@@ -40,162 +21,14 @@ public partial class App : Application
     {
         var services = new ServiceCollection();
 
-        // Register shared HttpClient with GitHub-compatible User-Agent
-        var httpClient = new HttpClient();
-        httpClient.DefaultRequestHeaders.UserAgent.Add(
-            new ProductInfoHeaderValue("ConnectAPICPro", "1.0"));
-        services.AddSingleton(httpClient);
+        services.AddUpdateFeature();
+        services.AddAiAssistantFeature();
+        services.AddExportFeature();
+        services.AddCoreServices();
+        services.AddCanvasAndPanels();
+        services.AddSettingsFeature();
+        services.AddPdkOffsetFeature();
 
-        // Register update services
-        services.AddSingleton(sp => new UpdateChecker(
-            sp.GetRequiredService<HttpClient>(),
-            owner: "aignermax",
-            repo: "Connect-A-PIC-Pro"));
-        services.AddSingleton(sp => new UpdateDownloader(
-            sp.GetRequiredService<HttpClient>()));
-        services.AddSingleton<IUrlLauncher, SystemUrlLauncher>();
-        services.AddSingleton<UpdateViewModel>();
-
-        // Register AI assistant services
-        services.AddSingleton<IAiService, AiService>(sp => new AiService(sp.GetRequiredService<HttpClient>()));
-        services.AddSingleton<IAiGridService>(sp => new AiGridService(
-            sp.GetRequiredService<DesignCanvasViewModel>(),
-            sp.GetRequiredService<LeftPanelViewModel>(),
-            sp.GetRequiredService<SimulationService>()));
-
-        // Register AI tools — add new tools here without modifying any other file
-        services.AddTransient<IAiTool, GetGridStateTool>();
-        services.AddTransient<IAiTool, GetAvailableTypesTool>();
-        services.AddTransient<IAiTool, PlaceComponentTool>();
-        services.AddTransient<IAiTool, CreateConnectionTool>();
-        services.AddTransient<IAiTool, RunSimulationTool>();
-        services.AddTransient<IAiTool, GetLightValuesTool>();
-        services.AddTransient<IAiTool, ClearGridTool>();
-        services.AddTransient<IAiTool, CreateGroupTool>();
-        services.AddTransient<IAiTool, UngroupTool>();
-        services.AddTransient<IAiTool, SaveAsPrefabTool>();
-        services.AddTransient<IAiTool, InspectGroupTool>();
-        services.AddTransient<IAiTool, CopyComponentTool>();
-        services.AddTransient<IAiTool, FitToViewTool>();
-        services.AddSingleton<IAiToolRegistry, AiToolRegistry>();
-
-        services.AddSingleton<AiAssistantViewModel>(sp => new AiAssistantViewModel(
-            sp.GetRequiredService<IAiService>(),
-            sp.GetRequiredService<UserPreferencesService>(),
-            sp.GetRequiredService<IAiToolRegistry>()));
-
-        // Register GdsExportViewModel as singleton so both FileOperations and
-        // GdsExportSettingsPage share the same instance.
-        services.AddSingleton<GdsExportViewModel>(sp =>
-        {
-            var vm = new GdsExportViewModel(
-                sp.GetRequiredService<GdsExportService>(),
-                sp.GetRequiredService<CAP_Core.ErrorConsoleService>());
-            var prefs = sp.GetRequiredService<UserPreferencesService>();
-            vm.Initialize(prefs.GetCustomPythonPath());
-            vm.OnPythonPathChanged = path => prefs.SetCustomPythonPath(path);
-            return vm;
-        });
-
-        // PhotonTorchExportViewModel: singleton so the dialog and any other
-        // consumer of FileOperations.PhotonTorchExport see the same state.
-        services.AddSingleton<CAP_Core.Export.PhotonTorchExporter>();
-        services.AddSingleton<PhotonTorchExportViewModel>();
-
-        // Register core services
-        services.AddSingleton<IDataAccessor, FileDataAccessor>();
-        services.AddSingleton<CAP_Core.Components.Creation.GroupLibraryManager>();
-        services.AddSingleton<GdsExportService>();
-        services.AddSingleton<CAP_Core.Export.VerilogAExporter>();
-        services.AddSingleton<VerilogAFileWriter>();
-        services.AddSingleton<CAP_Core.ErrorConsoleService>();
-
-        // Register application services
-        services.AddSingleton<SimulationService>();
-        services.AddSingleton<SimpleNazcaExporter>();
-        services.AddSingleton<CAP_Core.Export.SaxExporter>();
-        services.AddSingleton<PdkLoader>();
-        services.AddSingleton<PdkImportService>();
-        services.AddSingleton<Commands.CommandManager>();
-        services.AddSingleton<UserPreferencesService>();
-        services.AddSingleton<ProjectPersistenceService>();
-        // User-global PDK template S-matrix overrides — persists across projects
-        // so editing a template's S-matrix isn't silently confined to the .lun
-        // file the user happened to be in.
-        services.AddSingleton<UserSMatrixOverrideStore>(sp =>
-            new UserSMatrixOverrideStore(sp.GetService<CAP_Core.ErrorConsoleService>()));
-        services.AddSingleton<Services.GroupPreviewGenerator>();
-        services.AddSingleton<IInputDialogService, InputDialogService>();
-        services.AddSingleton<IPortMappingDialogService, PortMappingDialogService>();
-
-        // Register DesignCanvasViewModel as singleton (shared across all panel VMs)
-        services.AddSingleton<DesignCanvasViewModel>();
-        services.AddSingleton<ViewportControlViewModel>();
-
-        // Register sub-ViewModels (Left panel)
-        services.AddTransient<HierarchyPanelViewModel>();
-        services.AddSingleton<PdkManagerViewModel>();
-        services.AddTransient<ComponentLibraryViewModel>();
-
-        // Register sub-ViewModels (Right panel)
-        // Singleton so the Settings-window page and the RightPanel reference share state.
-        services.AddSingleton<ChipSizeViewModel>();
-        services.AddTransient<ParameterSweepViewModel>();
-        services.AddTransient<RoutingDiagnosticsViewModel>();
-        services.AddTransient<DesignValidationViewModel>();
-        services.AddTransient<ComponentDimensionDiagnosticsViewModel>();
-        services.AddTransient<ComponentDimensionViewModel>();
-        services.AddTransient<ExportValidationViewModel>();
-        services.AddTransient<SMatrixPerformanceViewModel>();
-        services.AddTransient<CompressLayoutViewModel>();
-        services.AddTransient<GroupSMatrixViewModel>();
-        services.AddTransient<ArchitectureReportViewModel>();
-        services.AddTransient<PdkConsistencyViewModel>();
-
-        // VerilogAExportViewModel: singleton so the dialog and FileOperations
-        // share the same state.
-        services.AddSingleton<VerilogAExportViewModel>();
-
-        // Register sub-ViewModels (Bottom panel)
-        services.AddTransient<WaveguideLengthViewModel>();
-        services.AddTransient<ElementLockViewModel>();
-        services.AddTransient<ErrorConsoleViewModel>();
-
-        // Register settings pages — each implements ISettingsPage; SettingsWindowViewModel enumerates them all.
-        // To add a new settings page: add one line here + create the page class. Nothing else changes.
-        services.AddTransient<ISettingsPage, GeneralSettingsPage>();
-        services.AddTransient<ISettingsPage, GridSnapSettingsPage>();
-        services.AddTransient<ISettingsPage, UpdateSettingsPage>();
-        services.AddTransient<ISettingsPage, GdsExportSettingsPage>();
-        services.AddTransient<ISettingsPage, ChipSizeSettingsPage>();
-        services.AddTransient<ISettingsPage, AiAssistantSettingsPage>();
-        services.AddTransient<SettingsWindowViewModel>();
-
-        // Register panel ViewModels as singletons
-        services.AddSingleton<LeftPanelViewModel>();
-        services.AddSingleton<RightPanelViewModel>();
-        services.AddSingleton<BottomPanelViewModel>();
-
-        // Register PDK offset editor services and ViewModel.
-        // The ViewModel is Singleton so that MainViewModel can hold it as a
-        // property — this preserves editor state (loaded PDK, unsaved edits)
-        // when the user re-opens the window. Transient here would give the
-        // MainViewModel a different instance than any other DI resolution.
-        services.AddSingleton<PdkJsonSaver>();
-        services.AddSingleton(sp =>
-        {
-            var prefs = sp.GetRequiredService<UserPreferencesService>();
-            var python = prefs.GetCustomPythonPath() ?? ResolvePythonExecutable();
-            var script = FindPreviewScript();
-            return new NazcaComponentPreviewService(python, script);
-        });
-        services.AddSingleton(sp => new PdkOffsetEditorViewModel(
-            sp.GetRequiredService<PdkLoader>(),
-            sp.GetRequiredService<PdkJsonSaver>(),
-            sp.GetRequiredService<PdkManagerViewModel>(),
-            sp.GetRequiredService<NazcaComponentPreviewService>()));
-
-        // Register main ViewModel
         services.AddSingleton<MainViewModel>();
 
         Services = services.BuildServiceProvider();
@@ -218,79 +51,5 @@ public partial class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
-    }
-
-    /// <summary>
-    /// Searches for render_component_preview.py relative to the application base directory.
-    /// Returns the first candidate path found, or the primary candidate when none exist
-    /// (the service will return a graceful failure result at render time).
-    /// </summary>
-    private static string FindPreviewScript()
-    {
-        const string scriptName = "render_component_preview.py";
-        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
-
-        // First: a "scripts" folder copied next to the binary (publish path).
-        var local = Path.Combine(baseDir, "scripts", scriptName);
-        if (File.Exists(local)) return local;
-
-        // Otherwise walk up the directory tree looking for repo/scripts/<name>.
-        // Hard-coded "..","..",".." chains break whenever the running configuration's
-        // depth changes (debug vs release vs single-file publish vs net8.0 subfolder).
-        var current = new DirectoryInfo(baseDir);
-        while (current != null)
-        {
-            var candidate = Path.Combine(current.FullName, "scripts", scriptName);
-            if (File.Exists(candidate)) return candidate;
-            current = current.Parent;
-        }
-
-        // Best-effort fallback — NazcaComponentPreviewService returns a graceful
-        // failure with a clear message when the path doesn't resolve.
-        return local;
-    }
-
-    /// <summary>
-    /// Picks the first runnable Python interpreter from a per-platform candidate
-    /// list. Windows installers map differently (`python`, `py`-launcher) than
-    /// most Linux distros (`python3`); falling back to a single hard-coded name
-    /// caused the Nazca-preview to silently fail on default Windows installs.
-    /// </summary>
-    private static string ResolvePythonExecutable()
-    {
-        var candidates = OperatingSystem.IsWindows()
-            ? new[] { "python", "py", "python3" }
-            : new[] { "python3", "python" };
-
-        foreach (var candidate in candidates)
-        {
-            try
-            {
-                using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = candidate,
-                    Arguments = "--version",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                });
-                if (p == null) continue;
-                p.WaitForExit(2000);
-                if (p.ExitCode == 0) return candidate;
-            }
-            catch (System.ComponentModel.Win32Exception)
-            {
-                // Candidate not on PATH — try next
-            }
-            catch (Exception)
-            {
-                // Anything else: skip and try next
-            }
-        }
-
-        // Best-effort fallback — preview service returns a clear error message
-        // when this turns out not to be runnable.
-        return OperatingSystem.IsWindows() ? "python" : "python3";
     }
 }

--- a/CAP.Avalonia/DI/AiAssistantFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/AiAssistantFeatureExtensions.cs
@@ -1,0 +1,54 @@
+using System.Net.Http;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.AiTools;
+using CAP.Avalonia.Services.AiTools.GridTools;
+using CAP.Avalonia.ViewModels.AI;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Panels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers the AI assistant services, tools, and ViewModel.
+/// </summary>
+internal static class AiAssistantFeatureExtensions
+{
+    /// <summary>
+    /// Adds the AI service, all registered <see cref="IAiTool"/> implementations,
+    /// the tool registry, and the <see cref="AiAssistantViewModel"/>.
+    /// To add a new AI tool: add one <c>AddTransient&lt;IAiTool, YourTool&gt;()</c> line here.
+    /// </summary>
+    public static IServiceCollection AddAiAssistantFeature(this IServiceCollection services)
+    {
+        services.AddSingleton<IAiService, AiService>(sp =>
+            new AiService(sp.GetRequiredService<HttpClient>()));
+
+        services.AddSingleton<IAiGridService>(sp => new AiGridService(
+            sp.GetRequiredService<DesignCanvasViewModel>(),
+            sp.GetRequiredService<LeftPanelViewModel>(),
+            sp.GetRequiredService<SimulationService>()));
+
+        services.AddTransient<IAiTool, GetGridStateTool>();
+        services.AddTransient<IAiTool, GetAvailableTypesTool>();
+        services.AddTransient<IAiTool, PlaceComponentTool>();
+        services.AddTransient<IAiTool, CreateConnectionTool>();
+        services.AddTransient<IAiTool, RunSimulationTool>();
+        services.AddTransient<IAiTool, GetLightValuesTool>();
+        services.AddTransient<IAiTool, ClearGridTool>();
+        services.AddTransient<IAiTool, CreateGroupTool>();
+        services.AddTransient<IAiTool, UngroupTool>();
+        services.AddTransient<IAiTool, SaveAsPrefabTool>();
+        services.AddTransient<IAiTool, InspectGroupTool>();
+        services.AddTransient<IAiTool, CopyComponentTool>();
+        services.AddTransient<IAiTool, FitToViewTool>();
+        services.AddSingleton<IAiToolRegistry, AiToolRegistry>();
+
+        services.AddSingleton<AiAssistantViewModel>(sp => new AiAssistantViewModel(
+            sp.GetRequiredService<IAiService>(),
+            sp.GetRequiredService<UserPreferencesService>(),
+            sp.GetRequiredService<IAiToolRegistry>()));
+
+        return services;
+    }
+}

--- a/CAP.Avalonia/DI/CanvasAndPanelExtensions.cs
+++ b/CAP.Avalonia/DI/CanvasAndPanelExtensions.cs
@@ -1,0 +1,56 @@
+using CAP.Avalonia.ViewModels.Analysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Hierarchy;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers the design canvas, viewport, and all panel ViewModels.
+/// </summary>
+internal static class CanvasAndPanelExtensions
+{
+    /// <summary>
+    /// Adds DesignCanvasViewModel, ViewportControlViewModel, and the three panel
+    /// ViewModels together with all their sub-ViewModels.
+    /// </summary>
+    public static IServiceCollection AddCanvasAndPanels(this IServiceCollection services)
+    {
+        services.AddSingleton<DesignCanvasViewModel>();
+        services.AddSingleton<ViewportControlViewModel>();
+
+        // Left panel sub-ViewModels
+        services.AddTransient<HierarchyPanelViewModel>();
+        services.AddSingleton<PdkManagerViewModel>();
+        services.AddTransient<ComponentLibraryViewModel>();
+
+        // Right panel sub-ViewModels
+        services.AddSingleton<ChipSizeViewModel>();
+        services.AddTransient<ParameterSweepViewModel>();
+        services.AddTransient<RoutingDiagnosticsViewModel>();
+        services.AddTransient<DesignValidationViewModel>();
+        services.AddTransient<ComponentDimensionDiagnosticsViewModel>();
+        services.AddTransient<ComponentDimensionViewModel>();
+        services.AddTransient<ExportValidationViewModel>();
+        services.AddTransient<SMatrixPerformanceViewModel>();
+        services.AddTransient<CompressLayoutViewModel>();
+        services.AddTransient<GroupSMatrixViewModel>();
+        services.AddTransient<ArchitectureReportViewModel>();
+        services.AddTransient<PdkConsistencyViewModel>();
+
+        // Bottom panel sub-ViewModels
+        services.AddTransient<WaveguideLengthViewModel>();
+        services.AddTransient<ElementLockViewModel>();
+        services.AddTransient<ErrorConsoleViewModel>();
+
+        // Panel host singletons
+        services.AddSingleton<LeftPanelViewModel>();
+        services.AddSingleton<RightPanelViewModel>();
+        services.AddSingleton<BottomPanelViewModel>();
+
+        return services;
+    }
+}

--- a/CAP.Avalonia/DI/CoreServicesExtensions.cs
+++ b/CAP.Avalonia/DI/CoreServicesExtensions.cs
@@ -1,0 +1,39 @@
+using CAP.Avalonia.Services;
+using CAP_Contracts;
+using CAP_Core.Helpers;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers core domain services, persistence, and application-wide infrastructure.
+/// </summary>
+internal static class CoreServicesExtensions
+{
+    /// <summary>
+    /// Adds data access, serialization, simulation, PDK, commands, preferences,
+    /// and other application-wide services.
+    /// </summary>
+    public static IServiceCollection AddCoreServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IDataAccessor, FileDataAccessor>();
+        services.AddSingleton<CAP_Core.Components.Creation.GroupLibraryManager>();
+        services.AddSingleton<CAP_Core.ErrorConsoleService>();
+        services.AddSingleton<SimpleNazcaExporter>();
+
+        services.AddSingleton<SimulationService>();
+        services.AddSingleton<PdkLoader>();
+        services.AddSingleton<PdkImportService>();
+        services.AddSingleton<Commands.CommandManager>();
+        services.AddSingleton<UserPreferencesService>();
+        services.AddSingleton<ProjectPersistenceService>();
+        services.AddSingleton<UserSMatrixOverrideStore>(sp =>
+            new UserSMatrixOverrideStore(sp.GetService<CAP_Core.ErrorConsoleService>()));
+        services.AddSingleton<Services.GroupPreviewGenerator>();
+        services.AddSingleton<IInputDialogService, InputDialogService>();
+        services.AddSingleton<IPortMappingDialogService, PortMappingDialogService>();
+
+        return services;
+    }
+}

--- a/CAP.Avalonia/DI/ExportFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/ExportFeatureExtensions.cs
@@ -1,0 +1,43 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Export;
+using CAP_Core.Export;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers all export format services and ViewModels (GDS, PhotonTorch, VerilogA).
+/// All export ViewModels are Singletons so that dialog DataContexts and
+/// FileOperations commands share the same instance and state.
+/// </summary>
+internal static class ExportFeatureExtensions
+{
+    /// <summary>
+    /// Adds GDS, PhotonTorch, and VerilogA export services and ViewModels.
+    /// </summary>
+    public static IServiceCollection AddExportFeature(this IServiceCollection services)
+    {
+        services.AddSingleton<GdsExportService>();
+        services.AddSingleton<GdsExportViewModel>(sp =>
+        {
+            var vm = new GdsExportViewModel(
+                sp.GetRequiredService<GdsExportService>(),
+                sp.GetRequiredService<CAP_Core.ErrorConsoleService>());
+            var prefs = sp.GetRequiredService<UserPreferencesService>();
+            vm.Initialize(prefs.GetCustomPythonPath());
+            vm.OnPythonPathChanged = path => prefs.SetCustomPythonPath(path);
+            return vm;
+        });
+
+        services.AddSingleton<PhotonTorchExporter>();
+        services.AddSingleton<PhotonTorchExportViewModel>();
+
+        services.AddSingleton<VerilogAExporter>();
+        services.AddSingleton<VerilogAFileWriter>();
+        services.AddSingleton<VerilogAExportViewModel>();
+
+        services.AddSingleton<SaxExporter>();
+
+        return services;
+    }
+}

--- a/CAP.Avalonia/DI/PdkOffsetFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/PdkOffsetFeatureExtensions.cs
@@ -1,0 +1,99 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.PdkOffset;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers the PDK offset editor feature: saver, Nazca preview service, and ViewModel.
+/// The ViewModel is Singleton so that MainViewModel always receives the same instance —
+/// this preserves editor state (loaded PDK, unsaved edits) when the user re-opens the window.
+/// </summary>
+internal static class PdkOffsetFeatureExtensions
+{
+    /// <summary>
+    /// Adds PDK JSON saving, the Nazca component preview service, and the
+    /// <see cref="PdkOffsetEditorViewModel"/> as a singleton.
+    /// </summary>
+    public static IServiceCollection AddPdkOffsetFeature(this IServiceCollection services)
+    {
+        services.AddSingleton<PdkJsonSaver>();
+        services.AddSingleton(sp =>
+        {
+            var prefs = sp.GetRequiredService<UserPreferencesService>();
+            var python = prefs.GetCustomPythonPath() ?? ResolvePythonExecutable();
+            var script = FindPreviewScript();
+            return new NazcaComponentPreviewService(python, script);
+        });
+        services.AddSingleton(sp => new PdkOffsetEditorViewModel(
+            sp.GetRequiredService<PdkLoader>(),
+            sp.GetRequiredService<PdkJsonSaver>(),
+            sp.GetRequiredService<PdkManagerViewModel>(),
+            sp.GetRequiredService<NazcaComponentPreviewService>()));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Searches for render_component_preview.py relative to the application base directory.
+    /// Returns the first candidate path found, or the primary candidate when none exist.
+    /// </summary>
+    private static string FindPreviewScript()
+    {
+        const string ScriptName = "render_component_preview.py";
+        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+
+        var local = Path.Combine(baseDir, "scripts", ScriptName);
+        if (File.Exists(local)) return local;
+
+        var current = new DirectoryInfo(baseDir);
+        while (current != null)
+        {
+            var candidate = Path.Combine(current.FullName, "scripts", ScriptName);
+            if (File.Exists(candidate)) return candidate;
+            current = current.Parent;
+        }
+
+        return local;
+    }
+
+    /// <summary>
+    /// Picks the first runnable Python interpreter from a per-platform candidate list.
+    /// </summary>
+    private static string ResolvePythonExecutable()
+    {
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { "python", "py", "python3" }
+            : new[] { "python3", "python" };
+
+        foreach (var candidate in candidates)
+        {
+            try
+            {
+                using var p = Process.Start(new ProcessStartInfo
+                {
+                    FileName = candidate,
+                    Arguments = "--version",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                });
+                if (p == null) continue;
+                p.WaitForExit(2000);
+                if (p.ExitCode == 0) return candidate;
+            }
+            catch (Win32Exception) { }
+            catch (Exception) { }
+        }
+
+        return OperatingSystem.IsWindows() ? "python" : "python3";
+    }
+}

--- a/CAP.Avalonia/DI/SettingsFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/SettingsFeatureExtensions.cs
@@ -1,0 +1,28 @@
+using CAP.Avalonia.ViewModels.Settings;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers settings page implementations and the settings window ViewModel.
+/// To add a new settings page: add one <c>AddTransient&lt;ISettingsPage, YourPage&gt;()</c> here.
+/// </summary>
+internal static class SettingsFeatureExtensions
+{
+    /// <summary>
+    /// Adds all <see cref="ISettingsPage"/> implementations and the
+    /// <see cref="SettingsWindowViewModel"/> that enumerates them.
+    /// </summary>
+    public static IServiceCollection AddSettingsFeature(this IServiceCollection services)
+    {
+        services.AddTransient<ISettingsPage, GeneralSettingsPage>();
+        services.AddTransient<ISettingsPage, GridSnapSettingsPage>();
+        services.AddTransient<ISettingsPage, UpdateSettingsPage>();
+        services.AddTransient<ISettingsPage, GdsExportSettingsPage>();
+        services.AddTransient<ISettingsPage, ChipSizeSettingsPage>();
+        services.AddTransient<ISettingsPage, AiAssistantSettingsPage>();
+        services.AddTransient<SettingsWindowViewModel>();
+
+        return services;
+    }
+}

--- a/CAP.Avalonia/DI/UpdateFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/UpdateFeatureExtensions.cs
@@ -1,0 +1,35 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Update;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers the HTTP client and application update feature services.
+/// </summary>
+internal static class UpdateFeatureExtensions
+{
+    /// <summary>
+    /// Adds a shared <see cref="HttpClient"/>, update checking, and update downloading.
+    /// </summary>
+    public static IServiceCollection AddUpdateFeature(this IServiceCollection services)
+    {
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue("ConnectAPICPro", "1.0"));
+        services.AddSingleton(httpClient);
+
+        services.AddSingleton(sp => new UpdateChecker(
+            sp.GetRequiredService<HttpClient>(),
+            owner: "aignermax",
+            repo: "Connect-A-PIC-Pro"));
+        services.AddSingleton(sp => new UpdateDownloader(
+            sp.GetRequiredService<HttpClient>()));
+        services.AddSingleton<IUrlLauncher, SystemUrlLauncher>();
+        services.AddSingleton<UpdateViewModel>();
+
+        return services;
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,61 @@ C# / Avalonia / MVVM photonic simulation tool. Stability, clarity, and architect
 
 ---
 
+## 1.1 Vertical Slice Convention
+
+Lunima uses a **vertical-slice** layout: each feature ships with mirrored subfolders across all layers, named identically.
+
+### Folder pattern
+
+```
+Connect-A-Pic-Core/<DomainArea>/<FeatureName>/
+CAP-DataAccess/<RelevantArea>/<FeatureName>/   (only if persistence is touched)
+CAP.Avalonia/ViewModels/<RelevantArea>/<FeatureName>/
+CAP.Avalonia/Views/Panels/<FeatureName>Panel.axaml   (only for panel features)
+UnitTests/<RelevantArea>/<FeatureName>/
+```
+
+**Concrete examples:**
+- GDS preview (Issue #525): `CAP.Avalonia/Controls/Canvas/ComponentPreview/` + tests
+- ONA sweep (Issue #526): `Connect-A-Pic-Core/Analysis/OnaAnalysis/` + `CAP.Avalonia/ViewModels/Analysis/OnaAnalysis/` + tests
+- Time-domain (Issue #527): `Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/` + tests
+- Nazca override (Issue #528): `CAP.Avalonia/Services/ComponentInstanceOverride/` + tests
+
+### Cross-feature dependency rule
+
+A feature's code **must only** import from:
+- Its own namespace
+- The shared kernel (see allow-list below)
+- Platform / framework namespaces (`System.*`, `Avalonia.*`, `Microsoft.*`, `CommunityToolkit.*`)
+
+**Shared kernel allow-list:**
+`CAP_Core.Components`, `CAP_Core.Helpers`, `CAP_Core.Grid`, `CAP_Core.Tiles`,
+`CAP_Core.ExternalPorts`, `CAP_Core.Routing`, `CAP_Core.LightCalculation`,
+`CAP_Core.Resources`, `CAP_Contracts`, `CAP.Avalonia.Services`,
+`CAP.Avalonia.ViewModels.Canvas`, `CAP.Avalonia.ViewModels.Panels`, `CAP_DataAccess`
+
+Architecture tests in `UnitTests/Architecture/VerticalSliceConventionTests.cs` enforce this rule for enumerated features and will fail CI if violated.
+
+### DI registration
+
+Each feature group has a dedicated extension method in `CAP.Avalonia/DI/`:
+
+```csharp
+public static IServiceCollection AddExportFeature(this IServiceCollection s);
+public static IServiceCollection AddAiAssistantFeature(this IServiceCollection s);
+```
+
+`App.axaml.cs` calls these methods instead of raw `services.AddSingleton<X>()` lines.
+To add a service: add the registration inside the relevant extension method, not directly in `App.axaml.cs`.
+
+### What "vertical slice" is NOT
+
+- Prism, MediatR, or any modular plug-in framework — **not adopted**.
+- Splitting the solution into multiple `.csproj` files — **out of scope**.
+- Mandatory for every single file — **only for new cross-cutting features**.
+
+---
+
 ## 1. Architecture Rules
 
 - Follow SOLID principles strictly.

--- a/UnitTests/Architecture/ExportViewModelLifetimeTests.cs
+++ b/UnitTests/Architecture/ExportViewModelLifetimeTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using Shouldly;
 
 namespace UnitTests.Architecture;
@@ -11,19 +12,41 @@ namespace UnitTests.Architecture;
 /// resolve to the same instance. If either is accidentally flipped to Transient,
 /// the dialog edits state that the export command never sees — the user changes
 /// wavelength in the dialog, hits Export, and the underlying export VM still has
-/// the old value. This test catches that regression by scanning the App DI
-/// registration directly.
+/// the old value. This test catches that regression by scanning all DI registration
+/// files in the CAP.Avalonia project.
 /// </summary>
 public class ExportViewModelLifetimeTests
 {
-    private static readonly string AppDiFile =
-        Path.Combine(FindRepoRoot(), "CAP.Avalonia", "App.axaml.cs");
+    /// <summary>
+    /// Reads all DI registration files (App.axaml.cs and the DI extension folder)
+    /// and concatenates their content for lifetime scanning.
+    /// </summary>
+    private static string AllDiRegistrations
+    {
+        get
+        {
+            var root = FindRepoRoot();
+            var appDi = Path.Combine(root, "CAP.Avalonia", "App.axaml.cs");
+            var diFolder = Path.Combine(root, "CAP.Avalonia", "DI");
+
+            var parts = new System.Collections.Generic.List<string>();
+            if (File.Exists(appDi))
+                parts.Add(File.ReadAllText(appDi));
+
+            if (Directory.Exists(diFolder))
+            {
+                foreach (var f in Directory.GetFiles(diFolder, "*.cs", SearchOption.TopDirectoryOnly))
+                    parts.Add(File.ReadAllText(f));
+            }
+
+            return string.Concat(parts);
+        }
+    }
 
     [Fact]
     public void VerilogAExportViewModel_IsRegisteredAsSingleton()
     {
-        var content = File.ReadAllText(AppDiFile);
-
+        var content = AllDiRegistrations;
         content.ShouldContain("AddSingleton<VerilogAExportViewModel>");
         content.ShouldNotContain("AddTransient<VerilogAExportViewModel>");
     }
@@ -31,8 +54,7 @@ public class ExportViewModelLifetimeTests
     [Fact]
     public void PhotonTorchExportViewModel_IsRegisteredAsSingleton()
     {
-        var content = File.ReadAllText(AppDiFile);
-
+        var content = AllDiRegistrations;
         content.ShouldContain("AddSingleton<PhotonTorchExportViewModel>");
         content.ShouldNotContain("AddTransient<PhotonTorchExportViewModel>");
     }
@@ -40,8 +62,7 @@ public class ExportViewModelLifetimeTests
     [Fact]
     public void GdsExportViewModel_IsRegisteredAsSingleton()
     {
-        var content = File.ReadAllText(AppDiFile);
-
+        var content = AllDiRegistrations;
         content.ShouldContain("AddSingleton<GdsExportViewModel>");
         content.ShouldNotContain("AddTransient<GdsExportViewModel>");
     }
@@ -50,9 +71,8 @@ public class ExportViewModelLifetimeTests
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir != null && !File.Exists(Path.Combine(dir.FullName, "CAP.Avalonia", "App.axaml.cs")))
-        {
             dir = dir.Parent;
-        }
+
         return dir?.FullName ?? throw new InvalidOperationException("Could not locate repository root");
     }
 }

--- a/UnitTests/Architecture/FileSizeLimitTests.cs
+++ b/UnitTests/Architecture/FileSizeLimitTests.cs
@@ -165,11 +165,15 @@ public class FileSizeLimitTests
     private static string GetRepositoryRoot()
     {
         var dir = Directory.GetCurrentDirectory();
-        while (dir != null && !Directory.Exists(Path.Combine(dir, ".git")))
+        while (dir != null)
         {
+            var gitPath = Path.Combine(dir, ".git");
+            // In a normal clone .git is a directory; in a git worktree it is a file.
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                return dir;
             dir = Directory.GetParent(dir)?.FullName;
         }
 
-        return dir ?? throw new InvalidOperationException("Could not find repository root (.git directory).");
+        throw new InvalidOperationException("Could not find repository root (.git directory or file).");
     }
 }

--- a/UnitTests/Architecture/VerticalSliceConventionTests.cs
+++ b/UnitTests/Architecture/VerticalSliceConventionTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Architecture;
+
+/// <summary>
+/// Enforces the vertical-slice convention documented in CLAUDE.md §1.1.
+/// Each feature's code should only reference its own namespace or the shared kernel.
+/// Prevents feature A from reaching into feature B's internals as the codebase grows.
+/// </summary>
+public class VerticalSliceConventionTests
+{
+    /// <summary>
+    /// Folders belonging to each feature, relative to the repository root.
+    /// Add the feature's folder paths across all layers (Core, ViewModels, Tests).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string[]> FeatureFolders =
+        new Dictionary<string, string[]>
+        {
+            ["Analysis"] = new[]
+            {
+                Path.Combine("Connect-A-Pic-Core", "Analysis"),
+                Path.Combine("CAP.Avalonia", "ViewModels", "Analysis"),
+                Path.Combine("UnitTests", "Analysis"),
+            },
+            ["Export"] = new[]
+            {
+                Path.Combine("Connect-A-Pic-Core", "Export"),
+                Path.Combine("CAP.Avalonia", "ViewModels", "Export"),
+                Path.Combine("UnitTests", "Export"),
+            },
+        };
+
+    /// <summary>
+    /// Namespace prefixes of each feature. Files inside a feature folder must not
+    /// import the namespace of a <em>sibling</em> feature (any entry other than their own).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string[]> FeatureNamespaces =
+        new Dictionary<string, string[]>
+        {
+            ["Analysis"] = new[] { "CAP_Core.Analysis", "CAP.Avalonia.ViewModels.Analysis" },
+            ["Export"]   = new[] { "CAP_Core.Export",   "CAP.Avalonia.ViewModels.Export"   },
+        };
+
+    /// <summary>
+    /// Namespace prefixes that every feature is allowed to import — the shared kernel.
+    /// Platform and framework namespaces are implicitly allowed via the "System.", "Avalonia." etc.
+    /// entries. Add domain-level shared types here as the codebase grows.
+    /// </summary>
+    private static readonly string[] SharedKernelPrefixes = new[]
+    {
+        // Framework / tooling
+        "System.", "Microsoft.", "Avalonia.", "CommunityToolkit.", "Moq.", "Xunit.", "Shouldly.",
+        // Domain shared kernel
+        "CAP_Core.Components",
+        "CAP_Core.Helpers",
+        "CAP_Core.Grid",
+        "CAP_Core.Tiles",
+        "CAP_Core.ExternalPorts",
+        "CAP_Core.Routing",
+        "CAP_Core.Resources",
+        "CAP_Core.LightCalculation",
+        "CAP_Contracts",
+        // Bare root namespaces (ErrorConsoleService, SimulationService, etc.)
+        "CAP_Core;",
+        // UI shared infrastructure
+        "CAP.Avalonia.Services",
+        "CAP.Avalonia.ViewModels.Canvas",
+        "CAP.Avalonia.ViewModels.Panels",
+        "CAP.Avalonia.ViewModels.Converters",
+        "CAP.Avalonia.Commands",
+        "CAP.Avalonia;",
+        // Data access layer (not feature-specific)
+        "CAP_DataAccess",
+    };
+
+    /// <summary>
+    /// For each enumerated feature, verifies that no source file inside the feature's
+    /// folders contains a <c>using</c> directive that points to a sibling feature's namespace.
+    /// Cross-feature reach-ins break the vertical-slice convention and make refactoring harder.
+    /// </summary>
+    [Theory]
+    [InlineData("Analysis")]
+    [InlineData("Export")]
+    public void Feature_OnlyReferencesItsOwnNamespaceOrSharedKernel(string featureName)
+    {
+        var repoRoot = FindRepoRoot();
+        var siblingNamespaces = FeatureNamespaces
+            .Where(kv => kv.Key != featureName)
+            .SelectMany(kv => kv.Value)
+            .ToArray();
+
+        var violations = new List<string>();
+
+        foreach (var relativeFolder in FeatureFolders[featureName])
+        {
+            var absoluteFolder = Path.Combine(repoRoot, relativeFolder);
+            if (!Directory.Exists(absoluteFolder))
+                continue;
+
+            foreach (var file in Directory.GetFiles(absoluteFolder, "*.cs", SearchOption.AllDirectories))
+            {
+                CollectViolations(file, repoRoot, siblingNamespaces, violations);
+            }
+        }
+
+        violations.ShouldBeEmpty(
+            $"\nFeature '{featureName}' has cross-feature reach-ins into sibling feature namespaces.\n\n" +
+            string.Join("\n", violations.Select(v => $"  ✗ {v}")) +
+            "\n\nEach feature should only reference its own namespace or the shared kernel.\n" +
+            "See CLAUDE.md §1.1 for the vertical-slice convention and shared-kernel allow-list.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static void CollectViolations(
+        string filePath,
+        string repoRoot,
+        string[] siblingNamespaces,
+        List<string> violations)
+    {
+        var lines = File.ReadAllLines(filePath);
+        var relativePath = Path.GetRelativePath(repoRoot, filePath);
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (!trimmed.StartsWith("using "))
+                continue;
+
+            var afterUsing = trimmed[6..].TrimEnd(';', ' ');
+
+            // Skip alias imports (e.g., "using Alias = Some.Namespace") — the target
+            // is visible in the type reference, not the using statement.
+            if (afterUsing.Contains(" = "))
+                continue;
+
+            // Skip global using and static using modifiers
+            if (afterUsing.StartsWith("global ") || afterUsing.StartsWith("static "))
+                continue;
+
+            if (siblingNamespaces.Any(ns => afterUsing.StartsWith(ns)))
+            {
+                violations.Add($"{relativePath}: `using {afterUsing}`");
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var gitPath = Path.Combine(dir.FullName, ".git");
+            // In a normal clone .git is a directory; in a git worktree it is a file.
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root (.git directory or file).");
+    }
+}


### PR DESCRIPTION
## Summary

- Documents the vertical-slice convention in `CLAUDE.md §1.1` with folder pattern, cross-feature dependency rules, and shared-kernel allow-list
- Adds `VerticalSliceConventionTests` — a `[Theory]` over `Analysis` and `Export` that fails CI when a feature reaches into a sibling feature's internal namespace
- Slims `App.axaml.cs` (~297 → 51 lines) by extracting DI registrations into seven feature extension methods in `CAP.Avalonia/DI/`
- Updates `ExportViewModelLifetimeTests` to scan both `App.axaml.cs` and the new `DI/` folder
- Fixes repo-root detection in architecture tests to work in git worktrees (`.git` file vs. directory)
- Adds `.github/pull_request_template.md` with a vertical-slice compliance checklist

## Related issue

Closes #530

## Test plan

- [x] Build passes — no errors, no warnings
- [x] Architecture tests: 21/21 pass (includes 2 new `VerticalSliceConventionTests` + 3 `ExportViewModelLifetimeTests`)
- [x] No new file exceeds 250 lines

## Architecture checklist

- [x] Follows vertical-slice convention: `CAP.Avalonia/DI/` groups registrations per feature
- [x] No cross-feature reach-in: architecture tests enforce this on Analysis and Export
- [x] New DI registrations go into feature extension methods, not directly in `App.axaml.cs`
- [x] No new file exceeds 250 lines

## Notes for reviewer

`App.axaml.cs` is a pure organisational refactor — behaviour is identical to before. The `FindPreviewScript` and `ResolvePythonExecutable` helpers moved from `App` into `PdkOffsetFeatureExtensions` (same assembly, same access level). The worktree `.git`-detection fix in `FileSizeLimitTests` is a pre-existing bug that was silently broken in agent worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)