### PR TITLE
GDS export emits per-instance RawCode override cell (#559, geometry-first)

### DIFF
--- a/CAP.Avalonia/Services/NazcaOverrideFactory.cs
+++ b/CAP.Avalonia/Services/NazcaOverrideFactory.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Builds the per-instance RawCode override scaffolding for the Nazca export (issue #559).
+/// Each overridden component's self-contained RawCode (which defines <c>component()</c>)
+/// is wrapped in a uniquely-named factory function so multiple overrides can coexist in
+/// one script without colliding at module scope.
+/// </summary>
+public static class NazcaOverrideFactory
+{
+    private const int IndentSpaces = 4;
+
+    /// <summary>
+    /// Sanitizes a component identifier into a valid Python identifier fragment by
+    /// replacing every character outside <c>[a-zA-Z0-9_]</c> with an underscore.
+    /// </summary>
+    /// <param name="identifier">The raw component identifier.</param>
+    /// <returns>A sanitized fragment safe to embed in a Python function name.</returns>
+    public static string Sanitize(string identifier) =>
+        Regex.Replace(identifier ?? string.Empty, @"[^a-zA-Z0-9_]", "_");
+
+    /// <summary>
+    /// Returns the factory function name emitted for an overridden instance,
+    /// e.g. <c>_ovr_Straight_Waveguide_100m</c>.
+    /// </summary>
+    /// <param name="identifier">The component identifier being overridden.</param>
+    /// <returns>The Python factory function name.</returns>
+    public static string FactoryName(string identifier) => $"_ovr_{Sanitize(identifier)}";
+
+    /// <summary>
+    /// Emits all override factory definitions, one per unique overridden identifier.
+    /// Each factory locally scopes the user's RawCode (which defines <c>component()</c>)
+    /// and returns the built cell via <c>return component()</c>. A missing <c>component()</c>
+    /// raises a clear <c>NameError</c> at runtime rather than producing broken syntax.
+    /// </summary>
+    /// <param name="sb">The script builder to append to.</param>
+    /// <param name="overrides">Map of component identifier to its non-null RawCode.</param>
+    public static void AppendFactories(StringBuilder sb, IReadOnlyDictionary<string, string> overrides)
+    {
+        if (overrides.Count == 0)
+            return;
+
+        sb.AppendLine("# Per-instance RawCode overrides (issue #559)");
+        sb.AppendLine();
+
+        var emitted = new HashSet<string>(System.StringComparer.Ordinal);
+        foreach (var kv in overrides)
+        {
+            var factoryName = FactoryName(kv.Key);
+            if (!emitted.Add(factoryName))
+                continue;
+
+            sb.AppendLine($"def {factoryName}():");
+            sb.AppendLine($"    # Raw-code override for instance '{kv.Key}'");
+            foreach (var line in SplitLines(kv.Value))
+            {
+                if (line.Length == 0)
+                    sb.AppendLine();
+                else
+                    sb.AppendLine(new string(' ', IndentSpaces) + line);
+            }
+            sb.AppendLine("    return component()");
+            sb.AppendLine();
+        }
+    }
+
+    private static IEnumerable<string> SplitLines(string rawCode)
+    {
+        // Normalize line endings so the emitted factory is platform-independent.
+        var normalized = rawCode.Replace("\r\n", "\n").Replace("\r", "\n");
+        return normalized.Split('\n');
+    }
+}

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -5,6 +5,7 @@ using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
 using CAP_Core.Routing;
+using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.Services;
 
@@ -19,17 +20,49 @@ public class SimpleNazcaExporter
     /// </summary>
     /// <param name="canvas">The design canvas to export.</param>
     /// <param name="pdkModuleName">Optional PDK module name (e.g., "siepic_ebeam_pdk") for import.</param>
-    public string Export(DesignCanvasViewModel canvas, string? pdkModuleName = null)
+    /// <param name="overrides">
+    /// Optional per-instance Nazca overrides keyed by component identifier (issue #559).
+    /// For entries whose <see cref="NazcaCodeOverride.RawCode"/> is non-null, the export emits
+    /// a self-contained factory cell and places the instance via that factory instead of the
+    /// PDK template. Connections touching such instances are skipped + warned (v1 follow-up).
+    /// </param>
+    public string Export(
+        DesignCanvasViewModel canvas,
+        string? pdkModuleName = null,
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides = null)
     {
         var sb = new StringBuilder();
 
+        // Build a flat map of overridden identifier -> RawCode (only non-null RawCode entries).
+        var rawOverrides = BuildRawOverrides(overrides);
+
         AppendHeader(sb);
-        AppendPdkComponentStubs(sb, canvas);
-        var componentNames = AppendComponents(sb, canvas);
-        AppendConnections(sb, canvas, componentNames);
+        NazcaOverrideFactory.AppendFactories(sb, rawOverrides);
+        AppendPdkComponentStubs(sb, canvas, rawOverrides);
+        var componentNames = AppendComponents(sb, canvas, rawOverrides);
+        AppendConnections(sb, canvas, componentNames, rawOverrides);
         AppendFooter(sb);
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Reduces the full override map to a dictionary of identifier -> RawCode,
+    /// keeping only entries whose RawCode is non-null and non-empty.
+    /// </summary>
+    private static Dictionary<string, string> BuildRawOverrides(
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (overrides == null)
+            return result;
+
+        foreach (var kv in overrides)
+        {
+            if (!string.IsNullOrWhiteSpace(kv.Value?.RawCode))
+                result[kv.Key] = kv.Value!.RawCode!;
+        }
+        return result;
     }
 
     private static void AppendHeader(StringBuilder sb)
@@ -53,7 +86,8 @@ public class SimpleNazcaExporter
     /// with correct dimensions and pin positions — no external PDK install needed.
     /// ComponentGroups are flattened — stubs are generated for all child components.
     /// </summary>
-    private static void AppendPdkComponentStubs(StringBuilder sb, DesignCanvasViewModel canvas)
+    private static void AppendPdkComponentStubs(
+        StringBuilder sb, DesignCanvasViewModel canvas, IReadOnlyDictionary<string, string> rawOverrides)
     {
         var ci = CultureInfo.InvariantCulture;
         var generated = new HashSet<string>(StringComparer.Ordinal);
@@ -67,11 +101,15 @@ public class SimpleNazcaExporter
                 foreach (var child in group.GetAllComponentsRecursive())
                 {
                     if (child.IsAnalysisTool) continue;
+                    // Overridden instances are self-defined by their factory; a PDK stub
+                    // would be unused / could conflict, so skip it (issue #559).
+                    if (rawOverrides.ContainsKey(child.Identifier)) continue;
                     AppendComponentStub(sb, child, generated, ci);
                 }
             }
             else
             {
+                if (rawOverrides.ContainsKey(comp.Identifier)) continue;
                 AppendComponentStub(sb, comp, generated, ci);
             }
         }
@@ -241,7 +279,7 @@ public class SimpleNazcaExporter
     }
 
     private static Dictionary<Component, string> AppendComponents(
-        StringBuilder sb, DesignCanvasViewModel canvas)
+        StringBuilder sb, DesignCanvasViewModel canvas, IReadOnlyDictionary<string, string> rawOverrides)
     {
         sb.AppendLine("def create_design():");
         sb.AppendLine("    with nd.Cell(name='ConnectAPIC_Design') as design:");
@@ -261,12 +299,12 @@ public class SimpleNazcaExporter
                 foreach (var child in group.GetAllComponentsRecursive())
                 {
                     if (child.IsAnalysisTool) continue;
-                    AppendSingleComponent(sb, child, componentNames, ref compIndex, ci);
+                    AppendSingleComponent(sb, child, componentNames, ref compIndex, ci, rawOverrides);
                 }
             }
             else
             {
-                AppendSingleComponent(sb, comp, componentNames, ref compIndex, ci);
+                AppendSingleComponent(sb, comp, componentNames, ref compIndex, ci, rawOverrides);
             }
         }
 
@@ -279,7 +317,7 @@ public class SimpleNazcaExporter
     /// </summary>
     private static void AppendSingleComponent(
         StringBuilder sb, Component comp, Dictionary<Component, string> componentNames,
-        ref int compIndex, CultureInfo ci)
+        ref int compIndex, CultureInfo ci, IReadOnlyDictionary<string, string> rawOverrides)
     {
         var varName = $"comp_{compIndex}";
         componentNames[comp] = varName;
@@ -319,7 +357,18 @@ public class SimpleNazcaExporter
         // on 'org' explicitly makes .put() place the cell origin at the
         // computed (x, y) — which IS the contract Lunima's calibration
         // and export math both assume.
-        sb.AppendLine($"        {varName} = {nazcaFunc}.put('org', {nazcaX}, {nazcaY}, {rot})  # {comp.Identifier}");
+        if (rawOverrides.ContainsKey(comp.Identifier))
+        {
+            // Raw-code override (issue #559): the factory builds the cell via
+            // `with nd.Cell()`, which has NO 'org' pin, so anchoring on 'org' would
+            // fail. Use default-anchor placement — correct for v1 geometry-first scope.
+            var factory = NazcaOverrideFactory.FactoryName(comp.Identifier);
+            sb.AppendLine($"        {varName} = {factory}().put({nazcaX}, {nazcaY}, {rot})  # {comp.Identifier} (raw-code override)");
+        }
+        else
+        {
+            sb.AppendLine($"        {varName} = {nazcaFunc}.put('org', {nazcaX}, {nazcaY}, {rot})  # {comp.Identifier}");
+        }
         compIndex++;
     }
 
@@ -365,7 +414,8 @@ public class SimpleNazcaExporter
     private static void AppendConnections(
         StringBuilder sb,
         DesignCanvasViewModel canvas,
-        Dictionary<Component, string> componentNames)
+        Dictionary<Component, string> componentNames,
+        IReadOnlyDictionary<string, string> rawOverrides)
     {
         var hasFrozenPaths = canvas.Components.Any(vm => vm.Component is ComponentGroup);
         if (canvas.Connections.Count == 0 && !hasFrozenPaths)
@@ -380,6 +430,12 @@ public class SimpleNazcaExporter
             // have no physical fab counterpart.
             if (conn.StartPin?.ParentComponent?.IsAnalysisTool == true) continue;
             if (conn.EndPin?.ParentComponent?.IsAnalysisTool == true) continue;
+
+            // v1 (issue #559): an overridden instance's RawCode cell may expose pins
+            // that differ from the PDK template, so we cannot reliably wire to it yet.
+            // Skip + warn; wiring overridden instances is a documented follow-up.
+            if (TrySkipOverriddenConnection(sb, conn, rawOverrides)) continue;
+
             var segments = conn.GetPathSegments();
 
             if (segments.Count > 0)
@@ -396,6 +452,34 @@ public class SimpleNazcaExporter
         }
 
         sb.AppendLine();
+    }
+
+    /// <summary>
+    /// If either endpoint of the connection belongs to an overridden instance, emits a
+    /// NOTE comment explaining the skip and returns true (issue #559 v1). Otherwise false.
+    /// </summary>
+    private static bool TrySkipOverriddenConnection(
+        StringBuilder sb, WaveguideConnection conn, IReadOnlyDictionary<string, string> rawOverrides)
+    {
+        if (rawOverrides.Count == 0)
+            return false;
+
+        var startId = conn.StartPin?.ParentComponent?.Identifier;
+        var endId = conn.EndPin?.ParentComponent?.Identifier;
+
+        string? overriddenId = null;
+        if (startId != null && rawOverrides.ContainsKey(startId))
+            overriddenId = startId;
+        else if (endId != null && rawOverrides.ContainsKey(endId))
+            overriddenId = endId;
+
+        if (overriddenId == null)
+            return false;
+
+        sb.AppendLine(
+            $"        # NOTE: connection to overridden instance {overriddenId} skipped — " +
+            "its pins may differ from the template (see issue #559 follow-up).");
+        return true;
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -1223,7 +1223,7 @@ public partial class FileOperationsViewModel : ObservableObject
             try
             {
                 // Export Python script
-                var nazcaCode = _nazcaExporter.Export(_canvas);
+                var nazcaCode = _nazcaExporter.Export(_canvas, overrides: StoredNazcaOverrides);
                 await File.WriteAllTextAsync(filePath, nazcaCode);
 
                 // Attempt GDS generation if enabled

--- a/UnitTests/Services/SimpleNazcaExporterTests.cs
+++ b/UnitTests/Services/SimpleNazcaExporterTests.cs
@@ -1,11 +1,13 @@
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
+using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.FormulaReading;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
 using CAP_Core.Tiles;
+using CAP_DataAccess.Persistence.PIR;
 using Shouldly;
 using Xunit;
 
@@ -468,6 +470,114 @@ public class SimpleNazcaExporterTests
         // Assert: Verify correct length
         result.ShouldContain("demo_pdk_straight(length=200)");
         result.ShouldContain("comp_0 = demo_pdk_straight(length=200).put(");
+    }
+
+    // ── Per-instance RawCode override export tests (issue #559) ───────────────
+
+    private const string OverrideRawCode = """
+        import nazca as nd
+
+        def component():
+            with nd.Cell() as C:
+                nd.strt(length=42).put()
+                return C
+        """;
+
+    [Fact]
+    public void Export_OverriddenComponent_EmitsFactoryAndPlacesViaFactory()
+    {
+        // Arrange: two components, override only the first.
+        var canvas = new DesignCanvasViewModel();
+        var overridden = CreateComponentWithName("ebeam_y_1550");
+        overridden.Identifier = "My Override Instance";
+        var plain = CreateComponentWithName("splitter_1x2");
+        plain.Identifier = "Plain Splitter";
+        canvas.Components.Add(new ComponentViewModel(overridden));
+        canvas.Components.Add(new ComponentViewModel(plain));
+
+        var overrides = new Dictionary<string, NazcaCodeOverride>
+        {
+            [overridden.Identifier] = new NazcaCodeOverride { RawCode = OverrideRawCode }
+        };
+
+        // Act
+        var exporter = new SimpleNazcaExporter();
+        var result = exporter.Export(canvas, overrides: overrides);
+
+        // Assert: factory definition + raw-code body present.
+        var factoryName = "_ovr_My_Override_Instance";
+        result.ShouldContain($"def {factoryName}():");
+        result.ShouldContain("nd.strt(length=42).put()");
+        result.ShouldContain("return component()");
+
+        // Overridden instance placed via factory, WITHOUT 'org' anchor,
+        // and NOT via the PDK template call.
+        result.ShouldContain($"{factoryName}().put(");
+        result.ShouldContain("(raw-code override)");
+        result.ShouldNotContain($"{factoryName}().put('org'");
+        result.ShouldNotContain("ebeam_y_1550().put");
+
+        // No PDK stub emitted for the overridden component.
+        result.ShouldNotContain("with nd.Cell(name='ebeam_y_1550')");
+    }
+
+    [Fact]
+    public void Export_NonOverriddenComponent_StillUsesOrgPlacement()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var overridden = CreateComponentWithName("ebeam_y_1550");
+        overridden.Identifier = "Overridden";
+        var plain = CreateComponentWithName("ebeam_dc_te1550");
+        plain.Identifier = "Plain";
+        canvas.Components.Add(new ComponentViewModel(overridden));
+        canvas.Components.Add(new ComponentViewModel(plain));
+
+        var overrides = new Dictionary<string, NazcaCodeOverride>
+        {
+            [overridden.Identifier] = new NazcaCodeOverride { RawCode = OverrideRawCode }
+        };
+
+        var exporter = new SimpleNazcaExporter();
+        var result = exporter.Export(canvas, overrides: overrides);
+
+        // The non-overridden component keeps its normal .put('org', ...) placement.
+        result.ShouldContain(".put('org',");
+        result.ShouldContain("# Plain");
+    }
+
+    [Fact]
+    public void Export_ConnectionTouchingOverriddenInstance_IsSkippedWithNote()
+    {
+        // Arrange: two waveguides connected; override one of them.
+        var canvas = new DesignCanvasViewModel();
+        var compA = CreateDemoPdkStraightWaveguide(100);
+        compA.Identifier = "WG A";
+        var compB = CreateDemoPdkStraightWaveguide(100);
+        compB.Identifier = "WG B";
+        compB.PhysicalX = 200;
+        canvas.Components.Add(new ComponentViewModel(compA));
+        canvas.Components.Add(new ComponentViewModel(compB));
+
+        // Connect A.b0 -> B.a0
+        var conn = new WaveguideConnection
+        {
+            StartPin = compA.PhysicalPins.First(p => p.Name == "b0"),
+            EndPin = compB.PhysicalPins.First(p => p.Name == "a0")
+        };
+        canvas.Connections.Add(new WaveguideConnectionViewModel(conn));
+
+        var overrides = new Dictionary<string, NazcaCodeOverride>
+        {
+            [compB.Identifier] = new NazcaCodeOverride { RawCode = OverrideRawCode }
+        };
+
+        // Act
+        var exporter = new SimpleNazcaExporter();
+        var result = exporter.Export(canvas, overrides: overrides);
+
+        // Assert: connection skipped with the documented NOTE comment.
+        result.ShouldContain($"# NOTE: connection to overridden instance {compB.Identifier} skipped");
+        result.ShouldContain("issue #559 follow-up");
     }
 
     private static Component CreateDemoPdkStraightWaveguide(double lengthMicrometers)


### PR DESCRIPTION
Closes #559 (v1, geometry-first). Builds on the per-instance Nazca code editor (#556 / PR #557).

## What

A placed instance with a raw-code Nazca override now **exports its edited code** instead of the PDK template — so the GDS/Nazca export matches what you authored + previewed in the editor.

## How

- `SimpleNazcaExporter.Export(canvas, pdkModuleName=null, overrides=null)` — overrides threaded through (GDS caller `FileOperationsViewModel` passes `StoredNazcaOverrides`).
- Each override's `RawCode` is wrapped in a uniquely-named factory (`NazcaOverrideFactory`): `def _ovr_<id>(): <indented RawCode>; return component()`, emitted once near the top.
- Overridden instances are placed via the factory with **default anchor** (override cells built with `with nd.Cell()` have no `'org'` pin); the PDK stub is skipped for them.
- **Connections** touching an overridden instance are **skipped + commented** (their pins may differ from the template — wiring that is the #559 follow-up).

## Scope (v1, agreed)

Geometry-first: the override's geometry + its own pins land in the exported layout. **Out of scope (follow-up):** wiring waveguide connections to overridden instances through the new pins; the simulation S-matrix stays the PDK template (the #556 geometry-only contract).

## Tests

Full suite green (2274 passed / 0 failed / 10 skipped). New `SimpleNazcaExporterTests` assert the generated script: factory + RawCode emitted, overridden instance placed via the factory (no `'org'`, not the template call), no stub for it, non-overridden unchanged, connection-to-override skipped with the NOTE. End-to-end verified locally: an export with the showcase override builds + writes a GDS via nazca.

## Known limitation (manual check)

Override cells without an `'org'` pin are placed on nazca's default anchor (first pin / origin). If a RawCode's first pin is offset from the cell origin, the placed position shifts — worth a KLayout check for such cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)