### PR TITLE
(*) NazcaCoordinateMapper: Single Source of Truth + selbstverifizierender GDS-Export (#565)

### DIFF
--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -567,17 +567,15 @@ public class SimpleNazcaExporter
             double nazcaY;
             if (startPin != null)
             {
-                // FIXED (#329, #338): Use correct Nazca pin position accounting for
-                // NazcaOriginOffset and component rotation transformation.
-                var (pinNazcaX, pinNazcaY) = startPin.GetAbsoluteNazcaPosition();
-                nazcaX = pinNazcaX;
-                nazcaY = pinNazcaY;
+                // Anchor the chain on the pin's world position so the waveguide
+                // starts exactly where the component's stub pin sits.
+                (nazcaX, nazcaY) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
             }
             else
             {
-                // Fallback: naive coordinate flip (legacy behavior without pin info)
-                nazcaX = straight.StartPoint.X;
-                nazcaY = -straight.StartPoint.Y;
+                // Without pin info the segment's own start point is the best anchor.
+                (nazcaX, nazcaY) = NazcaCoordinateMapper.ToNazca(
+                    straight.StartPoint.X, straight.StartPoint.Y);
             }
 
             var x = NormalizeZero(nazcaX).ToString("F2", ci);
@@ -614,16 +612,14 @@ public class SimpleNazcaExporter
             double nazcaY;
             if (startPin != null)
             {
-                // FIXED (#329, #338): Use correct Nazca pin position accounting for
-                // NazcaOriginOffset and component rotation transformation.
-                var (pinNazcaX, pinNazcaY) = startPin.GetAbsoluteNazcaPosition();
-                nazcaX = pinNazcaX;
-                nazcaY = pinNazcaY;
+                // Anchor the chain on the pin's world position so the waveguide
+                // starts exactly where the component's stub pin sits.
+                (nazcaX, nazcaY) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
             }
             else
             {
-                nazcaX = bend.StartPoint.X;
-                nazcaY = -bend.StartPoint.Y;
+                (nazcaX, nazcaY) = NazcaCoordinateMapper.ToNazca(
+                    bend.StartPoint.X, bend.StartPoint.Y);
             }
 
             var x = NormalizeZero(nazcaX).ToString("F2", ci);

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -154,13 +154,27 @@ public class SimpleNazcaExporter
     /// <summary>
     /// Generates a parametric straight waveguide stub that uses nd.strt() with length parameter.
     /// The cell-internal layout follows the <see cref="NazcaCoordinateMapper"/> contract:
-    /// org sits oy above the cell bottom, so the waveguide centre line is at oy - H/2
-    /// and pins render at the plain Y negation of their app offsets (oy - OffsetY).
+    /// the cell is org-anchored on the offset (ox, oy) the mapper places it by — for a
+    /// parametric straight that is the FIRST pin's offset, NOT NazcaOriginOffsetY. The
+    /// straight's centre line coincides with its pins (same OffsetY on a straight), so it
+    /// sits at oy - firstPin.OffsetY, and every pin renders at the plain Y negation of its
+    /// app offset relative to org (oy - OffsetY). Using the mapper's own anchor keeps the
+    /// rendered pins coincident with <see cref="NazcaCoordinateMapper.GetPinNazcaPosition"/>;
+    /// the old NazcaOriginOffsetY-based anchor differed from the placement and shifted the
+    /// rendered geometry off the pins (issue #565).
     /// </summary>
     private static void AppendParametricStraightStub(
         StringBuilder sb, string funcName, Component comp, CultureInfo ci)
     {
-        var strtY = NormalizeZero(comp.NazcaOriginOffsetY - comp.HeightMicrometers / 2).ToString("F2", ci);
+        // The cell is rotation-independent (placement applies .put(rot)); use the
+        // UNROTATED first-pin offset as the org anchor (oy), mirroring the mapper. The
+        // straight's centre line coincides with its pins, so it sits at oy - firstPin.oy.
+        var (_, anchorY) = NazcaCoordinateMapper.GetStubAnchor(comp);
+        var firstPin = comp.PhysicalPins.FirstOrDefault();
+        var firstPinY = firstPin != null
+            ? NazcaCoordinateMapper.GetUnrotatedPinOffset(comp, firstPin).OffsetY
+            : 0;
+        var strtY = NazcaCoordinateMapper.NormalizeZero(anchorY - firstPinY).ToString("F2", ci);
 
         // Sanitize function name for valid Python identifier (replace non-alphanumeric/underscore chars)
         var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_]", "_");
@@ -171,21 +185,19 @@ public class SimpleNazcaExporter
         sb.AppendLine($"        # Use nd.strt() for proper waveguide with specified length");
         sb.AppendLine($"        nd.strt(length=length, width=0.45, layer=1).put(0, {strtY})");
 
-        // Generate pins with Nazca coordinates
+        // Generate pins from the UNROTATED offsets, relative to org (the mapper anchor);
+        // a straight's pins share the centre line, so their local Y is oy - OffsetY = 0.
         foreach (var pin in comp.PhysicalPins)
         {
-            var py = NormalizeZero(comp.NazcaOriginOffsetY - pin.OffsetYMicrometers).ToString("F2", ci);
-            var pa = NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
+            var (uox, uoy) = NazcaCoordinateMapper.GetUnrotatedPinOffset(comp, pin);
+            var py = NazcaCoordinateMapper.NormalizeZero(anchorY - uoy).ToString("F2", ci);
+            var pa = NazcaCoordinateMapper.NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
 
-            // For straight waveguides: input pin at x=0, output pin at x=length
-            if (pin.OffsetXMicrometers == 0)
-            {
+            // For straight waveguides: input pin at x=0, output pin at x=length.
+            if (uox == 0)
                 sb.AppendLine($"        nd.Pin('{pin.Name}').put(0, {py}, {pa})");
-            }
             else
-            {
                 sb.AppendLine($"        nd.Pin('{pin.Name}').put(length, {py}, {pa})");
-            }
         }
 
         sb.AppendLine($"    return cell");
@@ -220,10 +232,10 @@ public class SimpleNazcaExporter
         double offsetX = comp.NazcaOriginOffsetX;
         double offsetY = comp.NazcaOriginOffsetY;
 
-        var px0 = NormalizeZero(-offsetX).ToString("F2", ci);
-        var py0 = NormalizeZero(offsetY - h).ToString("F2", ci);
-        var px1 = NormalizeZero(w - offsetX).ToString("F2", ci);
-        var py1 = NormalizeZero(offsetY).ToString("F2", ci);
+        var px0 = NazcaCoordinateMapper.NormalizeZero(-offsetX).ToString("F2", ci);
+        var py0 = NazcaCoordinateMapper.NormalizeZero(offsetY - h).ToString("F2", ci);
+        var px1 = NazcaCoordinateMapper.NormalizeZero(w - offsetX).ToString("F2", ci);
+        var py1 = NazcaCoordinateMapper.NormalizeZero(offsetY).ToString("F2", ci);
 
         sb.AppendLine($"    nd.Polygon(points=[({px0},{py0}),({px1},{py0}),({px1},{py1}),({px0},{py1})], layer=1).put(0, 0)");
 
@@ -231,9 +243,9 @@ public class SimpleNazcaExporter
         // of the app pin offsets (NazcaCoordinateMapper.GetPinNazcaPosition contract).
         foreach (var pin in comp.PhysicalPins)
         {
-            var px = NormalizeZero(pin.OffsetXMicrometers - offsetX).ToString("F2", ci);
-            var py = NormalizeZero(offsetY - pin.OffsetYMicrometers).ToString("F2", ci);
-            var pa = NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
+            var px = NazcaCoordinateMapper.NormalizeZero(pin.OffsetXMicrometers - offsetX).ToString("F2", ci);
+            var py = NazcaCoordinateMapper.NormalizeZero(offsetY - pin.OffsetYMicrometers).ToString("F2", ci);
+            var pa = NazcaCoordinateMapper.NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
             sb.AppendLine($"    nd.Pin('{pin.Name}').put({px}, {py}, {pa})");
         }
 
@@ -328,7 +340,6 @@ public class SimpleNazcaExporter
         IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
     {
         var varName = $"comp_{compIndex}";
-        componentNames[comp] = varName;
 
         bool isRawOverride = rawOverrides.ContainsKey(comp.Identifier);
 
@@ -354,8 +365,8 @@ public class SimpleNazcaExporter
         // originOffset is the effective put-position offset relative to the editor
         // top-left, derived from the mapper placement so the diagnosis can never
         // drift from the emitted coordinates.
-        double originOffsetX = NormalizeZero(placement.X - comp.PhysicalX);
-        double originOffsetY = NormalizeZero(-placement.Y - comp.PhysicalY);
+        double originOffsetX = NazcaCoordinateMapper.NormalizeZero(placement.X - comp.PhysicalX);
+        double originOffsetY = NazcaCoordinateMapper.NormalizeZero(-placement.Y - comp.PhysicalY);
         sb.AppendLine($"        # COORD: {comp.Identifier} " +
                       $"editor=({comp.PhysicalX.ToString("F2", ci)},{comp.PhysicalY.ToString("F2", ci)}) " +
                       $"originOffset=({originOffsetX.ToString("F2", ci)},{originOffsetY.ToString("F2", ci)}) " +
@@ -397,6 +408,10 @@ public class SimpleNazcaExporter
         {
             sb.AppendLine($"        {varName} = {nazcaFunc}.put('org', {nazcaX}, {nazcaY}, {rot})  # {comp.Identifier}");
         }
+
+        // Record the variable only after its put-line was emitted: a half-failed append
+        // must not leave a name pointing at a component that was never placed.
+        componentNames[comp] = varName;
         compIndex++;
     }
 
@@ -530,9 +545,9 @@ public class SimpleNazcaExporter
         double angleDeg = Math.Atan2(dy, dx) * 180.0 / Math.PI;
 
         var l = length.ToString("F2", ci);
-        var x = NormalizeZero(nazcaStartX).ToString("F2", ci);
-        var y = NormalizeZero(nazcaStartY).ToString("F2", ci);
-        var a = NormalizeZero(angleDeg).ToString("F2", ci);
+        var x = NazcaCoordinateMapper.NormalizeZero(nazcaStartX).ToString("F2", ci);
+        var y = NazcaCoordinateMapper.NormalizeZero(nazcaStartY).ToString("F2", ci);
+        var a = NazcaCoordinateMapper.NormalizeZero(angleDeg).ToString("F2", ci);
         return $"        nd.strt(length={l}).put({x}, {y}, {a})";
     }
 
@@ -544,10 +559,10 @@ public class SimpleNazcaExporter
         BendSegment bend, double nazcaX, double nazcaY, CultureInfo ci)
     {
         var radius = bend.RadiusMicrometers.ToString("F2", ci);
-        var sweepAngle = NormalizeZero(-bend.SweepAngleDegrees).ToString("F2", ci);
-        var x = NormalizeZero(nazcaX).ToString("F2", ci);
-        var y = NormalizeZero(nazcaY).ToString("F2", ci);
-        var angle = NormalizeZero(-bend.StartAngleDegrees).ToString("F2", ci);
+        var sweepAngle = NazcaCoordinateMapper.NormalizeZero(-bend.SweepAngleDegrees).ToString("F2", ci);
+        var x = NazcaCoordinateMapper.NormalizeZero(nazcaX).ToString("F2", ci);
+        var y = NazcaCoordinateMapper.NormalizeZero(nazcaY).ToString("F2", ci);
+        var angle = NazcaCoordinateMapper.NormalizeZero(-bend.StartAngleDegrees).ToString("F2", ci);
         return $"        nd.bend(radius={radius}, angle={sweepAngle}).put({x}, {y}, {angle})";
     }
 
@@ -567,9 +582,9 @@ public class SimpleNazcaExporter
         double length = Math.Sqrt(dx * dx + dy * dy);
         double angleDeg = Math.Atan2(dy, dx) * 180.0 / Math.PI;
 
-        var x = NormalizeZero(sx).ToString("F2", ci);
-        var y = NormalizeZero(sy).ToString("F2", ci);
-        var a = NormalizeZero(angleDeg).ToString("F2", ci);
+        var x = NazcaCoordinateMapper.NormalizeZero(sx).ToString("F2", ci);
+        var y = NazcaCoordinateMapper.NormalizeZero(sy).ToString("F2", ci);
+        var a = NazcaCoordinateMapper.NormalizeZero(angleDeg).ToString("F2", ci);
         var l = length.ToString("F2", ci);
 
         return $"        nd.strt(length={l}).put({x}, {y}, {a})";
@@ -592,12 +607,6 @@ public class SimpleNazcaExporter
             _ => $"        # Unknown segment type: {segment.GetType().Name}"
         };
     }
-
-    /// <summary>
-    /// Normalizes negative zero to positive zero to avoid "-0.00" in output.
-    /// </summary>
-    private static double NormalizeZero(double value) =>
-        value == 0.0 ? 0.0 : value;
 
     private static string FormatStraightSegment(
         StraightSegment straight, CultureInfo ci, bool isFirst, PhysicalPin? startPin = null)
@@ -627,9 +636,9 @@ public class SimpleNazcaExporter
                     straight.StartPoint.X, straight.StartPoint.Y);
             }
 
-            var x = NormalizeZero(nazcaX).ToString("F2", ci);
-            var y = NormalizeZero(nazcaY).ToString("F2", ci);
-            var angle = NormalizeZero(-straight.StartAngleDegrees).ToString("F2", ci);
+            var x = NazcaCoordinateMapper.NormalizeZero(nazcaX).ToString("F2", ci);
+            var y = NazcaCoordinateMapper.NormalizeZero(nazcaY).ToString("F2", ci);
+            var angle = NazcaCoordinateMapper.NormalizeZero(-straight.StartAngleDegrees).ToString("F2", ci);
             return $"        nd.strt(length={lengthStr}).put({x}, {y}, {angle})";
         }
 
@@ -653,7 +662,7 @@ public class SimpleNazcaExporter
     private static string FormatBendSegment(BendSegment bend, CultureInfo ci, bool isFirst, PhysicalPin? startPin = null)
     {
         var radius = bend.RadiusMicrometers.ToString("F2", ci);
-        var sweepAngle = NormalizeZero(-bend.SweepAngleDegrees).ToString("F2", ci);
+        var sweepAngle = NazcaCoordinateMapper.NormalizeZero(-bend.SweepAngleDegrees).ToString("F2", ci);
 
         if (isFirst)
         {
@@ -671,9 +680,9 @@ public class SimpleNazcaExporter
                     bend.StartPoint.X, bend.StartPoint.Y);
             }
 
-            var x = NormalizeZero(nazcaX).ToString("F2", ci);
-            var y = NormalizeZero(nazcaY).ToString("F2", ci);
-            var angle = NormalizeZero(-bend.StartAngleDegrees).ToString("F2", ci);
+            var x = NazcaCoordinateMapper.NormalizeZero(nazcaX).ToString("F2", ci);
+            var y = NazcaCoordinateMapper.NormalizeZero(nazcaY).ToString("F2", ci);
+            var angle = NazcaCoordinateMapper.NormalizeZero(-bend.StartAngleDegrees).ToString("F2", ci);
             return $"        nd.bend(radius={radius}, angle={sweepAngle}).put({x}, {y}, {angle})";
         }
 

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -4,6 +4,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
+using CAP_Core.Export;
 using CAP_Core.Routing;
 using CAP_DataAccess.Persistence.PIR;
 
@@ -128,7 +129,7 @@ public class SimpleNazcaExporter
         if (!generated.Add(funcName))
             return;
 
-        if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
+        if (NazcaCoordinateMapper.IsParametricStraight(funcName, comp.NazcaFunctionParameters))
             AppendParametricStraightStub(sb, funcName, comp, ci);
         else
             AppendStandardComponentStub(sb, funcName, comp, ci);
@@ -139,31 +140,19 @@ public class SimpleNazcaExporter
     /// Returns true for real PDK functions and demo_pdk functions.
     /// </summary>
     private static bool RequiresStub(string funcName) =>
-        IsPdkFunction(funcName) ||
+        NazcaCoordinateMapper.IsPdkFunction(funcName) ||
         funcName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Checks if a component is a parametric straight waveguide.
-    /// </summary>
-    private static bool IsParametricStraight(string funcName, string parameters)
-    {
-        if (string.IsNullOrEmpty(parameters))
-            return false;
-
-        var lower = funcName.ToLowerInvariant();
-        var hasLength = parameters.Contains("length=", StringComparison.OrdinalIgnoreCase);
-        var isStraight = lower.Contains("straight") || lower.Contains("strt");
-
-        return hasLength && isStraight;
-    }
-
-    /// <summary>
     /// Generates a parametric straight waveguide stub that uses nd.strt() with length parameter.
+    /// The cell-internal layout follows the <see cref="NazcaCoordinateMapper"/> contract:
+    /// org sits oy above the cell bottom, so the waveguide centre line is at oy - H/2
+    /// and pins render at the plain Y negation of their app offsets (oy - OffsetY).
     /// </summary>
     private static void AppendParametricStraightStub(
         StringBuilder sb, string funcName, Component comp, CultureInfo ci)
     {
-        var h = comp.HeightMicrometers.ToString("F2", ci);
+        var strtY = NormalizeZero(comp.NazcaOriginOffsetY - comp.HeightMicrometers / 2).ToString("F2", ci);
 
         // Sanitize function name for valid Python identifier (replace non-alphanumeric/underscore chars)
         var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_]", "_");
@@ -172,12 +161,12 @@ public class SimpleNazcaExporter
         sb.AppendLine($"    \"\"\"Auto-generated parametric straight waveguide stub for {funcName}.\"\"\"");
         sb.AppendLine($"    with nd.Cell(name='{funcName}_{{length}}') as cell:");
         sb.AppendLine($"        # Use nd.strt() for proper waveguide with specified length");
-        sb.AppendLine($"        nd.strt(length=length, width=0.45, layer=1).put(0, {h}/2)");
+        sb.AppendLine($"        nd.strt(length=length, width=0.45, layer=1).put(0, {strtY})");
 
         // Generate pins with Nazca coordinates
         foreach (var pin in comp.PhysicalPins)
         {
-            var py = NormalizeZero(comp.HeightMicrometers - pin.OffsetYMicrometers).ToString("F2", ci);
+            var py = NormalizeZero(comp.NazcaOriginOffsetY - pin.OffsetYMicrometers).ToString("F2", ci);
             var pa = NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
 
             // For straight waveguides: input pin at x=0, output pin at x=length
@@ -197,9 +186,12 @@ public class SimpleNazcaExporter
 
     /// <summary>
     /// Generates a standard non-parametric component stub using a polygon box.
-    /// When NazcaOriginOffset is set, the polygon box is shifted so that the cell's
-    /// (0,0) origin is at the offset position, not the bottom-left corner.
-    /// This ensures component boxes appear in the correct location in KLayout/GDS viewers.
+    /// The cell-internal layout follows the placement contract of
+    /// <see cref="NazcaCoordinateMapper"/>: the geometry bbox is
+    /// [-ox, oy-H] .. [W-ox, oy] around the cell origin, because at rotation 0
+    /// the org pin is put at (PhysicalX+ox, -(PhysicalY+oy)) and the box top edge
+    /// must lie oy above org. Pins render exactly where the app model places them
+    /// (plain Y negation), so exported waveguides meet the stub pins.
     /// </summary>
     private static void AppendStandardComponentStub(
         StringBuilder sb, string funcName, Component comp, CultureInfo ci)
@@ -214,61 +206,25 @@ public class SimpleNazcaExporter
         sb.AppendLine($"with nd.Cell(name='{funcName}') as _{pythonFuncName}_cell:");
         sb.AppendLine($"    \"\"\"Auto-generated stub for {funcName} ({comp.WidthMicrometers}x{comp.HeightMicrometers} µm).\"\"\"");
 
-        // When NazcaOriginOffset is set, the cell origin (0,0) is NOT at the bottom-left corner.
-        // The polygon must be shifted so it appears at the correct position relative to the origin.
-        // Example: GC with offset (15, 30) → polygon from (-15, -30) to (15, 0)
-        // This matches the real PDK behavior where .put() places the origin, not the box corner.
+        // Stubs are only generated for PDK-named components (see RequiresStub), whose
+        // placement always uses the calibrated origin offset — (0,0) means org at the
+        // box top-left. Example: GC with offset (0, 9.5), H=19 → polygon (0,-9.5)..(W,9.5).
         double offsetX = comp.NazcaOriginOffsetX;
         double offsetY = comp.NazcaOriginOffsetY;
 
-        // Check if this component actually uses NazcaOriginOffset
-        bool usesOriginOffset = (offsetX != 0 || offsetY != 0) ||
-                               (IsPdkFunction(funcName) || funcName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase));
+        var px0 = NormalizeZero(-offsetX).ToString("F2", ci);
+        var py0 = NormalizeZero(offsetY - h).ToString("F2", ci);
+        var px1 = NormalizeZero(w - offsetX).ToString("F2", ci);
+        var py1 = NormalizeZero(offsetY).ToString("F2", ci);
 
-        if (usesOriginOffset && (offsetX != 0 || offsetY != 0))
-        {
-            // Shifted polygon: corner is at (-offsetX, -offsetY) relative to cell origin
-            double x0 = -offsetX;
-            double y0 = -offsetY;
-            double x1 = w - offsetX;
-            double y1 = h - offsetY;
+        sb.AppendLine($"    nd.Polygon(points=[({px0},{py0}),({px1},{py0}),({px1},{py1}),({px0},{py1})], layer=1).put(0, 0)");
 
-            var px0 = NormalizeZero(x0).ToString("F2", ci);
-            var py0 = NormalizeZero(y0).ToString("F2", ci);
-            var px1 = NormalizeZero(x1).ToString("F2", ci);
-            var py1 = NormalizeZero(y1).ToString("F2", ci);
-
-            sb.AppendLine($"    nd.Polygon(points=[({px0},{py0}),({px1},{py0}),({px1},{py1}),({px0},{py1})], layer=1).put(0, 0)");
-        }
-        else
-        {
-            // Legacy/simple components: box at (0,0) to (w,h)
-            var ws = w.ToString("F2", ci);
-            var hs = h.ToString("F2", ci);
-            sb.AppendLine($"    nd.Polygon(points=[(0,0),({ws},0),({ws},{hs}),(0,{hs})], layer=1).put(0, 0)");
-        }
-
-        // Generate pins with Nazca coordinates
-        // Pin positions must be relative to the cell origin (which may be shifted)
+        // Pins relative to org: local = (OffsetX-ox, oy-OffsetY), the plain Y negation
+        // of the app pin offsets (NazcaCoordinateMapper.GetPinNazcaPosition contract).
         foreach (var pin in comp.PhysicalPins)
         {
-            double pinX, pinY;
-
-            if (usesOriginOffset && (offsetX != 0 || offsetY != 0))
-            {
-                // Pin position relative to shifted origin
-                pinX = pin.OffsetXMicrometers - offsetX;
-                pinY = (comp.HeightMicrometers - pin.OffsetYMicrometers) - offsetY;
-            }
-            else
-            {
-                // Legacy: pin position in standard Nazca Y-up coordinates
-                pinX = pin.OffsetXMicrometers;
-                pinY = comp.HeightMicrometers - pin.OffsetYMicrometers;
-            }
-
-            var px = NormalizeZero(pinX).ToString("F2", ci);
-            var py = NormalizeZero(pinY).ToString("F2", ci);
+            var px = NormalizeZero(pin.OffsetXMicrometers - offsetX).ToString("F2", ci);
+            var py = NormalizeZero(offsetY - pin.OffsetYMicrometers).ToString("F2", ci);
             var pa = NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
             sb.AppendLine($"    nd.Pin('{pin.Name}').put({px}, {py}, {pa})");
         }
@@ -326,21 +282,31 @@ public class SimpleNazcaExporter
         componentNames[comp] = varName;
 
         bool isRawOverride = rawOverrides.ContainsKey(comp.Identifier);
-        var overrideBbox = isRawOverride ? GetOverrideBboxAnchor(comp, overrides) : null;
 
-        // A bbox-anchored override computes its own origin offset: the cell-internal
-        // bbox corner (XMin, YMax) must land on the component's grid rectangle.
-        var (originOffsetX, originOffsetY) = overrideBbox is { } anchor
-            ? RotateOffset(-anchor.XMin, anchor.YMax, comp.RotationDegrees)
-            : CalculateOriginOffset(comp);
+        // A raw-code override persists the cell-internal bbox anchor (XMin, YMax) so
+        // the mapper can land the rendered geometry on the component's grid rectangle.
+        // Overrides saved before the anchor fields existed leave the anchor null.
+        (double XMin, double YMax)? overrideAnchor = null;
+        if (isRawOverride && overrides != null
+            && overrides.TryGetValue(comp.Identifier, out var overrideRecord)
+            && overrideRecord.OverrideBboxXMinMicrometers is { } anchorXMin
+            && overrideRecord.OverrideBboxYMaxMicrometers is { } anchorYMax)
+        {
+            overrideAnchor = (anchorXMin, anchorYMax);
+        }
 
-        var nazcaX = (comp.PhysicalX + originOffsetX).ToString("F2", ci);
-        var nazcaY = NormalizeZero(-(comp.PhysicalY + originOffsetY)).ToString("F2", ci);
-        var rot = NormalizeZero(-comp.RotationDegrees).ToString("F0", ci);
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, overrideAnchor);
+        var nazcaX = placement.X.ToString("F2", ci);
+        var nazcaY = placement.Y.ToString("F2", ci);
+        var rot = placement.RotationDegrees.ToString("F0", ci);
         var nazcaFunc = GetNazcaFunction(comp);
 
         // Diagnostic logging (Issue #334): trace coordinate transform for each component.
-        // Format: # COORD: <id> editor=(<physX>,<physY>) originOffset=(<ox>,<oy>) nazca=(<nx>,<ny>) rot=<r>
+        // originOffset is the effective put-position offset relative to the editor
+        // top-left, derived from the mapper placement so the diagnosis can never
+        // drift from the emitted coordinates.
+        double originOffsetX = NormalizeZero(placement.X - comp.PhysicalX);
+        double originOffsetY = NormalizeZero(-placement.Y - comp.PhysicalY);
         sb.AppendLine($"        # COORD: {comp.Identifier} " +
                       $"editor=({comp.PhysicalX.ToString("F2", ci)},{comp.PhysicalY.ToString("F2", ci)}) " +
                       $"originOffset=({originOffsetX.ToString("F2", ci)},{originOffsetY.ToString("F2", ci)}) " +
@@ -349,7 +315,7 @@ public class SimpleNazcaExporter
         // Pin coordinate diagnostics: show expected Nazca pin positions for alignment verification.
         foreach (var pin in comp.PhysicalPins)
         {
-            var (pinNazcaX, pinNazcaY) = GetNazcaPinPosition(pin, rawOverrides);
+            var (pinNazcaX, pinNazcaY) = NazcaCoordinateMapper.GetPinNazcaPosition(pin);
             sb.AppendLine($"        # PIN: {pin.Name} expected_nazca=({pinNazcaX.ToString("F2", ci)},{pinNazcaY.ToString("F2", ci)})");
         }
 
@@ -374,7 +340,7 @@ public class SimpleNazcaExporter
             // lands exactly on the grid rectangle (issue #561). Every nd.Cell() has
             // an 'org' pin. Overrides saved before the anchor existed fall back to
             // the old default-anchor placement.
-            sb.AppendLine(overrideBbox != null
+            sb.AppendLine(overrideAnchor != null
                 ? $"        {varName} = {factory}().put('org', {nazcaX}, {nazcaY}, {rot})  # {comp.Identifier} (raw-code override, bbox-anchored)"
                 : $"        {varName} = {factory}().put({nazcaX}, {nazcaY}, {rot})  # {comp.Identifier} (raw-code override)");
         }
@@ -383,92 +349,6 @@ public class SimpleNazcaExporter
             sb.AppendLine($"        {varName} = {nazcaFunc}.put('org', {nazcaX}, {nazcaY}, {rot})  # {comp.Identifier}");
         }
         compIndex++;
-    }
-
-    /// <summary>
-    /// Returns the persisted cell-internal bbox anchor (XMin, YMax) of a raw-code
-    /// override, or null when the override predates the anchor fields.
-    /// </summary>
-    private static (double XMin, double YMax)? GetOverrideBboxAnchor(
-        Component comp, IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
-    {
-        if (overrides == null || !overrides.TryGetValue(comp.Identifier, out var record))
-            return null;
-        if (record.OverrideBboxXMinMicrometers is { } xMin
-            && record.OverrideBboxYMaxMicrometers is { } yMax)
-            return (xMin, yMax);
-        return null;
-    }
-
-    /// <summary>
-    /// Rotates a cell-local origin-offset vector by the component rotation — the same
-    /// convention <see cref="CalculateOriginOffset"/> applies to PDK origin offsets.
-    /// </summary>
-    private static (double OffsetX, double OffsetY) RotateOffset(
-        double offsetX, double offsetY, double rotationDegrees)
-    {
-        double rotRad = rotationDegrees * Math.PI / 180.0;
-        return (offsetX * Math.Cos(rotRad) - offsetY * Math.Sin(rotRad),
-                offsetX * Math.Sin(rotRad) + offsetY * Math.Cos(rotRad));
-    }
-
-    /// <summary>
-    /// World-space Nazca position of a connection endpoint pin. Pins of raw-code–
-    /// overridden components are bbox-anchored, so their app-space position converts
-    /// 1:1 (plain Y negation). Regular PDK pins go through the calibrated
-    /// NazcaOriginOffset math in <see cref="PhysicalPin.GetAbsoluteNazcaPosition"/> —
-    /// which, applied to an override pin, would shift the waveguide by the stale
-    /// template offset (manual finding: 109.505 µm in KLayout, issue #561).
-    /// </summary>
-    private static (double X, double Y) GetNazcaPinPosition(
-        PhysicalPin pin, IReadOnlyDictionary<string, string>? rawOverrides)
-    {
-        var identifier = pin.ParentComponent?.Identifier;
-        if (identifier != null && rawOverrides != null && rawOverrides.ContainsKey(identifier))
-        {
-            var (x, y) = pin.GetAbsolutePosition();
-            return (x, -y);
-        }
-        return pin.GetAbsoluteNazcaPosition();
-    }
-
-    /// <summary>
-    /// Calculates the Nazca origin offset for a component based on its type.
-    /// </summary>
-    private static (double OffsetX, double OffsetY) CalculateOriginOffset(Component comp)
-    {
-        var funcName = comp.NazcaFunctionName;
-
-        bool hasPdkFunctionName = !string.IsNullOrEmpty(funcName) &&
-            (IsPdkFunction(funcName) || funcName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase));
-
-        // Also use explicit NazcaOriginOffset when set (non-zero), regardless of function name.
-        // Fixes components with auto-generated names (e.g. "nazca_grating_coupler") that still
-        // have a physical Nazca origin offset. Issue #355.
-        bool hasExplicitOriginOffset = comp.NazcaOriginOffsetX != 0 || comp.NazcaOriginOffsetY != 0;
-
-        if (hasPdkFunctionName || hasExplicitOriginOffset)
-        {
-            double rotRad = comp.RotationDegrees * Math.PI / 180.0;
-            double offsetX = comp.NazcaOriginOffsetX * Math.Cos(rotRad) - comp.NazcaOriginOffsetY * Math.Sin(rotRad);
-            double offsetY = comp.NazcaOriginOffsetX * Math.Sin(rotRad) + comp.NazcaOriginOffsetY * Math.Cos(rotRad);
-            return (offsetX, offsetY);
-        }
-
-        if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
-        {
-            var firstPin = comp.PhysicalPins.FirstOrDefault();
-            if (firstPin != null)
-            {
-                double rotRad = comp.RotationDegrees * Math.PI / 180.0;
-                double offsetX = firstPin.OffsetXMicrometers * Math.Cos(rotRad) - firstPin.OffsetYMicrometers * Math.Sin(rotRad);
-                double offsetY = firstPin.OffsetXMicrometers * Math.Sin(rotRad) + firstPin.OffsetYMicrometers * Math.Cos(rotRad);
-                return (offsetX, offsetY);
-            }
-        }
-
-        // Fallback for legacy components with no explicit Nazca origin offset
-        return (0, comp.HeightMicrometers);
     }
 
     private static void AppendConnections(
@@ -499,7 +379,7 @@ public class SimpleNazcaExporter
             var segments = conn.GetPathSegments();
 
             if (segments.Count > 0)
-                AppendSegmentExport(sb, segments, conn.StartPin, conn.EndPin, rawOverrides);
+                AppendSegmentExport(sb, segments, conn.StartPin, conn.EndPin);
             else
                 AppendFallbackExport(sb, conn, componentNames, rawOverrides);
         }
@@ -508,7 +388,7 @@ public class SimpleNazcaExporter
         foreach (var compVm in canvas.Components)
         {
             if (compVm.Component is ComponentGroup group)
-                AppendGroupFrozenPaths(sb, group, rawOverrides);
+                AppendGroupFrozenPaths(sb, group);
         }
 
         sb.AppendLine();
@@ -517,71 +397,52 @@ public class SimpleNazcaExporter
     /// <summary>
     /// Exports all frozen waveguide paths from a ComponentGroup (and nested groups) as Nazca segments.
     /// </summary>
-    private static void AppendGroupFrozenPaths(
-        StringBuilder sb, ComponentGroup group, IReadOnlyDictionary<string, string> rawOverrides)
+    private static void AppendGroupFrozenPaths(StringBuilder sb, ComponentGroup group)
     {
         foreach (var frozenPath in group.InternalPaths)
         {
             if (frozenPath?.Path?.Segments?.Count > 0)
-                AppendSegmentExport(sb, frozenPath.Path.Segments, frozenPath.StartPin, frozenPath.EndPin, rawOverrides);
+                AppendSegmentExport(sb, frozenPath.Path.Segments, frozenPath.StartPin, frozenPath.EndPin);
         }
 
         foreach (var child in group.ChildComponents)
         {
             if (child is ComponentGroup nestedGroup)
-                AppendGroupFrozenPaths(sb, nestedGroup, rawOverrides);
+                AppendGroupFrozenPaths(sb, nestedGroup);
         }
     }
 
     /// <summary>
     /// Appends segment-by-segment Nazca export for a routed connection.
-    /// Uses absolute .put(x, y, angle) for EVERY segment to avoid coordinate accumulation errors
-    /// that occur with Nazca's chaining syntax (.put() without coordinates).
-    ///
-    /// Fix #355 (single straight): direct pin-to-pin geometry avoids NazcaOriginOffset mismatch.
-    /// Fix #366 (multi-segment): absolute positioning for each segment.
-    /// Fix #456 (last segment Y-offset): all segments now use the SAME delta offset derived from
-    /// startPin, ensuring a continuous waveguide path with no coordinate-system jump between segments.
-    /// Fix #458: straight segment length and angle are recomputed from transformed Nazca endpoints
-    /// instead of relying on editor-space stored values, eliminating misalignment for diagonal segments.
-    /// All segments use the same uniform offset — no per-segment distortion.
+    /// Uses absolute .put(x, y, angle) for EVERY segment to avoid coordinate accumulation
+    /// errors that occur with Nazca's chaining syntax (.put() without coordinates).
+    /// App→Nazca conversion of path geometry is the plain Y negation
+    /// (<see cref="NazcaCoordinateMapper.ToNazca"/>); pins live at the same conversion,
+    /// so no start-pin offset correction exists — cells are placed so their rendered
+    /// pins coincide with the app pins.
     /// </summary>
-    /// <param name="startPin">Start pin used to calculate the editor-to-Nazca offset for all segments.</param>
-    /// <param name="endPin">End pin used only for single-straight-segment paths (direct pin-to-pin geometry).</param>
+    /// <param name="sb">Target script builder.</param>
+    /// <param name="segments">Routed path segments in editor (app) coordinates.</param>
+    /// <param name="startPin">Start pin, used for single-straight pin-to-pin geometry.</param>
+    /// <param name="endPin">End pin, used for single-straight pin-to-pin geometry.</param>
     internal static void AppendSegmentExport(
         StringBuilder sb, IReadOnlyList<PathSegment> segments,
-        PhysicalPin? startPin = null, PhysicalPin? endPin = null,
-        IReadOnlyDictionary<string, string>? rawOverrides = null)
+        PhysicalPin? startPin = null, PhysicalPin? endPin = null)
     {
-        // Single straight segment: compute geometry directly from both pin positions.
+        // Single straight segment: compute geometry directly from both pin positions
+        // so the waveguide hits both pins exactly even if the stored segment drifts.
         if (segments.Count == 1 && segments[0] is StraightSegment && startPin != null && endPin != null)
         {
-            sb.AppendLine(FormatStraightSegmentFromPins(startPin, endPin, rawOverrides));
+            sb.AppendLine(FormatStraightSegmentFromPins(startPin, endPin));
             return;
         }
 
-        // Multi-segment: Transform all segment endpoints from editor space to Nazca space.
-        // The SAME offset is applied to every segment — no per-segment or end-pin correction.
-        // The routing path geometry must be preserved exactly; if the endpoint doesn't hit the
-        // pin, the issue is in the offset calculation or component placement, not the segments.
-        double offsetX = 0;
-        double offsetY = 0;
-        if (startPin != null && segments.Count > 0)
+        foreach (var segment in segments)
         {
-            var (editorPinX, editorPinY) = startPin.GetAbsolutePosition();
-            var (nazcaPinX, nazcaPinY) = GetNazcaPinPosition(startPin, rawOverrides);
-            offsetX = nazcaPinX - editorPinX;
-            offsetY = nazcaPinY - (-editorPinY);
-        }
+            var (nStartX, nStartY) = NazcaCoordinateMapper.ToNazca(segment.StartPoint.X, segment.StartPoint.Y);
+            var (nEndX, nEndY) = NazcaCoordinateMapper.ToNazca(segment.EndPoint.X, segment.EndPoint.Y);
 
-        for (int i = 0; i < segments.Count; i++)
-        {
-            double nStartX = segments[i].StartPoint.X + offsetX;
-            double nStartY = -segments[i].StartPoint.Y + offsetY;
-            double nEndX = segments[i].EndPoint.X + offsetX;
-            double nEndY = -segments[i].EndPoint.Y + offsetY;
-
-            sb.AppendLine(FormatSegmentAbsolute(segments[i], nStartX, nStartY, nEndX, nEndY));
+            sb.AppendLine(FormatSegmentAbsolute(segment, nStartX, nStartY, nEndX, nEndY));
         }
     }
 
@@ -644,16 +505,13 @@ public class SimpleNazcaExporter
     /// <summary>
     /// Formats a straight waveguide segment using absolute Nazca pin positions.
     /// Computes length and angle from start pin to end pin in Nazca coordinates,
-    /// ensuring the waveguide reaches the end pin exactly regardless of NazcaOriginOffset.
-    /// Fix for Issue #355: end pin misalignment when NazcaOriginOffsetY ≠ HeightMicrometers.
+    /// ensuring the waveguide reaches both pins exactly.
     /// </summary>
-    private static string FormatStraightSegmentFromPins(
-        PhysicalPin startPin, PhysicalPin endPin,
-        IReadOnlyDictionary<string, string>? rawOverrides)
+    private static string FormatStraightSegmentFromPins(PhysicalPin startPin, PhysicalPin endPin)
     {
         var ci = CultureInfo.InvariantCulture;
-        var (sx, sy) = GetNazcaPinPosition(startPin, rawOverrides);
-        var (ex, ey) = GetNazcaPinPosition(endPin, rawOverrides);
+        var (sx, sy) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
+        var (ex, ey) = NazcaCoordinateMapper.GetPinNazcaPosition(endPin);
 
         double dx = ex - sx;
         double dy = ey - sy;
@@ -812,11 +670,10 @@ public class SimpleNazcaExporter
             return $"{name}.pin['{pin.Name}']";
 
         var ci = CultureInfo.InvariantCulture;
-        var (x, y) = pin.GetAbsoluteNazcaPosition();
-        var px = NormalizeZero(x).ToString("F2", ci);
-        var py = NormalizeZero(y).ToString("F2", ci);
-        // App space is Y-down, Nazca is Y-up: negate the world-space pin angle.
-        var pa = NormalizeZero(-pin.GetAbsoluteAngle()).ToString("F0", ci);
+        var (x, y) = NazcaCoordinateMapper.GetPinNazcaPosition(pin);
+        var px = x.ToString("F2", ci);
+        var py = y.ToString("F2", ci);
+        var pa = NazcaCoordinateMapper.GetPinNazcaAngle(pin).ToString("F0", ci);
         return $"({px}, {py}, {pa})";
     }
 
@@ -838,22 +695,6 @@ public class SimpleNazcaExporter
     }
 
     /// <summary>
-    /// Returns true if the function name looks like a real PDK function (e.g., "ebeam_y_1550").
-    /// Recognizes SiEPIC EBeam PDK naming patterns.
-    /// </summary>
-    internal static bool IsPdkFunction(string name) =>
-        name.StartsWith("ebeam_", StringComparison.OrdinalIgnoreCase) ||
-        name.StartsWith("GC_", StringComparison.Ordinal) ||
-        name.StartsWith("ANT_", StringComparison.Ordinal) ||
-        name.StartsWith("crossing_", StringComparison.OrdinalIgnoreCase) ||
-        name.StartsWith("taper_", StringComparison.OrdinalIgnoreCase) ||
-        // SiEPIC ships a few generic-named PCells too (the `contra_*` family
-        // is the directional-coupler set under the EBeam library).
-        name.StartsWith("contra_", StringComparison.OrdinalIgnoreCase) ||
-        (name.Contains(".", StringComparison.Ordinal) &&
-         !name.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase));
-
-    /// <summary>
     /// Maps a component to its Nazca function call string.
     /// Uses the stored NazcaFunctionName when it's a real PDK function,
     /// falls back to heuristic demofab mapping otherwise.
@@ -862,7 +703,7 @@ public class SimpleNazcaExporter
     {
         // Use stored PDK function name if available and looks like a real function
         var funcName = comp.NazcaFunctionName;
-        if (!string.IsNullOrEmpty(funcName) && IsPdkFunction(funcName))
+        if (!string.IsNullOrEmpty(funcName) && NazcaCoordinateMapper.IsPdkFunction(funcName))
         {
             // Keep dots (for module attribute access like demo.mmi2x2_dp), replace other invalid chars
             var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_.]", "_");
@@ -883,7 +724,7 @@ public class SimpleNazcaExporter
 
             // Skip parameters for stub components - stubs don't support them
             var funcParams = comp.NazcaFunctionParameters;
-            bool isParametricStraight = IsParametricStraight(funcName, funcParams);
+            bool isParametricStraight = NazcaCoordinateMapper.IsParametricStraight(funcName, funcParams);
 
             if (isParametricStraight && !string.IsNullOrEmpty(funcParams))
                 return $"{pythonFuncName}({funcParams})";

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -28,10 +28,16 @@ public class SimpleNazcaExporter
     /// PDK template — org-anchored on the persisted bbox corner so the geometry lands on the
     /// component's grid rectangle. Connections to such instances export normally (issue #561).
     /// </param>
+    /// <param name="emitVerification">
+    /// When true, appends a machine-readable verification epilog (issue #565) that dumps
+    /// every placed instance's ACTUAL world pin positions — reported by the same nazca
+    /// engine that writes the GDS — to '&lt;script&gt;.pins.json' next to the script.
+    /// </param>
     public string Export(
         DesignCanvasViewModel canvas,
         string? pdkModuleName = null,
-        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides = null)
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides = null,
+        bool emitVerification = false)
     {
         var sb = new StringBuilder();
 
@@ -41,9 +47,11 @@ public class SimpleNazcaExporter
         AppendHeader(sb);
         NazcaOverrideFactory.AppendFactories(sb, rawOverrides);
         AppendPdkComponentStubs(sb, canvas, rawOverrides);
-        var componentNames = AppendComponents(sb, canvas, rawOverrides, overrides);
+        var componentNames = AppendComponents(sb, canvas, rawOverrides, overrides, emitVerification);
         AppendConnections(sb, canvas, componentNames, rawOverrides);
         AppendFooter(sb);
+        if (emitVerification)
+            AppendVerificationEpilog(sb);
 
         return sb.ToString();
     }
@@ -237,7 +245,7 @@ public class SimpleNazcaExporter
 
     private static Dictionary<Component, string> AppendComponents(
         StringBuilder sb, DesignCanvasViewModel canvas, IReadOnlyDictionary<string, string> rawOverrides,
-        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides, bool emitVerification = false)
     {
         sb.AppendLine("def create_design():");
         sb.AppendLine("    with nd.Cell(name='ConnectAPIC_Design') as design:");
@@ -266,8 +274,49 @@ public class SimpleNazcaExporter
             }
         }
 
+        if (emitVerification)
+            AppendVerificationRegistry(sb, componentNames);
+
         sb.AppendLine();
         return componentNames;
+    }
+
+    /// <summary>
+    /// Exposes the placed instances to the verification epilog. The comp_N variables
+    /// are locals of create_design(), but the epilog runs at module level after the
+    /// GDS export — a module-level registry bridges the two scopes.
+    /// </summary>
+    private static void AppendVerificationRegistry(
+        StringBuilder sb, Dictionary<Component, string> componentNames)
+    {
+        var pairs = string.Join(", ", componentNames.Values.Select(n => $"('{n}', {n})"));
+        sb.AppendLine();
+        sb.AppendLine("        # Instance registry for the alignment verification epilog.");
+        sb.AppendLine("        global _verify_instances");
+        sb.AppendLine($"        _verify_instances = [{pairs}]");
+    }
+
+    /// <summary>
+    /// Emits the self-verification footer (issue #565): the TRUE world pin positions of
+    /// every placed instance, asked from the same nazca engine that wrote the GDS — the
+    /// GDS itself carries no pins. The result is written as JSON next to the script so
+    /// tests (and tooling) can compare it against <see cref="NazcaCoordinateMapper"/>.
+    /// </summary>
+    private static void AppendVerificationEpilog(StringBuilder sb)
+    {
+        sb.AppendLine();
+        sb.AppendLine("# --- Alignment verification (machine-readable) ---");
+        sb.AppendLine("import json as _json");
+        sb.AppendLine("_verify = {}");
+        sb.AppendLine("for _name, _inst in _verify_instances:");
+        sb.AppendLine("    _pins = {}");
+        sb.AppendLine("    for _pn, _pin in _inst.pin.items():");
+        sb.AppendLine("        _px, _py, _pa = _pin.xya()");
+        sb.AppendLine("        # float() unwraps numpy scalars, which json cannot serialize.");
+        sb.AppendLine("        _pins[_pn] = [float(_px), float(_py), float(_pa)]");
+        sb.AppendLine("    _verify[_name] = _pins");
+        sb.AppendLine("with open(os.path.splitext(script_path)[0] + '.pins.json', 'w') as _f:");
+        sb.AppendLine("    _json.dump(_verify, _f)");
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Diagnostics/ExportValidationViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/ExportValidationViewModel.cs
@@ -7,6 +7,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.CodeExporter;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
+using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.ViewModels.Diagnostics;
 
@@ -39,6 +40,14 @@ public partial class ExportValidationViewModel : ObservableObject
 
     public ObservableCollection<ValidationMessage> Messages { get; } = new();
 
+    /// <summary>
+    /// Supplies the live per-instance Nazca overrides (keyed by component identifier)
+    /// so validation exports and checks the SAME script the production exporter emits.
+    /// Wired by <c>MainViewModel</c> to <c>FileOperations.StoredNazcaOverrides</c>; null
+    /// means "no overrides" (validation then behaves as a plain PDK export).
+    /// </summary>
+    public Func<IReadOnlyDictionary<string, NazcaCodeOverride>>? OverridesProvider { get; set; }
+
     private readonly SimpleNazcaExporter _exporter;
     private readonly ExportValidator _validator;
     private readonly ErrorConsoleService? _errorConsole;
@@ -69,15 +78,21 @@ public partial class ExportValidationViewModel : ObservableObject
 
         try
         {
+            // Use the SAME overrides the production export uses, so the validator never
+            // checks a different script than the one shipped to fab.
+            var overrides = OverridesProvider?.Invoke();
+
             // Export to Nazca code
-            var nazcaCode = _exporter.Export(canvas);
+            var nazcaCode = _exporter.Export(canvas, overrides: overrides);
 
             // Collect components and connections
             var components = canvas.Components.Select(vm => vm.Component).ToList();
             var connections = canvas.Connections.Select(vm => vm.Connection).ToList();
 
-            // Run validation
-            var result = _validator.Validate(components, connections, nazcaCode);
+            // Run validation, passing the persisted bbox anchors of raw-code overrides
+            // so bbox-anchored placements are not flagged as position mismatches.
+            var result = _validator.Validate(
+                components, connections, nazcaCode, BuildOverrideAnchors(overrides));
 
             // Update UI with results
             DisplayResults(result);
@@ -88,6 +103,31 @@ public partial class ExportValidationViewModel : ObservableObject
             ValidationStatus = $"Validation failed: {ex.Message}";
             HasResults = false;
         }
+    }
+
+    /// <summary>
+    /// Extracts the persisted bbox anchors (XMin, YMax) from raw-code overrides into the
+    /// plain tuple map the Core validator accepts (Core must not reference CAP-DataAccess).
+    /// Only entries with a RawCode AND both anchor fields are placed bbox-anchored — those
+    /// are the ones whose expected position depends on the anchor.
+    /// </summary>
+    private static IReadOnlyDictionary<string, (double XMin, double YMax)>? BuildOverrideAnchors(
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+    {
+        if (overrides == null)
+            return null;
+
+        var anchors = new Dictionary<string, (double XMin, double YMax)>(StringComparer.Ordinal);
+        foreach (var kv in overrides)
+        {
+            if (!string.IsNullOrWhiteSpace(kv.Value?.RawCode)
+                && kv.Value!.OverrideBboxXMinMicrometers is { } xMin
+                && kv.Value.OverrideBboxYMaxMicrometers is { } yMax)
+            {
+                anchors[kv.Key] = (xMin, yMax);
+            }
+        }
+        return anchors;
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -369,6 +369,10 @@ public partial class MainViewModel : ObservableObject
     {
         FileOperations.PhotonTorchExport.UpdateStatus = UpdateStatusText;
         FileOperations.RebuildHierarchy = LeftPanel.HierarchyPanel.RebuildTree;
+
+        // Export validation must run against the SAME per-instance Nazca overrides the
+        // production export uses; FileOperations owns the live store (issue #565 F1).
+        RightPanel.ExportValidation.OverridesProvider = () => FileOperations.StoredNazcaOverrides;
         FileOperations.ZoomToFitAfterLoad = (w, h) =>
         {
             var (vpWidth, vpHeight) = ViewportControl.GetViewportSize?.Invoke() ?? (w, h);

--- a/Connect-A-Pic-Core/CodeExporter/ExportValidator.cs
+++ b/Connect-A-Pic-Core/CodeExporter/ExportValidator.cs
@@ -16,17 +16,28 @@ public class ExportValidator
     /// <summary>
     /// Validates that exported Nazca code correctly represents the design.
     /// </summary>
+    /// <param name="components">The design components.</param>
+    /// <param name="connections">The waveguide connections.</param>
+    /// <param name="nazcaCode">The exported Nazca script to validate against.</param>
+    /// <param name="overrideAnchors">
+    /// Optional per-instance raw-code-override bbox anchors (XMin, YMax) keyed by
+    /// component identifier. Bbox-anchored overrides are placed relative to this anchor,
+    /// so the expected position must use it; omitting it reports false position mismatches
+    /// for overridden instances. A plain (XMin, YMax) tuple is used rather than the
+    /// CAP-DataAccess override type so Core stays free of that dependency.
+    /// </param>
     public ValidationResult Validate(
         List<Component> components,
         List<WaveguideConnection> connections,
-        string nazcaCode)
+        string nazcaCode,
+        IReadOnlyDictionary<string, (double XMin, double YMax)>? overrideAnchors = null)
     {
         var result = new ValidationResult();
         var parser = new NazcaCodeParser();
         var parsed = parser.Parse(nazcaCode);
 
         // Validate component positions
-        ValidateComponentPositions(components, parsed, result);
+        ValidateComponentPositions(components, parsed, result, overrideAnchors);
 
         // Validate waveguide endpoints match pin positions
         ValidateWaveguideEndpoints(connections, components, parsed, result);
@@ -44,7 +55,8 @@ public class ExportValidator
     private static void ValidateComponentPositions(
         List<Component> components,
         ParsedNazcaDesign parsed,
-        ValidationResult result)
+        ValidationResult result,
+        IReadOnlyDictionary<string, (double XMin, double YMax)>? overrideAnchors)
     {
         if (parsed.Components.Count != components.Count)
         {
@@ -62,8 +74,14 @@ public class ExportValidator
 
             var placement = parsed.Components[i];
 
-            // Calculate expected Nazca position
-            var expectedPos = CalculateExpectedNazcaPosition(comp);
+            // Calculate expected Nazca position, honouring a persisted override anchor.
+            (double XMin, double YMax)? anchor = null;
+            if (overrideAnchors != null && comp.Identifier != null
+                && overrideAnchors.TryGetValue(comp.Identifier, out var stored))
+            {
+                anchor = stored;
+            }
+            var expectedPos = CalculateExpectedNazcaPosition(comp, anchor);
 
             // Compare positions
             var xDiff = Math.Abs(placement.X - expectedPos.X);
@@ -194,9 +212,10 @@ public class ExportValidator
     /// <see cref="NazcaCoordinateMapper"/> — the same single source of truth the
     /// exporter uses, so the validator can never drift from the export math.
     /// </summary>
-    private static (double X, double Y) CalculateExpectedNazcaPosition(Component comp)
+    private static (double X, double Y) CalculateExpectedNazcaPosition(
+        Component comp, (double XMin, double YMax)? overrideAnchor)
     {
-        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, rawOverrideAnchor: null);
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, overrideAnchor);
         return (placement.X, placement.Y);
     }
 

--- a/Connect-A-Pic-Core/CodeExporter/ExportValidator.cs
+++ b/Connect-A-Pic-Core/CodeExporter/ExportValidator.cs
@@ -1,5 +1,6 @@
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
+using CAP_Core.Export;
 
 namespace CAP_Core.CodeExporter;
 
@@ -189,45 +190,15 @@ public class ExportValidator
     }
 
     /// <summary>
-    /// Calculates the expected Nazca position for a component.
-    /// Uses NazcaOriginOffset when explicitly set (non-zero) or for known PDK function names.
-    /// Mirrors the logic in SimpleNazcaExporter.CalculateOriginOffset (Issue #355 fix).
+    /// Calculates the expected Nazca position for a component via
+    /// <see cref="NazcaCoordinateMapper"/> — the same single source of truth the
+    /// exporter uses, so the validator can never drift from the export math.
     /// </summary>
-    private (double X, double Y) CalculateExpectedNazcaPosition(Component comp)
+    private static (double X, double Y) CalculateExpectedNazcaPosition(Component comp)
     {
-        var funcName = comp.NazcaFunctionName;
-
-        bool hasPdkFunctionName = !string.IsNullOrEmpty(funcName) && IsPdkFunction(funcName);
-        bool hasExplicitOriginOffset = comp.NazcaOriginOffsetX != 0 || comp.NazcaOriginOffsetY != 0;
-
-        double originOffsetX = 0;
-        double originOffsetY = 0;
-
-        if (hasPdkFunctionName || hasExplicitOriginOffset)
-        {
-            double rotRad = comp.RotationDegrees * Math.PI / 180.0;
-            originOffsetX = comp.NazcaOriginOffsetX * Math.Cos(rotRad) - comp.NazcaOriginOffsetY * Math.Sin(rotRad);
-            originOffsetY = comp.NazcaOriginOffsetX * Math.Sin(rotRad) + comp.NazcaOriginOffsetY * Math.Cos(rotRad);
-        }
-        else
-        {
-            originOffsetY = comp.HeightMicrometers;
-        }
-
-        var nazcaX = comp.PhysicalX + originOffsetX;
-        var nazcaY = -(comp.PhysicalY + originOffsetY);
-
-        return (nazcaX, nazcaY);
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, rawOverrideAnchor: null);
+        return (placement.X, placement.Y);
     }
-
-    /// <summary>
-    /// Checks if a function name looks like a real PDK function.
-    /// </summary>
-    private static bool IsPdkFunction(string name) =>
-        name.StartsWith("ebeam_", StringComparison.OrdinalIgnoreCase) ||
-        name.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase) ||
-        (name.Contains(".", StringComparison.Ordinal) &&
-         !name.StartsWith("demo.", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Normalizes an angle to 0-360 range.

--- a/Connect-A-Pic-Core/CodeExporter/ExportValidator.cs
+++ b/Connect-A-Pic-Core/CodeExporter/ExportValidator.cs
@@ -41,7 +41,7 @@ public class ExportValidator
     /// <summary>
     /// Validates that component placements in Nazca code match expected positions.
     /// </summary>
-    private void ValidateComponentPositions(
+    private static void ValidateComponentPositions(
         List<Component> components,
         ParsedNazcaDesign parsed,
         ValidationResult result)

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -111,31 +111,6 @@ namespace CAP_Core.Components.Connections
         /// </summary>
         public double TotalLossDb { get; private set; }
 
-        // Nazca-Export
-        public string ExportToNazca()
-        {
-            var startComp = StartPin.ParentComponent;
-            var endComp = EndPin.ParentComponent;
-            var startCellName = $"cell_{startComp.PhysicalX}_{startComp.PhysicalY}";
-            var endCellName = $"cell_{endComp.PhysicalX}_{endComp.PhysicalY}";
-
-            return Type switch
-            {
-                WaveguideType.Straight =>
-                    $"        ic.strt_p2p(pin1={startCellName}.pin['{StartPin.Name}'], " +
-                    $"pin2={endCellName}.pin['{EndPin.Name}']).put()\n",
-
-                WaveguideType.SBend =>
-                    $"        ic.sbend_p2p(pin1={startCellName}.pin['{StartPin.Name}'], " +
-                    $"pin2={endCellName}.pin['{EndPin.Name}'], " +
-                    $"radius={BendRadiusMicrometers}).put()\n",
-
-                _ => // Auto: Nazca wählt automatisch
-                    $"        ic.cobra_p2p(pin1={startCellName}.pin['{StartPin.Name}'], " +
-                    $"pin2={endCellName}.pin['{EndPin.Name}']).put()\n"
-            };
-        }
-
         /// <summary>
         /// Recalculates the transmission coefficient based on current pin positions and loss parameters.
         /// Should be called whenever connected components are moved.

--- a/Connect-A-Pic-Core/Components/Core/PhysicalPin.cs
+++ b/Connect-A-Pic-Core/Components/Core/PhysicalPin.cs
@@ -1,3 +1,5 @@
+using CAP_Core.Export;
+
 namespace CAP_Core.Components.Core
 {
     /// <summary>
@@ -29,72 +31,14 @@ namespace CAP_Core.Components.Core
         }
 
         /// <summary>
-        /// Gets the absolute Nazca-coordinate position of this pin.
-        /// Accounts for Y-flip, NazcaOriginOffset, and component rotation transformations.
-        /// Used for GDS/Nazca export where waveguide coordinates must match stub pin positions.
-        /// Fix for Issue #329: NazcaOriginOffset compensation.
-        /// Fix for Issue #338: Rotation transformation applied to local pin coordinates.
+        /// Gets the absolute Nazca-coordinate position of this pin: the plain Y negation
+        /// of the app-space position (app is Y-down, Nazca is Y-up). The app model is the
+        /// truth for where pins are; cell placement is calibrated separately so rendered
+        /// pins coincide. Delegates to <see cref="NazcaCoordinateMapper.GetPinNazcaPosition"/>.
         /// </summary>
         public (double x, double y) GetAbsoluteNazcaPosition()
         {
-            // Component Nazca placement
-            var (originOffsetX, originOffsetY) = CalculateOriginOffset(ParentComponent);
-            double nazcaCompX = ParentComponent.PhysicalX + originOffsetX;
-            double nazcaCompY = -(ParentComponent.PhysicalY + originOffsetY);
-
-            // Local pin Nazca coordinates in unrotated component space
-            // When NazcaOriginOffset is set, pins are positioned relative to the shifted origin
-            double localPinNazcaX = OffsetXMicrometers - originOffsetX;
-            double localPinNazcaY = (ParentComponent.HeightMicrometers - OffsetYMicrometers) - originOffsetY;
-
-            // Apply component rotation to local pin coordinates
-            // Nazca places cells with .put(x, y, -RotationDegrees), so pin world positions
-            // must use the same negated rotation to match stub pin locations.
-            double rotRad = -ParentComponent.RotationDegrees * Math.PI / 180.0;
-            double rotatedPinX = localPinNazcaX * Math.Cos(rotRad) - localPinNazcaY * Math.Sin(rotRad);
-            double rotatedPinY = localPinNazcaX * Math.Sin(rotRad) + localPinNazcaY * Math.Cos(rotRad);
-
-            return (nazcaCompX + rotatedPinX, nazcaCompY + rotatedPinY);
-        }
-
-        /// <summary>
-        /// Calculates the Nazca origin offset for a component (same logic as SimpleNazcaExporter).
-        /// Uses NazcaOriginOffset when explicitly set (non-zero) or for known PDK function names.
-        /// Fallback: height-based offset for legacy components with no explicit origin.
-        /// Fix for Issue #355: components with explicit NazcaOriginOffset but non-PDK function names
-        /// (e.g., auto-generated names like "nazca_grating_coupler") now use the correct offset.
-        /// </summary>
-        private static (double OffsetX, double OffsetY) CalculateOriginOffset(Component comp)
-        {
-            var funcName = comp.NazcaFunctionName;
-
-            // Must match SimpleNazcaExporter.CalculateOriginOffset exactly!
-            // PDK components use their stored NazcaOriginOffset (often 0,0).
-            // Recognized by: known prefixes, module.function dot-notation, or explicit offset.
-            bool hasPdkFunctionName = !string.IsNullOrEmpty(funcName) &&
-                (funcName.StartsWith("ebeam_", StringComparison.OrdinalIgnoreCase) ||
-                 funcName.StartsWith("GC_", StringComparison.Ordinal) ||
-                 funcName.StartsWith("ANT_", StringComparison.Ordinal) ||
-                 funcName.StartsWith("crossing_", StringComparison.OrdinalIgnoreCase) ||
-                 funcName.StartsWith("taper_", StringComparison.OrdinalIgnoreCase) ||
-                 funcName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase) ||
-                 funcName.Contains('.'));
-
-            // Also use PDK formula when explicit NazcaOriginOffset is set (non-zero).
-            // This handles components with auto-generated function names that still have
-            // a physical Nazca origin offset defined (e.g., grating couplers loaded from templates).
-            bool hasExplicitOriginOffset = comp.NazcaOriginOffsetX != 0 || comp.NazcaOriginOffsetY != 0;
-
-            if (hasPdkFunctionName || hasExplicitOriginOffset)
-            {
-                double rotRad = comp.RotationDegrees * Math.PI / 180.0;
-                double offsetX = comp.NazcaOriginOffsetX * Math.Cos(rotRad) - comp.NazcaOriginOffsetY * Math.Sin(rotRad);
-                double offsetY = comp.NazcaOriginOffsetX * Math.Sin(rotRad) + comp.NazcaOriginOffsetY * Math.Cos(rotRad);
-                return (offsetX, offsetY);
-            }
-
-            // Fallback for legacy components with no explicit Nazca origin offset
-            return (0, comp.HeightMicrometers);
+            return NazcaCoordinateMapper.GetPinNazcaPosition(this);
         }
 
         /// <summary>

--- a/Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs
+++ b/Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs
@@ -137,7 +137,7 @@ public static class NazcaCoordinateMapper
 
     /// <summary>
     /// Origin offset (ox, oy) of a non-override component. Detection rules are
-    /// behaviour-identical to the heuristics the exporter historically applied:
+    /// the established export heuristics:
     /// PDK name or explicit calibrated offset → stored NazcaOriginOffset (issue #355
     /// covers auto-generated names with a calibrated offset); parametric straights
     /// anchor on their first pin; everything else uses the legacy bottom-left fallback.

--- a/Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs
+++ b/Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs
@@ -1,0 +1,199 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Export;
+
+/// <summary>
+/// Where and how a component's Nazca cell is placed in the exported script.
+/// The anchor is always the cell's 'org' pin:
+/// <c>factory().put('org', X, Y, RotationDegrees)</c>.
+/// </summary>
+/// <param name="X">Nazca X coordinate where the cell origin is put.</param>
+/// <param name="Y">Nazca Y coordinate where the cell origin is put.</param>
+/// <param name="RotationDegrees">Put rotation, i.e. the negated app rotation (Nazca is Y-up).</param>
+public record CellPlacement(double X, double Y, double RotationDegrees);
+
+/// <summary>
+/// Single source of truth for all app→Nazca coordinate answers (issue #565).
+/// App space is Y-down with the component box anchored at its top-left corner;
+/// Nazca space is Y-up. Points convert by Y negation, angles by negation.
+/// </summary>
+public static class NazcaCoordinateMapper
+{
+    /// <summary>
+    /// Computes where the component's cell must be put ('org'-anchored) so that the
+    /// rotated cell geometry lands exactly on the component's app-space box.
+    /// The cell-internal unrotated bbox is rotated by the put rotation and re-anchored
+    /// so its top-left corner hits the app box top-left (PhysicalX, -PhysicalY) — the
+    /// app rotates pin offsets about the box centre while keeping the top-left fixed,
+    /// and rotating about a different point only differs by a translation that this
+    /// bbox re-anchoring absorbs exactly.
+    /// </summary>
+    /// <param name="comp">The component to place.</param>
+    /// <param name="rawOverrideAnchor">
+    /// Cell-internal bbox anchor (XMin, YMax) persisted with a raw-code override,
+    /// or null for PDK/legacy components.
+    /// </param>
+    public static CellPlacement GetCellPlacement(
+        Component comp, (double XMin, double YMax)? rawOverrideAnchor)
+    {
+        var (w0, h0) = GetUnrotatedDimensions(comp);
+        var bbox = GetUnrotatedCellBbox(comp, rawOverrideAnchor, w0, h0);
+        double putRotation = NormalizeZero(-comp.RotationDegrees);
+        var (minX, maxY) = GetRotatedBboxAnchor(bbox, putRotation);
+        return new CellPlacement(
+            NormalizeZero(comp.PhysicalX - minX),
+            NormalizeZero(-comp.PhysicalY - maxY),
+            putRotation);
+    }
+
+    /// <summary>
+    /// World-space Nazca position of a pin. Universal plain Y negation of the app
+    /// position: the app model is the truth for where pins ARE (the canvas draws them
+    /// there); calibration data only influences where the CELL is placed so its
+    /// rendered pins coincide with the app pins.
+    /// </summary>
+    public static (double X, double Y) GetPinNazcaPosition(PhysicalPin pin)
+    {
+        var (x, y) = pin.GetAbsolutePosition();
+        return ToNazca(x, y);
+    }
+
+    /// <summary>
+    /// World-space Nazca angle of a pin: the negated app world angle
+    /// (AngleDegrees + RotationDegrees, normalised to [0, 360) first), so the result
+    /// lies in (-360, 0] — the convention the exporter has always emitted.
+    /// </summary>
+    public static double GetPinNazcaAngle(PhysicalPin pin) =>
+        NormalizeZero(-pin.GetAbsoluteAngle());
+
+    /// <summary>
+    /// Converts an app-space point (Y-down) to Nazca space (Y-up).
+    /// </summary>
+    public static (double X, double Y) ToNazca(double appX, double appY) =>
+        (appX, NormalizeZero(-appY));
+
+    /// <summary>
+    /// Returns true if the function name looks like a real PDK function (e.g.
+    /// "ebeam_y_1550"). Recognizes SiEPIC EBeam PDK naming patterns and module
+    /// dot-notation; demo_pdk stubs are excluded because they are exported as
+    /// locally generated cells, not PDK calls.
+    /// </summary>
+    public static bool IsPdkFunction(string name) =>
+        name.StartsWith("ebeam_", StringComparison.OrdinalIgnoreCase) ||
+        name.StartsWith("GC_", StringComparison.Ordinal) ||
+        name.StartsWith("ANT_", StringComparison.Ordinal) ||
+        name.StartsWith("crossing_", StringComparison.OrdinalIgnoreCase) ||
+        name.StartsWith("taper_", StringComparison.OrdinalIgnoreCase) ||
+        // SiEPIC ships a few generic-named PCells too (the `contra_*` family
+        // is the directional-coupler set under the EBeam library).
+        name.StartsWith("contra_", StringComparison.OrdinalIgnoreCase) ||
+        (name.Contains('.', StringComparison.Ordinal) &&
+         !name.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Checks if a component is a parametric straight waveguide: the function name
+    /// hints at a straight ("straight"/"strt") and the parameters carry a length
+    /// argument, so the export emits nd.strt(length=...) instead of a fixed cell.
+    /// </summary>
+    public static bool IsParametricStraight(string funcName, string parameters)
+    {
+        if (string.IsNullOrEmpty(parameters))
+            return false;
+
+        var lower = funcName.ToLowerInvariant();
+        var hasLength = parameters.Contains("length=", StringComparison.OrdinalIgnoreCase);
+        var isStraight = lower.Contains("straight") || lower.Contains("strt");
+
+        return hasLength && isStraight;
+    }
+
+    /// <summary>
+    /// Unrotated cell dimensions. Component.Width/Height hold the CURRENT
+    /// (rotation-swapped) values, so 90°/270° states swap them back.
+    /// </summary>
+    private static (double Width, double Height) GetUnrotatedDimensions(Component comp) =>
+        comp.RotationDegrees % 180 == 0
+            ? (comp.WidthMicrometers, comp.HeightMicrometers)
+            : (comp.HeightMicrometers, comp.WidthMicrometers);
+
+    /// <summary>
+    /// Cell-internal unrotated bbox (Nazca Y-up, org = cell origin) — the single
+    /// branching point between the component kinds.
+    /// </summary>
+    private static (double XMin, double YMin, double XMax, double YMax) GetUnrotatedCellBbox(
+        Component comp, (double XMin, double YMax)? rawOverrideAnchor, double w0, double h0)
+    {
+        // A raw-code override persists its own measured bbox anchor; the cell geometry
+        // is whatever the user's code renders, so the anchor is authoritative.
+        if (rawOverrideAnchor is { } anchor)
+            return (anchor.XMin, anchor.YMax - h0, anchor.XMin + w0, anchor.YMax);
+
+        // Calibrated/heuristic origin offset (ox, oy): at rotation 0 the org pin must
+        // land on (PhysicalX + ox, -(PhysicalY + oy)) — the long-standing calibrated
+        // convention — which parameterises the bbox as [-ox, oy - H0, -ox + W0, oy].
+        var (ox, oy) = GetOriginOffset(comp, h0);
+        return (-ox, oy - h0, -ox + w0, oy);
+    }
+
+    /// <summary>
+    /// Origin offset (ox, oy) of a non-override component. Detection rules are
+    /// behaviour-identical to the heuristics the exporter historically applied:
+    /// PDK name or explicit calibrated offset → stored NazcaOriginOffset (issue #355
+    /// covers auto-generated names with a calibrated offset); parametric straights
+    /// anchor on their first pin; everything else uses the legacy bottom-left fallback.
+    /// </summary>
+    private static (double OffsetX, double OffsetY) GetOriginOffset(
+        Component comp, double unrotatedHeight)
+    {
+        var funcName = comp.NazcaFunctionName;
+
+        bool hasPdkFunctionName = !string.IsNullOrEmpty(funcName) &&
+            (IsPdkFunction(funcName) || funcName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase));
+        bool hasExplicitOriginOffset = comp.NazcaOriginOffsetX != 0 || comp.NazcaOriginOffsetY != 0;
+
+        if (hasPdkFunctionName || hasExplicitOriginOffset)
+            return (comp.NazcaOriginOffsetX, comp.NazcaOriginOffsetY);
+
+        if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
+        {
+            var firstPin = comp.PhysicalPins.FirstOrDefault();
+            if (firstPin != null)
+                return (firstPin.OffsetXMicrometers, firstPin.OffsetYMicrometers);
+        }
+
+        // Legacy components without calibration data: org at the box bottom-left.
+        return (0, unrotatedHeight);
+    }
+
+    /// <summary>
+    /// Rotates the bbox corners by the put rotation and returns the values the
+    /// placement needs: the rotated bbox's min X and max Y (its top-left corner).
+    /// </summary>
+    private static (double MinX, double MaxY) GetRotatedBboxAnchor(
+        (double XMin, double YMin, double XMax, double YMax) bbox, double rotationDegrees)
+    {
+        double rad = rotationDegrees * Math.PI / 180.0;
+        double cos = Math.Cos(rad);
+        double sin = Math.Sin(rad);
+
+        double minX = double.PositiveInfinity;
+        double maxY = double.NegativeInfinity;
+        foreach (var (x, y) in new[]
+        {
+            (bbox.XMin, bbox.YMin), (bbox.XMax, bbox.YMin),
+            (bbox.XMax, bbox.YMax), (bbox.XMin, bbox.YMax),
+        })
+        {
+            minX = Math.Min(minX, x * cos - y * sin);
+            maxY = Math.Max(maxY, x * sin + y * cos);
+        }
+        return (minX, maxY);
+    }
+
+    /// <summary>
+    /// Normalizes negative zero to positive zero so formatted output never
+    /// shows "-0.00".
+    /// </summary>
+    private static double NormalizeZero(double value) =>
+        value == 0.0 ? 0.0 : value;
+}

--- a/Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs
+++ b/Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs
@@ -108,6 +108,47 @@ public static class NazcaCoordinateMapper
     }
 
     /// <summary>
+    /// Cell-internal origin offset (ox, oy) the placement uses for this component —
+    /// the SAME value <see cref="GetCellPlacement"/> derives the bbox from. The stub
+    /// generator anchors its geometry and pins on this so the rendered cell pins land
+    /// exactly where <see cref="GetPinNazcaPosition"/> places the app pins; computing it
+    /// independently would re-introduce the dual-source drift this mapper removes.
+    /// Returns the calibrated/heuristic offset; raw-code overrides do not use it.
+    /// </summary>
+    public static (double OffsetX, double OffsetY) GetStubAnchor(Component comp)
+    {
+        var (_, h0) = GetUnrotatedDimensions(comp);
+        return GetOriginOffset(comp, h0);
+    }
+
+    /// <summary>
+    /// A pin's offset in the component's UNROTATED frame (its value at RotationDegrees=0).
+    /// A Nazca cell is rotation-independent — the export rotates it via <c>.put(rot)</c> —
+    /// but rotating a component physically mutates its live pin offsets, so a stub built
+    /// from the live offsets would bake the rotation in twice. This inverts the 90°-step
+    /// offset rotation the rotate command applies, giving the stub the rotation-free
+    /// geometry the placement's <c>.put(rot)</c> then orients correctly.
+    /// </summary>
+    public static (double OffsetX, double OffsetY) GetUnrotatedPinOffset(Component comp, PhysicalPin pin)
+    {
+        double x = pin.OffsetXMicrometers;
+        double y = pin.OffsetYMicrometers;
+        // Current live dimensions; each inverse 90° step swaps them back.
+        double width = comp.WidthMicrometers;
+        double height = comp.HeightMicrometers;
+
+        int steps = (((int)Math.Round(comp.RotationDegrees / 90.0)) % 4 + 4) % 4;
+        for (int i = 0; i < steps; i++)
+        {
+            // Inverse of the rotate command's CCW step (x,y)->(H0 - y, x) on dims
+            // (W0,H0)->(H0,W0): with current width W1 = H0, the original is (y, W1 - x).
+            (x, y) = (y, width - x);
+            (width, height) = (height, width);
+        }
+        return (x, y);
+    }
+
+    /// <summary>
     /// Unrotated cell dimensions. Component.Width/Height hold the CURRENT
     /// (rotation-swapped) values, so 90°/270° states swap them back.
     /// </summary>
@@ -157,8 +198,12 @@ public static class NazcaCoordinateMapper
         if (IsParametricStraight(funcName, comp.NazcaFunctionParameters))
         {
             var firstPin = comp.PhysicalPins.FirstOrDefault();
+            // The cell is unrotated; anchor on the first pin's UNROTATED offset so the
+            // anchor matches the unrotated bbox even when the live component is rotated.
             if (firstPin != null)
-                return (firstPin.OffsetXMicrometers, firstPin.OffsetYMicrometers);
+                return GetUnrotatedPinOffset(comp, firstPin);
+            // A parametric straight with no pins is a misconfigured PDK component; fall
+            // through to the legacy bottom-left fallback rather than guessing an anchor.
         }
 
         // Legacy components without calibration data: org at the box bottom-left.
@@ -192,8 +237,9 @@ public static class NazcaCoordinateMapper
 
     /// <summary>
     /// Normalizes negative zero to positive zero so formatted output never
-    /// shows "-0.00".
+    /// shows "-0.00". Public so the exporter shares this single definition
+    /// instead of keeping a duplicate copy (issue #565).
     /// </summary>
-    private static double NormalizeZero(double value) =>
+    public static double NormalizeZero(double value) =>
         value == 0.0 ? 0.0 : value;
 }

--- a/Connect-A-Pic-Core/Export/NazcaReferenceGenerator.cs
+++ b/Connect-A-Pic-Core/Export/NazcaReferenceGenerator.cs
@@ -45,10 +45,11 @@ public class NazcaReferenceGenerator
     public const double WaveguideLength = Component2X - ComponentWidth; // 200.0
 
     // ── Derived Nazca coordinate values ──────────────────────────────────
-    // With NazcaOriginOffset=(0, ComponentHeight), pin Nazca positions account for the shifted origin:
-    // Component Nazca Y = -(PhysicalY + ComponentHeight)
-    // Pin local Y in stub = (ComponentHeight - PinOffsetY) - ComponentHeight = -PinOffsetY
-    // Pin absolute Nazca Y = Component Y + Pin local Y = -ComponentHeight + (-PinOffsetY) = -(ComponentHeight + PinOffsetY)
+    // With NazcaOriginOffset=(0, ComponentHeight) the cell origin is the box
+    // bottom-left: Component Nazca Y = -(PhysicalY + ComponentHeight).
+    // The stub pin sits (ComponentHeight - PinOffsetY) above that origin, so its
+    // world position is the plain Y negation of the app pin — the universal pin
+    // conversion of NazcaCoordinateMapper (issue #565). Waveguides start there.
 
     /// <summary>Nazca Y for component 1 placement.</summary>
     public const double NazcaComp1Y = -(Component1Y + ComponentHeight); // -50.0
@@ -59,8 +60,8 @@ public class NazcaReferenceGenerator
     /// <summary>Nazca X for waveguide start point.</summary>
     public const double NazcaWgStartX = Component1X + PinOffsetX;      // 100.0
 
-    /// <summary>Nazca Y for waveguide start point (with NazcaOriginOffset=(0,ComponentHeight)).</summary>
-    public const double NazcaWgStartY = -(Component1Y + ComponentHeight + PinOffsetY);   // -(0 + 50 + 25) = -75.0
+    /// <summary>Nazca Y for waveguide start point: plain Y negation of the app pin.</summary>
+    public const double NazcaWgStartY = -(Component1Y + PinOffsetY);   // -(0 + 25) = -25.0
 
     // ── Public API ────────────────────────────────────────────────────────
 

--- a/UnitTests/ComponentSettings/InstanceOverride/NazcaCodeTemplateBuilderTests.cs
+++ b/UnitTests/ComponentSettings/InstanceOverride/NazcaCodeTemplateBuilderTests.cs
@@ -88,17 +88,6 @@ public class NazcaCodeTemplateBuilderTests
         result.XMax.ShouldBeGreaterThan(result.XMin);
     }
 
-    private static string? FindRealPreviewScript()
-    {
-        const string scriptName = "render_component_preview.py";
-        var current = new DirectoryInfo(
-            Path.GetDirectoryName(typeof(NazcaCodeTemplateBuilderTests).Assembly.Location)!);
-        while (current != null)
-        {
-            var candidate = Path.Combine(current.FullName, "scripts", scriptName);
-            if (File.Exists(candidate)) return candidate;
-            current = current.Parent;
-        }
-        return null;
-    }
+    private static string? FindRealPreviewScript() =>
+        UnitTests.Integration.GdsAlignmentTestSetup.FindRealPreviewScript();
 }

--- a/UnitTests/ComponentSettings/InstanceOverride/NazcaEditorPreviewIntegrationTests.cs
+++ b/UnitTests/ComponentSettings/InstanceOverride/NazcaEditorPreviewIntegrationTests.cs
@@ -144,17 +144,6 @@ public class NazcaEditorPreviewIntegrationTests
         return (python, FindRealPreviewScript());
     }
 
-    private static string? FindRealPreviewScript()
-    {
-        const string scriptName = "render_component_preview.py";
-        var current = new DirectoryInfo(
-            Path.GetDirectoryName(typeof(NazcaEditorPreviewIntegrationTests).Assembly.Location)!);
-        while (current != null)
-        {
-            var candidate = Path.Combine(current.FullName, "scripts", scriptName);
-            if (File.Exists(candidate)) return candidate;
-            current = current.Parent;
-        }
-        return null;
-    }
+    private static string? FindRealPreviewScript() =>
+        UnitTests.Integration.GdsAlignmentTestSetup.FindRealPreviewScript();
 }

--- a/UnitTests/Components/SiepicPdkTests.cs
+++ b/UnitTests/Components/SiepicPdkTests.cs
@@ -2,6 +2,7 @@ using CAP.Avalonia.Services;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.FormulaReading;
+using CAP_Core.Export;
 using CAP_Core.LightCalculation;
 using CAP_Core.Tiles;
 using CAP_DataAccess.Components.ComponentDraftMapper;
@@ -211,24 +212,24 @@ public class SiepicPdkTests
     [Fact]
     public void IsPdkFunction_EbeamPrefix_ReturnsTrue()
     {
-        SimpleNazcaExporter.IsPdkFunction("ebeam_y_1550").ShouldBeTrue();
-        SimpleNazcaExporter.IsPdkFunction("ebeam_dc_te1550").ShouldBeTrue();
-        SimpleNazcaExporter.IsPdkFunction("ebeam_gc_te1550").ShouldBeTrue();
+        NazcaCoordinateMapper.IsPdkFunction("ebeam_y_1550").ShouldBeTrue();
+        NazcaCoordinateMapper.IsPdkFunction("ebeam_dc_te1550").ShouldBeTrue();
+        NazcaCoordinateMapper.IsPdkFunction("ebeam_gc_te1550").ShouldBeTrue();
     }
 
     [Fact]
     public void IsPdkFunction_DottedName_ReturnsTrue()
     {
-        SimpleNazcaExporter.IsPdkFunction("siepic_ebeam_pdk.ebeam_y_1550").ShouldBeTrue();
-        SimpleNazcaExporter.IsPdkFunction("amf.mmi2x2").ShouldBeTrue();
+        NazcaCoordinateMapper.IsPdkFunction("siepic_ebeam_pdk.ebeam_y_1550").ShouldBeTrue();
+        NazcaCoordinateMapper.IsPdkFunction("amf.mmi2x2").ShouldBeTrue();
     }
 
     [Fact]
     public void IsPdkFunction_HeuristicName_ReturnsFalse()
     {
-        SimpleNazcaExporter.IsPdkFunction("grating_coupler").ShouldBeFalse();
-        SimpleNazcaExporter.IsPdkFunction("phase_shifter").ShouldBeFalse();
-        SimpleNazcaExporter.IsPdkFunction("splitter_1x2").ShouldBeFalse();
+        NazcaCoordinateMapper.IsPdkFunction("grating_coupler").ShouldBeFalse();
+        NazcaCoordinateMapper.IsPdkFunction("phase_shifter").ShouldBeFalse();
+        NazcaCoordinateMapper.IsPdkFunction("splitter_1x2").ShouldBeFalse();
     }
 
     [Fact]

--- a/UnitTests/Export/NazcaCoordinateMapperTests.cs
+++ b/UnitTests/Export/NazcaCoordinateMapperTests.cs
@@ -1,0 +1,250 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Export;
+
+/// <summary>
+/// Pure-math unit tests for <see cref="NazcaCoordinateMapper"/>: placement formula for
+/// every bbox parameterisation, rotation handling, pin conversion and detection rules.
+/// </summary>
+public class NazcaCoordinateMapperTests
+{
+    private const double Tolerance = 1e-9;
+
+    /// <summary>
+    /// Creates a bare component at app top-left (x, y) with the given UNROTATED size,
+    /// then applies <paramref name="rotationSteps"/> app rotations via <see cref="RotateLikeApp"/>.
+    /// </summary>
+    private static Component CreateComponent(
+        double x, double y, double w0, double h0,
+        string nazcaFunctionName = "placeCell_StraightWG", int rotationSteps = 0)
+    {
+        var comp = TestComponentFactory.CreateStraightWaveGuide();
+        comp.PhysicalX = x;
+        comp.PhysicalY = y;
+        comp.WidthMicrometers = w0;
+        comp.HeightMicrometers = h0;
+        comp.NazcaFunctionName = nazcaFunctionName;
+        for (int i = 0; i < rotationSteps; i++)
+            RotateLikeApp(comp);
+        return comp;
+    }
+
+    /// <summary>
+    /// Mirrors the app's RotateComponentCommand semantics: pin offsets rotate 90° CCW about
+    /// the box centre, width/height swap, top-left stays fixed, RotationDegrees += 90.
+    /// </summary>
+    private static void RotateLikeApp(Component comp)
+    {
+        double w = comp.WidthMicrometers;
+        double h = comp.HeightMicrometers;
+        foreach (var pin in comp.PhysicalPins)
+        {
+            double x = pin.OffsetXMicrometers - w / 2;
+            double y = pin.OffsetYMicrometers - h / 2;
+            pin.OffsetXMicrometers = -y + h / 2;
+            pin.OffsetYMicrometers = x + w / 2;
+        }
+        comp.WidthMicrometers = h;
+        comp.HeightMicrometers = w;
+        comp.RotationDegrees = (comp.RotationDegrees + 90) % 360;
+    }
+
+    // Override anchor XMin=-3, YMax=10 with unrotated size W0=45, H0=11 gives the
+    // cell-internal bbox B = [-3, -1, 42, 10] (Nazca Y-up). The put rotation
+    // r = -RotationDegrees rotates B's four corners; the put position is
+    // T = (PhysX - minx', -PhysY - maxy') with the component box at (100, 50):
+    //  r=0:    B unchanged                                       -> minx'=-3,  maxy'=10 -> T=(103, -60)
+    //  r=-90:  (x,y)->(y,-x): (-1,3) (-1,-42) (10,-42) (10,3)    -> minx'=-1,  maxy'=3  -> T=(101, -53)
+    //  r=-180: (x,y)->(-x,-y): (3,1) (-42,1) (-42,-10) (3,-10)   -> minx'=-42, maxy'=1  -> T=(142, -51)
+    //  r=-270: (x,y)->(-y,x): (1,-3) (1,42) (-10,42) (-10,-3)    -> minx'=-10, maxy'=42 -> T=(110, -92)
+    [Theory]
+    [InlineData(0, 103, -60, 0)]
+    [InlineData(1, 101, -53, -90)]
+    [InlineData(2, 142, -51, -180)]
+    [InlineData(3, 110, -92, -270)]
+    public void GetCellPlacement_OverrideAnchor_AllRotations(
+        int rotationSteps, double expectedX, double expectedY, double expectedRotation)
+    {
+        var comp = CreateComponent(100, 50, w0: 45, h0: 11, rotationSteps: rotationSteps);
+
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, (-3, 10));
+
+        placement.X.ShouldBe(expectedX, Tolerance);
+        placement.Y.ShouldBe(expectedY, Tolerance);
+        placement.RotationDegrees.ShouldBe(expectedRotation, Tolerance);
+    }
+
+    // PDK calibration offset (ox=0, oy=30) with W0=250, H0=60 parameterises
+    // B = [-ox, oy-H0, -ox+W0, oy] = [0, -30, 250, 30]; component box at (100, 50):
+    //  r=0:   minx'=0, maxy'=30 -> T=(100, -80) — must equal the calibrated legacy
+    //         convention org = (PhysX + ox, -(PhysY + oy)).
+    //  r=-90: (x,y)->(y,-x): (-30,0) (-30,-250) (30,-250) (30,0) -> minx'=-30, maxy'=0
+    //         -> T=(130, -50)
+    [Theory]
+    [InlineData(0, 100, -80, 0)]
+    [InlineData(1, 130, -50, -90)]
+    public void GetCellPlacement_PdkExplicitOffset_Rotation0And90(
+        int rotationSteps, double expectedX, double expectedY, double expectedRotation)
+    {
+        var comp = CreateComponent(100, 50, 250, 60, "demo.mmi2x2_dp", rotationSteps);
+        comp.NazcaOriginOffsetX = 0;
+        comp.NazcaOriginOffsetY = 30;
+
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, null);
+
+        placement.X.ShouldBe(expectedX, Tolerance);
+        placement.Y.ShouldBe(expectedY, Tolerance);
+        placement.RotationDegrees.ShouldBe(expectedRotation, Tolerance);
+    }
+
+    [Fact]
+    public void GetCellPlacement_LegacyFallback_AnchorsOrgAtBoxBottomLeft()
+    {
+        // No PDK name, no explicit offset, no parametric straight -> (ox, oy) = (0, H0),
+        // i.e. B = [0, 0, W0, H0]; at rot 0: T = (PhysX, -(PhysY + H0)) = (10, -270).
+        var comp = CreateComponent(10, 20, 250, 250);
+
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, null);
+
+        placement.X.ShouldBe(10, Tolerance);
+        placement.Y.ShouldBe(-270, Tolerance);
+        placement.RotationDegrees.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetCellPlacement_ParametricStraight_UsesFirstPinOffsetAsOrigin()
+    {
+        // Parametric straights (name contains "straight"/"strt" AND parameters contain
+        // "length=") anchor org on the first pin: (ox, oy) = (0, 125), H0 = 250
+        // -> B = [0, -125, 250, 125]; at rot 0: T = (10 - 0, -20 - 125) = (10, -145).
+        var comp = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        comp.PhysicalX = 10;
+        comp.PhysicalY = 20;
+        comp.WidthMicrometers = 250;
+        comp.HeightMicrometers = 250;
+        comp.NazcaFunctionParameters = "length=250";
+
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, null);
+
+        placement.X.ShouldBe(10, Tolerance);
+        placement.Y.ShouldBe(-145, Tolerance);
+    }
+
+    [Fact]
+    public void GetCellPlacement_NullAnchorWithPdkName_TakesCalibrationPathEvenWithZeroOffset()
+    {
+        // PDK detection must NOT fall through to the legacy (0, H0) fallback when the
+        // calibrated offset happens to be (0, 0): B = [0, -60, 250, 0] -> T = (100, -50);
+        // the legacy fallback would give (100, -110) instead.
+        var comp = CreateComponent(100, 50, 250, 60, "demo.mmi2x2_dp");
+
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, null);
+
+        placement.X.ShouldBe(100, Tolerance);
+        placement.Y.ShouldBe(-50, Tolerance);
+    }
+
+    [Fact]
+    public void GetCellPlacement_ExplicitOffsetWithoutPdkName_TakesCalibrationPath()
+    {
+        // Auto-named components with a calibrated offset (grating couplers, issue #355)
+        // must use it: ox=15, oy=30, W0=H0=30 -> B = [-15, 0, 15, 30];
+        // at rot 0: T = (0 + 15, -0 - 30) = (15, -30).
+        var comp = CreateComponent(0, 0, 30, 30, "nazca_grating_coupler");
+        comp.NazcaOriginOffsetX = 15;
+        comp.NazcaOriginOffsetY = 30;
+
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, null);
+
+        placement.X.ShouldBe(15, Tolerance);
+        placement.Y.ShouldBe(-30, Tolerance);
+    }
+
+    [Fact]
+    public void GetPinNazcaPosition_IsPlainYNegationOfAppPosition()
+    {
+        // App pin world position (100+10, 50+20) = (110, 70) -> Nazca (110, -70).
+        var comp = CreateComponent(100, 50, 45, 11);
+        var pin = new PhysicalPin
+        { Name = "p", ParentComponent = comp, OffsetXMicrometers = 10, OffsetYMicrometers = 20 };
+
+        var (x, y) = NazcaCoordinateMapper.GetPinNazcaPosition(pin);
+
+        x.ShouldBe(110, Tolerance);
+        y.ShouldBe(-70, Tolerance);
+    }
+
+    [Fact]
+    public void GetPinNazcaPosition_RotatedComponent_UsesPreRotatedOffsets()
+    {
+        // The app pre-rotates pin offsets about the box centre: pin (0, 5.5) on a 45x11
+        // box has centre distance (-22.5, 0); CCW screen rotation maps it to (0, -22.5),
+        // re-anchored on the swapped centre (5.5, 22.5) -> offset (5.5, 0).
+        // App world position = (100 + 5.5, 50 + 0) -> Nazca (105.5, -50).
+        var comp = CreateComponent(100, 50, 45, 11);
+        comp.PhysicalPins.Add(new PhysicalPin
+        { Name = "p", ParentComponent = comp, OffsetXMicrometers = 0, OffsetYMicrometers = 5.5 });
+        RotateLikeApp(comp);
+
+        var (x, y) = NazcaCoordinateMapper.GetPinNazcaPosition(comp.PhysicalPins[^1]);
+
+        x.ShouldBe(105.5, Tolerance);
+        y.ShouldBe(-50, Tolerance);
+    }
+
+    // Nazca pin angle = -(world angle), world angle = AngleDegrees + RotationDegrees
+    // normalised to [0, 360) first — same convention as the exporter's existing
+    // "-pin.GetAbsoluteAngle()" output, so emitted scripts stay byte-identical.
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(180, 0, -180)]
+    [InlineData(180, 90, -270)]   // world 270 -> -270
+    [InlineData(270, 180, -90)]   // world 450 normalises to 90 -> -90
+    public void GetPinNazcaAngle_NegatesNormalisedWorldAngle(
+        double pinAngle, double rotationDegrees, double expected)
+    {
+        var comp = CreateComponent(0, 0, 10, 10);
+        comp.RotationDegrees = rotationDegrees;
+
+        NazcaCoordinateMapper.GetPinNazcaAngle(
+            new PhysicalPin { Name = "p", ParentComponent = comp, AngleDegrees = pinAngle })
+            .ShouldBe(expected, Tolerance);
+    }
+
+    [Fact]
+    public void ToNazca_NegatesY_AndAvoidsNegativeZero()
+    {
+        NazcaCoordinateMapper.ToNazca(5, 7).ShouldBe((5d, -7d));
+        var (_, y) = NazcaCoordinateMapper.ToNazca(3, 0);
+        double.IsNegative(y).ShouldBeFalse();
+    }
+
+    // Detection rules must stay behaviour-identical to the exporter heuristics they
+    // replace: known SiEPIC prefixes, module dot-notation (except demo_pdk stubs).
+    [Theory]
+    [InlineData("ebeam_y_1550", true)]
+    [InlineData("GC_TE_1550_8degOxide_BB", true)]
+    [InlineData("ANT_MMI_1x2", true)]
+    [InlineData("crossing_horizontal", true)]
+    [InlineData("taper_350nm", true)]
+    [InlineData("contra_dc", true)]
+    [InlineData("demo.mmi2x2_dp", true)]
+    [InlineData("demo_pdk.splitter", false)]
+    [InlineData("placeCell_StraightWG", false)]
+    public void IsPdkFunction_MatchesExporterHeuristic(string name, bool expected) =>
+        NazcaCoordinateMapper.IsPdkFunction(name).ShouldBe(expected);
+
+    // Parametric straight = name contains "straight" or "strt" AND parameters carry a
+    // length argument; the check is case-insensitive on the length key.
+    [Theory]
+    [InlineData("cell_straight", "length=100", true)]
+    [InlineData("my_strt", "Length=5", true)]
+    [InlineData("cell_straight", "", false)]
+    [InlineData("mmi2x2", "length=100", false)]
+    public void IsParametricStraight_MatchesExporterHeuristic(
+        string funcName, string parameters, bool expected) =>
+        NazcaCoordinateMapper.IsParametricStraight(funcName, parameters).ShouldBe(expected);
+}

--- a/UnitTests/Export/NazcaCoordinateMapperTests.cs
+++ b/UnitTests/Export/NazcaCoordinateMapperTests.cs
@@ -52,10 +52,9 @@ public class NazcaCoordinateMapperTests
         comp.RotationDegrees = (comp.RotationDegrees + 90) % 360;
     }
 
-    // Override anchor XMin=-3, YMax=10 with unrotated size W0=45, H0=11 gives the
-    // cell-internal bbox B = [-3, -1, 42, 10] (Nazca Y-up). The put rotation
-    // r = -RotationDegrees rotates B's four corners; the put position is
-    // T = (PhysX - minx', -PhysY - maxy') with the component box at (100, 50):
+    // Override anchor XMin=-3, YMax=10 with unrotated W0=45, H0=11 gives the cell-internal
+    // bbox B = [-3, -1, 42, 10] (Nazca Y-up). Put rotation r = -RotationDegrees rotates B's
+    // four corners; put position T = (PhysX - minx', -PhysY - maxy'), box at (100, 50):
     //  r=0:    B unchanged                                       -> minx'=-3,  maxy'=10 -> T=(103, -60)
     //  r=-90:  (x,y)->(y,-x): (-1,3) (-1,-42) (10,-42) (10,3)    -> minx'=-1,  maxy'=3  -> T=(101, -53)
     //  r=-180: (x,y)->(-x,-y): (3,1) (-42,1) (-42,-10) (3,-10)   -> minx'=-42, maxy'=1  -> T=(142, -51)
@@ -78,15 +77,19 @@ public class NazcaCoordinateMapperTests
     }
 
     // PDK calibration offset (ox=0, oy=30) with W0=250, H0=60 parameterises
-    // B = [-ox, oy-H0, -ox+W0, oy] = [0, -30, 250, 30]; component box at (100, 50):
-    //  r=0:   minx'=0, maxy'=30 -> T=(100, -80) — must equal the calibrated legacy
-    //         convention org = (PhysX + ox, -(PhysY + oy)).
-    //  r=-90: (x,y)->(y,-x): (-30,0) (-30,-250) (30,-250) (30,0) -> minx'=-30, maxy'=0
-    //         -> T=(130, -50)
+    // B = [-ox, oy-H0, -ox+W0, oy] = [0, -30, 250, 30]; component box at (100, 50),
+    // T = (PhysX - minx', -PhysY - maxy'). Hand-derived per put rotation:
+    //  r=0:    B unchanged    -> minx'=0,    maxy'=30  -> T=(100, -80) — must equal the
+    //          calibrated legacy convention org = (PhysX + ox, -(PhysY + oy)).
+    //  r=-90:  (x,y)->(y,-x)  -> minx'=-30,  maxy'=0   -> T=(130, -50)
+    //  r=-180: (x,y)->(-x,-y) -> minx'=-250, maxy'=30  -> T=(350, -80)
+    //  r=-270: (x,y)->(-y,x)  -> minx'=-30,  maxy'=250 -> T=(130, -300)
     [Theory]
     [InlineData(0, 100, -80, 0)]
     [InlineData(1, 130, -50, -90)]
-    public void GetCellPlacement_PdkExplicitOffset_Rotation0And90(
+    [InlineData(2, 350, -80, -180)]
+    [InlineData(3, 130, -300, -270)]
+    public void GetCellPlacement_PdkExplicitOffset_AllRotations(
         int rotationSteps, double expectedX, double expectedY, double expectedRotation)
     {
         var comp = CreateComponent(100, 50, 250, 60, "demo.mmi2x2_dp", rotationSteps);
@@ -117,8 +120,7 @@ public class NazcaCoordinateMapperTests
     [Fact]
     public void GetCellPlacement_ParametricStraight_UsesFirstPinOffsetAsOrigin()
     {
-        // Parametric straights (name contains "straight"/"strt" AND parameters contain
-        // "length=") anchor org on the first pin: (ox, oy) = (0, 125), H0 = 250
+        // Parametric straights anchor org on the first pin: (ox, oy) = (0, 125), H0 = 250
         // -> B = [0, -125, 250, 125]; at rot 0: T = (10 - 0, -20 - 125) = (10, -145).
         var comp = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
         comp.PhysicalX = 10;
@@ -180,10 +182,9 @@ public class NazcaCoordinateMapperTests
     [Fact]
     public void GetPinNazcaPosition_RotatedComponent_UsesPreRotatedOffsets()
     {
-        // The app pre-rotates pin offsets about the box centre: pin (0, 5.5) on a 45x11
-        // box has centre distance (-22.5, 0); CCW screen rotation maps it to (0, -22.5),
-        // re-anchored on the swapped centre (5.5, 22.5) -> offset (5.5, 0).
-        // App world position = (100 + 5.5, 50 + 0) -> Nazca (105.5, -50).
+        // The app pre-rotates pin offsets about the box centre: pin (0, 5.5) on a 45x11 box
+        // has centre distance (-22.5, 0); CCW rotation gives (0, -22.5), re-anchored on the
+        // swapped centre (5.5, 22.5) -> offset (5.5, 0); world (105.5, 50) -> Nazca (105.5, -50).
         var comp = CreateComponent(100, 50, 45, 11);
         comp.PhysicalPins.Add(new PhysicalPin
         { Name = "p", ParentComponent = comp, OffsetXMicrometers = 0, OffsetYMicrometers = 5.5 });
@@ -195,9 +196,8 @@ public class NazcaCoordinateMapperTests
         y.ShouldBe(-50, Tolerance);
     }
 
-    // Nazca pin angle = -(world angle), world angle = AngleDegrees + RotationDegrees
-    // normalised to [0, 360) first — same convention as the exporter's existing
-    // "-pin.GetAbsoluteAngle()" output, so emitted scripts stay byte-identical.
+    // Nazca pin angle = -(AngleDegrees + RotationDegrees normalised to [0, 360)) — same
+    // convention as "-pin.GetAbsoluteAngle()" in the exporter, so scripts stay byte-identical.
     [Theory]
     [InlineData(0, 0, 0)]
     [InlineData(180, 0, -180)]

--- a/UnitTests/Integration/GdsAlignmentTestSetup.cs
+++ b/UnitTests/Integration/GdsAlignmentTestSetup.cs
@@ -1,0 +1,66 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.ComponentSettings.InstanceOverride;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Environment resolution and override setup shared by the alignment test matrix
+/// (<see cref="GdsExportAlignmentTests"/>). Uses the same env-skip pattern and
+/// editor-VM flow as <see cref="NazcaOverrideFullFlowIntegrationTests"/>.
+/// </summary>
+internal static class GdsAlignmentTestSetup
+{
+    /// <summary>Resolves (nazca-capable python, preview script path), or nulls to skip.</summary>
+    public static async Task<(string? Python, string? Script)> ResolveEnvironmentAsync()
+    {
+        var python = await new PythonDiscoveryService().FindFirstNazcaPythonPathAsync();
+        return (python, FindRealPreviewScript());
+    }
+
+    /// <summary>Pastes the showcase code, runs a REAL preview and applies the override.</summary>
+    public static async Task<Dictionary<string, NazcaCodeOverride>> ApplyShowcaseOverrideAsync(
+        DesignCanvasViewModel canvas, Component dut, string python, string previewScript)
+    {
+        var store = new Dictionary<string, NazcaCodeOverride>();
+        var vm = new InstanceNazcaCodeEditorViewModel(
+            componentKey: dut.Identifier,
+            storedOverrides: store,
+            liveComponent: dut,
+            moduleName: dut.NazcaModuleName,
+            nazcaFunction: dut.NazcaFunctionName ?? string.Empty,
+            nazcaParameters: dut.NazcaFunctionParameters,
+            templateCode: NazcaCodeTemplateBuilder.Build(
+                dut.NazcaModuleName, dut.NazcaFunctionName, dut.NazcaFunctionParameters),
+            previewService: new NazcaComponentPreviewService(python, previewScript),
+            onPinsChanged: _ => canvas.OnComponentPinsChanged(dut));
+        await vm.InitializeAsync();
+
+        vm.Code = NazcaCodeExamples.Complex;
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        vm.IsValid.ShouldBeTrue($"showcase preview must render. Error: {vm.PreviewError}");
+        vm.ApplyOverrideCommand.Execute(null);
+
+        store[dut.Identifier].OverrideBboxXMinMicrometers.ShouldNotBeNull(
+            "Apply must persist the bbox anchor — the mapper needs it for placement");
+        return store;
+    }
+
+    private static string? FindRealPreviewScript()
+    {
+        const string scriptName = "render_component_preview.py";
+        var current = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(GdsAlignmentTestSetup).Assembly.Location)!);
+        while (current != null)
+        {
+            var candidate = Path.Combine(current.FullName, "scripts", scriptName);
+            if (File.Exists(candidate)) return candidate;
+            current = current.Parent;
+        }
+        return null;
+    }
+}

--- a/UnitTests/Integration/GdsAlignmentTestSetup.cs
+++ b/UnitTests/Integration/GdsAlignmentTestSetup.cs
@@ -50,7 +50,12 @@ internal static class GdsAlignmentTestSetup
         return store;
     }
 
-    private static string? FindRealPreviewScript()
+    /// <summary>
+    /// Walks up from the test assembly to the repo root and returns the path to
+    /// <c>scripts/render_component_preview.py</c>, or null if not found. Shared by the
+    /// nazca-preview tests so the lookup lives in one place (issue #565).
+    /// </summary>
+    internal static string? FindRealPreviewScript()
     {
         const string scriptName = "render_component_preview.py";
         var current = new DirectoryInfo(

--- a/UnitTests/Integration/GdsComplexLayoutTests.cs
+++ b/UnitTests/Integration/GdsComplexLayoutTests.cs
@@ -50,13 +50,10 @@ public class GdsComplexLayoutTests
             {
                 var (globalX, globalY) = pin.GetAbsoluteNazcaPosition();
 
-                // Manual calculation to verify
-                double compNazcaX = x + mmi2x2Template.NazcaOriginOffsetX;
-                double compNazcaY = -(y + mmi2x2Template.NazcaOriginOffsetY);
-                double pinLocalNazcaY = mmi2x2Template.HeightMicrometers - pin.OffsetYMicrometers;
-
-                double expectedGlobalX = compNazcaX + pin.OffsetXMicrometers;
-                double expectedGlobalY = compNazcaY + pinLocalNazcaY;
+                // Pin Nazca position is the plain Y negation of the app world position —
+                // calibration data only moves the CELL, never the pins (issue #565).
+                double expectedGlobalX = x + pin.OffsetXMicrometers;
+                double expectedGlobalY = -(y + pin.OffsetYMicrometers);
 
                 double xDev = Math.Abs(expectedGlobalX - globalX);
                 double yDev = Math.Abs(expectedGlobalY - globalY);
@@ -97,13 +94,9 @@ public class GdsComplexLayoutTests
             {
                 var (globalX, globalY) = pin.GetAbsoluteNazcaPosition();
 
-                // Manual calculation
-                double compNazcaX = x + mmi1x2Template.NazcaOriginOffsetX;
-                double compNazcaY = -(y + mmi1x2Template.NazcaOriginOffsetY);
-                double pinLocalNazcaY = mmi1x2Template.HeightMicrometers - pin.OffsetYMicrometers;
-
-                double expectedGlobalX = compNazcaX + pin.OffsetXMicrometers;
-                double expectedGlobalY = compNazcaY + pinLocalNazcaY;
+                // Universal Y negation — see MMI2x2 test above for the rationale.
+                double expectedGlobalX = x + pin.OffsetXMicrometers;
+                double expectedGlobalY = -(y + pin.OffsetYMicrometers);
 
                 double xDev = Math.Abs(expectedGlobalX - globalX);
                 double yDev = Math.Abs(expectedGlobalY - globalY);
@@ -141,15 +134,10 @@ public class GdsComplexLayoutTests
             {
                 var (globalX, globalY) = pin.GetAbsoluteNazcaPosition();
 
-                // Manual calculation for stub-based (legacy) component:
-                // The stub cell origin is at the bottom-left (Nazca y=0 = editor y=HeightMicrometers).
-                // NazcaOriginOffsetY applies to real PDK cells; legacy stubs use HeightMicrometers.
-                double compNazcaX = x + gcTemplate.NazcaOriginOffsetX;
-                double compNazcaY = -(y + gcTemplate.HeightMicrometers);
-                double pinLocalNazcaY = gcTemplate.HeightMicrometers - pin.OffsetYMicrometers;
-
-                double expectedGlobalX = compNazcaX + pin.OffsetXMicrometers;
-                double expectedGlobalY = compNazcaY + pinLocalNazcaY;
+                // Y negation applies to legacy stub components exactly like PDK cells:
+                // the legacy (0, Height) origin fallback only affects cell placement.
+                double expectedGlobalX = x + pin.OffsetXMicrometers;
+                double expectedGlobalY = -(y + pin.OffsetYMicrometers);
 
                 double xDev = Math.Abs(expectedGlobalX - globalX);
                 double yDev = Math.Abs(expectedGlobalY - globalY);
@@ -208,19 +196,10 @@ public class GdsComplexLayoutTests
             {
                 var (globalX, globalY) = pin.GetAbsoluteNazcaPosition();
 
-                // Calculate expected position.
-                // "Grating Coupler" has no PDK function name → legacy stub with origin at bottom.
-                // Legacy fallback: CalculateOriginOffset returns (0, HeightMicrometers).
-                bool isPdkFunc = !string.IsNullOrEmpty(template.NazcaFunctionName) &&
-                    (template.NazcaFunctionName.StartsWith("ebeam_", StringComparison.OrdinalIgnoreCase) ||
-                     template.NazcaFunctionName.StartsWith("demo_pdk.", StringComparison.OrdinalIgnoreCase));
-                double effectiveOriginY = isPdkFunc ? template.NazcaOriginOffsetY : template.HeightMicrometers;
-                double compNazcaX = x + template.NazcaOriginOffsetX;
-                double compNazcaY = -(y + effectiveOriginY);
-                double pinLocalNazcaY = template.HeightMicrometers - pin.OffsetYMicrometers;
-
-                double expectedGlobalX = compNazcaX + pin.OffsetXMicrometers;
-                double expectedGlobalY = compNazcaY + pinLocalNazcaY;
+                // One expectation for ALL component kinds: the universal Y negation.
+                // No per-kind branching — exactly the property issue #565 establishes.
+                double expectedGlobalX = x + pin.OffsetXMicrometers;
+                double expectedGlobalY = -(y + pin.OffsetYMicrometers);
 
                 double xDev = Math.Abs(expectedGlobalX - globalX);
                 double yDev = Math.Abs(expectedGlobalY - globalY);

--- a/UnitTests/Integration/GdsCoordinateVerificationTests.cs
+++ b/UnitTests/Integration/GdsCoordinateVerificationTests.cs
@@ -40,6 +40,12 @@ namespace UnitTests.Integration;
 ///     Mismatch               = 9.5 µm
 ///
 /// These tests FAIL when the bug is present, providing exact deviation data.
+///
+/// Scope: this is a STRUCTURAL check that the exporter routes its coordinates through
+/// <see cref="NazcaCoordinateMapper"/> (it asserts against the same mapper the exporter
+/// uses, so it cannot catch a wrong mapper FORMULA). Formula correctness is proven by
+/// NazcaCoordinateMapperTests (hand-computed expectations) and by GdsExportAlignmentTests
+/// (verified against the real nazca engine that writes the GDS).
 /// </summary>
 public class GdsCoordinateVerificationTests
 {

--- a/UnitTests/Integration/GdsCoordinateVerificationTests.cs
+++ b/UnitTests/Integration/GdsCoordinateVerificationTests.cs
@@ -499,9 +499,11 @@ public class GdsCoordinateVerificationTests
             return;
         }
 
-        // Use the pin's GetAbsoluteNazcaPosition() method which correctly handles
-        // rotation and NazcaOriginOffset transformations
-        var (expectedX, expectedY) = pin1.GetAbsoluteNazcaPosition();
+        // Expected via NazcaCoordinateMapper (#565): pin positions convert by plain
+        // Y negation for every rotation — the segment was routed from the app pin
+        // position, so the exported start must be its Y-negated image. The old
+        // rotated-origin-offset pin formula diverged here and was part of the bug.
+        var (expectedX, expectedY) = NazcaCoordinateMapper.GetPinNazcaPosition(pin1);
 
         var wg = parsed.WaveguideStubs.First();
         double xDev = Math.Abs(expectedX - wg.StartX);

--- a/UnitTests/Integration/GdsCoordinateVerificationTests.cs
+++ b/UnitTests/Integration/GdsCoordinateVerificationTests.cs
@@ -500,9 +500,9 @@ public class GdsCoordinateVerificationTests
         }
 
         // Expected via NazcaCoordinateMapper (#565): pin positions convert by plain
-        // Y negation for every rotation — the segment was routed from the app pin
-        // position, so the exported start must be its Y-negated image. The old
-        // rotated-origin-offset pin formula diverged here and was part of the bug.
+        // Y negation for every rotation — the segment is routed from the app pin
+        // position, so the exported start must be its Y-negated image. A rotated
+        // origin-offset pin formula would diverge here (the #565 misalignment).
         var (expectedX, expectedY) = NazcaCoordinateMapper.GetPinNazcaPosition(pin1);
 
         var wg = parsed.WaveguideStubs.First();

--- a/UnitTests/Integration/GdsExportAlignmentTests.cs
+++ b/UnitTests/Integration/GdsExportAlignmentTests.cs
@@ -16,8 +16,8 @@ namespace UnitTests.Integration;
 /// Acceptance matrix for issue #565: {PDK component, raw-code override} × {0°, 90°,
 /// 180°, 270°}. Each cell exports the design with the verification epilog, EXECUTES
 /// the script with real nazca and compares the engine-reported world pin positions
-/// (.pins.json) against <see cref="NazcaCoordinateMapper"/> — closing the loop that
-/// previously only existed as a comment pair ("must match exactly!").
+/// (.pins.json) against <see cref="NazcaCoordinateMapper"/> — so the alignment
+/// contract is checked by the same nazca engine that writes the GDS.
 ///
 /// Requires a nazca-capable Python (resolved via <see cref="PythonDiscoveryService"/>);
 /// skips cleanly when none is available so CI without nazca still passes.

--- a/UnitTests/Integration/GdsExportAlignmentTests.cs
+++ b/UnitTests/Integration/GdsExportAlignmentTests.cs
@@ -27,7 +27,16 @@ public class GdsExportAlignmentTests
     private const double ToleranceMicrometers = 0.01;
     private const double ToleranceDegrees = 0.01;
 
+    private readonly System.Collections.ObjectModel.ObservableCollection<ComponentTemplate> _library;
+
+    public GdsExportAlignmentTests()
+    {
+        _library = new System.Collections.ObjectModel.ObservableCollection<ComponentTemplate>(
+            TestPdkLoader.LoadAllTemplates());
+    }
+
     /// <summary>Nazca bookkeeping pins every cell ships; they are not user pins.</summary>
+    // Must match INTERNAL in scripts/render_component_preview.py — keep in sync manually.
     private static readonly HashSet<string> NazcaInternalPins = new(StringComparer.Ordinal)
     {
         "org", "cc", "lb", "lc", "lt", "tl", "tc", "tr", "rt", "rc", "rb", "br", "bc", "bl"
@@ -41,7 +50,7 @@ public class GdsExportAlignmentTests
 
         // "2x2 MMI Coupler" — calibrated against the real demofab cell (org at the
         // left-centre, offset (0, 30)), so its rendered pins must hit the app pins.
-        var template = TestPdkLoader.LoadAllTemplates()
+        var template = _library
             .First(t => t.NazcaFunctionName == "demo.mmi2x2_dp");
         var canvas = new DesignCanvasViewModel();
         var dut = ComponentTemplates.CreateFromTemplate(template, 100, 400);
@@ -64,8 +73,7 @@ public class GdsExportAlignmentTests
         var (python, previewScript) = await GdsAlignmentTestSetup.ResolveEnvironmentAsync();
         if (python == null || previewScript == null) return;   // env skip
 
-        var library = TestPdkLoader.LoadAllTemplates();
-        var mmiTemplate = library.First(t => t.Name == "1x2 MMI Splitter");
+        var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
         var canvas = new DesignCanvasViewModel();
         var dut = ComponentTemplates.CreateFromTemplate(mmiTemplate, 100, 400);
         dut.Identifier = "align_override_dut";
@@ -83,6 +91,67 @@ public class GdsExportAlignmentTests
         await RunRotationMatrixAsync(canvas, dutVm, dut, python, store);
     }
 
+    [Fact]
+    public async Task ParametricStraight_Rotated_PinsAlignInGds()
+    {
+        var (python, _) = await GdsAlignmentTestSetup.ResolveEnvironmentAsync();
+        if (python == null) return;   // env skip
+
+        // A parametric demo_pdk.straight with NazcaOriginOffset=(0,0) and pins on the
+        // centre line (OffsetY = H/2). The mapper anchors parametric straights on the
+        // first pin (oy = H/2), but the stub used NazcaOriginOffsetY (=0), so before
+        // the fix the rendered waveguide/pins sat H/2 below where the mapper claims —
+        // a real GDS misalignment that the engine-reported pins expose here.
+        var canvas = new DesignCanvasViewModel();
+        var dut = CreateParametricStraight("align_strt_dut", 100, lengthMicrometers: 200, x: 100, y: 400);
+        var dutVm = canvas.AddComponent(dut);
+        var partner = CreateParametricStraight("align_strt_partner", 100, lengthMicrometers: 200, x: 900, y: 400);
+        canvas.AddComponent(partner);
+
+        canvas.ConnectPins(
+            dut.PhysicalPins.First(p => p.Name == "b0"),
+            partner.PhysicalPins.First(p => p.Name == "a0"));
+
+        // 0° and 90° are sufficient to catch the anchor mismatch on both axes.
+        await RunRotationMatrixAsync(canvas, dutVm, dut, python, overrides: null, maxSteps: 2);
+    }
+
+    /// <summary>
+    /// Builds a parametric straight waveguide (demo_pdk.straight, length=...) with the
+    /// origin offset left at (0,0) and both pins on the cell centre line (OffsetY = H/2),
+    /// mirroring the SimpleNazcaExporterTests straight fixture.
+    /// </summary>
+    private static Component CreateParametricStraight(
+        string identifier, double heightMicrometers, double lengthMicrometers, double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+        var comp = new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, CAP_Core.LightCalculation.SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: "demo_pdk.straight",
+            nazcaFunctionParams: $"length={lengthMicrometers.ToString(CultureInfo.InvariantCulture)}",
+            parts: parts,
+            typeNumber: 0,
+            identifier: identifier,
+            rotationCounterClock: DiscreteRotation.R0);
+        comp.WidthMicrometers = lengthMicrometers;
+        comp.HeightMicrometers = heightMicrometers;
+        comp.PhysicalX = x;
+        comp.PhysicalY = y;
+        comp.PhysicalPins.Add(new PhysicalPin
+        {
+            Name = "a0", OffsetXMicrometers = 0, OffsetYMicrometers = heightMicrometers / 2,
+            AngleDegrees = 180, ParentComponent = comp
+        });
+        comp.PhysicalPins.Add(new PhysicalPin
+        {
+            Name = "b0", OffsetXMicrometers = lengthMicrometers, OffsetYMicrometers = heightMicrometers / 2,
+            AngleDegrees = 0, ParentComponent = comp
+        });
+        return comp;
+    }
+
     // ── Matrix driver ────────────────────────────────────────────────────────
 
     /// <summary>
@@ -92,9 +161,9 @@ public class GdsExportAlignmentTests
     /// </summary>
     private static async Task RunRotationMatrixAsync(
         DesignCanvasViewModel canvas, ComponentViewModel dutVm, Component dut,
-        string python, IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+        string python, IReadOnlyDictionary<string, NazcaCodeOverride>? overrides, int maxSteps = 4)
     {
-        for (int rotationSteps = 0; rotationSteps < 4; rotationSteps++)
+        for (int rotationSteps = 0; rotationSteps < maxSteps; rotationSteps++)
         {
             if (rotationSteps > 0)
             {

--- a/UnitTests/Integration/GdsExportAlignmentTests.cs
+++ b/UnitTests/Integration/GdsExportAlignmentTests.cs
@@ -1,0 +1,236 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Acceptance matrix for issue #565: {PDK component, raw-code override} × {0°, 90°,
+/// 180°, 270°}. Each cell exports the design with the verification epilog, EXECUTES
+/// the script with real nazca and compares the engine-reported world pin positions
+/// (.pins.json) against <see cref="NazcaCoordinateMapper"/> — closing the loop that
+/// previously only existed as a comment pair ("must match exactly!").
+///
+/// Requires a nazca-capable Python (resolved via <see cref="PythonDiscoveryService"/>);
+/// skips cleanly when none is available so CI without nazca still passes.
+/// </summary>
+public class GdsExportAlignmentTests
+{
+    private const double ToleranceMicrometers = 0.01;
+    private const double ToleranceDegrees = 0.01;
+
+    /// <summary>Nazca bookkeeping pins every cell ships; they are not user pins.</summary>
+    private static readonly HashSet<string> NazcaInternalPins = new(StringComparer.Ordinal)
+    {
+        "org", "cc", "lb", "lc", "lt", "tl", "tc", "tr", "rt", "rc", "rb", "br", "bc", "bl"
+    };
+
+    [Fact]
+    public async Task PdkComponent_AllRotations_PinsAlignInGds()
+    {
+        var (python, _) = await GdsAlignmentTestSetup.ResolveEnvironmentAsync();
+        if (python == null) return;   // env skip (CI without nazca)
+
+        // "2x2 MMI Coupler" — calibrated against the real demofab cell (org at the
+        // left-centre, offset (0, 30)), so its rendered pins must hit the app pins.
+        var template = TestPdkLoader.LoadAllTemplates()
+            .First(t => t.NazcaFunctionName == "demo.mmi2x2_dp");
+        var canvas = new DesignCanvasViewModel();
+        var dut = ComponentTemplates.CreateFromTemplate(template, 100, 400);
+        dut.Identifier = "align_dut";
+        var dutVm = canvas.AddComponent(dut, template.Name);
+        var partner = ComponentTemplates.CreateFromTemplate(template, 900, 400);
+        partner.Identifier = "align_partner";
+        canvas.AddComponent(partner, template.Name);
+
+        canvas.ConnectPins(
+            dut.PhysicalPins.First(p => p.Name == "out1"),
+            partner.PhysicalPins.First(p => p.Name == "in1"));
+
+        await RunRotationMatrixAsync(canvas, dutVm, dut, python, overrides: null);
+    }
+
+    [Fact]
+    public async Task OverrideComponent_AllRotations_PinsAlignInGds()
+    {
+        var (python, previewScript) = await GdsAlignmentTestSetup.ResolveEnvironmentAsync();
+        if (python == null || previewScript == null) return;   // env skip
+
+        var library = TestPdkLoader.LoadAllTemplates();
+        var mmiTemplate = library.First(t => t.Name == "1x2 MMI Splitter");
+        var canvas = new DesignCanvasViewModel();
+        var dut = ComponentTemplates.CreateFromTemplate(mmiTemplate, 100, 400);
+        dut.Identifier = "align_override_dut";
+        var dutVm = canvas.AddComponent(dut, mmiTemplate.Name);
+        var partner = ComponentTemplates.CreateFromTemplate(mmiTemplate, 900, 400);
+        partner.Identifier = "align_override_partner";
+        canvas.AddComponent(partner, mmiTemplate.Name);
+
+        var store = await GdsAlignmentTestSetup.ApplyShowcaseOverrideAsync(
+            canvas, dut, python, previewScript);
+        canvas.ConnectPins(
+            dut.PhysicalPins.First(p => p.Name == "out"),
+            partner.PhysicalPins.First(p => p.Name == "in"));
+
+        await RunRotationMatrixAsync(canvas, dutVm, dut, python, store);
+    }
+
+    // ── Matrix driver ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Rotates the DUT through 0/90/180/270° via the REAL rotate command, exporting
+    /// and python-verifying after each step. A loop instead of a Theory keeps the
+    /// python startup cost at one run per rotation instead of per test case.
+    /// </summary>
+    private static async Task RunRotationMatrixAsync(
+        DesignCanvasViewModel canvas, ComponentViewModel dutVm, Component dut,
+        string python, IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+    {
+        for (int rotationSteps = 0; rotationSteps < 4; rotationSteps++)
+        {
+            if (rotationSteps > 0)
+            {
+                var cmd = new RotateComponentCommand(canvas, dutVm);
+                cmd.Execute();
+                cmd.WasApplied.ShouldBeTrue($"rotation step {rotationSteps} must not be blocked");
+            }
+            await canvas.RecalculateRoutesAsync();
+
+            var script = new SimpleNazcaExporter().Export(
+                canvas, overrides: overrides, emitVerification: true);
+            var (pins, scriptPath, tempDir) = await RunScriptAsync(script, python, rotationSteps);
+
+            AssertDutPinsAlign(dut, pins["comp_0"], rotationSteps, scriptPath);
+            AssertConnectionHitsPins(canvas, script, rotationSteps);
+
+            // Reached only when this rotation passed — failures keep the script,
+            // .gds and .pins.json on disk for analysis.
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>Writes the script to a temp dir, executes it and parses .pins.json.</summary>
+    private static async Task<(Dictionary<string, Dictionary<string, double[]>> Pins,
+        string ScriptPath, string TempDir)> RunScriptAsync(
+        string script, string python, int rotationSteps)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("lunima_align_").FullName;
+        var scriptPath = Path.Combine(tempDir, $"alignment_rot{rotationSteps}.py");
+        await File.WriteAllTextAsync(scriptPath, script);
+
+        var gdsService = new GdsExportService();
+        gdsService.SetCustomPythonPath(python);
+        var result = await gdsService.ExportToGdsAsync(scriptPath, generateGds: true);
+
+        result.Success.ShouldBeTrue(
+            $"rot={rotationSteps * 90}°: generated script must run without errors. " +
+            $"Error: {result.ErrorMessage}\n--- script ---\n{script}");
+        File.Exists(result.GdsPath).ShouldBeTrue(
+            $"rot={rotationSteps * 90}°: a .gds file must be produced");
+
+        var pinsJsonPath = Path.ChangeExtension(scriptPath, ".pins.json");
+        File.Exists(pinsJsonPath).ShouldBeTrue(
+            $"rot={rotationSteps * 90}°: the verification epilog must write the pins json");
+        var pins = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, double[]>>>(
+            await File.ReadAllTextAsync(pinsJsonPath))!;
+        return (pins, scriptPath, tempDir);
+    }
+
+    // ── Asserts ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Every app pin of the DUT must coincide with a rendered instance pin — in
+    /// position AND direction. Override cells expose the app pin names directly; PDK
+    /// cells use nazca's own naming (a0/b0/…), so there the geometrically nearest
+    /// rendered pin must coincide — then the angle check guards against a wrong pin
+    /// merely passing by (e.g. a mirrored cell). Note mmi2x2_dp is 180°-symmetric
+    /// (a0↔b1 incl. angles), so a put-rotation SIGN error renders identical GDS for
+    /// it; that error class is caught by the asymmetric override cell's matrix.
+    /// </summary>
+    private static void AssertDutPinsAlign(
+        Component dut, Dictionary<string, double[]> instancePins, int rotationSteps,
+        string scriptPath)
+    {
+        var rendered = instancePins
+            .Where(kv => !NazcaInternalPins.Contains(kv.Key)).ToList();
+        rendered.ShouldNotBeEmpty(
+            $"rot={rotationSteps * 90}°: the placed instance must expose rendered pins");
+
+        foreach (var pin in dut.PhysicalPins)
+        {
+            var (wantX, wantY) = NazcaCoordinateMapper.GetPinNazcaPosition(pin);
+            var (matchName, actual) = instancePins.TryGetValue(pin.Name, out var byName)
+                ? (pin.Name, byName)
+                : rendered.OrderBy(kv => Distance(kv.Value, wantX, wantY))
+                    .Select(kv => (kv.Key, kv.Value)).First();
+
+            Distance(actual, wantX, wantY).ShouldBeLessThan(ToleranceMicrometers,
+                $"pin '{pin.Name}' (nazca pin '{matchName}') at rot={rotationSteps * 90}°: " +
+                $"actual=({actual[0]:F3},{actual[1]:F3}) expected=({wantX:F3},{wantY:F3}) " +
+                $"script={scriptPath}");
+
+            var wantAngle = NazcaCoordinateMapper.GetPinNazcaAngle(pin);
+            AngleDifference(actual[2], wantAngle).ShouldBeLessThan(ToleranceDegrees,
+                $"pin '{pin.Name}' (nazca pin '{matchName}') at rot={rotationSteps * 90}°: " +
+                $"angle actual={actual[2]:F1}° expected={wantAngle:F1}° script={scriptPath}");
+        }
+    }
+
+    /// <summary>Absolute angular difference folded into [0, 180].</summary>
+    private static double AngleDifference(double a, double b) =>
+        Math.Abs((((a - b) % 360) + 540) % 360 - 180);
+
+    /// <summary>
+    /// The emitted waveguide geometry must hit both connection pins: the routed path's
+    /// endpoints convert to the pins' nazca positions, and the script's first absolute
+    /// segment put sits on the start pin.
+    /// </summary>
+    private static void AssertConnectionHitsPins(
+        DesignCanvasViewModel canvas, string script, int rotationSteps)
+    {
+        var conn = canvas.Connections.Single().Connection;
+        var segments = conn.GetPathSegments();
+        segments.Count.ShouldBeGreaterThan(0,
+            $"rot={rotationSteps * 90}°: the connection must carry a routed path");
+
+        var (sx, sy) = NazcaCoordinateMapper.GetPinNazcaPosition(conn.StartPin!);
+        var (ex, ey) = NazcaCoordinateMapper.GetPinNazcaPosition(conn.EndPin!);
+        var (fx, fy) = NazcaCoordinateMapper.ToNazca(
+            segments[0].StartPoint.X, segments[0].StartPoint.Y);
+        var (lx, ly) = NazcaCoordinateMapper.ToNazca(
+            segments[^1].EndPoint.X, segments[^1].EndPoint.Y);
+
+        Distance(new[] { fx, fy }, sx, sy).ShouldBeLessThan(ToleranceMicrometers,
+            $"rot={rotationSteps * 90}°: route start ({fx:F3},{fy:F3}) must hit start pin ({sx:F3},{sy:F3})");
+        Distance(new[] { lx, ly }, ex, ey).ShouldBeLessThan(ToleranceMicrometers,
+            $"rot={rotationSteps * 90}°: route end ({lx:F3},{ly:F3}) must hit end pin ({ex:F3},{ey:F3})");
+
+        var (px, py) = FirstWaveguidePut(script);
+        Distance(new[] { px, py }, sx, sy).ShouldBeLessThan(ToleranceMicrometers,
+            $"rot={rotationSteps * 90}°: first emitted segment put ({px:F3},{py:F3}) " +
+            $"must sit on start pin ({sx:F3},{sy:F3})");
+    }
+
+    /// <summary>Parses the first absolute waveguide put after the connections marker.</summary>
+    private static (double X, double Y) FirstWaveguidePut(string script)
+    {
+        var idx = script.IndexOf("# Waveguide Connections", StringComparison.Ordinal);
+        idx.ShouldBeGreaterThan(-1, "script must contain a connections section");
+        var match = Regex.Match(
+            script[idx..], @"nd\.(strt|bend)\([^\n]*\.put\((-?\d+\.\d+), (-?\d+\.\d+)");
+        match.Success.ShouldBeTrue("script must emit an absolute first waveguide segment");
+        return (double.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture),
+                double.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture));
+    }
+
+    private static double Distance(double[] actual, double x, double y) =>
+        Math.Sqrt(Math.Pow(actual[0] - x, 2) + Math.Pow(actual[1] - y, 2));
+}

--- a/UnitTests/Integration/GdsGroundTruthTests.cs
+++ b/UnitTests/Integration/GdsGroundTruthTests.cs
@@ -180,8 +180,7 @@ public class GdsGroundTruthTests
     }
 
     /// <summary>
-    /// Verifies that NazcaReferenceGenerator Nazca coordinates use the Y-flip convention
-    /// and account for NazcaOriginOffset.
+    /// Verifies that NazcaReferenceGenerator Nazca coordinates use the Y-flip convention.
     /// </summary>
     [Fact]
     public void NazcaReferenceGenerator_GetExpectedNazcaCoordinates_YFlipped()
@@ -193,7 +192,10 @@ public class GdsGroundTruthTests
         coords["comp2_nazca"].X.ShouldBe(300.0,  PositionTolerance);
         coords["comp2_nazca"].Y.ShouldBe(-50.0,  PositionTolerance);
         coords["wg_start_nazca"].X.ShouldBe(100.0,  PositionTolerance);
-        coords["wg_start_nazca"].Y.ShouldBe(-75.0,  PositionTolerance); // -(0 + 50 + 25) with NazcaOriginOffset
+        // Plain Y negation of the app pin (NazcaCoordinateMapper convention, #565);
+        // matches scripts/generate_reference_nazca.py and lands ON the stub pin
+        // (placement -50 + stub pin local +25 = -25).
+        coords["wg_start_nazca"].Y.ShouldBe(-25.0,  PositionTolerance);
     }
 
     /// <summary>
@@ -208,8 +210,9 @@ public class GdsGroundTruthTests
         script.ShouldContain("0.00, -50.00, 0");   // comp1
         script.ShouldContain("300.00, -50.00, 0"); // comp2
 
-        // Waveguide start (with NazcaOriginOffset accounted for)
-        script.ShouldContain("100.00, -75.00, 0"); // wg start
+        // Waveguide start: plain Y negation of the app pin (#565) — coincides with
+        // the reference stub pin world position (-50 + 25 = -25).
+        script.ShouldContain("100.00, -25.00, 0"); // wg start
 
         // Waveguide length
         script.ShouldContain("200.00"); // wg length

--- a/UnitTests/Integration/GdsWaveguideAlignmentTests.cs
+++ b/UnitTests/Integration/GdsWaveguideAlignmentTests.cs
@@ -16,13 +16,15 @@ namespace UnitTests.Integration;
 /// <summary>
 /// Validates that waveguide segments are exported with correct Nazca coordinates.
 ///
-/// Root cause (Issue #366): multi-segment paths used Nazca chaining (.put()) for all
-/// segments after the first. The first segment starts at nazcaPin1 (correct via
-/// GetAbsoluteNazcaPosition), but the chain's NazcaOriginOffset correction is not
-/// propagated to subsequent segments.
+/// Motivation (Issue #366): multi-segment paths once used Nazca chaining (.put() without
+/// coordinates) for every segment after the first, which let coordinate errors accumulate
+/// along the chain. Every segment is now emitted with an absolute .put(x, y, angle).
 ///
-/// Fix: use absolute .put(x, y, angle) for every segment. All segments (including last)
-/// use simple Y-flip transformation from editor coordinates. No special pin-snapping.
+/// Current contract (issue #565): all app→Nazca coordinates flow through
+/// <see cref="NazcaCoordinateMapper"/>. Path geometry converts to Nazca by the universal
+/// Y negation (ToNazca); pins convert the same way (GetPinNazcaPosition). There is no
+/// separate NazcaOriginOffset correction on segments — cells are placed so their rendered
+/// pins coincide with the app pins, so segments simply meet those pins.
 ///
 /// Test categories:
 ///   A - Single straight segments (covered by #355; regression guard)

--- a/UnitTests/Integration/Mmi2x2PinAlignmentTests.cs
+++ b/UnitTests/Integration/Mmi2x2PinAlignmentTests.cs
@@ -1,3 +1,4 @@
+using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
@@ -9,14 +10,16 @@ using Xunit;
 namespace UnitTests.Integration;
 
 /// <summary>
-/// Tests for Issue #347: MMI 2x2 waveguide endpoints don't align with component pins.
+/// MMI 2x2 pin/waveguide alignment (issues #347, #565).
 ///
-/// Root cause: rotation sign error in GetAbsoluteNazcaPosition() and CalculateOriginOffset().
-/// Nazca places cells with .put(x, y, -RotationDegrees), so pin world positions must use
-/// R(-RotationDegrees) — not R(+RotationDegrees) as was previously done.
+/// Pin Nazca positions are the plain Y negation of the app world position
+/// (<see cref="CAP_Core.Export.NazcaCoordinateMapper.GetPinNazcaPosition"/>): the app
+/// pre-rotates pin offsets via RotateComponentCommand, so no rotation term may appear
+/// in the pin formula. These tests drive the REAL rotate command and compare against
+/// hand-derived offsets, so a sign error in the command or a reintroduced rotation
+/// term in the pin math both surface as tens-of-µm deviations.
 ///
-/// These tests use the demo_pdk.mmi2x2 component (120×50 µm, NazcaOriginOffset=(0,0))
-/// at all 4 rotation states to catch the specific bug reported by the user.
+/// Fixture: demo_pdk.mmi2x2 (120×50 µm, NazcaOriginOffset=(0,0), 4 pins).
 /// </summary>
 public class Mmi2x2PinAlignmentTests
 {
@@ -51,54 +54,54 @@ public class Mmi2x2PinAlignmentTests
     };
 
     /// <summary>
-    /// Verifies MMI 2x2 pin world positions match the Nazca math for all 4 rotations.
+    /// Verifies pin Nazca world positions for all 4 app rotation states, rotating via the
+    /// real <see cref="RotateComponentCommand"/>.
     ///
-    /// For a component at (physX, physY) with NazcaOriginOffset=(0,0):
-    ///   cellX = physX, cellY = -physY
-    ///   pinLocalX = pinOffsetX, pinLocalY = height - pinOffsetY
-    ///   worldPinX = cellX + R(-rot) * (localX, localY).x
-    ///   worldPinY = cellY + R(-rot) * (localX, localY).y
+    /// One CCW app rotation step maps an offset (ox, oy) in a w×h box to (h − oy, ox)
+    /// and swaps the dimensions; Nazca position = (physX + ox, −(physY + oy)).
+    /// Hand-derived offsets for the 120×50 box:
+    ///   a0 (0, 12.5):  k=1 → (37.5, 0);   k=2 → (120, 37.5); k=3 → (12.5, 120)
+    ///   b1 (120, 37.5): k=1 → (12.5, 120); k=2 → (0, 12.5);   k=3 → (37.5, 0)
     /// </summary>
     [Theory]
-    [InlineData(0,   100, 200)]
-    [InlineData(90,  100, 200)]
-    [InlineData(180, 100, 200)]
-    [InlineData(270, 100, 200)]
-    [InlineData(0,   0,   0)]
-    [InlineData(90,  0,   0)]
-    public void Mmi2x2_AllRotations_PinPositionsMatchNazcaMath(
-        int rotationDegrees, double physX, double physY)
+    [InlineData(0, 0,    12.5,  120,  37.5)]
+    [InlineData(1, 37.5, 0,     12.5, 120)]
+    [InlineData(2, 120,  37.5,  0,    12.5)]
+    [InlineData(3, 12.5, 120,   37.5, 0)]
+    public void Mmi2x2_AllRotations_PinPositionsAreYNegatedAppPositions(
+        int rotationSteps, double a0OffX, double a0OffY, double b1OffX, double b1OffY)
     {
+        const double physX = 100;
+        const double physY = 200;
+        var canvas = new DesignCanvasViewModel();
         var template = CreateMmi2x2Template();
         var mmi = ComponentTemplates.CreateFromTemplate(template, physX, physY);
-        mmi.RotationDegrees = rotationDegrees;
+        var vm = canvas.AddComponent(mmi, template.Name);
 
-        // NazcaOriginOffset=(0,0) so cell origin is just physX, -physY
-        double cellX = physX;
-        double cellY = -physY;
-
-        double rotRad = -rotationDegrees * Math.PI / 180.0; // Nazca sign
-
-        foreach (var pin in mmi.PhysicalPins)
+        for (int i = 0; i < rotationSteps; i++)
         {
-            double localX = pin.OffsetXMicrometers;
-            double localY = mmi.HeightMicrometers - pin.OffsetYMicrometers;
-
-            double expectedX = cellX + localX * Math.Cos(rotRad) - localY * Math.Sin(rotRad);
-            double expectedY = cellY + localX * Math.Sin(rotRad) + localY * Math.Cos(rotRad);
-
-            var (actualX, actualY) = pin.GetAbsoluteNazcaPosition();
-
-            double xDev = Math.Abs(expectedX - actualX);
-            double yDev = Math.Abs(expectedY - actualY);
-
-            xDev.ShouldBeLessThan(PinAlignmentTolerance,
-                $"MMI 2x2 pin '{pin.Name}' at rot={rotationDegrees}°: X deviation {xDev:F4} µm " +
-                $"(expected {expectedX:F3}, got {actualX:F3})");
-            yDev.ShouldBeLessThan(PinAlignmentTolerance,
-                $"MMI 2x2 pin '{pin.Name}' at rot={rotationDegrees}°: Y deviation {yDev:F4} µm " +
-                $"(expected {expectedY:F3}, got {actualY:F3})");
+            var command = new RotateComponentCommand(canvas, vm);
+            command.Execute();
+            command.WasApplied.ShouldBeTrue($"rotation step {i + 1} must not be blocked");
         }
+
+        AssertPinNazcaPosition(mmi, "a0", physX + a0OffX, -(physY + a0OffY), rotationSteps);
+        AssertPinNazcaPosition(mmi, "b1", physX + b1OffX, -(physY + b1OffY), rotationSteps);
+    }
+
+    private static void AssertPinNazcaPosition(
+        CAP_Core.Components.Core.Component comp, string pinName,
+        double expectedX, double expectedY, int rotationSteps)
+    {
+        var pin = comp.PhysicalPins.First(p => p.Name == pinName);
+        var (actualX, actualY) = pin.GetAbsoluteNazcaPosition();
+
+        Math.Abs(expectedX - actualX).ShouldBeLessThan(PinAlignmentTolerance,
+            $"MMI 2x2 pin '{pinName}' after {rotationSteps}×90°: " +
+            $"X expected {expectedX:F3}, got {actualX:F3}");
+        Math.Abs(expectedY - actualY).ShouldBeLessThan(PinAlignmentTolerance,
+            $"MMI 2x2 pin '{pinName}' after {rotationSteps}×90°: " +
+            $"Y expected {expectedY:F3}, got {actualY:F3}");
     }
 
     /// <summary>
@@ -165,36 +168,24 @@ public class Mmi2x2PinAlignmentTests
     }
 
     /// <summary>
-    /// Specific regression test for Issue #347:
-    /// MMI 2x2 at rotation 90° — pin a0 was 75 µm off in X with the wrong rotation sign.
-    ///
-    /// Pin a0 local Nazca: (0, 37.5).
-    /// At rotation=90° with correct formula R(-90°):
-    ///   worldPinX = physX + 37.5
-    ///   worldPinY = -physY + 0
-    /// With the bug (R(+90°)):
-    ///   worldPinX = physX - 37.5  ← 75 µm error!
+    /// Regression guard for Issue #347 (pin a0 ended up 75 µm off in X after one rotation):
+    /// a 90° CCW rotation of the 120×50 box maps a0's offset (0, 12.5) to (37.5, 0),
+    /// so its Nazca position must be (physX + 37.5, −physY). A wrong rotation sign in
+    /// the command (or a rotation term sneaking back into the pin formula) shifts X
+    /// by tens of µm and fails the 10 nm tolerance.
     /// </summary>
     [Fact]
     public void Mmi2x2_Rotation90_PinA0_NotShiftedNegatively()
     {
+        var canvas = new DesignCanvasViewModel();
         var template = CreateMmi2x2Template();
         var mmi = ComponentTemplates.CreateFromTemplate(template, 100, 100);
-        mmi.RotationDegrees = 90;
+        var vm = canvas.AddComponent(mmi, template.Name);
 
-        var pinA0 = mmi.PhysicalPins.First(p => p.Name == "a0");
-        var (actualX, actualY) = pinA0.GetAbsoluteNazcaPosition();
+        var command = new RotateComponentCommand(canvas, vm);
+        command.Execute();
+        command.WasApplied.ShouldBeTrue("rotation must not be blocked");
 
-        // localX=0, localY=37.5; R(-90°): rotatedX=+37.5, rotatedY=0
-        double expectedX = 100.0 + 37.5;  // = 137.5
-        double expectedY = -100.0 + 0.0;  // = -100.0
-
-        double xDev = Math.Abs(expectedX - actualX);
-        double yDev = Math.Abs(expectedY - actualY);
-
-        xDev.ShouldBeLessThan(PinAlignmentTolerance,
-            $"MMI 2x2 rot90 a0 X: expected {expectedX:F1}, got {actualX:F1}, Δ={xDev:F4} µm (was -75 µm off with bug)");
-        yDev.ShouldBeLessThan(PinAlignmentTolerance,
-            $"MMI 2x2 rot90 a0 Y: expected {expectedY:F1}, got {actualY:F1}, Δ={yDev:F4} µm");
+        AssertPinNazcaPosition(mmi, "a0", 100.0 + 37.5, -100.0, rotationSteps: 1);
     }
 }

--- a/UnitTests/Integration/NazcaExportEndToEndTests.cs
+++ b/UnitTests/Integration/NazcaExportEndToEndTests.cs
@@ -153,8 +153,9 @@ public class NazcaExportEndToEndTests
         // Assert: Check dimensions in stub comment
         nazcaCode.ShouldContain("(120x50 µm)");
 
-        // Check polygon dimensions in stub: with no offset, box is at origin
-        nazcaCode.ShouldContain("nd.Polygon(points=[(0,0),(120.00,0),(120.00,50.00),(0,50.00)], layer=1)");
+        // Check polygon dimensions in stub: bbox [0,-H] .. [W,0] around the org pin
+        // (NazcaCoordinateMapper contract for calibration (0,0), #565).
+        nazcaCode.ShouldContain("nd.Polygon(points=[(0.00,-50.00),(120.00,-50.00),(120.00,0.00),(0.00,0.00)], layer=1)");
     }
 
     [Fact]
@@ -196,19 +197,20 @@ public class NazcaExportEndToEndTests
 
         parsed.PinDefinitions.Count.ShouldBeGreaterThanOrEqualTo(2);
 
-        // Find a0 pin: With NazcaOriginOffset=(0,0) and demo_pdk prefix, pin coordinates are:
-        // Pin at editor offset (0, 12.5) → Nazca stub coordinates: (0-0, (50-12.5)-0) = (0, 37.5)
+        // Stub pins render at the plain Y negation of the app pin offsets relative
+        // to org (NazcaCoordinateMapper contract, #565): with calibration (0,0)
+        // pin a0 at editor offset (0, 12.5) sits at local (0, -12.5).
         var a0Pin = parsed.PinDefinitions.FirstOrDefault(p => p.Name == "a0");
         a0Pin.ShouldNotBeNull();
         a0Pin.X.ShouldBe(0.00, tolerance: 0.01);
-        a0Pin.Y.ShouldBe(37.50, tolerance: 0.01);
+        a0Pin.Y.ShouldBe(-12.50, tolerance: 0.01);
         a0Pin.AngleDegrees.ShouldBe(-180, tolerance: 0.1);
 
         // Find b0 pin
         var b0Pin = parsed.PinDefinitions.FirstOrDefault(p => p.Name == "b0");
         b0Pin.ShouldNotBeNull();
         b0Pin.X.ShouldBe(120.00, tolerance: 0.01);
-        b0Pin.Y.ShouldBe(37.50, tolerance: 0.01);
+        b0Pin.Y.ShouldBe(-12.50, tolerance: 0.01);
         b0Pin.AngleDegrees.ShouldBe(0, tolerance: 0.1);
     }
 

--- a/UnitTests/Integration/NazcaExportEndToEndTests.cs
+++ b/UnitTests/Integration/NazcaExportEndToEndTests.cs
@@ -259,6 +259,50 @@ public class NazcaExportEndToEndTests
         result.PassedChecks.ShouldBeGreaterThan(0);
     }
 
+    [Fact]
+    public void Validate_BboxAnchoredOverride_ReportsNoPositionMismatch()
+    {
+        // A raw-code override is placed org-anchored on its persisted bbox corner, so
+        // the validator must receive that anchor to compute the expected position. With
+        // it the placement validates; with anchor=null (the old hard-coded behaviour)
+        // the same component is flagged as a position mismatch (asserted below).
+        var canvas = new DesignCanvasViewModel();
+        var comp = CreateTestComponent("RawOverride_1", 100, 50, 80, 40);
+        comp.PhysicalPins.Add(CreatePin(comp, "p0", 0, 20, 180));
+        canvas.AddComponent(comp, "RawOverride_1");
+
+        var overrides = new Dictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>
+        {
+            ["RawOverride_1"] = new()
+            {
+                RawCode = "with nd.Cell() as cell:\n    nd.strt(length=80).put(0,0)\n",
+                OverrideWidthMicrometers = 80,
+                OverrideHeightMicrometers = 40,
+                OverrideBboxXMinMicrometers = 5,
+                OverrideBboxYMaxMicrometers = 20,
+            }
+        };
+        var anchors = new Dictionary<string, (double XMin, double YMax)>
+        {
+            ["RawOverride_1"] = (5, 20)
+        };
+
+        var exporter = new SimpleNazcaExporter();
+        var nazcaCode = exporter.Export(canvas, overrides: overrides);
+        var components = canvas.Components.Select(vm => vm.Component).ToList();
+        var connections = canvas.Connections.Select(vm => vm.Connection).ToList();
+        var validator = new ExportValidator();
+
+        var withAnchor = validator.Validate(components, connections, nazcaCode, anchors);
+        withAnchor.Errors.ShouldBeEmpty(
+            $"bbox-anchored override must validate:\n{string.Join("\n", withAnchor.Errors)}");
+
+        // Guard: without the anchor the placement is judged against the wrong (legacy)
+        // expectation, proving the anchor is what makes the check correct.
+        var noAnchor = validator.Validate(components, connections, nazcaCode);
+        noAnchor.Errors.ShouldContain(e => e.Contains("position mismatch"));
+    }
+
     /// <summary>
     /// Creates a test component with specified properties.
     /// </summary>

--- a/UnitTests/Integration/NazcaOverrideFullFlowIntegrationTests.cs
+++ b/UnitTests/Integration/NazcaOverrideFullFlowIntegrationTests.cs
@@ -141,17 +141,6 @@ public class NazcaOverrideFullFlowIntegrationTests
         return (python, FindRealPreviewScript());
     }
 
-    private static string? FindRealPreviewScript()
-    {
-        const string scriptName = "render_component_preview.py";
-        var current = new DirectoryInfo(
-            Path.GetDirectoryName(typeof(NazcaOverrideFullFlowIntegrationTests).Assembly.Location)!);
-        while (current != null)
-        {
-            var candidate = Path.Combine(current.FullName, "scripts", scriptName);
-            if (File.Exists(candidate)) return candidate;
-            current = current.Parent;
-        }
-        return null;
-    }
+    private static string? FindRealPreviewScript() =>
+        GdsAlignmentTestSetup.FindRealPreviewScript();
 }

--- a/UnitTests/PdkOffset/NazcaComponentPreviewServiceTests.cs
+++ b/UnitTests/PdkOffset/NazcaComponentPreviewServiceTests.cs
@@ -316,24 +316,8 @@ public class NazcaComponentPreviewServiceTests
     // These tests catch regressions in the script ↔ service contract that the
     // pure-JSON ParseOutput tests can't, e.g. Nazca chatter polluting stdout.
 
-    /// <summary>
-    /// Walks up the directory tree from the test assembly location looking
-    /// for scripts/render_component_preview.py.  Returns null when not found
-    /// (test will skip gracefully).
-    /// </summary>
-    private static string? FindRealPreviewScript()
-    {
-        const string scriptName = "render_component_preview.py";
-        var current = new DirectoryInfo(
-            Path.GetDirectoryName(typeof(NazcaComponentPreviewServiceTests).Assembly.Location)!);
-        while (current != null)
-        {
-            var candidate = Path.Combine(current.FullName, "scripts", scriptName);
-            if (File.Exists(candidate)) return candidate;
-            current = current.Parent;
-        }
-        return null;
-    }
+    private static string? FindRealPreviewScript() =>
+        UnitTests.Integration.GdsAlignmentTestSetup.FindRealPreviewScript();
 
     private async Task AssertRendersValidPreviewOrSkip(string moduleName, string functionName, string? parameters = null)
     {

--- a/UnitTests/PdkOffset/RenderRawCodeAsyncTests.cs
+++ b/UnitTests/PdkOffset/RenderRawCodeAsyncTests.cs
@@ -39,20 +39,8 @@ public class RenderRawCodeAsyncTests
         return null;
     }
 
-    /// <summary>Walks up from the test assembly to locate scripts/render_component_preview.py.</summary>
-    private static string? FindRealPreviewScript()
-    {
-        const string scriptName = "render_component_preview.py";
-        var current = new DirectoryInfo(
-            Path.GetDirectoryName(typeof(RenderRawCodeAsyncTests).Assembly.Location)!);
-        while (current != null)
-        {
-            var candidate = Path.Combine(current.FullName, "scripts", scriptName);
-            if (File.Exists(candidate)) return candidate;
-            current = current.Parent;
-        }
-        return null;
-    }
+    private static string? FindRealPreviewScript() =>
+        UnitTests.Integration.GdsAlignmentTestSetup.FindRealPreviewScript();
 
     [Fact]
     public async Task RenderRawCodeAsync_WithNonExistentScript_ReturnsFailureNotThrows()

--- a/UnitTests/Services/ComponentDimensionExportTests.cs
+++ b/UnitTests/Services/ComponentDimensionExportTests.cs
@@ -91,9 +91,12 @@ public class ComponentDimensionExportTests
         var exporter = new SimpleNazcaExporter();
         var result = exporter.Export(canvas);
 
-        // Stub should use original dimensions (100x50), not swapped
+        // Stub should use original dimensions (100x50), not swapped.
+        // Cell-internal bbox follows the NazcaCoordinateMapper contract (#565):
+        // with calibration (0,0) the org pin is the box TOP-left, so the polygon
+        // spans [0,-H] .. [W,0] below the origin.
         result.ShouldContain("Auto-generated stub for ebeam_test_device (100x50 µm)");
-        result.ShouldContain("nd.Polygon(points=[(0,0),(100.00,0),(100.00,50.00),(0,50.00)], layer=1)");
+        result.ShouldContain("nd.Polygon(points=[(0.00,-50.00),(100.00,-50.00),(100.00,0.00),(0.00,0.00)], layer=1)");
 
         // Component placement should include rotation angle (pin offset may vary)
         result.ShouldContain(", -90)  #"); // Rotation angle should be -90 (Y-axis flipped)
@@ -135,10 +138,11 @@ public class ComponentDimensionExportTests
         // Verify dimensions in comment
         result.ShouldContain($"Auto-generated stub for ebeam_component ({width}x{height} µm)");
 
-        // Verify polygon coordinates
+        // Verify polygon coordinates: bbox [0,-H] .. [W,0] around the org pin
+        // (NazcaCoordinateMapper contract for calibration (0,0), #565).
         var w = width.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
         var h = height.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
-        result.ShouldContain($"nd.Polygon(points=[(0,0),({w},0),({w},{h}),(0,{h})], layer=1)");
+        result.ShouldContain($"nd.Polygon(points=[(0.00,-{h}),({w},-{h}),({w},0.00),(0.00,0.00)], layer=1)");
     }
 
     [Fact]
@@ -202,18 +206,21 @@ public class ComponentDimensionExportTests
         var exporter = new SimpleNazcaExporter();
         var result = exporter.Export(canvas);
 
-        // Pins use Nazca Y-up coordinate system: nazca_y = height - editor_y
-        // a0: (0, 50 - 12.5 = 37.5), angle 180 -> -180
-        result.ShouldContain("nd.Pin('a0').put(0.00, 37.50, -180)");
+        // Stub pins render at the plain Y negation of the app pin offsets relative
+        // to org (NazcaCoordinateMapper contract, #565): local = (OffsetX, -OffsetY)
+        // for calibration (0,0). This puts the rendered pins exactly where the
+        // exported waveguides expect them.
+        // a0: (0, -12.5), angle 180 -> -180
+        result.ShouldContain("nd.Pin('a0').put(0.00, -12.50, -180)");
 
-        // a1: (0, 50 - 37.5 = 12.5), angle 180 -> -180
-        result.ShouldContain("nd.Pin('a1').put(0.00, 12.50, -180)");
+        // a1: (0, -37.5), angle 180 -> -180
+        result.ShouldContain("nd.Pin('a1').put(0.00, -37.50, -180)");
 
-        // b0: (120, 50 - 12.5 = 37.5), angle 0 -> 0
-        result.ShouldContain("nd.Pin('b0').put(120.00, 37.50, 0)");
+        // b0: (120, -12.5), angle 0 -> 0
+        result.ShouldContain("nd.Pin('b0').put(120.00, -12.50, 0)");
 
-        // b1: (120, 50 - 37.5 = 12.5), angle 0 -> 0
-        result.ShouldContain("nd.Pin('b1').put(120.00, 12.50, 0)");
+        // b1: (120, -37.5), angle 0 -> 0
+        result.ShouldContain("nd.Pin('b1').put(120.00, -37.50, 0)");
     }
 
     private static ComponentTemplate ConvertPdkComponentToTemplate(

--- a/UnitTests/Services/NazcaExportAllComponentsTests.cs
+++ b/UnitTests/Services/NazcaExportAllComponentsTests.cs
@@ -1,6 +1,7 @@
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Export;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using Shouldly;
 using Xunit;
@@ -275,13 +276,16 @@ public class NazcaExportAllComponentsTests
         var exporter = new SimpleNazcaExporter();
         var result = exporter.Export(canvas);
 
-        // 180° rotation: rotated offset = (-originX, -originY).
-        // Physical + rotated offset, Y-flipped:
+        // Rotated placement comes from the bbox re-anchoring formula in
+        // NazcaCoordinateMapper (hand-verified per rotation in its unit tests, #565);
+        // the old rotated-origin-offset expectation WAS the rotation misalignment bug.
+        // Here we pin down that the exporter routes through the mapper and emits the
+        // org-anchored put with the negated rotation.
         var ci = System.Globalization.CultureInfo.InvariantCulture;
-        var nx = (100 - template.NazcaOriginOffsetX).ToString("F2", ci);
-        var ny = -(100 - template.NazcaOriginOffsetY);
+        var placement = NazcaCoordinateMapper.GetCellPlacement(component, null);
         result.ShouldContain("ebeam_gc_te1550()");
-        result.ShouldContain($".put('org', {nx}, {ny.ToString("F2", ci)}, -180)");
+        result.ShouldContain(
+            $".put('org', {placement.X.ToString("F2", ci)}, {placement.Y.ToString("F2", ci)}, -180)");
     }
 
     private static string? FindPdkFile(string fileName)

--- a/UnitTests/Services/NazcaExportAllComponentsTests.cs
+++ b/UnitTests/Services/NazcaExportAllComponentsTests.cs
@@ -278,9 +278,9 @@ public class NazcaExportAllComponentsTests
 
         // Rotated placement comes from the bbox re-anchoring formula in
         // NazcaCoordinateMapper (hand-verified per rotation in its unit tests, #565);
-        // the old rotated-origin-offset expectation WAS the rotation misalignment bug.
-        // Here we pin down that the exporter routes through the mapper and emits the
-        // org-anchored put with the negated rotation.
+        // rotating the origin offset instead would misplace the cell — exactly the
+        // misalignment bug #565 covers. Here we pin down that the exporter routes
+        // through the mapper and emits the org-anchored put with the negated rotation.
         var ci = System.Globalization.CultureInfo.InvariantCulture;
         var placement = NazcaCoordinateMapper.GetCellPlacement(component, null);
         result.ShouldContain("ebeam_gc_te1550()");

--- a/UnitTests/Services/SiepicGratingCouplerExportTests.cs
+++ b/UnitTests/Services/SiepicGratingCouplerExportTests.cs
@@ -3,6 +3,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
+using CAP_Core.Export;
 using CAP_Core.LightCalculation;
 using CAP_Core.Tiles;
 using CAP_DataAccess.Components.ComponentDraftMapper;
@@ -53,7 +54,8 @@ public class SiepicGratingCouplerExportTests
             first.Name, first.OffsetXMicrometers, first.OffsetYMicrometers);
     }
 
-    private static string ExportAt(GcCalibration cal, double x, double y, double rotationDegrees)
+    private static (string Script, Component Component) ExportAt(
+        GcCalibration cal, double x, double y, double rotationDegrees)
     {
         var pdk = new PdkLoader().LoadFromFile(GetSiepicPdkPath());
         var draft = pdk.Components.First(c => c.Name == "Grating Coupler TE 1550");
@@ -62,18 +64,16 @@ public class SiepicGratingCouplerExportTests
         component.RotationDegrees = rotationDegrees;
         var canvas = new DesignCanvasViewModel();
         canvas.AddComponent(component, "GC_TE1550");
-        return new SimpleNazcaExporter().Export(canvas);
+        return (new SimpleNazcaExporter().Export(canvas), component);
     }
 
-    /// <summary>Apply the same rotation/Y-flip as the exporter to derive expected coords.</summary>
+    /// <summary>
+    /// Expected put coordinates at rotation 0: org lands at (x+ox, -(y+oy)) — the
+    /// long-standing calibrated convention the mapper reproduces exactly.
+    /// </summary>
     private static (double X, double Y) ExpectedNazcaPosition(
-        GcCalibration cal, double x, double y, double rotationDegrees)
-    {
-        var rad = rotationDegrees * Math.PI / 180.0;
-        var rotX = cal.OriginX * Math.Cos(rad) - cal.OriginY * Math.Sin(rad);
-        var rotY = cal.OriginX * Math.Sin(rad) + cal.OriginY * Math.Cos(rad);
-        return (x + rotX, -(y + rotY));
-    }
+        GcCalibration cal, double x, double y)
+        => (x + cal.OriginX, -(y + cal.OriginY));
 
     private static SMatrix CreatePassThroughSMatrix(List<Pin> pins)
     {
@@ -110,8 +110,8 @@ public class SiepicGratingCouplerExportTests
         var cal = LoadGcCalibration();
         if (cal is null) return;
 
-        var result = ExportAt(cal, 0, 0, 0);
-        var (nx, ny) = ExpectedNazcaPosition(cal, 0, 0, 0);
+        var (result, _) = ExportAt(cal, 0, 0, 0);
+        var (nx, ny) = ExpectedNazcaPosition(cal, 0, 0);
 
         var ci = CultureInfo.InvariantCulture;
         // Anchor on 'org' explicitly so .put() places the cell origin at the
@@ -127,8 +127,8 @@ public class SiepicGratingCouplerExportTests
         var cal = LoadGcCalibration();
         if (cal is null) return;
 
-        var result = ExportAt(cal, 100, 200, 0);
-        var (nx, ny) = ExpectedNazcaPosition(cal, 100, 200, 0);
+        var (result, _) = ExportAt(cal, 100, 200, 0);
+        var (nx, ny) = ExpectedNazcaPosition(cal, 100, 200);
 
         var ci = CultureInfo.InvariantCulture;
         result.ShouldContain($"ebeam_gc_te1550().put('org', {nx.ToString("F2", ci)}, {ny.ToString("F2", ci)}, 0)");
@@ -146,8 +146,15 @@ public class SiepicGratingCouplerExportTests
         var cal = LoadGcCalibration();
         if (cal is null) return;
 
-        var result = ExportAt(cal, x, y, rotationDegrees);
-        var (nx, ny) = ExpectedNazcaPosition(cal, x, y, rotationDegrees);
+        var (result, component) = ExportAt(cal, x, y, rotationDegrees);
+        // Rotated placement comes from the bbox re-anchoring formula in
+        // NazcaCoordinateMapper (hand-verified there per rotation, #565); the old
+        // rotated-origin-offset expectation WAS the rotation misalignment bug.
+        // This test pins down that the exporter routes through the mapper and
+        // formats the org-anchored put correctly. At rotation 0 the values equal
+        // the historical (x+ox, -(y+oy)) convention.
+        var placement = NazcaCoordinateMapper.GetCellPlacement(component, null);
+        var (nx, ny) = (placement.X, placement.Y);
 
         // The export rotation is the negation of the editor rotation (Y-axis
         // flip), normalized to 0/-90/-180/-270 (or 90 for the symmetric case).
@@ -165,11 +172,12 @@ public class SiepicGratingCouplerExportTests
     {
         var cal = LoadGcCalibration();
         if (cal is null) return;
-        var result = ExportAt(cal, 0, 0, 90);
-        var (nx, ny) = ExpectedNazcaPosition(cal, 0, 0, 90);
+        var (result, component) = ExportAt(cal, 0, 0, 90);
+        // Mapper-based expectation: see VariousPositionsAndRotations for rationale (#565).
+        var placement = NazcaCoordinateMapper.GetCellPlacement(component, null);
         var ci = CultureInfo.InvariantCulture;
         result.ShouldMatch(
-            $@"ebeam_gc_te1550\(\)\.put\('org',\s*{Regex.Escape(nx.ToString("F2", ci))},\s*{Regex.Escape(ny.ToString("F2", ci))},\s*-90\)");
+            $@"ebeam_gc_te1550\(\)\.put\('org',\s*{Regex.Escape(placement.X.ToString("F2", ci))},\s*{Regex.Escape(placement.Y.ToString("F2", ci))},\s*-90\)");
     }
 
     [Fact]
@@ -177,11 +185,12 @@ public class SiepicGratingCouplerExportTests
     {
         var cal = LoadGcCalibration();
         if (cal is null) return;
-        var result = ExportAt(cal, 0, 0, 180);
-        var (nx, ny) = ExpectedNazcaPosition(cal, 0, 0, 180);
+        var (result, component) = ExportAt(cal, 0, 0, 180);
+        // Mapper-based expectation: see VariousPositionsAndRotations for rationale (#565).
+        var placement = NazcaCoordinateMapper.GetCellPlacement(component, null);
         var ci = CultureInfo.InvariantCulture;
         result.ShouldMatch(
-            $@"ebeam_gc_te1550\(\)\.put\('org',\s*{Regex.Escape(nx.ToString("F2", ci))},\s*{Regex.Escape(ny.ToString("F2", ci))},\s*-?180\)");
+            $@"ebeam_gc_te1550\(\)\.put\('org',\s*{Regex.Escape(placement.X.ToString("F2", ci))},\s*{Regex.Escape(placement.Y.ToString("F2", ci))},\s*-?180\)");
     }
 
     [Fact]
@@ -189,11 +198,12 @@ public class SiepicGratingCouplerExportTests
     {
         var cal = LoadGcCalibration();
         if (cal is null) return;
-        var result = ExportAt(cal, 0, 0, 270);
-        var (nx, ny) = ExpectedNazcaPosition(cal, 0, 0, 270);
+        var (result, component) = ExportAt(cal, 0, 0, 270);
+        // Mapper-based expectation: see VariousPositionsAndRotations for rationale (#565).
+        var placement = NazcaCoordinateMapper.GetCellPlacement(component, null);
         var ci = CultureInfo.InvariantCulture;
         result.ShouldMatch(
-            $@"ebeam_gc_te1550\(\)\.put\('org',\s*{Regex.Escape(nx.ToString("F2", ci))},\s*{Regex.Escape(ny.ToString("F2", ci))},\s*(-270|90)\)");
+            $@"ebeam_gc_te1550\(\)\.put\('org',\s*{Regex.Escape(placement.X.ToString("F2", ci))},\s*{Regex.Escape(placement.Y.ToString("F2", ci))},\s*(-270|90)\)");
     }
 
     [Fact]
@@ -202,11 +212,16 @@ public class SiepicGratingCouplerExportTests
         var cal = LoadGcCalibration();
         if (cal is null) return;
 
-        var result = ExportAt(cal, 0, 0, 0);
+        var (result, _) = ExportAt(cal, 0, 0, 0);
 
         var ci = CultureInfo.InvariantCulture;
+        // Stub pins render at the app pin position relative to org (#565):
+        // local = (pinOffset - originOffset) with the app Y axis negated, i.e.
+        // (FirstPinX - ox, oy - FirstPinY). The cell is placed so org hits
+        // (x+ox, -(y+oy)), which puts this pin exactly at the plain Y negation
+        // of the app pin — where the exported waveguides expect it.
         var pinX = (cal.FirstPinX - cal.OriginX).ToString("F2", ci);
-        var pinY = ((cal.Height - cal.FirstPinY) - cal.OriginY).ToString("F2", ci);
+        var pinY = (cal.OriginY - cal.FirstPinY).ToString("F2", ci);
         result.ShouldContain($"nd.Pin('{cal.FirstPinName}').put({pinX}, {pinY},");
     }
 }

--- a/UnitTests/Services/SiepicGratingCouplerExportTests.cs
+++ b/UnitTests/Services/SiepicGratingCouplerExportTests.cs
@@ -148,11 +148,11 @@ public class SiepicGratingCouplerExportTests
 
         var (result, component) = ExportAt(cal, x, y, rotationDegrees);
         // Rotated placement comes from the bbox re-anchoring formula in
-        // NazcaCoordinateMapper (hand-verified there per rotation, #565); the old
-        // rotated-origin-offset expectation WAS the rotation misalignment bug.
-        // This test pins down that the exporter routes through the mapper and
-        // formats the org-anchored put correctly. At rotation 0 the values equal
-        // the historical (x+ox, -(y+oy)) convention.
+        // NazcaCoordinateMapper (hand-verified there per rotation, #565); rotating
+        // the origin offset instead would misplace the cell — exactly the
+        // misalignment bug #565 covers. This test pins down that the exporter
+        // routes through the mapper and formats the org-anchored put correctly.
+        // At rotation 0 the values equal the calibrated (x+ox, -(y+oy)) convention.
         var placement = NazcaCoordinateMapper.GetCellPlacement(component, null);
         var (nx, ny) = (placement.X, placement.Y);
 

--- a/UnitTests/Services/SimpleNazcaExporterTests.cs
+++ b/UnitTests/Services/SimpleNazcaExporterTests.cs
@@ -783,6 +783,40 @@ public class SimpleNazcaExporterTests
         result.ShouldNotContain("300.00, 5.00");
     }
 
+    [Fact]
+    public void Export_DefaultFlags_OmitsVerificationEpilog()
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Components.Add(new ComponentViewModel(CreateDemoPdkStraightWaveguide(100)));
+
+        var result = new SimpleNazcaExporter().Export(canvas);
+
+        // The verification epilog is opt-in (issue #565): a regular export must stay
+        // a plain fab script without introspection side effects.
+        result.ShouldNotContain("Alignment verification");
+        result.ShouldNotContain("_verify_instances");
+        result.ShouldNotContain(".pins.json");
+    }
+
+    [Fact]
+    public void Export_WithEmitVerification_AppendsPinEpilogAfterGdsExport()
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Components.Add(new ComponentViewModel(CreateDemoPdkStraightWaveguide(100)));
+
+        var result = new SimpleNazcaExporter().Export(canvas, emitVerification: true);
+
+        // The registry bridges the function-local comp_N variables to the module-level
+        // epilog, which dumps every instance's TRUE nazca pin positions to .pins.json.
+        result.ShouldContain("_verify_instances = [('comp_0', comp_0)]");
+        result.ShouldContain("# --- Alignment verification (machine-readable) ---");
+        result.ShouldContain("_pin.xya()");
+        result.ShouldContain(".pins.json");
+        result.IndexOf("nd.export_gds", StringComparison.Ordinal).ShouldBeLessThan(
+            result.IndexOf("# --- Alignment verification", StringComparison.Ordinal),
+            "the epilog must run after the GDS was written");
+    }
+
     private static Component CreateDemoPdkStraightWaveguide(double lengthMicrometers)
     {
         var parts = new Part[1, 1];

--- a/UnitTests/Services/SimpleNazcaExporterTests.cs
+++ b/UnitTests/Services/SimpleNazcaExporterTests.cs
@@ -4,6 +4,7 @@ using CAP_Core.Components;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.FormulaReading;
+using CAP_Core.Export;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
 using CAP_Core.Tiles;
@@ -361,24 +362,26 @@ public class SimpleNazcaExporterTests
         return count;
     }
 
+    // IsPdkFunction lives in NazcaCoordinateMapper (single source of truth, #565);
+    // the exporter consumes it from there.
     [Fact]
     public void IsPdkFunction_RealPdkFunction_ReturnsTrue()
     {
-        var result = SimpleNazcaExporter.IsPdkFunction("ebeam_y_1550");
+        var result = NazcaCoordinateMapper.IsPdkFunction("ebeam_y_1550");
         result.ShouldBeTrue();
     }
 
     [Fact]
     public void IsPdkFunction_DemoPdkFunction_ReturnsFalse()
     {
-        var result = SimpleNazcaExporter.IsPdkFunction("demo_pdk.mmi1x2");
+        var result = NazcaCoordinateMapper.IsPdkFunction("demo_pdk.mmi1x2");
         result.ShouldBeFalse();
     }
 
     [Fact]
     public void IsPdkFunction_ExternalPdkWithDot_ReturnsTrue()
     {
-        var result = SimpleNazcaExporter.IsPdkFunction("siepic.gc_te1550");
+        var result = NazcaCoordinateMapper.IsPdkFunction("siepic.gc_te1550");
         result.ShouldBeTrue();
     }
 

--- a/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
+++ b/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
@@ -6,6 +6,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
+using CAP_Core.Export;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
 using CAP_Core.Tiles;
@@ -19,9 +20,11 @@ namespace UnitTests.Services;
 /// Verifies that exported waveguide paths start and end exactly at the
 /// correct Nazca pin positions for all component types and rotations.
 ///
-/// Issue #355: End pins don't align when NazcaOriginOffsetY ≠ HeightMicrometers.
-/// Root cause: path routing uses editor coordinates; Nazca export uses Nazca coordinates.
-/// For PDK components with NazcaOriginOffset, these differ, causing endpoint errors.
+/// Expected pin positions come from <see cref="NazcaCoordinateMapper.GetPinNazcaPosition"/>
+/// (issue #565): the app model is the truth for where pins are, and the conversion is a
+/// plain Y negation for every component kind. Calibration data only moves the CELL so its
+/// rendered pins coincide with the app pins — it never bends segment coordinates, so the
+/// old NazcaOriginOffset-dependent pin formula (which diverged for oy ≠ H/2) is gone.
 /// </summary>
 public class WaveguideEndpointAlignmentTests
 {
@@ -32,8 +35,7 @@ public class WaveguideEndpointAlignmentTests
     [Fact]
     public void SingleStraightWaveguide_TwoLegacyComponents_StartAndEndAlign()
     {
-        // Legacy components: NazcaOriginOffset uses fallback (height).
-        // delta = H - NazcaOriginOffsetY = 0 → GetAbsoluteNazcaPosition() == (editorX, -editorY)
+        // Legacy components: pin truth is the plain Y negation (editorX, -editorY).
         var (compA, pinOut) = CreateLegacyComponent("CompA", x: 0, y: 0, width: 100, height: 50,
             pinOffsetX: 100, pinOffsetY: 25, pinAngle: 0);
         var (compB, pinIn) = CreateLegacyComponent("CompB", x: 200, y: 0, width: 100, height: 50,
@@ -41,8 +43,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), "start");
         AssertAligned(endPt, (expectedEndX, expectedEndY), "end");
@@ -62,8 +64,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), "start");
         AssertAligned(endPt, (expectedEndX, expectedEndY), "end (Issue #355)");
@@ -80,8 +82,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), "start");
         AssertAligned(endPt, (expectedEndX, expectedEndY), "end (Issue #355)");
@@ -98,8 +100,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), "start");
         AssertAligned(endPt, (expectedEndX, expectedEndY), "end (different PDK offsets)");
@@ -116,8 +118,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), "start");
         AssertAligned(endPt, (expectedEndX, expectedEndY), "end (same PDK offset)");
@@ -137,8 +139,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), "start");
         AssertAligned(endPt, (expectedEndX, expectedEndY), "end (grating coupler)");
@@ -160,8 +162,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), $"start (rot={rotation}°)");
         AssertAligned(endPt, (expectedEndX, expectedEndY), $"end (rot={rotation}°)");
@@ -181,8 +183,8 @@ public class WaveguideEndpointAlignmentTests
 
         var (startPt, endPt) = ExportAndExtractEndpoints(pinOut, pinIn);
 
-        var (expectedStartX, expectedStartY) = pinOut.GetAbsoluteNazcaPosition();
-        var (expectedEndX, expectedEndY) = pinIn.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinIn);
 
         AssertAligned(startPt, (expectedStartX, expectedStartY), $"start PDK (rot={rotation}°)");
         AssertAligned(endPt, (expectedEndX, expectedEndY), $"end PDK (rot={rotation}°)");
@@ -264,7 +266,7 @@ public class WaveguideEndpointAlignmentTests
             .First(l => l.Contains("nd.strt(") || l.Contains("nd.bend("));
 
         var (startX, startY) = ExtractStartPoint(firstLine);
-        var (expectedX, expectedY) = pinOut.GetAbsoluteNazcaPosition();
+        var (expectedX, expectedY) = NazcaCoordinateMapper.GetPinNazcaPosition(pinOut);
 
         Math.Abs(startX - expectedX).ShouldBeLessThan(AlignmentTolerance,
             $"Multi-segment start X off: {startX} vs {expectedX}");
@@ -304,7 +306,7 @@ public class WaveguideEndpointAlignmentTests
 
     // ── Private helpers ───────────────────────────────────────────────────────
 
-    /// <summary>Creates a legacy component (no PDK function → CalculateOriginOffset uses height fallback).</summary>
+    /// <summary>Creates a legacy component (no PDK function → bottom-left origin fallback in the mapper).</summary>
     private static (Component comp, PhysicalPin pin) CreateLegacyComponent(
         string name, double x, double y, double width, double height,
         double pinOffsetX, double pinOffsetY, double pinAngle, double rotation = 0)
@@ -344,7 +346,7 @@ public class WaveguideEndpointAlignmentTests
     }
 
     /// <summary>
-    /// Creates a PDK component (ebeam_ prefix → CalculateOriginOffset uses NazcaOriginOffset).
+    /// Creates a PDK component (ebeam_ prefix → calibrated NazcaOriginOffset cell placement).
     /// </summary>
     private static (Component comp, PhysicalPin pin) CreatePdkComponent(
         string name, double x, double y, double width, double height,
@@ -509,7 +511,7 @@ public class WaveguideEndpointAlignmentTests
 
         // Verify first segment starts at mmi1.out1 pin
         var (firstStartX, firstStartY) = ExtractStartPoint(lines[0]);
-        var (expectedStartX, expectedStartY) = mmi1_out1.GetAbsoluteNazcaPosition();
+        var (expectedStartX, expectedStartY) = NazcaCoordinateMapper.GetPinNazcaPosition(mmi1_out1);
 
         AssertAligned((firstStartX, firstStartY), (expectedStartX, expectedStartY),
             "MMI1.out1 -> PhaseShifter.in: first segment start");
@@ -531,7 +533,7 @@ public class WaveguideEndpointAlignmentTests
         // Verify last segment ends at phase_shifter.in pin
         var lastSegment = lines[lines.Count - 1];
         var (lastEndX, lastEndY) = ComputeEndPoint(lastSegment);
-        var (expectedEndX, expectedEndY) = ps_in.GetAbsoluteNazcaPosition();
+        var (expectedEndX, expectedEndY) = NazcaCoordinateMapper.GetPinNazcaPosition(ps_in);
         AssertAligned((lastEndX, lastEndY), (expectedEndX, expectedEndY),
             "MMI1.out1 -> PhaseShifter.in: last segment end");
     }

--- a/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
+++ b/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
@@ -23,8 +23,8 @@ namespace UnitTests.Services;
 /// Expected pin positions come from <see cref="NazcaCoordinateMapper.GetPinNazcaPosition"/>
 /// (issue #565): the app model is the truth for where pins are, and the conversion is a
 /// plain Y negation for every component kind. Calibration data only moves the CELL so its
-/// rendered pins coincide with the app pins — it never bends segment coordinates, so the
-/// old NazcaOriginOffset-dependent pin formula (which diverged for oy ≠ H/2) is gone.
+/// rendered pins coincide with the app pins — it never bends segment coordinates
+/// (an origin-offset-dependent pin formula would diverge wherever oy ≠ H/2).
 /// </summary>
 public class WaveguideEndpointAlignmentTests
 {

--- a/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
+++ b/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
@@ -25,6 +25,12 @@ namespace UnitTests.Services;
 /// plain Y negation for every component kind. Calibration data only moves the CELL so its
 /// rendered pins coincide with the app pins — it never bends segment coordinates
 /// (an origin-offset-dependent pin formula would diverge wherever oy ≠ H/2).
+///
+/// Scope: this is a STRUCTURAL check that the exporter routes its coordinates through the
+/// mapper (it compares exporter output to the same mapper the exporter calls, so it cannot
+/// catch a wrong mapper FORMULA). Formula correctness is proven independently by
+/// NazcaCoordinateMapperTests (hand-computed expectations) and by GdsExportAlignmentTests
+/// (verified against the real nazca engine that writes the GDS).
 /// </summary>
 public class WaveguideEndpointAlignmentTests
 {

--- a/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
+++ b/UnitTests/Services/WaveguideEndpointAlignmentTests.cs
@@ -193,10 +193,11 @@ public class WaveguideEndpointAlignmentTests
     // ── Multi-segment: verify uniform coordinate transformation (Issue #456) ──
 
     /// <summary>
-    /// Multi-segment path with PDK component: adjacent segments must be continuous in Nazca space.
-    /// Root cause (Issue #456): segment[0] used GetAbsoluteNazcaPosition() (includes NazcaOriginOffset)
-    /// while segment[1+] used a plain Y-flip — different coordinate systems caused a visible Y-gap.
-    /// Fix: all segments use the same delta offset derived from the start pin.
+    /// Multi-segment path with PDK component: adjacent segments must be continuous in Nazca
+    /// space. Guards against mixing coordinate systems between segment[0] and segment[1+]
+    /// (issue #456 was a visible Y-gap from exactly that). Every segment point goes
+    /// through the same universal Y negation (NazcaCoordinateMapper), so no per-segment
+    /// offset machinery exists that could drift apart.
     /// </summary>
     [Fact]
     public void MultiSegmentWaveguide_PdkComponent_SegmentsAreContinuousInNazca_Issue456()

--- a/docs/superpowers/plans/2026-06-12-issue-565-coordinate-mapper.md
+++ b/docs/superpowers/plans/2026-06-12-issue-565-coordinate-mapper.md
@@ -1,0 +1,99 @@
+# Issue #565 NazcaCoordinateMapper Implementation Plan
+
+> **For agentic workers:** Tasks werden sequenziell von Workflow-Agents implementiert; nach jedem Task läuft ein Verifikations-Agent. Spec (VERBINDLICH, zuerst lesen): `docs/superpowers/specs/2026-06-12-issue-565-nazca-coordinate-mapper-design.md`.
+
+**Goal:** Single Source of Truth `NazcaCoordinateMapper` für alle App→Nazca-Koordinaten + selbstverifizierender GDS-Export; fixt Rotations-Misalignment für PDK- und Override-Komponenten.
+
+**Branch:** `feature/issue-565-nazca-coordinate-mapper` (bereits ausgecheckt). Tests: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" <Pattern>` — NIE `dotnet test`. Harte Limits: kein File > 500 Zeilen (CI), neue Files ≤ 250 Zeilen, XML-Doku auf allen public Members, Kommentare erklären WARUM (nie Änderungshistorie).
+
+---
+
+### Task 1: `NazcaCoordinateMapper` + Unit-Tests (TDD)
+
+**Files:**
+- Create: `Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs`
+- Create: `UnitTests/Export/NazcaCoordinateMapperTests.cs`
+
+API, Platzierungsformel, bbox-Parameterisierungstabelle, unrotierte Dimensionen: exakt wie im Spec-Abschnitt „Lever A". Die Erkennungslogik (PDK-Namensmuster `IsPdkFunction`-Liste, expliziter Offset, Parametric-Straight, Legacy-Fallback) wird aus `CAP.Avalonia/Services/SimpleNazcaExporter.cs::CalculateOriginOffset` (~Zeile 415) und `IsPdkFunction`/`IsParametricStraight` VERHALTENSGLEICH übernommen (Code dort lesen!). `IsPdkFunction`/`IsParametricStraight` ziehen mit in den Mapper um (public/internal), der Exporter referenziert sie von dort (Task 2 entfernt die Originale).
+
+Methodensignaturen (verbindlich):
+```csharp
+public record CellPlacement(double X, double Y, double RotationDegrees);
+public static class NazcaCoordinateMapper
+{
+    public static CellPlacement GetCellPlacement(Component comp, (double XMin, double YMax)? rawOverrideAnchor);
+    public static (double X, double Y) GetPinNazcaPosition(PhysicalPin pin);
+    public static double GetPinNazcaAngle(PhysicalPin pin);
+    public static (double X, double Y) ToNazca(double appX, double appY);
+}
+```
+
+TDD-Reihenfolge: Tests zuerst (rot), dann implementieren. Pflicht-Testfälle (Erwartungswerte von Hand herleiten, im Test als Kommentar begründen):
+1. Override-Anker (XMin=−3, YMax=10, W₀=45, H₀=11, comp 100/50) × Rotation 0/90/180/270 — bei 0°: T=(103, −60). Für 90/180/270 die vier rotierten bbox-Ecken von Hand rechnen (r = −RotationDegrees!), Component.Width/Height VOR dem Assert rotationsgerecht tauschen (App-Semantik!).
+2. PDK expliziter Offset (ox=0, oy=30, W₀=250, H₀=60) × 0/90 — bei 0°: T=(PhysX, −(PhysY+30))… ACHTUNG Spec: T=(PhysX+ox−…)= bei ox=0: minx′=−0 ⇒ T.x=PhysX; maxy′=30 ⇒ T.y=−PhysY−30 ✓ (= heutiges Verhalten).
+3. Legacy-Fallback (kein PDK-Name, Offsets 0): bei 0° T=(PhysX, −(PhysY+H₀)).
+4. Parametric Straight: ox/oy = Offset des ersten Pins (Regel aus Exporter übernehmen).
+5. `GetPinNazcaPosition` = (app.X, −app.Y); `GetPinNazcaAngle` = −(AngleDegrees+RotationDegrees) normalisiert auf (−180, 180] oder [0,360) — Konvention der bestehenden Ausgaben beibehalten (Exporter emittiert „F0", `NormalizeZero`).
+6. rawOverrideAnchor=null + kein PDK-Name → Legacy; rawOverrideAnchor=null + PDK-Name → Kalibrier-Pfad.
+
+Helper: `TestComponentFactory` für Components; für Rotation die Offsets/Dims von Hand setzen (NICHT RotateComponentCommand im Core-Test — der liegt in CAP.Avalonia; stattdessen App-Semantik im Test nachbilden: Offsets rotiert, Dims getauscht, RotationDegrees gesetzt — als Helper im Testfile).
+
+Commit: `(+) NazcaCoordinateMapper: Single Source of Truth fuer App->Nazca-Koordinaten (#565)`
+
+---
+
+### Task 2: Exporter-Migration
+
+**Files:**
+- Modify: `CAP.Avalonia/Services/SimpleNazcaExporter.cs`
+- Modify: `UnitTests/Services/SimpleNazcaExporterTests.cs` (Erwartungen für rotierte/oy≠H/2-Fälle bewusst anpassen)
+
+Migrationsliste exakt wie Spec-Tabelle „Konsumenten-Migration": Placement (`AppendSingleComponent`) via `GetCellPlacement` (Override-mit-Anker → org-Put; Alt-Override ohne Anker → bisheriger Default-Put bleibt!); `# COORD`/`# PIN`-Diagnosen via Mapper; `AppendSegmentExport`-Offset-Maschinerie ersatzlos streichen (nur noch `ToNazca` je Segmentpunkt); `FormatStraightSegmentFromPins` + `BuildEndpointReference` via Mapper; lokale Helfer `CalculateOriginOffset`, `RotateOffset`, `GetOverrideBboxAnchor` (Anker-Extraktion in den Aufruf inline/Mapper), `GetNazcaPinPosition`, `IsPdkFunction`, `IsParametricStraight` LÖSCHEN (Mapper ist Heimat).
+
+WICHTIG: Bestehende Tests, die heutiges Verhalten asserten, einzeln durchgehen: Tests für UNROTIERTE kalibrierte Fälle MÜSSEN unverändert grün bleiben (Formel ist bei rot=0 verhaltensgleich — wenn so ein Test bricht, ist die Implementierung falsch, NICHT der Test!). Nur Tests, deren Fixture oy ≠ H/2-Pin-Mathe oder Rotation prüft, dürfen angepasst werden — je mit Begründung im Assert-Kommentar.
+
+Danach: `py …smart_test.py SimpleNazcaExporter`, `NazcaOverrideFullFlow`, `NazcaCoordinateMapper` grün; `dotnet build` 0 Fehler.
+
+Commit: `(~) Exporter auf NazcaCoordinateMapper migriert; Formelkopie geloescht (#565)`
+
+---
+
+### Task 3: `PhysicalPin`-Delegation + Aufrufer-Audit
+
+**Files:**
+- Modify: `Connect-A-Pic-Core/Components/Core/PhysicalPin.cs`
+- Modify: betroffene Aufrufer (Audit!)
+
+`GetAbsoluteNazcaPosition()` → Body = `NazcaCoordinateMapper.GetPinNazcaPosition(this)`; private `CalculateOriginOffset` + „Must match…"-Kommentar löschen; XML-Doku ehrlich neu (Y-Negation, Verweis auf Mapper). DANN: `grep GetAbsoluteNazcaPosition` über das ganze Repo — jeden Aufrufer lesen und entscheiden: bleibt korrekt (dokumentieren im Report) oder migrieren. `WaveguideConnection.ExportToNazca` prüfen: wird es noch aufgerufen? Wenn tot → löschen (mit Aufrufer-Beweis im Report). PdkOffset-Editor-Code prüfen, dass keine Abhängigkeit auf die alte Formel-Semantik bricht (PdkOffsetEditorViewModel*).
+
+Volle Suite + FileSizeLimit prüfen. Commit: `(~) PhysicalPin.GetAbsoluteNazcaPosition delegiert an Mapper; Legacy-Formel entfernt (#565)`
+
+---
+
+### Task 4: Verifikations-Epilog + `GdsExportAlignmentTests` (Lever B)
+
+**Files:**
+- Modify: `CAP.Avalonia/Services/SimpleNazcaExporter.cs` (`Export(..., bool emitVerification = false)`, Epilog exakt wie Spec; componentNames-Map liefert die Variablennamen)
+- Create: `UnitTests/Integration/GdsExportAlignmentTests.cs`
+- Modify (falls nötig): `UnitTests/Services/SimpleNazcaExporterTests.cs` (Test: Epilog wird nur bei Flag emittiert)
+
+Testaufbau exakt wie Spec „Lever B": Env-Skip-Muster + Python-Discovery aus `UnitTests/Integration/NazcaOverrideFullFlowIntegrationTests.cs` kopieren (gleiches Muster). Zwei Facts:
+- `PdkComponent_AllRotations_PinsAlignInGds`: `demo.mmi2x2_dp`-Komponente aus der Template-Library (`TestPdkLoader.LoadAllTemplates`, Name „2x2 MMI Coupler"? — exakten Namen im Library-Code nachschlagen; sonst das im Repo vorhandene Template mit nazcaFunction `demo.mmi2x2_dp`), verbunden mit einem zweiten MMI; Schleife k=0..3: Rotation via `RotateComponentCommand` (CAP.Avalonia-Referenz ist im UnitTests-Projekt vorhanden), Export mit `emitVerification: true` in Temp-Dir, `GdsExportService` (SetCustomPythonPath!) ausführen, `.pins.json` lesen (System.Text.Json), für jeden `comp.PhysicalPins`-Pin: Ist-Position der gleichnamigen Instanz-Pins (nazca-interne Namen org/cc/lb/lc/lt/tl/tc/tr/rt/rc/rb/br/bc/bl ignorieren) gegen `NazcaCoordinateMapper.GetPinNazcaPosition` mit ε=0,01 asserten. Aussagekräftige Fehlermeldung: Pin-Name, Rotation, Ist, Soll, Skriptpfad.
+- `OverrideComponent_AllRotations_PinsAlignInGds`: wie Full-Flow-Test ein Override per Editor-VM-Apply (Showcase-Code) aufbauen, dann dieselbe Rotationsschleife.
+Beide Facts loggen pro Rotation die Dauer nicht — schlict halten. Erwartete Gesamtlaufzeit ≈ 1 Minute.
+
+ACHTUNG Erwartung: Diese Tests sind die EIGENTLICHE Abnahme. Wenn eine Rotations-Zelle FAILT, ist das ein echter Befund: Mapper-Mathe gegen Nazca-Realität prüfen (Skript + .pins.json im Report zitieren), Implementierung fixen, NICHT den Test aufweichen. Genau dafür gibt es diese Schleife.
+
+Commit: `(+) Selbstverifizierender GDS-Export: Pin-Epilog + Alignment-Testmatrix (#565)`
+
+---
+
+### Task 5: Gesamtverifikation
+
+`dotnet build` (0 Fehler), komplette Suite (`py …smart_test.py`, 0 Failures), FileSizeLimit, Diff-Review (keine Fremddateien, keine Change-Narration-Kommentare). Tool-Usage-Report gemäß CLAUDE.md §8.1 in den Task-Report.
+
+---
+
+### Danach (macht der Orchestrator, nicht die Task-Agents)
+
+PR gegen main, Review-Run, Findings fixen, CI.

--- a/docs/superpowers/specs/2026-06-12-issue-565-nazca-coordinate-mapper-design.md
+++ b/docs/superpowers/specs/2026-06-12-issue-565-nazca-coordinate-mapper-design.md
@@ -1,0 +1,187 @@
+# Issue #565 — NazcaCoordinateMapper + selbstverifizierender GDS-Export
+
+**Datum:** 2026-06-12 (Design vom User freigegeben; User für 6h abwesend, Umsetzung autonom)
+**Branch:** `feature/issue-565-nazca-coordinate-mapper` (von main nach Merge von #562)
+
+## Problem
+
+Die App→Nazca-Koordinaten-Transformation existiert doppelt (`PhysicalPin.GetAbsoluteNazcaPosition`
++ `SimpleNazcaExporter.CalculateOriginOffset`, synchron gehalten nur per Kommentar), ist ein
+Heuristik-Stapel (Namens-Mustererkennung, Fallbacks, seit #561 eine dritte Konvention) und hat
+keinen maschinellen Verifikations-Regelkreis. Folge: wiederkehrende Alignment-Bugs
+(#329/#334/#338/#355/#456/#458, zweimal in #561). Akut: **rotierte Komponenten** (90°) sind im
+GDS-Export falsch platziert — Override- UND reguläre PDK-Komponenten.
+
+## Ground Truth: App-Semantik (verbindlich für alle Formeln)
+
+- App-Raum ist Y-down. Komponenten-Box: obere linke Ecke (PhysicalX, PhysicalY), Breite/Höhe
+  sind die AKTUELLEN (rotations-getauschten) Werte.
+- Rotation (`RotateComponentCommand`): Pin-OFFSETS werden physisch um das Box-Zentrum rotiert,
+  Breite/Höhe getauscht, Box-Topleft bleibt fix. `RotationDegrees` (+90 je Schritt) ist reine
+  Buchhaltung für Pin-Winkel und Export.
+- Pin-Weltposition (App) = (PhysicalX + OffsetX, PhysicalY + OffsetY) — OHNE Rotationsterm,
+  weil Offsets vorrotiert sind (`PhysicalPin.GetAbsolutePosition`).
+- Pin-Weltwinkel (App) = AngleDegrees + RotationDegrees (`GetAbsoluteAngle`).
+- Nazca-Raum ist Y-up. Punktkonversion: (x, y)app → (x, −y)nazca. Winkel: a → −a.
+  Nazca-Put-Rotation = −RotationDegrees (bestehende Konvention).
+
+## Lever A: `NazcaCoordinateMapper` (Single Source of Truth)
+
+Neue statische Klasse `Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs` (< 250 Zeilen).
+ALLE App→Nazca-Antworten kommen von hier:
+
+### API
+
+```csharp
+/// Where and how the component's Nazca cell is .put(...) in the export.
+public record CellPlacement(double X, double Y, double RotationDegrees);
+// Anchor ist immer der org-Pin der Zelle: factory().put('org', X, Y, RotationDegrees).
+
+public static class NazcaCoordinateMapper
+{
+    // (1) Zell-Platzierung. rawOverrideAnchor = (XMin, YMax) aus NazcaCodeOverride,
+    //     null für PDK/Legacy. unrotatedW/H siehe "Unrotierte Dimensionen".
+    public static CellPlacement GetCellPlacement(Component comp, (double XMin, double YMax)? rawOverrideAnchor);
+
+    // (2) Pin-Weltposition in Nazca — UNIVERSAL: einfache Y-Negation der App-Position.
+    public static (double X, double Y) GetPinNazcaPosition(PhysicalPin pin);
+
+    // (3) Pin-Weltwinkel in Nazca.
+    public static double GetPinNazcaAngle(PhysicalPin pin);   // = −(AngleDegrees + RotationDegrees), normalisiert
+
+    // (4) Punktkonversion für Pfadsegmente.
+    public static (double X, double Y) ToNazca(double appX, double appY);   // = (appX, −appY)
+}
+```
+
+### Platzierungsformel (generisch, kein Quadranten-Casework)
+
+Eingabe: zellinterne UNROTIERTE bbox `B = [xmin, ymin, xmax, ymax]` (Nazca-Y-up, org = Zellursprung),
+Put-Rotation `r = −RotationDegrees`.
+
+1. Vier Ecken von B mit R(r) rotieren → rotierte bbox `[minx′, miny′, maxx′, maxy′]`.
+2. Ziel: rotierte Geometrie-bbox liegt auf der App-Box → Nazca-Topleft = (PhysicalX, −PhysicalY).
+3. Put-Position `T = (PhysicalX − minx′, −PhysicalY − maxy′)`.
+4. Emit: `put('org', T.x, T.y, r)`.
+
+Begründung Konsistenz mit Pins: Die App rotiert Pin-Offsets um das Box-Zentrum und fixiert das
+Topleft; Rotation um einen anderen Punkt unterscheidet sich nur um eine Translation, die das
+bbox-Re-Anchoring exakt aufhebt. Für 90°-Vielfache (einzige App-Rotationen) gilt
+rotierte bbox = getauschte Dimensionen ⇒ Zellgeometrie und App-Pins decken sich exakt.
+
+### bbox-Parameterisierung je Komponentenart (die EINZIGE Verzweigung, an EINER Stelle)
+
+| Art | bbox B |
+|---|---|
+| Raw-Code-Override (Anker persistiert) | `[XMin, YMax − H₀, XMin + W₀, YMax]` aus `NazcaCodeOverride` (OverrideBboxXMin/YMax + OverrideWidth/Height = unrotierte Werte) |
+| PDK / expliziter Kalibrier-Offset (ox, oy) | `[−ox, oy − H₀, −ox + W₀, oy]` — Herleitung: bei rot=0 muss org auf (PhysicalX + ox, −(PhysicalY + oy)) liegen (bestehende, kalibrierte Konvention) |
+| Parametric Straight (bestehender Sonderfall) | ox/oy = Offset des ersten Pins (Regel zieht 1:1 aus `SimpleNazcaExporter.CalculateOriginOffset` um) |
+| Legacy-Fallback (kein PDK-Name, kein expliziter Offset) | ox=0, oy=H₀ (entspricht heutigem `(0, Height)`-Fallback) |
+| Alt-Override OHNE persistierten Anker | wie bisher: Default-Anker-Put ohne org (Legacy-Pfad bleibt im Exporter, dokumentiert) |
+
+Erkennungslogik (PDK-Namensmuster, expliziter Offset, Parametric Straight) zieht aus
+`SimpleNazcaExporter.CalculateOriginOffset` UNVERÄNDERT in den Mapper um.
+
+**Unrotierte Dimensionen:** `Component.Width/Height` sind rotations-getauscht. Mapper:
+`(W₀, H₀) = RotationDegrees % 180 == 0 ? (W, H) : (H, W)`.
+
+### Pin-Positionen: universelle Y-Negation (bewusste Vereinfachung)
+
+`GetPinNazcaPosition` = `ToNazca(pin.GetAbsolutePosition())` für ALLE Komponentenarten.
+Begründung: Das App-Modell ist die Wahrheit dafür, wo Pins SIND (so zeichnet sie der Canvas).
+Aufgabe der Kalibrierung (Offset-Editor) ist, die ZELLE so zu platzieren, dass ihre gerenderten
+Pins mit den App-Pins zusammenfallen — Kalibrierdaten fließen in die Platzierung (oben), nicht
+in eine zweite Pin-Formel. Die bisherige Legacy-Pin-Formel stimmte mit der Y-Negation überein,
+wo oy = H/2 (z.B. demofab mmi2x2: org vertikal mittig) — wo sie abwich, war sie Teil des
+Problems. Abweichungen Zelle↔App-Pins sind ab jetzt Kalibrierfehler, die Lever B PRO TEMPLATE
+sichtbar macht, statt sie in Formelpaaren zu verstecken.
+
+`PhysicalPin.GetAbsoluteNazcaPosition()` wird zum dünnen Delegaten auf den Mapper (Verhalten =
+Y-Negation); seine private `CalculateOriginOffset`-Kopie und der „Must match exactly!"-Kommentar
+werden GELÖSCHT. Alle Aufrufer werden auditiert und auf den Mapper migriert (bekannt:
+SimpleNazcaExporter mehrfach, evtl. PdkOffset-Editor, WaveguideConnection.ExportToNazca —
+Letzteres auf toten Code prüfen).
+
+## Lever B: Selbstverifizierender Export
+
+### Verifikations-Epilog im Exporter
+
+`SimpleNazcaExporter.Export(..., bool emitVerification = false)`. Bei true hängt der Footer an
+(nach `design.put()` / `export_gds`):
+
+```python
+# --- Alignment verification (machine-readable) ---
+import json as _json
+_verify = {}
+for _name, _inst in [('comp_0', comp_0), ('comp_1', comp_1), ...]:   # aus componentNames generiert
+    _pins = {}
+    for _pn, _pin in _inst.pin.items():
+        _px, _py, _pa = _pin.xya()
+        _pins[_pn] = [_px, _py, _pa]
+    _verify[_name] = _pins
+with open(os.path.splitext(script_path)[0] + '.pins.json', 'w') as _f:
+    _json.dump(_verify, _f)
+```
+
+Liefert die TATSÄCHLICHEN Welt-Pinpositionen aller platzierten Instanzen — von derselben
+Nazca-Engine, die das GDS schreibt. (GDS selbst kennt keine Pins; die Wahrheit kommt aus der
+Nazca-Introspektion, genau wie im Preview-Skript.)
+
+### Integrationstest `UnitTests/Integration/GdsExportAlignmentTests.cs`
+
+Env-Skip-Muster wie `NazcaEditorPreviewIntegrationTests` (kein nazca-Python → return, CI grün).
+Matrix: **{demo-PDK `demo.mmi2x2_dp`, Raw-Code-Override (Showcase-Beispiel)} × {0°, 90°, 180°, 270°}**,
+je mit einer Verbindung zu einer zweiten Komponente. Pro Zelle der Matrix:
+
+1. Design im Canvas bauen (Override-Fall: Editor-VM-Apply wie in `NazcaOverrideFullFlowIntegrationTests`),
+   Komponente k-mal via `RotateComponentCommand` drehen.
+2. Export mit `emitVerification: true`, Skript ausführen (`GdsExportService`, discovered python).
+3. Asserts: (a) Exit 0 + .gds existiert; (b) `.pins.json`: für jeden App-Pin der Komponente
+   stimmt die Nazca-Ist-Position mit `NazcaCoordinateMapper.GetPinNazcaPosition` überein
+   (ε = 0,01 µm; Instanz-Pins per Name gematcht, nazca-interne Namen org/cc/Ecken ignoriert);
+   (c) die im Skript emittierten Segment-Endkoordinaten treffen die erwarteten Pin-Positionen (ε).
+
+Rotationen laufen NICHT als Theory-Einzeltests gegen python (Laufzeit), sondern als Schleife in
+wenigen Facts (~2 Facts × 4 Rotationen, ≈ 8 Skript-Läufe, grob 1 Minute auf Dev-PC).
+
+### Unit-Tests `UnitTests/Export/NazcaCoordinateMapperTests.cs`
+
+Reine Mathematik, ohne Python: Platzierungsformel für beide Parameterisierungen × 4 Rotationen
+(Erwartungswerte von Hand hergeleitet), Pin-Position/Winkel-Konversion, unrotierte Dimensionen,
+Legacy-/Parametric-Regeln, Alt-Override-Fallback.
+
+## Konsumenten-Migration (vollständige Liste)
+
+| Stelle | Änderung |
+|---|---|
+| `SimpleNazcaExporter.AppendSingleComponent` | Platzierung + `# COORD`/`# PIN`-Diagnosen via Mapper; eigene `CalculateOriginOffset`/`RotateOffset`/`GetOverrideBboxAnchor`-Helfer entfallen bzw. wandern in den Mapper |
+| `SimpleNazcaExporter.AppendSegmentExport` | Start-Pin-Offset-Maschinerie ENTFÄLLT (universelle Y-Negation ⇒ Offset ist immer 0): Segmente direkt via `ToNazca` |
+| `SimpleNazcaExporter.FormatStraightSegmentFromPins` | beide Endpunkte via `GetPinNazcaPosition` |
+| `SimpleNazcaExporter.BuildEndpointReference` (p2p) | PDK-Tupel via `GetPinNazcaPosition`/`GetPinNazcaAngle`; Override weiterhin Pin-Referenz |
+| `SimpleNazcaExporter.GetNazcaPinPosition` (Helfer aus a0d26201) | entfällt zugunsten des Mappers |
+| `PhysicalPin.GetAbsoluteNazcaPosition` + private `CalculateOriginOffset` | Delegat auf Mapper (Y-Negation); Kopie gelöscht |
+| Aufrufer-Audit (`GetAbsoluteNazcaPosition`-Verwendungen außerhalb) | migrieren oder als korrekt bestätigen; `WaveguideConnection.ExportToNazca` auf toten Code prüfen, ggf. löschen |
+| PdkOffset-Editor | UNVERÄNDERT (Kalibrierdaten sind Mapper-Input); nur prüfen, dass er nicht von der alten Pin-Formel abhängt |
+
+## Bewusste Verhaltensänderungen
+
+1. Exporte ROTIERTER Komponenten (PDK + Override) ändern sich — das ist der Fix.
+2. Segment-/Pin-Koordinaten von Komponenten mit oy ≠ H/2 ändern sich (Y-Negation statt
+   Legacy-Formel) — Lever-B-Matrix weist die Korrektheit auf dem Dev-PC nach; bestehende
+   Exporter-Unit-Tests, die das alte Verhalten asserten, werden bewusst angepasst.
+3. Alt-Overrides ohne bbox-Anker: unverändert Legacy-Placement (kein Anspruch auf Alignment).
+
+## Akzeptanzkriterien
+
+- [ ] Eine einzige Koordinaten-Implementierung; „Must match exactly!"-Kommentarpaar entfernt.
+- [ ] `GdsExportAlignmentTests`-Matrix (2 Arten × 4 Rotationen) grün auf nazca-fähigem Rechner;
+      sauberer Env-Skip ohne nazca.
+- [ ] Mapper-Unit-Tests decken Platzierungsformel und alle Parameterisierungen ab.
+- [ ] Komplette Suite grün; `FileSizeLimitTests` eingehalten (kein File > 500 Zeilen).
+- [ ] PR gegen main mit Review-Run; bestätigte Findings gefixt.
+
+## Folgerichtung (nicht dieses Issue)
+
+Ansatz 3 „volle Render-Wahrheit": Auch PDK-Pin-/Platzierungsdaten pro Template aus echten
+Renders ableiten (Preview-Skript liefert sie bereits) und die Namens-Heuristik abschaffen.
+Der Mapper kapselt die Verzweigung so, dass dieser Schritt später nur EINE Stelle ändert.


### PR DESCRIPTION
## Closes #565 — NazcaCoordinateMapper + selbstverifizierender GDS-Export

Fixt das Rotations-Misalignment im GDS-Export (Override- UND reguläre PDK-Komponenten) durch Beseitigung des strukturellen Defekts dahinter: Die App→Nazca-Koordinaten-Transformation existierte doppelt, war ein Heuristik-Stapel und hatte keinen maschinellen Verifikations-Regelkreis (Historie: #329/#334/#338/#355/#456/#458, 2× in #561).

Spec: `docs/superpowers/specs/2026-06-12-issue-565-nazca-coordinate-mapper-design.md` · Plan: `docs/superpowers/plans/2026-06-12-issue-565-coordinate-mapper.md`

### Lever A — Single Source of Truth

- **Neu: `Connect-A-Pic-Core/Export/NazcaCoordinateMapper.cs`** (199 Zeilen): einzige Stelle für Zell-Platzierung (`GetCellPlacement`), Pin-Weltposition (`GetPinNazcaPosition` = universelle Y-Negation der App-Position), Pin-Winkel und Punktkonversion. Kern ist eine **generische Rotations-Platzierungsformel** (Ziel-Topleft minus rotierte bbox-Ecke über die vier rotierten Eckpunkte — kein Quadranten-Casework), parametrisiert pro Komponentenart (Override-bbox-Anker / Kalibrier-Offset / Parametric-Straight / Legacy-Fallback) an genau **einer** Verzweigungsstelle. Bei Rotation 0 verhaltensgleich zum bisherigen Export — bewiesen durch unveränderte Bestandstests.
- **Konsumenten migriert:** `SimpleNazcaExporter` (Placement, Segmente, p2p-Endpunkte, Diagnosen; 826 → ~717 Zeilen), `PhysicalPin.GetAbsoluteNazcaPosition` (Delegat; private Formelkopie + „Must match exactly!"-Kommentar **gelöscht**), `ExportValidator` entdoppelt, totes `WaveguideConnection.ExportToNazca` entfernt (Aufrufer-Beweis im Commit).
- Die Segment-Export-Offset-Maschinerie entfällt komplett (universelle Y-Negation ⇒ Offset konstruktiv 0).

### Lever B — Selbstverifizierender Export

- `Export(..., emitVerification: true)` hängt einen Python-Epilog an, der die **tatsächlichen** Welt-Pinpositionen aller platzierten Instanzen als `.pins.json` schreibt — von derselben Nazca-Engine, die das GDS erzeugt.
- **Neu: `GdsExportAlignmentTests`** — Matrix **{demo-PDK mmi2x2, Raw-Code-Override (Showcase)} × {0°, 90°, 180°, 270°}**, je mit Verbindung: Export ausführen, GDS + `.pins.json` prüfen, Ist-Pinpositionen gegen Mapper-Erwartung mit ε=0,01 µm (Position UND Winkel) asserten. Läuft echt auf nazca-fähigen Rechnern (~30 s), skippt sauber auf CI ohne nazca. **Diese Fehlerklasse ist damit auf Dev-/Agenten-PCs unship-bar.**

### Verifikation

- `dotnet build`: 0 Fehler, keine neuen Warnings (eine neue CA1822 behoben)
- Komplette Suite: **2344 passed / 0 failed** (10 bekannte Skips)
- Alignment-Matrix: 2/2 Facts grün mit echten nazca-Läufen (~29 s)
- Workflow-Ausführung mit unabhängiger Verifikation pro Task + Review-Phase (Code-Qualität, Silent-Failure-Jagd): bestanden

### Bewusste Verhaltensänderungen (siehe Spec)

1. Exporte **rotierter** Komponenten ändern sich — das ist der Fix.
2. Pin-/Segmentkoordinaten von Zellen mit org ≠ vertikale Mitte folgen jetzt der App-Wahrheit (Y-Negation) statt der Legacy-Formel; Kalibrierabweichungen macht die Testmatrix sichtbar statt sie zu verstecken.
3. Alt-Overrides ohne persistierten bbox-Anker behalten den Legacy-Put (kein Alignment-Anspruch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
