### PR TITLE
Agent: Hierarchy ↔ Canvas selection state not synchronised

### DIFF
--- a/CAP.Avalonia/Controls/DesignCanvas.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.cs
@@ -313,8 +313,11 @@ public class DesignCanvas : Control
         if (e.PropertyName is nameof(DesignCanvasViewModel.ShowPowerFlow)
             or nameof(DesignCanvasViewModel.IsRouting)
             or nameof(DesignCanvasViewModel.PanX)
-            or nameof(DesignCanvasViewModel.PanY))
+            or nameof(DesignCanvasViewModel.PanY)
+            or nameof(DesignCanvasViewModel.SelectedComponent))
         {
+            // SelectedComponent: redraw so the highlight follows a selection made
+            // outside the canvas (e.g. clicking a node in the hierarchy panel).
             InvalidateVisual();
         }
     }

--- a/CAP.Avalonia/ViewModels/Hierarchy/HierarchyNodeViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Hierarchy/HierarchyNodeViewModel.cs
@@ -228,6 +228,18 @@ public partial class HierarchyNodeViewModel : ObservableObject
     }
 
     /// <summary>
+    /// When the node becomes selected — whether by clicking its row (native tree
+    /// selection, bound two-way) or by code — request the matching canvas selection.
+    /// The handler is idempotent (it no-ops when the canvas already matches), so this
+    /// does not loop with the canvas → hierarchy sync.
+    /// </summary>
+    partial void OnIsSelectedChanged(bool value)
+    {
+        if (value)
+            SelectionRequested?.Invoke(this);
+    }
+
+    /// <summary>
     /// Recursively finds a node by its component reference.
     /// </summary>
     public HierarchyNodeViewModel? FindNodeByComponent(Component component)

--- a/CAP.Avalonia/ViewModels/Hierarchy/HierarchyPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Hierarchy/HierarchyPanelViewModel.cs
@@ -309,6 +309,10 @@ public partial class HierarchyPanelViewModel : ObservableObject
     private void SelectComponent(HierarchyNodeViewModel node)
     {
         if (node.ComponentViewModel == null) return;
+        // Already the canvas selection — nothing to push. This value-equality guard is
+        // what stops the node.IsSelected → SelectionRequested → canvas → node.IsSelected
+        // cycle from recursing.
+        if (_canvas.SelectedComponent == node.ComponentViewModel) return;
 
         _suppressSync = true;
         try

--- a/CAP.Avalonia/ViewModels/Hierarchy/HierarchyPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Hierarchy/HierarchyPanelViewModel.cs
@@ -52,12 +52,30 @@ public partial class HierarchyPanelViewModel : ObservableObject
     /// </summary>
     public Func<string, bool>? CheckHasSMatrixOverride { get; set; }
 
+    /// <summary>
+    /// Guards against re-entrant selection sync when hierarchy triggers a canvas update.
+    /// </summary>
+    private bool _suppressSync;
+
     public HierarchyPanelViewModel(DesignCanvasViewModel canvas)
     {
         _canvas = canvas ?? throw new ArgumentNullException(nameof(canvas));
 
         // Subscribe to canvas changes
         _canvas.Components.CollectionChanged += (s, e) => RebuildTree();
+
+        // Canvas → Hierarchy: mirror SelectedComponent changes into the hierarchy tree.
+        _canvas.PropertyChanged += OnCanvasPropertyChanged;
+    }
+
+    /// <summary>
+    /// Responds to <see cref="DesignCanvasViewModel.SelectedComponent"/> changes
+    /// so that clicking a component on the canvas automatically highlights its node.
+    /// </summary>
+    private void OnCanvasPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(DesignCanvasViewModel.SelectedComponent) && !_suppressSync)
+            SyncSelectionFromCanvas(_canvas.SelectedComponent);
     }
 
     /// <summary>
@@ -285,26 +303,35 @@ public partial class HierarchyPanelViewModel : ObservableObject
 
     /// <summary>
     /// Handles selection request from a hierarchy node (select on canvas).
+    /// Sets <see cref="_suppressSync"/> to avoid the canvas PropertyChanged listener
+    /// re-entering this path and causing an infinite loop.
     /// </summary>
     private void SelectComponent(HierarchyNodeViewModel node)
     {
         if (node.ComponentViewModel == null) return;
 
-        // Clear all canvas selections
-        _canvas.Selection.ClearSelection();
-        foreach (var comp in _canvas.Components)
+        _suppressSync = true;
+        try
         {
-            comp.IsSelected = false;
+            // Clear all canvas selections
+            _canvas.Selection.ClearSelection();
+            foreach (var comp in _canvas.Components)
+                comp.IsSelected = false;
+
+            // Select the component on canvas
+            node.ComponentViewModel.IsSelected = true;
+            _canvas.Selection.SelectedComponents.Add(node.ComponentViewModel);
+            _canvas.SelectedComponent = node.ComponentViewModel;
+
+            // Update hierarchy selection and expand parents so the node is visible
+            ClearAllSelections();
+            node.IsSelected = true;
+            ExpandParentsToNode(node);
         }
-
-        // Select the component
-        node.ComponentViewModel.IsSelected = true;
-        _canvas.Selection.SelectedComponents.Add(node.ComponentViewModel);
-        _canvas.SelectedComponent = node.ComponentViewModel;
-
-        // Update hierarchy selection
-        ClearAllSelections();
-        node.IsSelected = true;
+        finally
+        {
+            _suppressSync = false;
+        }
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -89,6 +89,23 @@ public partial class CanvasInteractionViewModel : ObservableObject
         _libraryViewModel = libraryViewModel;
         _previewGenerator = previewGenerator;
         _inputDialogService = inputDialogService;
+
+        // Hierarchy → right panel: when canvas.SelectedComponent changes externally
+        // (e.g. from the hierarchy panel), mirror it so the right-panel property editor updates.
+        _canvas.PropertyChanged += OnCanvasPropertyChanged;
+    }
+
+    /// <summary>
+    /// Keeps <see cref="SelectedComponent"/> in sync when
+    /// <see cref="DesignCanvasViewModel.SelectedComponent"/> is changed externally
+    /// (e.g. by the hierarchy panel).
+    /// CommunityToolkit's equality check prevents the setter from firing again when
+    /// the value is already up-to-date, so there is no feedback loop.
+    /// </summary>
+    private void OnCanvasPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(DesignCanvasViewModel.SelectedComponent))
+            SelectedComponent = _canvas.SelectedComponent;
     }
 
     partial void OnSelectedTemplateChanged(ComponentTemplate? value)
@@ -151,6 +168,10 @@ public partial class CanvasInteractionViewModel : ObservableObject
 
     partial void OnSelectedComponentChanged(ComponentViewModel? value)
     {
+        // Keep canvas in sync when this property is set from outside (e.g. tests or mirroring).
+        if (_canvas.SelectedComponent != value)
+            _canvas.SelectedComponent = value;
+
         if (value?.IsLightSource == true)
         {
             var cfg = value.LaserConfig!;

--- a/CAP.Avalonia/Views/HierarchyPanel.axaml
+++ b/CAP.Avalonia/Views/HierarchyPanel.axaml
@@ -30,6 +30,10 @@
                     <Style Selector="TreeViewItem">
                         <Setter Property="Padding" Value="2"/>
                         <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                        <!-- Unify the native tree selection with the node's IsSelected so a
+                             single click anywhere on the row selects, and canvas-driven
+                             selection highlights the matching node. -->
+                        <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
                     </Style>
 
                     <!-- Selected item highlight -->

--- a/UnitTests/ViewModels/SelectionSyncTests.cs
+++ b/UnitTests/ViewModels/SelectionSyncTests.cs
@@ -1,0 +1,169 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Hierarchy;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>
+/// Tests for bidirectional selection synchronisation between the
+/// hierarchy panel and the design canvas.
+/// </summary>
+public class SelectionSyncTests
+{
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private static (DesignCanvasViewModel canvas, HierarchyPanelViewModel hierarchy) CreateSetup()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var hierarchy = new HierarchyPanelViewModel(canvas);
+        return (canvas, hierarchy);
+    }
+
+    // ── 1. Hierarchy → Canvas ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Clicking a node in the hierarchy must update <see cref="DesignCanvasViewModel.SelectedComponent"/>.
+    /// </summary>
+    [Fact]
+    public void Hierarchy_SelectNode_UpdatesCanvasSelection()
+    {
+        var (canvas, hierarchy) = CreateSetup();
+
+        var comp1 = TestComponentFactory.CreateStraightWaveGuide();
+        var comp2 = TestComponentFactory.CreateStraightWaveGuide();
+        var vm1 = canvas.AddComponent(comp1, "Waveguide1");
+        var vm2 = canvas.AddComponent(comp2, "Waveguide2");
+        hierarchy.RebuildTree();
+
+        // Act – click the second node in the hierarchy
+        hierarchy.RootNodes[1].SelectCommand.Execute(null);
+
+        // Assert – canvas selection must reflect the hierarchy choice
+        canvas.SelectedComponent.ShouldBe(vm2);
+        vm2.IsSelected.ShouldBeTrue();
+        canvas.Selection.SelectedComponents.ShouldContain(vm2);
+        vm1.IsSelected.ShouldBeFalse();
+    }
+
+    // ── 2. Canvas → Hierarchy ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Setting <see cref="DesignCanvasViewModel.SelectedComponent"/> (as the canvas does on click)
+    /// must highlight the matching node in the hierarchy tree.
+    /// </summary>
+    [Fact]
+    public void Canvas_SelectComponent_HighlightsHierarchyNode()
+    {
+        var (canvas, hierarchy) = CreateSetup();
+
+        var comp1 = TestComponentFactory.CreateStraightWaveGuide();
+        var comp2 = TestComponentFactory.CreateStraightWaveGuide();
+        var vm1 = canvas.AddComponent(comp1, "Waveguide1");
+        var vm2 = canvas.AddComponent(comp2, "Waveguide2");
+        hierarchy.RebuildTree();
+
+        // Act – simulate canvas click selecting the second component
+        canvas.SelectedComponent = vm2;
+
+        // Assert – second node should be highlighted, first deselected
+        hierarchy.RootNodes[0].IsSelected.ShouldBeFalse();
+        hierarchy.RootNodes[1].IsSelected.ShouldBeTrue();
+    }
+
+    // ── 3. Loop prevention ────────────────────────────────────────────────
+
+    /// <summary>
+    /// A bidirectional sync must not cause an infinite loop or stack-overflow
+    /// when selection toggles back and forth.
+    /// </summary>
+    [Fact]
+    public void BidirectionalChange_DoesNotLoop()
+    {
+        var (canvas, hierarchy) = CreateSetup();
+
+        var comp1 = TestComponentFactory.CreateStraightWaveGuide();
+        var comp2 = TestComponentFactory.CreateStraightWaveGuide();
+        var vm1 = canvas.AddComponent(comp1, "Waveguide1");
+        var vm2 = canvas.AddComponent(comp2, "Waveguide2");
+        hierarchy.RebuildTree();
+
+        // Act – alternate between hierarchy and canvas selection several times.
+        // If there is an infinite loop this will throw StackOverflowException.
+        hierarchy.RootNodes[0].SelectCommand.Execute(null);
+        canvas.SelectedComponent = vm2;
+        hierarchy.RootNodes[1].SelectCommand.Execute(null);
+        canvas.SelectedComponent = vm1;
+
+        // Assert – final state is consistent
+        canvas.SelectedComponent.ShouldBe(vm1);
+        hierarchy.RootNodes[0].IsSelected.ShouldBeTrue();
+        hierarchy.RootNodes[1].IsSelected.ShouldBeFalse();
+    }
+
+    // ── 4. Group child Canvas → Hierarchy ─────────────────────────────────
+
+    /// <summary>
+    /// Selecting a group component on the canvas must highlight its node in the
+    /// hierarchy even when the tree contains nested children.
+    /// </summary>
+    [Fact]
+    public void Canvas_SelectGroupChild_HierarchyNodeIsHighlighted()
+    {
+        var (canvas, hierarchy) = CreateSetup();
+
+        var child1 = TestComponentFactory.CreateStraightWaveGuide();
+        var child2 = TestComponentFactory.CreateStraightWaveGuide();
+
+        var group = new ComponentGroup("TestGroup");
+        group.AddChild(child1);
+        group.AddChild(child2);
+
+        var groupVm = canvas.AddComponent(group, "Group");
+        hierarchy.RebuildTree();
+
+        // Act – select the group on the canvas
+        canvas.SelectedComponent = groupVm;
+
+        // Assert – group node highlighted, children not highlighted
+        hierarchy.RootNodes[0].IsSelected.ShouldBeTrue();
+        hierarchy.RootNodes[0].Children[0].IsSelected.ShouldBeFalse();
+        hierarchy.RootNodes[0].Children[1].IsSelected.ShouldBeFalse();
+    }
+
+    // ── 5. Auto-expand collapsed parent ───────────────────────────────────
+
+    /// <summary>
+    /// When the canvas selects a component that lives inside a collapsed group,
+    /// the parent group node must be auto-expanded so the selected node is visible
+    /// in the hierarchy tree (Canvas → Hierarchy direction with nested component).
+    /// </summary>
+    [Fact]
+    public void Hierarchy_SelectInsideCollapsedGroup_AutoExpandsParents()
+    {
+        var (canvas, hierarchy) = CreateSetup();
+
+        var child = TestComponentFactory.CreateStraightWaveGuide();
+        var group = new ComponentGroup("TestGroup");
+        group.AddChild(child);
+
+        // Add both group and child to canvas so the child gets a ComponentViewModel.
+        // In RebuildTree the child is filtered from root nodes (ParentGroup != null)
+        // but appears as a child node of the group node, with its ComponentViewModel set.
+        var groupVm = canvas.AddComponent(group, "Group");
+        var childVm = canvas.AddComponent(child, "Child");
+        hierarchy.RebuildTree();
+
+        var groupNode = hierarchy.RootNodes[0];
+        groupNode.IsExpanded = false; // collapse the group
+
+        // Act – canvas selects the child component (e.g. in group-edit mode)
+        canvas.SelectedComponent = childVm;
+
+        // Assert – the parent group node must be expanded so the child is visible
+        groupNode.IsExpanded.ShouldBeTrue();
+        // The child node inside the group is highlighted
+        groupNode.Children[0].IsSelected.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Automated implementation for #549

Confirmed — the ViewModel test suite (614 tests) completed successfully. Implementation is complete.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 92,744
- **Estimated cost:** $0.0519 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*