### PR TITLE
fix(calibration): apply Y-flip convention when copying Nazca pin angles

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkOffsetCalibration.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkOffsetCalibration.cs
@@ -107,8 +107,14 @@ public static class PdkOffsetCalibration
                     var dx = availableNazca[j].X - projections[i].x;
                     var dy = availableNazca[j].Y - projections[i].y;
                     var d  = Math.Sqrt(dx * dx + dy * dy);
+                    // Convert the Lunima (Y-down) angle into Nazca (Y-up) convention so
+                    // the comparison stays inside one coordinate system. Without the
+                    // flip a correctly-set Lunima angle of 90° would look 180° apart
+                    // from its true Nazca match at 270°, and the matcher would
+                    // cross-pair vertical pins on symmetric components.
                     var penalty = AngleDisagreementMicrometers(
-                        projections[i].lp.AngleDegrees, availableNazca[j].Angle, diag);
+                        FlipAngleConvention(projections[i].lp.AngleDegrees),
+                        availableNazca[j].Angle, diag);
                     var cost = d + penalty;
                     if (cost < best.cost) best = (i, j, cost);
                 }
@@ -126,13 +132,29 @@ public static class PdkOffsetCalibration
     /// Scaling against the bbox diagonal keeps the penalty large enough to
     /// dominate position ties on symmetric components but small enough that
     /// it doesn't override a real positional match on asymmetric ones.
+    /// Both inputs must be in the same convention (typically Nazca, since
+    /// callers convert Lunima angles via <see cref="FlipAngleConvention"/>
+    /// before passing them in).
     /// </summary>
     internal static double AngleDisagreementMicrometers(
-        double lunimaAngleDegrees, double nazcaAngleDegrees, double bboxDiagonal)
+        double angleDegreesA, double angleDegreesB, double bboxDiagonal)
     {
-        var delta = Math.Abs(NormalizeAngle(lunimaAngleDegrees - nazcaAngleDegrees));
+        var delta = Math.Abs(NormalizeAngle(angleDegreesA - angleDegreesB));
         if (delta > 180) delta = 360 - delta;  // wrap to [0, 180]
         return (delta / 180.0) * bboxDiagonal;
+    }
+
+    /// <summary>
+    /// Maps a pin angle between the Nazca (Y-up, mathematical) and Lunima
+    /// (Y-down, screen) conventions. The mapping is its own inverse:
+    /// <c>lunima = (360 − nazca) mod 360</c>. Angles 0° and 180° are invariant
+    /// under the flip; 90° and 270° swap. Used both when writing a Nazca pin
+    /// angle into a Lunima draft and when comparing Lunima angles against
+    /// Nazca ground truth.
+    /// </summary>
+    internal static double FlipAngleConvention(double angleDegrees)
+    {
+        return NormalizeAngle(360 - angleDegrees);
     }
 
     private static double NormalizeAngle(double a)
@@ -165,11 +187,13 @@ public static class PdkOffsetCalibration
         {
             lp.OffsetXMicrometers = np.X - result.XMin;
             lp.OffsetYMicrometers = result.YMax - np.Y;
-            // Adopt the Nazca pin's angle as well — leaving it on a stale
-            // hand-written value let us ship pin records where the angle
-            // implied a different edge than the position. With angle-aware
-            // matching the Nazca pin we picked is the right one to copy.
-            lp.AngleDegrees = np.Angle;
+            // Nazca pin angles live in Y-up math convention; Lunima renders in
+            // Avalonia's Y-down screen space. The Y-flip swaps 90° and 270° while
+            // leaving 0°/180° invariant — copying the raw Nazca angle into the
+            // draft produced vertical pin stubs that pointed into the component
+            // body instead of out of it (visible only after PR #539 made GDS
+            // polygons render on the canvas).
+            lp.AngleDegrees = FlipAngleConvention(np.Angle);
         }
         return AutoCalibrateOutcome.Success;
     }

--- a/CAP-DataAccess/PDKs/demo-pdk.json
+++ b/CAP-DataAccess/PDKs/demo-pdk.json
@@ -497,8 +497,8 @@
         {
           "name": "b0",
           "offsetXMicrometers": 200,
-          "offsetYMicrometers": 2.842170943040401E-14,
-          "angleDegrees": 90
+          "offsetYMicrometers": 0,
+          "angleDegrees": 270
         }
       ],
       "sMatrix": {

--- a/UnitTests/PdkOffset/NazcaComponentPreviewServiceTests.cs
+++ b/UnitTests/PdkOffset/NazcaComponentPreviewServiceTests.cs
@@ -855,12 +855,14 @@ public class NazcaComponentPreviewServiceTests
             NazcaOriginOffsetX = 4.85, NazcaOriginOffsetY = 4.85,
             Pins = new List<PhysicalPinDraft>
             {
-                // port 1 angle 180 (Left) but currently parked at the RIGHT edge
+                // port 1 angle 180 (Left in both conventions) but parked at the RIGHT edge
                 new() { Name = "port 1", OffsetXMicrometers = 9.65, OffsetYMicrometers = 4.85, AngleDegrees = 180 },
-                // port 2 angle 0 (Right) but currently parked at the LEFT edge
+                // port 2 angle 0 (Right in both conventions) but parked at the LEFT edge
                 new() { Name = "port 2", OffsetXMicrometers = 0.05, OffsetYMicrometers = 4.85, AngleDegrees = 0   },
-                new() { Name = "port 3", OffsetXMicrometers = 4.85, OffsetYMicrometers = 9.65, AngleDegrees = 270 },
-                new() { Name = "port 4", OffsetXMicrometers = 4.85, OffsetYMicrometers = 0.05, AngleDegrees = 90  },
+                // port 3 angle 90 in Lunima Y-down = stub points DOWN visually = away from box body at the BOTTOM edge
+                new() { Name = "port 3", OffsetXMicrometers = 4.85, OffsetYMicrometers = 9.65, AngleDegrees = 90  },
+                // port 4 angle 270 in Lunima Y-down = stub points UP visually = away from box body at the TOP edge
+                new() { Name = "port 4", OffsetXMicrometers = 4.85, OffsetYMicrometers = 0.05, AngleDegrees = 270 },
             }
         };
         var result = new NazcaPreviewResult
@@ -883,10 +885,16 @@ public class NazcaComponentPreviewServiceTests
         // matches its angle, not be silently permuted onto another pin.
         var p1 = draft.Pins.First(p => p.Name == "port 1");
         var p2 = draft.Pins.First(p => p.Name == "port 2");
-        p1.AngleDegrees.ShouldBe(180);
-        p1.OffsetXMicrometers.ShouldBe(0, tolerance: 0.01);    // left edge
-        p2.AngleDegrees.ShouldBe(0);
-        p2.OffsetXMicrometers.ShouldBe(9.7, tolerance: 0.01);  // right edge
+        var p3 = draft.Pins.First(p => p.Name == "port 3");
+        var p4 = draft.Pins.First(p => p.Name == "port 4");
+        p1.AngleDegrees.ShouldBe(180);                          // Nazca 180 → Lunima 180 (invariant)
+        p1.OffsetXMicrometers.ShouldBe(0, tolerance: 0.01);     // left edge
+        p2.AngleDegrees.ShouldBe(0);                            // Nazca 0   → Lunima 0   (invariant)
+        p2.OffsetXMicrometers.ShouldBe(9.7, tolerance: 0.01);   // right edge
+        p3.AngleDegrees.ShouldBe(90);                           // Nazca 270 → Lunima 90  (Y-flip)
+        p3.OffsetYMicrometers.ShouldBe(9.7, tolerance: 0.01);   // bottom edge in Y-down
+        p4.AngleDegrees.ShouldBe(270);                          // Nazca 90  → Lunima 270 (Y-flip)
+        p4.OffsetYMicrometers.ShouldBe(0, tolerance: 0.01);     // top edge in Y-down
     }
 
     [Fact]
@@ -895,6 +903,8 @@ public class NazcaComponentPreviewServiceTests
         // The Nazca pin angle is ground truth — leaving the Lunima
         // AngleDegrees on a stale value let us ship pin records where the
         // angle implied a different bbox edge than the position.
+        // 180° is invariant under the Y-flip convention so this case
+        // exercises the propagation path without the convention mapping.
         var draft = new PdkComponentDraft
         {
             Name = "rot", NazcaFunction = "x", WidthMicrometers = 10, HeightMicrometers = 10,
@@ -911,6 +921,55 @@ public class NazcaComponentPreviewServiceTests
 
         PdkOffsetCalibration.ApplyAutoCalibrate(draft, result);
         draft.Pins[0].AngleDegrees.ShouldBe(180);
+    }
+
+    [Theory]
+    [InlineData(0,   0)]    // invariant
+    [InlineData(180, 180)]  // invariant
+    [InlineData(90,  270)]  // Y-flip: Nazca up → Lunima up (in Y-down screen, 270 = stub up)
+    [InlineData(270, 90)]   // Y-flip: Nazca down → Lunima down (in Y-down screen, 90 = stub down)
+    [InlineData(360, 0)]    // wrap
+    [InlineData(45,  315)]  // diagonals also flip
+    public void AutoCalibrate_AppliesYFlipConventionToWrittenAngle(double nazcaAngle, double expectedLunima)
+    {
+        // Without the Y-flip, a Nazca pin angle of 90° landed in Lunima JSON as 90°
+        // and rendered as a downward stub on Avalonia's Y-down canvas — pointing
+        // into the component body instead of up out of it. The reverse for 270°.
+        // PR #539's GDS overlay made this visible; this test pins the conversion
+        // so future calibrations can't silently regress.
+        var draft = new PdkComponentDraft
+        {
+            Name = "vp", NazcaFunction = "x", WidthMicrometers = 10, HeightMicrometers = 10,
+            Pins = new List<PhysicalPinDraft>
+            {
+                new() { Name = "p", OffsetXMicrometers = 5, OffsetYMicrometers = 5, AngleDegrees = 0 }
+            }
+        };
+        var result = new NazcaPreviewResult
+        {
+            Success = true, XMin = 0, YMin = 0, XMax = 10, YMax = 10,
+            Pins = new List<NazcaPreviewPin> { new() { X = 5, Y = 5, Angle = nazcaAngle } }
+        };
+
+        PdkOffsetCalibration.ApplyAutoCalibrate(draft, result);
+        draft.Pins[0].AngleDegrees.ShouldBe(expectedLunima);
+    }
+
+    [Theory]
+    [InlineData(0,    0)]
+    [InlineData(90,   270)]
+    [InlineData(180,  180)]
+    [InlineData(270,  90)]
+    [InlineData(360,  0)]
+    [InlineData(-90,  90)]   // negative input
+    [InlineData(450,  270)]  // > 360 input
+    public void FlipAngleConvention_IsSelfInverseAndNormalisesInput(double input, double expected)
+    {
+        var flipped = PdkOffsetCalibration.FlipAngleConvention(input);
+        flipped.ShouldBe(expected, tolerance: 1e-9);
+        // Selbstinvers: applying twice returns the normalised input
+        var roundTrip = PdkOffsetCalibration.FlipAngleConvention(flipped);
+        roundTrip.ShouldBe(((input % 360) + 360) % 360, tolerance: 1e-9);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`PdkOffsetCalibration` was copying Nazca pin angles straight into Lunima drafts. Nazca uses Y-up math convention; Lunima renders on Avalonia's Y-down canvas — so 90° and 270° need to swap (0° and 180° are invariant under the flip). Result: vertical pin stubs pointed **into** the component body instead of out of it.

The bug only became visible after PR #539 made GDS polygons render on the canvas — before that the legacy rectangle hid the inverted stub direction.

## Root cause

`PdkOffsetCalibration.ApplyAutoCalibrate` Z. 172:
```csharp
lp.AngleDegrees = np.Angle;  // raw Nazca value, no Y-flip
```

`MatchPinsByGreedyNearest` Z. 110-111 compared Lunima angles (in Y-down convention) directly against Nazca angles (Y-up convention) — same blind spot.

## Fix

- New self-inverse `FlipAngleConvention` helper on `PdkOffsetCalibration` — `(360 − a) mod 360`.
- `ApplyAutoCalibrate` writes `FlipAngleConvention(np.Angle)` into the draft.
- `MatchPinsByGreedyNearest` converts the Lunima angle to Nazca convention before the disagreement penalty so the comparison stays in one coordinate system. Without this, a correctly-set Lunima 90° pin would look 180° apart from its true Nazca match at 270° and cross-pair on symmetric components (crossings, 2x2 MMIs).
- demo-pdk.json 90° Bend b0: angle 90 → 270 and offsetY float-noise → 0 so the shipped Demo PDK matches the new Lunima convention out of the box.

## Test plan

- [x] Build: 0 errors, 0 warnings
- [x] Full suite: 2128 passed, 0 failed, 14 skipped
- [x] Updated `AutoCalibrate_AngleAware_DoesNotCrossPairSymmetricCrossingPorts`: port 3/4 initial angles set to physically consistent values; asserts expanded to verify all four ports' final angles and positions
- [x] New `AutoCalibrate_AppliesYFlipConventionToWrittenAngle` (Theory) pins the Nazca→Lunima mapping at 0°/90°/180°/270°/360°/45°
- [x] New `FlipAngleConvention_IsSelfInverseAndNormalisesInput` (Theory) covers negative and >360 inputs

## Follow-up

`siepic-ebeam-pdk.json` ebeam_crossing4 components still carry bug-state vertical angles (port 3=270, port 4=90). Auto-Calibrate will now correct them when the user runs it — left as a user-triggered action rather than a blind data sweep in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)