### PR TITLE
FDTD S-matrix recompute via open-source Meep/Docker + ComponentSettings button (#569)

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -235,6 +235,17 @@ public partial class App : Application
         services.AddSingleton(sp =>
             new GdsPreviewRenderService(sp.GetRequiredService<NazcaComponentPreviewService>()));
 
+        // Register FDTD S-matrix service (open-source Meep via Docker, self-provisioning)
+        services.AddSingleton<CAP_Core.Solvers.Fdtd.IFdtdSMatrixService>(_ =>
+        {
+            var dockerfile = FindFdtdDockerfile();
+            // Build context = the scripts/ dir (parent of scripts/fdtd) so the small
+            // bridge script is COPYable without shipping the whole repo to the daemon.
+            var buildContext = Directory.GetParent(Path.GetDirectoryName(dockerfile)!)?.FullName
+                               ?? AppDomain.CurrentDomain.BaseDirectory;
+            return new CAP.Avalonia.Services.Solvers.DockerFdtdSMatrixService("lunima-meep:1", dockerfile, buildContext);
+        });
+
         // Register main ViewModel
         services.AddSingleton<MainViewModel>();
 
@@ -348,6 +359,28 @@ public partial class App : Application
 
         // Best-effort fallback — NazcaComponentPreviewService returns a graceful
         // failure with a clear message when the path doesn't resolve.
+        return local;
+    }
+
+    /// <summary>
+    /// Searches for scripts/fdtd/Dockerfile (the FDTD solver image recipe) relative
+    /// to the application base directory, using the same walk-up-the-tree strategy
+    /// as <see cref="FindPreviewScript"/>.
+    /// </summary>
+    private static string FindFdtdDockerfile()
+    {
+        var relative = Path.Combine("scripts", "fdtd", "Dockerfile");
+        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+        var local = Path.Combine(baseDir, relative);
+        if (File.Exists(local)) return local;
+
+        var current = new DirectoryInfo(baseDir);
+        while (current != null)
+        {
+            var candidate = Path.Combine(current.FullName, relative);
+            if (File.Exists(candidate)) return candidate;
+            current = current.Parent;
+        }
         return local;
     }
 

--- a/CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs
+++ b/CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs
@@ -1,0 +1,87 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
+
+namespace CAP.Avalonia.Services.Solvers;
+
+/// <summary>
+/// Builds an <see cref="FdtdSMatrixRequest"/> for a placed component by rendering
+/// its Nazca geometry (reusing <see cref="NazcaComponentPreviewService"/>, the
+/// same single-component renderer the PDK Offset Editor uses) and turning the
+/// rendered polygons and pin stubs into FDTD geometry and ports. Lunima knows
+/// its own pins, so ports come from the render rather than being reconstructed.
+/// </summary>
+public class ComponentFdtdRequestFactory
+{
+    /// <summary>Default port (waveguide) width in µm when the render doesn't carry one.</summary>
+    public const double DefaultPortWidthUm = 0.5;
+
+    /// <summary>
+    /// Default GDS layer carrying the optical waveguide. The render returns many
+    /// layers (metal, dummy, design-area); FDTD must only see the guiding layer,
+    /// so polygons are filtered to this layer (with a fall-back to all layers when
+    /// none match, so a non-standard PDK still produces geometry).
+    /// </summary>
+    public const int DefaultSiliconLayer = 1;
+
+    private readonly NazcaComponentPreviewService _preview;
+    private readonly double _portWidthUm;
+    private readonly int _siliconLayer;
+
+    /// <summary>Initializes the factory.</summary>
+    public ComponentFdtdRequestFactory(
+        NazcaComponentPreviewService preview,
+        double portWidthUm = DefaultPortWidthUm,
+        int siliconLayer = DefaultSiliconLayer)
+    {
+        _preview = preview ?? throw new ArgumentNullException(nameof(preview));
+        _portWidthUm = portWidthUm;
+        _siliconLayer = siliconLayer;
+    }
+
+    /// <summary>
+    /// Renders the component and builds an FDTD request, or returns null when the
+    /// geometry/pins could not be obtained (the caller surfaces a clear status).
+    /// </summary>
+    public async Task<FdtdSMatrixRequest?> BuildAsync(Component component, CancellationToken ct = default)
+    {
+        var preview = await _preview.RenderAsync(component.NazcaModuleName, component.NazcaFunctionName, null, ct);
+        if (!preview.Success || preview.Polygons.Count == 0 || preview.Pins.Count == 0)
+            return null;
+
+        return new FdtdSMatrixRequest
+        {
+            Polygons = BuildPolygons(preview.Polygons, _siliconLayer),
+            Ports = BuildPorts(preview.Pins, _portWidthUm),
+            LayerNumber = _siliconLayer,
+            Is3D = false, // 2D for a quick recompute; a 3D/accuracy toggle can come later
+        };
+    }
+
+    /// <summary>
+    /// Keeps only polygons on the optical layer (falls back to all layers when
+    /// none match, so a PDK that puts its guide on another layer still renders).
+    /// </summary>
+    internal static IReadOnlyList<FdtdPolygon> BuildPolygons(
+        IReadOnlyList<NazcaPreviewPolygon> polygons, int siliconLayer)
+    {
+        var onLayer = polygons.Where(p => p.Layer == siliconLayer).ToList();
+        var source = onLayer.Count > 0 ? onLayer : polygons;
+        return source.Select(p => new FdtdPolygon
+        {
+            Layer = p.Layer,
+            Points = p.Vertices.Select(v => new FdtdPoint(v.X, v.Y)).ToList(),
+        }).ToList();
+    }
+
+    /// <summary>Maps Nazca pin stubs to FDTD ports (orientation = pin angle).</summary>
+    internal static IReadOnlyList<FdtdPort> BuildPorts(IReadOnlyList<NazcaPreviewPin> pins, double portWidthUm) =>
+        pins.Select(pin => new FdtdPort
+        {
+            Name = pin.Name,
+            X = pin.X,
+            Y = pin.Y,
+            Orientation = pin.Angle,
+            Width = portWidthUm,
+        }).ToList();
+}

--- a/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
+++ b/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
@@ -21,6 +21,12 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
     private const string ContainerDataDir = "/data";
     private const string ContainerScript = "/work/fdtd_sparams.py";
 
+    /// <summary>
+    /// Shared-memory (/dev/shm) size for the container in MB. MPICH/UCX needs this
+    /// for inter-rank transport; Docker's 64 MB default makes MPI_Init fail.
+    /// </summary>
+    private const int ShmSizeMb = 2048;
+
     private readonly string _dockerExe;
     private readonly string _imageTag;
     private readonly string _dockerfilePath;
@@ -71,6 +77,10 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
             var si = new ProcessStartInfo { FileName = _dockerExe };
             si.ArgumentList.Add("run");
             si.ArgumentList.Add("--rm");
+            // MPICH/UCX uses shared memory (/dev/shm) for inter-rank transport.
+            // Docker's default /dev/shm is only 64 MB, which makes MPI_Init fail
+            // ("Not enough memory ... /dev/shm") once several ranks start. Enlarge it.
+            si.ArgumentList.Add($"--shm-size={ShmSizeMb}m");
             si.ArgumentList.Add("-v");
             si.ArgumentList.Add($"{ToDockerPath(workingDir)}:{ContainerDataDir}");
             si.ArgumentList.Add(_imageTag);

--- a/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
+++ b/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
@@ -54,7 +54,8 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
     }
 
     /// <inheritdoc/>
-    public async Task<FdtdSMatrixResult> SolveAsync(FdtdSMatrixRequest request, CancellationToken ct = default)
+    public async Task<FdtdSMatrixResult> SolveAsync(
+        FdtdSMatrixRequest request, IProgress<string>? progress = null, CancellationToken ct = default)
     {
         var hasGds = !string.IsNullOrWhiteSpace(request.GdsPath) && File.Exists(request.GdsPath);
         if (!hasGds && request.Polygons.Count == 0)
@@ -96,7 +97,8 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
             si.ArgumentList.Add(ContainerScript);
             si.ArgumentList.Add($"--spec={ContainerDataDir}/_fdtd_request.json");
 
-            var run = await SubprocessJsonRunner.RunAsync(si, string.Empty, _timeout, ct);
+            var run = await SubprocessJsonRunner.RunAsync(si, string.Empty, _timeout, ct,
+                onStderrLine: line => { if (IsProgressLine(line)) progress?.Report(line); });
             return MapRun(run);
         }
         finally
@@ -175,6 +177,14 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
     /// </summary>
     internal static int ResolveShmMb(int cores) =>
         Math.Clamp(cores * ShmMbPerRank, ShmFloorMb, ShmCeilingMb);
+
+    /// <summary>
+    /// Keeps the noise down: only forward solver lines that carry useful progress
+    /// (a tqdm/meep percentage or time-step), not every warning.
+    /// </summary>
+    private static bool IsProgressLine(string line) =>
+        line.Contains('%') || line.Contains("time step", StringComparison.OrdinalIgnoreCase)
+        || line.Contains("Meep progress", StringComparison.OrdinalIgnoreCase);
 
     private static string ToDockerPath(string path) => path.Replace('\\', '/');
 }

--- a/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
+++ b/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using CAP_Core.Solvers.Fdtd;
 
@@ -20,6 +21,13 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
 
     private const string ContainerDataDir = "/data";
     private const string ContainerScript = "/work/fdtd_sparams.py";
+
+    /// <summary>Label stamped on every solver container so orphans can be reaped.</summary>
+    private const string ContainerLabel = "lunima.fdtd=1";
+
+    /// <summary>Names of containers currently running, killed on process exit.</summary>
+    private static readonly ConcurrentDictionary<string, byte> ActiveContainers = new();
+    private static int _exitHookInstalled;
 
     /// <summary>Shared-memory budget per MPI rank in MB (UCX inter-rank buffers).</summary>
     private const int ShmMbPerRank = 256;
@@ -61,6 +69,9 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
         if (!hasGds && request.Polygons.Count == 0)
             return FdtdSMatrixResult.Fail("No geometry supplied: provide either a GDS file or polygons.");
 
+        InstallExitHook();
+        await ReapOrphanContainersAsync(); // clean up leftovers from a hard-killed session
+
         var provision = await EnsureImageAsync(ct);
         if (provision != null)
             return provision;
@@ -72,15 +83,24 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
             : (CreateTempDir(), true);
         var specPath = Path.Combine(workingDir, "_fdtd_request.json");
         var containerGds = hasGds ? $"{ContainerDataDir}/{Path.GetFileName(request.GdsPath)}" : string.Empty;
+        var containerName = "lunima-fdtd-" + Guid.NewGuid().ToString("N");
 
         try
         {
             await File.WriteAllTextAsync(specPath, FdtdJsonContract.SerialiseRequest(request, containerGds), ct);
+            ActiveContainers[containerName] = 0;
 
             var cores = ResolveCores(request);
             var si = new ProcessStartInfo { FileName = _dockerExe };
             si.ArgumentList.Add("run");
             si.ArgumentList.Add("--rm");
+            // Named + labelled so we can stop it on cancel/exit and reap orphans
+            // (a bare `docker run` leaves the container running in the daemon when
+            // the client process — or the whole app — is killed).
+            si.ArgumentList.Add("--name");
+            si.ArgumentList.Add(containerName);
+            si.ArgumentList.Add("--label");
+            si.ArgumentList.Add(ContainerLabel);
             // MPICH/UCX uses shared memory (/dev/shm) for inter-rank transport.
             // Docker's default /dev/shm is only 64 MB, which makes MPI_Init fail
             // ("Not enough memory ... /dev/shm") once several ranks start. Scale it
@@ -103,10 +123,63 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
         }
         finally
         {
+            // Ensure the container is gone even on cancel/timeout (killing the docker
+            // client does not stop the daemon-managed container; --rm only fires on
+            // a clean exit). rm -f is a no-op if it already exited.
+            await ForceRemoveContainerAsync(containerName);
+            ActiveContainers.TryRemove(containerName, out _);
             try { if (File.Exists(specPath)) File.Delete(specPath); } catch { /* best-effort */ }
             if (isTempDir)
                 try { Directory.Delete(workingDir, recursive: true); } catch { /* best-effort */ }
         }
+    }
+
+    private async Task ForceRemoveContainerAsync(string name)
+    {
+        var si = new ProcessStartInfo { FileName = _dockerExe };
+        si.ArgumentList.Add("rm");
+        si.ArgumentList.Add("-f");
+        si.ArgumentList.Add(name);
+        try { await SubprocessJsonRunner.RunAsync(si, string.Empty, TimeSpan.FromSeconds(20), CancellationToken.None); }
+        catch { /* best-effort */ }
+    }
+
+    /// <summary>Removes any solver containers left over from a previous (crashed) session.</summary>
+    private async Task ReapOrphanContainersAsync()
+    {
+        var list = new ProcessStartInfo { FileName = _dockerExe };
+        list.ArgumentList.Add("ps");
+        list.ArgumentList.Add("-aq");
+        list.ArgumentList.Add("--filter");
+        list.ArgumentList.Add($"label={ContainerLabel}");
+        SubprocessJsonRunner.RunResult res;
+        try { res = await SubprocessJsonRunner.RunAsync(list, string.Empty, TimeSpan.FromSeconds(20), CancellationToken.None); }
+        catch { return; }
+
+        if (res.Outcome != SubprocessJsonRunner.Outcome.Completed) return;
+        foreach (var id in res.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            await ForceRemoveContainerAsync(id);
+    }
+
+    private void InstallExitHook()
+    {
+        if (Interlocked.Exchange(ref _exitHookInstalled, 1) == 1) return;
+        var dockerExe = _dockerExe;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            foreach (var name in ActiveContainers.Keys)
+            {
+                try
+                {
+                    var si = new ProcessStartInfo { FileName = dockerExe, UseShellExecute = false, CreateNoWindow = true };
+                    si.ArgumentList.Add("rm");
+                    si.ArgumentList.Add("-f");
+                    si.ArgumentList.Add(name);
+                    Process.Start(si)?.WaitForExit(5000);
+                }
+                catch { /* best-effort on shutdown */ }
+            }
+        };
     }
 
     private static string CreateTempDir()

--- a/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
+++ b/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
@@ -118,7 +118,7 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
             si.ArgumentList.Add($"--spec={ContainerDataDir}/_fdtd_request.json");
 
             var run = await SubprocessJsonRunner.RunAsync(si, string.Empty, _timeout, ct,
-                onStderrLine: line => { if (IsProgressLine(line)) progress?.Report(line); });
+                onStderrLine: line => { if (IsProgressLine(line)) progress?.Report(CleanProgressLine(line)); });
             return MapRun(run);
         }
         finally
@@ -258,6 +258,16 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
     private static bool IsProgressLine(string line) =>
         line.Contains('%') || line.Contains("time step", StringComparison.OrdinalIgnoreCase)
         || line.Contains("Meep progress", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Strips the tqdm bar art (Unicode block-element glyphs and the surrounding
+    /// pipes) so the status shows just the useful "50% 3/4 [00:03&lt;00:01]" parts.
+    /// </summary>
+    internal static string CleanProgressLine(string line)
+    {
+        var noBlocks = System.Text.RegularExpressions.Regex.Replace(line, @"[▀-▟|]+", " ");
+        return System.Text.RegularExpressions.Regex.Replace(noBlocks, @"\s{2,}", " ").Trim();
+    }
 
     private static string ToDockerPath(string path) => path.Replace('\\', '/');
 }

--- a/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
+++ b/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
@@ -1,0 +1,157 @@
+using System.Diagnostics;
+using CAP_Core.Solvers.Fdtd;
+
+namespace CAP.Avalonia.Services.Solvers;
+
+/// <summary>
+/// Implements <see cref="IFdtdSMatrixService"/> by running the open-source Meep
+/// FDTD solver inside a pinned Docker image (Meep is conda-only and has no native
+/// Windows build). The image is built on first use if absent. The component GDS
+/// directory is volume-mounted; the request is passed as a spec file (robust under
+/// MPI, unlike stdin). Raw stderr is surfaced on failure — no silent fallback.
+/// </summary>
+public class DockerFdtdSMatrixService : IFdtdSMatrixService
+{
+    /// <summary>Default per-solve timeout. 3D runs can take many minutes.</summary>
+    public static readonly TimeSpan DefaultSolveTimeout = TimeSpan.FromMinutes(30);
+
+    /// <summary>Timeout for the one-time image build (conda solve + downloads).</summary>
+    public static readonly TimeSpan BuildTimeout = TimeSpan.FromMinutes(40);
+
+    private const string ContainerDataDir = "/data";
+    private const string ContainerScript = "/work/fdtd_sparams.py";
+
+    private readonly string _dockerExe;
+    private readonly string _imageTag;
+    private readonly string _dockerfilePath;
+    private readonly string _buildContext;
+    private readonly TimeSpan _timeout;
+
+    /// <summary>Initializes the service.</summary>
+    /// <param name="imageTag">Pinned image tag, e.g. "lunima-meep:1".</param>
+    /// <param name="dockerfilePath">Path to the Dockerfile used to build the image.</param>
+    /// <param name="buildContext">Docker build context (repo root, so the script can be COPYed).</param>
+    /// <param name="dockerExecutable">Docker CLI (default "docker").</param>
+    /// <param name="timeout">Optional per-solve timeout.</param>
+    public DockerFdtdSMatrixService(
+        string imageTag, string dockerfilePath, string buildContext,
+        string dockerExecutable = "docker", TimeSpan? timeout = null)
+    {
+        _imageTag = imageTag ?? throw new ArgumentNullException(nameof(imageTag));
+        _dockerfilePath = dockerfilePath ?? throw new ArgumentNullException(nameof(dockerfilePath));
+        _buildContext = buildContext ?? throw new ArgumentNullException(nameof(buildContext));
+        _dockerExe = dockerExecutable;
+        _timeout = timeout ?? DefaultSolveTimeout;
+    }
+
+    /// <inheritdoc/>
+    public async Task<FdtdSMatrixResult> SolveAsync(FdtdSMatrixRequest request, CancellationToken ct = default)
+    {
+        var hasGds = !string.IsNullOrWhiteSpace(request.GdsPath) && File.Exists(request.GdsPath);
+        if (!hasGds && request.Polygons.Count == 0)
+            return FdtdSMatrixResult.Fail("No geometry supplied: provide either a GDS file or polygons.");
+
+        var provision = await EnsureImageAsync(ct);
+        if (provision != null)
+            return provision;
+
+        // Working dir is mounted at /data. With a GDS we mount its folder; with
+        // polygons there is no file, so we use a throwaway temp folder for the spec.
+        var (workingDir, isTempDir) = hasGds
+            ? (Path.GetDirectoryName(Path.GetFullPath(request.GdsPath))!, false)
+            : (CreateTempDir(), true);
+        var specPath = Path.Combine(workingDir, "_fdtd_request.json");
+        var containerGds = hasGds ? $"{ContainerDataDir}/{Path.GetFileName(request.GdsPath)}" : string.Empty;
+
+        try
+        {
+            await File.WriteAllTextAsync(specPath, FdtdJsonContract.SerialiseRequest(request, containerGds), ct);
+
+            var cores = ResolveCores(request);
+            var si = new ProcessStartInfo { FileName = _dockerExe };
+            si.ArgumentList.Add("run");
+            si.ArgumentList.Add("--rm");
+            si.ArgumentList.Add("-v");
+            si.ArgumentList.Add($"{ToDockerPath(workingDir)}:{ContainerDataDir}");
+            si.ArgumentList.Add(_imageTag);
+            si.ArgumentList.Add("mpirun");
+            si.ArgumentList.Add("-np");
+            si.ArgumentList.Add(cores.ToString());
+            si.ArgumentList.Add("python");
+            si.ArgumentList.Add(ContainerScript);
+            si.ArgumentList.Add($"--spec={ContainerDataDir}/_fdtd_request.json");
+
+            var run = await SubprocessJsonRunner.RunAsync(si, string.Empty, _timeout, ct);
+            return MapRun(run);
+        }
+        finally
+        {
+            try { if (File.Exists(specPath)) File.Delete(specPath); } catch { /* best-effort */ }
+            if (isTempDir)
+                try { Directory.Delete(workingDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static string CreateTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "lunima-fdtd-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static FdtdSMatrixResult MapRun(SubprocessJsonRunner.RunResult run) => run.Outcome switch
+    {
+        SubprocessJsonRunner.Outcome.StartFailed =>
+            FdtdSMatrixResult.Fail($"Could not start Docker: {run.StartError}", missingDependency: "docker"),
+        SubprocessJsonRunner.Outcome.Cancelled => FdtdSMatrixResult.Fail("FDTD solve was cancelled."),
+        SubprocessJsonRunner.Outcome.TimedOut => FdtdSMatrixResult.Fail("FDTD solver timed out."),
+        _ => FdtdJsonContract.ParseOutput(run.Stdout, run.Stderr),
+    };
+
+    /// <summary>
+    /// Ensures the solver image exists, building it from the Dockerfile if not.
+    /// Returns null on success, or a failure result describing what went wrong.
+    /// </summary>
+    public async Task<FdtdSMatrixResult?> EnsureImageAsync(CancellationToken ct = default)
+    {
+        var inspect = new ProcessStartInfo { FileName = _dockerExe };
+        inspect.ArgumentList.Add("image");
+        inspect.ArgumentList.Add("inspect");
+        inspect.ArgumentList.Add(_imageTag);
+        var probe = await SubprocessJsonRunner.RunAsync(inspect, string.Empty, TimeSpan.FromSeconds(30), ct);
+
+        if (probe.Outcome == SubprocessJsonRunner.Outcome.StartFailed)
+            return FdtdSMatrixResult.Fail($"Could not start Docker: {probe.StartError}", missingDependency: "docker");
+        if (probe.Outcome == SubprocessJsonRunner.Outcome.Completed && probe.ExitCode == 0)
+            return null; // image present
+
+        var build = new ProcessStartInfo { FileName = _dockerExe };
+        build.ArgumentList.Add("build");
+        build.ArgumentList.Add("-f");
+        build.ArgumentList.Add(_dockerfilePath);
+        build.ArgumentList.Add("-t");
+        build.ArgumentList.Add(_imageTag);
+        build.ArgumentList.Add(_buildContext);
+        var built = await SubprocessJsonRunner.RunAsync(build, string.Empty, BuildTimeout, ct);
+
+        if (built.Outcome == SubprocessJsonRunner.Outcome.Completed && built.ExitCode == 0)
+            return null;
+        return FdtdSMatrixResult.Fail(
+            $"Failed to provision FDTD image '{_imageTag}'. {built.Outcome}.", rawStderr: built.Stderr);
+    }
+
+    /// <summary>
+    /// Picks an MPI rank count. 3D is capped lower because each rank holds a slice
+    /// of the 3D grid plus DFT monitors — too many ranks exhausted RAM and the OS
+    /// killed the run (the original 24-rank OOM). Honours an explicit request value.
+    /// </summary>
+    private static int ResolveCores(FdtdSMatrixRequest request)
+    {
+        if (request.Cores > 0)
+            return request.Cores;
+        var available = Math.Max(1, Environment.ProcessorCount);
+        return request.Is3D ? Math.Min(available, 8) : Math.Min(available, 16);
+    }
+
+    private static string ToDockerPath(string path) => path.Replace('\\', '/');
+}

--- a/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
+++ b/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
@@ -21,11 +21,14 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
     private const string ContainerDataDir = "/data";
     private const string ContainerScript = "/work/fdtd_sparams.py";
 
-    /// <summary>
-    /// Shared-memory (/dev/shm) size for the container in MB. MPICH/UCX needs this
-    /// for inter-rank transport; Docker's 64 MB default makes MPI_Init fail.
-    /// </summary>
-    private const int ShmSizeMb = 2048;
+    /// <summary>Shared-memory budget per MPI rank in MB (UCX inter-rank buffers).</summary>
+    private const int ShmMbPerRank = 256;
+
+    /// <summary>Floor for /dev/shm so even a 1-2 core machine has headroom.</summary>
+    private const int ShmFloorMb = 2048;
+
+    /// <summary>Ceiling so we never request an absurd tmpfs cap on big machines.</summary>
+    private const int ShmCeilingMb = 16384;
 
     private readonly string _dockerExe;
     private readonly string _imageTag;
@@ -79,8 +82,10 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
             si.ArgumentList.Add("--rm");
             // MPICH/UCX uses shared memory (/dev/shm) for inter-rank transport.
             // Docker's default /dev/shm is only 64 MB, which makes MPI_Init fail
-            // ("Not enough memory ... /dev/shm") once several ranks start. Enlarge it.
-            si.ArgumentList.Add($"--shm-size={ShmSizeMb}m");
+            // ("Not enough memory ... /dev/shm") once several ranks start. Scale it
+            // with the rank count (which itself scales with the machine's cores).
+            // /dev/shm is a tmpfs cap, not a reservation, so a generous size is free.
+            si.ArgumentList.Add($"--shm-size={ResolveShmMb(cores)}m");
             si.ArgumentList.Add("-v");
             si.ArgumentList.Add($"{ToDockerPath(workingDir)}:{ContainerDataDir}");
             si.ArgumentList.Add(_imageTag);
@@ -162,6 +167,14 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
         var available = Math.Max(1, Environment.ProcessorCount);
         return request.Is3D ? Math.Min(available, 8) : Math.Min(available, 16);
     }
+
+    /// <summary>
+    /// Sizes the container's /dev/shm to the rank count (UCX shared-memory transport
+    /// grows with ranks), clamped to a sane floor/ceiling. Since /dev/shm is a tmpfs
+    /// cap rather than an upfront reservation, over-provisioning is harmless.
+    /// </summary>
+    internal static int ResolveShmMb(int cores) =>
+        Math.Clamp(cores * ShmMbPerRank, ShmFloorMb, ShmCeilingMb);
 
     private static string ToDockerPath(string path) => path.Replace('\\', '/');
 }

--- a/CAP.Avalonia/Services/Solvers/FdtdJsonContract.cs
+++ b/CAP.Avalonia/Services/Solvers/FdtdJsonContract.cs
@@ -1,0 +1,134 @@
+using System.Numerics;
+using System.Text.Json;
+using CAP_Core.Solvers.Fdtd;
+
+namespace CAP.Avalonia.Services.Solvers;
+
+/// <summary>
+/// Translates between <see cref="FdtdSMatrixRequest"/>/<see cref="FdtdSMatrixResult"/>
+/// and the JSON contract of <c>scripts/fdtd_sparams.py</c>. Kept separate from the
+/// Docker driver so the contract can be unit-tested without spawning a container.
+/// </summary>
+public static class FdtdJsonContract
+{
+    /// <summary>
+    /// Serialises a request to the script's stdin/spec JSON. <paramref name="gdsPathInContainer"/>
+    /// is the GDS path as seen inside the container (the host file is volume-mounted).
+    /// </summary>
+    public static string SerialiseRequest(FdtdSMatrixRequest req, string gdsPathInContainer)
+    {
+        var obj = new
+        {
+            gds_path = gdsPathInContainer,
+            polygons = req.Polygons.Select(poly => new
+            {
+                layer = poly.Layer,
+                points = poly.Points.Select(pt => new[] { pt.X, pt.Y }),
+            }),
+            ports = req.Ports.Select(p => new
+            {
+                name = p.Name,
+                x = p.X,
+                y = p.Y,
+                orientation = p.Orientation,
+                width = p.Width,
+            }),
+            layer = new[] { req.LayerNumber, req.LayerDatatype },
+            wavelength_start = req.WavelengthStart,
+            wavelength_stop = req.WavelengthStop,
+            wavelength_points = req.WavelengthPoints,
+            resolution = req.Resolution,
+            is_3d = req.Is3D,
+            ymargin = req.YMargin,
+            xmargin = req.XMargin,
+        };
+        return JsonSerializer.Serialize(obj);
+    }
+
+    /// <summary>
+    /// Parses the JSON the script writes on stdout. Robust against log chatter
+    /// before the result. Surfaces solver failures with their raw stderr.
+    /// </summary>
+    public static FdtdSMatrixResult ParseOutput(string stdout, string stderr = "")
+    {
+        if (string.IsNullOrWhiteSpace(stdout))
+            return FdtdSMatrixResult.Fail("FDTD solver produced no output.", rawStderr: stderr);
+
+        var jsonLine = SubprocessJsonRunner.ExtractTrailingJsonLine(stdout);
+        if (jsonLine == null)
+            return FdtdSMatrixResult.Fail(
+                $"No JSON found in FDTD solver output: {Truncate(stdout, 300)}", rawStderr: stderr);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(jsonLine);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("success", out var sp) && !sp.GetBoolean())
+            {
+                var error = root.TryGetProperty("error", out var ep) ? ep.GetString() : null;
+                var missing = root.TryGetProperty("missing_backend", out var mb) ? mb.GetString() : null;
+                return FdtdSMatrixResult.Fail(error ?? "Unknown FDTD solver error", stderr, missing);
+            }
+
+            return new FdtdSMatrixResult
+            {
+                Success = true,
+                Is3D = root.TryGetProperty("is_3d", out var td) && td.GetBoolean(),
+                Ports = ReadStringArray(root, "ports"),
+                Wavelengths = ReadDoubleArray(root, "wavelengths"),
+                Entries = ReadEntries(root),
+                EnergySumPerInput = ReadEnergy(root),
+            };
+        }
+        catch (Exception ex)
+        {
+            return FdtdSMatrixResult.Fail($"Failed to parse FDTD output: {ex.Message}", rawStderr: stderr);
+        }
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonElement root, string name)
+    {
+        var list = new List<string>();
+        if (root.TryGetProperty(name, out var arr) && arr.ValueKind == JsonValueKind.Array)
+            foreach (var v in arr.EnumerateArray())
+                if (v.GetString() is { } s) list.Add(s);
+        return list;
+    }
+
+    private static IReadOnlyList<double> ReadDoubleArray(JsonElement root, string name)
+    {
+        var list = new List<double>();
+        if (root.TryGetProperty(name, out var arr) && arr.ValueKind == JsonValueKind.Array)
+            foreach (var v in arr.EnumerateArray()) list.Add(v.GetDouble());
+        return list;
+    }
+
+    private static IReadOnlyList<FdtdSEntry> ReadEntries(JsonElement root)
+    {
+        var list = new List<FdtdSEntry>();
+        if (!root.TryGetProperty("s", out var s) || s.ValueKind != JsonValueKind.Object)
+            return list;
+
+        foreach (var prop in s.EnumerateObject())
+        {
+            var values = new List<Complex>();
+            foreach (var pair in prop.Value.EnumerateArray())
+            {
+                values.Add(new Complex(pair[0].GetDouble(), pair[1].GetDouble()));
+            }
+            list.Add(new FdtdSEntry { Key = prop.Name, Values = values });
+        }
+        return list;
+    }
+
+    private static IReadOnlyDictionary<string, double> ReadEnergy(JsonElement root)
+    {
+        var dict = new Dictionary<string, double>();
+        if (root.TryGetProperty("energy_sum_per_input", out var e) && e.ValueKind == JsonValueKind.Object)
+            foreach (var prop in e.EnumerateObject()) dict[prop.Name] = prop.Value.GetDouble();
+        return dict;
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max] + "…";
+}

--- a/CAP.Avalonia/Services/Solvers/FdtdSMatrixConverter.cs
+++ b/CAP.Avalonia/Services/Solvers/FdtdSMatrixConverter.cs
@@ -1,0 +1,70 @@
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services.Solvers;
+
+/// <summary>
+/// Converts an <see cref="FdtdSMatrixResult"/> (keyed "out@mode,in@mode" with
+/// complex values per wavelength) into the <see cref="ComponentSMatrixData"/>
+/// shape the Component Settings dialog stores and applies — the same target type
+/// the file importers produce, so the FDTD result flows through the existing
+/// store-and-apply path.
+/// </summary>
+public static class FdtdSMatrixConverter
+{
+    /// <summary>
+    /// Builds per-wavelength row-major S-matrices from the solver result.
+    /// Only the fundamental mode (index 0) is used.
+    /// </summary>
+    /// <param name="result">A successful FDTD result.</param>
+    /// <param name="sourceNote">Provenance note stored on the data (e.g. "FDTD Meep 2D").</param>
+    public static ComponentSMatrixData ToComponentSMatrixData(FdtdSMatrixResult result, string sourceNote)
+    {
+        var ports = result.Ports.ToList();
+        var index = new Dictionary<string, int>();
+        for (int i = 0; i < ports.Count; i++)
+            index[ports[i]] = i;
+
+        var n = ports.Count;
+        var data = new ComponentSMatrixData { SourceNote = sourceNote };
+
+        for (int w = 0; w < result.Wavelengths.Count; w++)
+        {
+            var entry = new SMatrixWavelengthEntry
+            {
+                Rows = n,
+                Cols = n,
+                PortNames = ports,
+                Real = new List<double>(new double[n * n]),
+                Imag = new List<double>(new double[n * n]),
+            };
+
+            foreach (var s in result.Entries)
+            {
+                if (!TryParseKey(s.Key, out var outPort, out var inPort)) continue;
+                if (!index.TryGetValue(outPort, out var r) || !index.TryGetValue(inPort, out var c)) continue;
+                if (w >= s.Values.Count) continue;
+
+                var flat = r * n + c;
+                entry.Real[flat] = s.Values[w].Real;
+                entry.Imag[flat] = s.Values[w].Imaginary;
+            }
+
+            var nm = ((int)Math.Round(result.Wavelengths[w] * 1000.0)).ToString();
+            data.Wavelengths[nm] = entry;
+        }
+
+        return data;
+    }
+
+    /// <summary>Parses an "out@mode,in@mode" key into its output and input port names.</summary>
+    private static bool TryParseKey(string key, out string outPort, out string inPort)
+    {
+        outPort = inPort = string.Empty;
+        var comma = key.Split(',');
+        if (comma.Length != 2) return false;
+        outPort = comma[0].Split('@')[0];
+        inPort = comma[1].Split('@')[0];
+        return outPort.Length > 0 && inPort.Length > 0;
+    }
+}

--- a/CAP.Avalonia/Services/Solvers/SubprocessJsonRunner.cs
+++ b/CAP.Avalonia/Services/Solvers/SubprocessJsonRunner.cs
@@ -46,6 +46,10 @@ public static class SubprocessJsonRunner
         startInfo.RedirectStandardError = true;
         startInfo.UseShellExecute = false;
         startInfo.CreateNoWindow = true;
+        // Meep/tqdm progress uses UTF-8 block glyphs; decode them correctly so the
+        // status text isn't mojibake (the caller still strips the bar art for display).
+        startInfo.StandardOutputEncoding = System.Text.Encoding.UTF8;
+        startInfo.StandardErrorEncoding = System.Text.Encoding.UTF8;
 
         using var process = new Process { StartInfo = startInfo };
 

--- a/CAP.Avalonia/Services/Solvers/SubprocessJsonRunner.cs
+++ b/CAP.Avalonia/Services/Solvers/SubprocessJsonRunner.cs
@@ -33,8 +33,13 @@ public static class SubprocessJsonRunner
     /// <paramref name="stdinPayload"/> to its stdin, and captures stdout/stderr.
     /// Kills the process on timeout or cancellation.
     /// </summary>
+    /// <param name="onStderrLine">
+    /// Optional callback invoked for each stderr line as it arrives (used to surface
+    /// live solver progress). Called on a background thread.
+    /// </param>
     public static async Task<RunResult> RunAsync(
-        ProcessStartInfo startInfo, string stdinPayload, TimeSpan timeout, CancellationToken ct)
+        ProcessStartInfo startInfo, string stdinPayload, TimeSpan timeout, CancellationToken ct,
+        Action<string>? onStderrLine = null)
     {
         startInfo.RedirectStandardInput = true;
         startInfo.RedirectStandardOutput = true;
@@ -57,7 +62,7 @@ public static class SubprocessJsonRunner
         process.StandardInput.Close();
 
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
-        var stderrTask = process.StandardError.ReadToEndAsync();
+        var stderrTask = ReadStderrAsync(process, onStderrLine);
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         var timeoutTask = Task.Delay(timeout, cts.Token);
@@ -73,6 +78,24 @@ public static class SubprocessJsonRunner
         cts.Cancel(); // stop the timeout delay
         await process.WaitForExitAsync(CancellationToken.None);
         return new RunResult(Outcome.Completed, process.ExitCode, await stdoutTask, await stderrTask, null);
+    }
+
+    /// <summary>
+    /// Reads stderr line by line (Meep/tqdm progress uses '\r', which ReadLineAsync
+    /// also treats as a line break), forwarding each line to <paramref name="onLine"/>
+    /// while accumulating the full text for error reporting.
+    /// </summary>
+    private static async Task<string> ReadStderrAsync(Process process, Action<string>? onLine)
+    {
+        var sb = new System.Text.StringBuilder();
+        string? line;
+        while ((line = await process.StandardError.ReadLineAsync()) != null)
+        {
+            sb.AppendLine(line);
+            if (onLine != null && line.Trim().Length > 0)
+                onLine(line.Trim());
+        }
+        return sb.ToString();
     }
 
     /// <summary>

--- a/CAP.Avalonia/Services/Solvers/SubprocessJsonRunner.cs
+++ b/CAP.Avalonia/Services/Solvers/SubprocessJsonRunner.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace CAP.Avalonia.Services.Solvers;
+
+/// <summary>
+/// Runs an external process that takes a JSON request on stdin and emits a JSON
+/// result on stdout, with timeout, cancellation, and trailing-JSON extraction.
+/// Shared by the mode-solver (python) and FDTD (docker) bridges so the
+/// subprocess plumbing lives in exactly one place.
+/// </summary>
+public static class SubprocessJsonRunner
+{
+    /// <summary>How a subprocess run ended.</summary>
+    public enum Outcome
+    {
+        /// <summary>Process exited on its own (check <see cref="RunResult.ExitCode"/>).</summary>
+        Completed,
+        /// <summary>Killed after exceeding the timeout.</summary>
+        TimedOut,
+        /// <summary>Killed because the caller cancelled.</summary>
+        Cancelled,
+        /// <summary>Process could not be started (e.g. executable not found).</summary>
+        StartFailed,
+    }
+
+    /// <summary>Outcome plus captured streams of a subprocess run.</summary>
+    public readonly record struct RunResult(
+        Outcome Outcome, int ExitCode, string Stdout, string Stderr, string? StartError);
+
+    /// <summary>
+    /// Starts the process described by <paramref name="startInfo"/>, writes
+    /// <paramref name="stdinPayload"/> to its stdin, and captures stdout/stderr.
+    /// Kills the process on timeout or cancellation.
+    /// </summary>
+    public static async Task<RunResult> RunAsync(
+        ProcessStartInfo startInfo, string stdinPayload, TimeSpan timeout, CancellationToken ct)
+    {
+        startInfo.RedirectStandardInput = true;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            return new RunResult(Outcome.StartFailed, -1, string.Empty, string.Empty, ex.Message);
+        }
+
+        await process.StandardInput.WriteAsync(stdinPayload);
+        process.StandardInput.Close();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var timeoutTask = Task.Delay(timeout, cts.Token);
+        var completed = await Task.WhenAny(Task.WhenAll(stdoutTask, stderrTask), timeoutTask);
+
+        if (completed == timeoutTask || ct.IsCancellationRequested)
+        {
+            TryKill(process);
+            var outcome = ct.IsCancellationRequested ? Outcome.Cancelled : Outcome.TimedOut;
+            return new RunResult(outcome, -1, string.Empty, string.Empty, null);
+        }
+
+        cts.Cancel(); // stop the timeout delay
+        await process.WaitForExitAsync(CancellationToken.None);
+        return new RunResult(Outcome.Completed, process.ExitCode, await stdoutTask, await stderrTask, null);
+    }
+
+    /// <summary>
+    /// Walks stdout from the bottom up and returns the first line that parses as
+    /// a JSON object — robust against library log chatter printed before the result.
+    /// </summary>
+    public static string? ExtractTrailingJsonLine(string stdout)
+    {
+        var lines = stdout.Split('\n');
+        for (int i = lines.Length - 1; i >= 0; i--)
+        {
+            var trimmed = lines[i].Trim();
+            if (trimmed.Length == 0 || !trimmed.StartsWith('{')) continue;
+            try
+            {
+                using var _ = JsonDocument.Parse(trimmed);
+                return trimmed;
+            }
+            catch (JsonException) { /* keep looking */ }
+        }
+        return null;
+    }
+
+    private static void TryKill(Process process)
+    {
+        try { if (!process.HasExited) process.Kill(entireProcessTree: true); }
+        catch { /* best-effort */ }
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
@@ -1,0 +1,112 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Solvers.Fdtd;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.Solvers;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.ComponentSettings;
+
+/// <summary>
+/// FDTD "Recalculate S-matrix" half of the dialog: instead of loading an
+/// S-matrix from a file, compute it from the component's geometry with the
+/// open-source Meep solver and feed the result through the same store-and-apply
+/// path the file import uses.
+/// </summary>
+public partial class ComponentSettingsDialogViewModel
+{
+    private readonly IFdtdSMatrixService? _fdtdService;
+    private readonly Func<Component, CancellationToken, Task<FdtdSMatrixRequest?>>? _fdtdRequestFactory;
+    private CancellationTokenSource? _recalcCts;
+
+    /// <summary>True while an FDTD recompute is running.</summary>
+    [ObservableProperty]
+    private bool _isComputing;
+
+    /// <summary>
+    /// Live simulation/solver status shown in the dialog (provisioning, running,
+    /// energy-conservation summary, or the error/setup hint on failure).
+    /// </summary>
+    [ObservableProperty]
+    private string _solverStatus = string.Empty;
+
+    /// <summary>
+    /// True when FDTD recompute is wired up for this dialog instance (solver
+    /// service + geometry factory present and a live component is configured).
+    /// </summary>
+    public bool CanRecalculate =>
+        _fdtdService != null && _fdtdRequestFactory != null && _liveComponent != null;
+
+    private bool CanRunRecalculate => CanRecalculate && !IsComputing && !IsImporting;
+
+    partial void OnIsComputingChanged(bool value) => RecalculateSMatrixCommand.NotifyCanExecuteChanged();
+
+    /// <summary>
+    /// Recomputes this component's S-matrix from its geometry via FDTD and applies
+    /// it like an import. Surfaces the raw solver error on failure — no silent fallback.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanRunRecalculate))]
+    private async Task RecalculateSMatrix()
+    {
+        if (_fdtdService == null || _fdtdRequestFactory == null || _liveComponent == null || _storedSMatrices == null)
+            return;
+
+        IsComputing = true;
+        SolverStatus = "Preparing component geometry…";
+        _recalcCts = new CancellationTokenSource();
+
+        try
+        {
+            var request = await _fdtdRequestFactory(_liveComponent, _recalcCts.Token);
+            if (request == null)
+            {
+                SolverStatus = "Could not export this component's geometry for FDTD.";
+                return;
+            }
+
+            SolverStatus = "Running FDTD (Meep in Docker). The first run builds the solver image and may take several minutes…";
+            var result = await _fdtdService.SolveAsync(request, _recalcCts.Token);
+
+            if (!result.Success)
+            {
+                SolverStatus = result.MissingDependency != null
+                    ? $"FDTD unavailable — '{result.MissingDependency}' is required. {result.Error}"
+                    : $"FDTD failed: {result.Error}";
+                _errorConsole?.LogError($"FDTD recompute failed for '{_displayName}': {result.Error}\n{result.RawStderr}");
+                return;
+            }
+
+            var note = $"FDTD Meep {(result.Is3D ? "3D" : "2D")}";
+            var data = FdtdSMatrixConverter.ToComponentSMatrixData(result, note);
+            _storedSMatrices[_entityKey] = data;
+
+            var applyResult = SMatrixOverrideApplicator.Apply(_liveComponent, data, _errorConsole);
+            SolverStatus = BuildSolverStatus(result, applyResult);
+            StatusText = $"Recomputed S-matrix via FDTD ({note}).";
+        }
+        catch (OperationCanceledException)
+        {
+            SolverStatus = "FDTD recompute cancelled.";
+        }
+        catch (Exception ex)
+        {
+            SolverStatus = $"FDTD error: {ex.Message}";
+            _errorConsole?.LogError($"FDTD recompute crashed for '{_displayName}'", ex);
+        }
+        finally
+        {
+            IsComputing = false;
+            _recalcCts?.Dispose();
+            _recalcCts = null;
+            RefreshEntries(notifyChanged: true);
+        }
+    }
+
+    private static string BuildSolverStatus(FdtdSMatrixResult result, ApplyResult? apply)
+    {
+        var worst = result.EnergySumPerInput.Count > 0 ? result.EnergySumPerInput.Values.Max() : 0.0;
+        var energy = result.EnergySumPerInput.Count > 0 ? $" Energy Σ|S|² ≤ {worst:F3} per input." : "";
+        var applied = apply == null ? "" : $" Applied {apply.Applied} wavelength(s).";
+        return $"FDTD done: {result.Wavelengths.Count} wavelength(s).{energy}{applied}";
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using Avalonia.Threading;
 using CAP_Core.Components.Core;
 using CAP_Core.Solvers.Fdtd;
 using CAP.Avalonia.Services;
@@ -64,8 +66,7 @@ public partial class ComponentSettingsDialogViewModel
                 return;
             }
 
-            SolverStatus = "Running FDTD (Meep in Docker). The first run builds the solver image and may take several minutes…";
-            var result = await _fdtdService.SolveAsync(request, _recalcCts.Token);
+            var result = await RunWithLiveStatusAsync(request, _recalcCts.Token);
 
             if (!result.Success)
             {
@@ -101,6 +102,38 @@ public partial class ComponentSettingsDialogViewModel
             RefreshEntries(notifyChanged: true);
         }
     }
+
+    /// <summary>
+    /// Runs the solver while keeping <see cref="SolverStatus"/> alive: a once-per-second
+    /// elapsed-time heartbeat (so the long image build / FDTD run never looks frozen)
+    /// plus the latest progress line streamed from Meep.
+    /// </summary>
+    private async Task<FdtdSMatrixResult> RunWithLiveStatusAsync(FdtdSMatrixRequest request, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        string? lastLine = null;
+        const string baseMsg = "Running FDTD (Meep in Docker). First run builds the solver image (several minutes)";
+
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        timer.Tick += (_, _) =>
+            SolverStatus = lastLine == null
+                ? $"{baseMsg} — {stopwatch.Elapsed:m\\:ss} elapsed…"
+                : $"FDTD running ({stopwatch.Elapsed:m\\:ss}): {lastLine}";
+        SolverStatus = $"{baseMsg}…";
+        timer.Start();
+
+        var progress = new Progress<string>(line => lastLine = Shorten(line));
+        try
+        {
+            return await _fdtdService!.SolveAsync(request, progress, ct);
+        }
+        finally
+        {
+            timer.Stop();
+        }
+    }
+
+    private static string Shorten(string s) => s.Length <= 80 ? s : s[..80] + "…";
 
     private static string BuildSolverStatus(FdtdSMatrixResult result, ApplyResult? apply)
     {

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -7,6 +7,7 @@ using CAP_DataAccess.Persistence.PIR;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.ComponentSettings.InstanceOverride;
 using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using NazcaCodeOverride = CAP_DataAccess.Persistence.PIR.NazcaCodeOverride;
@@ -91,15 +92,28 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     /// to skip the interactive step (which causes the import to abort with a
     /// status-text explanation when names mismatch).
     /// </param>
+    /// <param name="fdtdService">
+    /// Optional FDTD solver used by the "Recalculate S-matrix" command. When null
+    /// (e.g. in tests, or when no solver is configured) the command is disabled.
+    /// </param>
+    /// <param name="fdtdRequestFactory">
+    /// Optional factory that turns the live component into an FDTD request
+    /// (renders its geometry and ports). Required alongside <paramref name="fdtdService"/>
+    /// for recompute to be available.
+    /// </param>
     public ComponentSettingsDialogViewModel(
         IFileDialogService fileDialogService,
         ErrorConsoleService? errorConsole = null,
         IReadOnlyList<ISParameterImporter>? importers = null,
-        IPortMappingDialogService? portMappingDialog = null)
+        IPortMappingDialogService? portMappingDialog = null,
+        IFdtdSMatrixService? fdtdService = null,
+        Func<Component, CancellationToken, Task<FdtdSMatrixRequest?>>? fdtdRequestFactory = null)
     {
         _fileDialogService = fileDialogService;
         _errorConsole = errorConsole;
         _portMappingDialog = portMappingDialog;
+        _fdtdService = fdtdService;
+        _fdtdRequestFactory = fdtdRequestFactory;
         _importers = importers ?? new ISParameterImporter[]
         {
             new LumericalSParameterImporter(),
@@ -239,8 +253,11 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         }
         OnPropertyChanged(nameof(NazcaCodeEditor));
 
+        SolverStatus = string.Empty;
         RefreshEntries(notifyChanged: false);
         RefreshEffectiveEntries();
+        OnPropertyChanged(nameof(CanRecalculate));
+        RecalculateSMatrixCommand.NotifyCanExecuteChanged();
     }
 
     /// <summary>

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -245,6 +245,34 @@
                 Background="#3d5d3d"
                 IsEnabled="{Binding IsImporting, Converter={x:Static BoolConverters.Not}}"/>
 
+        <!-- Recalculate via FDTD: like Load, but the S-matrix is computed from the
+             component geometry with the open-source Meep solver instead of imported. -->
+        <Button DockPanel.Dock="Bottom"
+                Content="Recalculate S-matrix (FDTD)…"
+                Command="{Binding RecalculateSMatrixCommand}"
+                HorizontalAlignment="Left"
+                Margin="0,6,0,0"
+                Padding="12,6"
+                Background="#3d4d6d"
+                IsVisible="{Binding CanRecalculate}"/>
+
+        <!-- Solver / simulation status -->
+        <Border DockPanel.Dock="Bottom"
+                Background="#161616"
+                CornerRadius="4"
+                Padding="8,6"
+                Margin="0,8,0,0"
+                IsVisible="{Binding SolverStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="⏳" FontSize="12" VerticalAlignment="Center"
+                           IsVisible="{Binding IsComputing}"/>
+                <TextBlock Text="{Binding SolverStatus}"
+                           Foreground="#aaccaa"
+                           FontSize="11"
+                           TextWrapping="Wrap"/>
+            </StackPanel>
+        </Border>
+
         <!-- Empty state -->
         <TextBlock DockPanel.Dock="Top"
                    Text="No S-matrices stored for this component.&#10;Use 'Load S-matrix from file…' to import Lumerical or Touchstone data."

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -535,11 +535,28 @@ public partial class MainWindow : Window
             as UserSMatrixOverrideStore;
         var portMappingDialog = App.Services.GetService(typeof(IPortMappingDialogService))
             as IPortMappingDialogService;
+
+        // FDTD "Recalculate S-matrix": wire the solver service and a factory that
+        // renders the component's geometry/pins into an FDTD request. Both are
+        // optional — the dialog hides the recompute button when they're absent.
+        var fdtdService = App.Services.GetService(typeof(CAP_Core.Solvers.Fdtd.IFdtdSMatrixService))
+            as CAP_Core.Solvers.Fdtd.IFdtdSMatrixService;
+        var previewService = App.Services.GetService(typeof(CAP_Core.Export.NazcaComponentPreviewService))
+            as CAP_Core.Export.NazcaComponentPreviewService;
+        Func<CAP_Core.Components.Core.Component, CancellationToken, Task<CAP_Core.Solvers.Fdtd.FdtdSMatrixRequest?>>? fdtdRequestFactory = null;
+        if (fdtdService != null && previewService != null)
+        {
+            var requestFactory = new CAP.Avalonia.Services.Solvers.ComponentFdtdRequestFactory(previewService);
+            fdtdRequestFactory = (component, ct) => requestFactory.BuildAsync(component, ct);
+        }
+
         var dialogVm = new ComponentSettingsDialogViewModel(
             new FileDialogService(this),
             errorConsole,
             importers: null,
-            portMappingDialog: portMappingDialog);
+            portMappingDialog: portMappingDialog,
+            fdtdService: fdtdService,
+            fdtdRequestFactory: fdtdRequestFactory);
 
         bool isTemplateMode = liveComponent == null && userStore != null;
         var store = isTemplateMode

--- a/Connect-A-Pic-Core/Solvers/Fdtd/FdtdPolygon.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/FdtdPolygon.cs
@@ -1,0 +1,19 @@
+namespace CAP_Core.Solvers.Fdtd;
+
+/// <summary>
+/// A geometry polygon on a GDS layer, used as an alternative to a GDS file when
+/// feeding a single component to the FDTD solver. Lets the solver build the
+/// component directly from the rendered geometry (e.g. from the Nazca preview)
+/// without writing and mounting an intermediate GDS file.
+/// </summary>
+public class FdtdPolygon
+{
+    /// <summary>GDS layer number the polygon sits on.</summary>
+    public int Layer { get; init; }
+
+    /// <summary>Polygon vertices in µm.</summary>
+    public IReadOnlyList<FdtdPoint> Points { get; init; } = Array.Empty<FdtdPoint>();
+}
+
+/// <summary>A 2D point in µm.</summary>
+public readonly record struct FdtdPoint(double X, double Y);

--- a/Connect-A-Pic-Core/Solvers/Fdtd/FdtdPort.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/FdtdPort.cs
@@ -1,0 +1,27 @@
+namespace CAP_Core.Solvers.Fdtd;
+
+/// <summary>
+/// A single optical port to attach to an imported GDS before FDTD.
+/// Lunima knows its own pin positions, so it supplies these explicitly rather
+/// than having the solver reconstruct them from the geometry.
+/// </summary>
+public class FdtdPort
+{
+    /// <summary>Port name (e.g. "o1"). Becomes part of the S-matrix keys.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Port centre x-coordinate in µm (GDS user units).</summary>
+    public double X { get; init; }
+
+    /// <summary>Port centre y-coordinate in µm (GDS user units).</summary>
+    public double Y { get; init; }
+
+    /// <summary>
+    /// Outward-facing orientation in degrees (0 = +x/east, 90 = +y/north,
+    /// 180 = -x/west, 270 = -y/south).
+    /// </summary>
+    public double Orientation { get; init; }
+
+    /// <summary>Port (waveguide) width in µm.</summary>
+    public double Width { get; init; }
+}

--- a/Connect-A-Pic-Core/Solvers/Fdtd/FdtdSMatrixRequest.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/FdtdSMatrixRequest.cs
@@ -1,0 +1,61 @@
+namespace CAP_Core.Solvers.Fdtd;
+
+/// <summary>
+/// Request for an FDTD S-matrix computation: an exported component GDS plus the
+/// ports and simulation settings. Consumed by <see cref="IFdtdSMatrixService"/>
+/// and serialised to the JSON contract of <c>scripts/fdtd_sparams.py</c>.
+/// </summary>
+public class FdtdSMatrixRequest
+{
+    /// <summary>
+    /// Absolute host path to the component's exported GDS file. Optional when
+    /// <see cref="Polygons"/> are supplied instead.
+    /// </summary>
+    public string GdsPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Geometry polygons to build the component from, as an alternative to
+    /// <see cref="GdsPath"/> (e.g. straight from the Nazca preview render).
+    /// When non-empty, the solver builds from these and ignores the GDS path.
+    /// </summary>
+    public IReadOnlyList<FdtdPolygon> Polygons { get; init; } = Array.Empty<FdtdPolygon>();
+
+    /// <summary>Ports to attach to the geometry before solving.</summary>
+    public IReadOnlyList<FdtdPort> Ports { get; init; } = Array.Empty<FdtdPort>();
+
+    /// <summary>Silicon layer/datatype the waveguide geometry sits on (default 1/0).</summary>
+    public int LayerNumber { get; init; } = 1;
+
+    /// <summary>Silicon datatype (default 0).</summary>
+    public int LayerDatatype { get; init; }
+
+    /// <summary>Sweep start wavelength in µm.</summary>
+    public double WavelengthStart { get; init; } = 1.5;
+
+    /// <summary>Sweep stop wavelength in µm.</summary>
+    public double WavelengthStop { get; init; } = 1.6;
+
+    /// <summary>Number of wavelength points in the sweep.</summary>
+    public int WavelengthPoints { get; init; } = 11;
+
+    /// <summary>Mesh resolution in pixels per µm. Higher = more accurate, slower.</summary>
+    public int Resolution { get; init; } = 20;
+
+    /// <summary>
+    /// When true, runs a full 3D simulation (accurate, expensive). When false,
+    /// a 2D approximation (fast, for quick checks). Default false.
+    /// </summary>
+    public bool Is3D { get; init; }
+
+    /// <summary>Simulation padding in y in µm (must exceed the port mode width).</summary>
+    public double YMargin { get; init; } = 2.0;
+
+    /// <summary>Simulation padding in x in µm.</summary>
+    public double XMargin { get; init; } = 2.0;
+
+    /// <summary>
+    /// Number of MPI ranks (CPU cores) to use. 0 lets the service choose a
+    /// memory-safe value. Meep is CPU-only; there is no GPU acceleration.
+    /// </summary>
+    public int Cores { get; init; }
+}

--- a/Connect-A-Pic-Core/Solvers/Fdtd/FdtdSMatrixResult.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/FdtdSMatrixResult.cs
@@ -1,0 +1,61 @@
+using System.Numerics;
+
+namespace CAP_Core.Solvers.Fdtd;
+
+/// <summary>
+/// One scattering-matrix element across the wavelength sweep, e.g. key
+/// "o2@0,o1@0" with complex transmission from input o1 (mode 0) to output o2.
+/// </summary>
+public class FdtdSEntry
+{
+    /// <summary>S-parameter key in "&lt;out&gt;@&lt;mode&gt;,&lt;in&gt;@&lt;mode&gt;" form.</summary>
+    public string Key { get; init; } = string.Empty;
+
+    /// <summary>Complex value per wavelength, aligned with <see cref="FdtdSMatrixResult.Wavelengths"/>.</summary>
+    public IReadOnlyList<Complex> Values { get; init; } = Array.Empty<Complex>();
+}
+
+/// <summary>
+/// Result of an FDTD S-matrix computation. On failure, carries a human-readable
+/// error plus the raw solver stderr — never a silently-guessed S-matrix.
+/// </summary>
+public class FdtdSMatrixResult
+{
+    /// <summary>True when the solver completed and produced an S-matrix.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Human-readable error when <see cref="Success"/> is false.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>Raw stderr from the solver, surfaced on failure (no silent fallback).</summary>
+    public string? RawStderr { get; init; }
+
+    /// <summary>
+    /// When non-null, names a missing dependency (e.g. "docker", "gdsfactory")
+    /// so the UI can show an install/setup hint instead of a generic error.
+    /// </summary>
+    public string? MissingDependency { get; init; }
+
+    /// <summary>Whether the run was 3D.</summary>
+    public bool Is3D { get; init; }
+
+    /// <summary>Port names in S-matrix index order (e.g. ["o1","o2"]).</summary>
+    public IReadOnlyList<string> Ports { get; init; } = Array.Empty<string>();
+
+    /// <summary>Wavelength grid in µm.</summary>
+    public IReadOnlyList<double> Wavelengths { get; init; } = Array.Empty<double>();
+
+    /// <summary>S-matrix elements.</summary>
+    public IReadOnlyList<FdtdSEntry> Entries { get; init; } = Array.Empty<FdtdSEntry>();
+
+    /// <summary>
+    /// Per-input-port summed |S|² at the centre wavelength. A passive device
+    /// should be ≤ 1; a value above 1 signals an unconverged (e.g. coarse-2D) run.
+    /// </summary>
+    public IReadOnlyDictionary<string, double> EnergySumPerInput { get; init; }
+        = new Dictionary<string, double>();
+
+    /// <summary>Creates a failure result.</summary>
+    public static FdtdSMatrixResult Fail(string error, string? rawStderr = null, string? missingDependency = null) =>
+        new() { Success = false, Error = error, RawStderr = rawStderr, MissingDependency = missingDependency };
+}

--- a/Connect-A-Pic-Core/Solvers/Fdtd/IFdtdSMatrixService.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/IFdtdSMatrixService.cs
@@ -1,0 +1,19 @@
+namespace CAP_Core.Solvers.Fdtd;
+
+/// <summary>
+/// Recomputes a component's scattering matrix from its geometry using an
+/// open-source FDTD solver (Meep), delegating to an external process.
+/// Implementations are responsible for provisioning the solver environment
+/// (e.g. a Docker image) on first use.
+/// </summary>
+public interface IFdtdSMatrixService
+{
+    /// <summary>
+    /// Runs the FDTD solver for the component GDS and ports in
+    /// <paramref name="request"/> and returns its S-matrix, or a failure result
+    /// with a human-readable error and raw stderr.
+    /// </summary>
+    /// <param name="request">Component GDS, ports, and simulation settings.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<FdtdSMatrixResult> SolveAsync(FdtdSMatrixRequest request, CancellationToken ct = default);
+}

--- a/Connect-A-Pic-Core/Solvers/Fdtd/IFdtdSMatrixService.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/IFdtdSMatrixService.cs
@@ -14,6 +14,8 @@ public interface IFdtdSMatrixService
     /// with a human-readable error and raw stderr.
     /// </summary>
     /// <param name="request">Component GDS, ports, and simulation settings.</param>
+    /// <param name="progress">Optional sink for live solver progress lines.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task<FdtdSMatrixResult> SolveAsync(FdtdSMatrixRequest request, CancellationToken ct = default);
+    Task<FdtdSMatrixResult> SolveAsync(
+        FdtdSMatrixRequest request, IProgress<string>? progress = null, CancellationToken ct = default);
 }

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
@@ -1,0 +1,93 @@
+using System.Numerics;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.ComponentSettings;
+using CAP_Core.Components.Core;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Persistence.PIR;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ComponentSettings;
+
+/// <summary>
+/// Verifies the FDTD "Recalculate S-matrix" command on the Component Settings
+/// dialog: gating, success (stores + status) and failure (status, no store).
+/// </summary>
+public class ComponentSettingsDialogFdtdTests
+{
+    private static Func<Component, CancellationToken, Task<FdtdSMatrixRequest?>> FakeFactory() =>
+        (_, _) => Task.FromResult<FdtdSMatrixRequest?>(new FdtdSMatrixRequest
+        {
+            Ports = new[] { new FdtdPort { Name = "o1" }, new FdtdPort { Name = "o2" } },
+        });
+
+    private static FdtdSMatrixResult SuccessResult() => new()
+    {
+        Success = true,
+        Is3D = false,
+        Ports = new[] { "o1", "o2" },
+        Wavelengths = new[] { 1.55 },
+        Entries = new[]
+        {
+            new FdtdSEntry { Key = "o2@0,o1@0", Values = new[] { new Complex(0.95, 0.0) } },
+            new FdtdSEntry { Key = "o1@0,o2@0", Values = new[] { new Complex(0.95, 0.0) } },
+        },
+        EnergySumPerInput = new Dictionary<string, double> { ["o1@0"] = 0.97, ["o2@0"] = 0.97 },
+    };
+
+    [Fact]
+    public void CanRecalculate_IsFalse_WithoutFdtdWiring()
+    {
+        var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
+        vm.Configure("c", "C", new Dictionary<string, ComponentSMatrixData>(),
+            liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
+
+        vm.CanRecalculate.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RecalculateSMatrix_OnSuccess_StoresDataAndReportsStatus()
+    {
+        var service = new Mock<IFdtdSMatrixService>();
+        service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(SuccessResult());
+        var store = new Dictionary<string, ComponentSMatrixData>();
+
+        var vm = new ComponentSettingsDialogViewModel(
+            Mock.Of<IFileDialogService>(),
+            fdtdService: service.Object,
+            fdtdRequestFactory: FakeFactory());
+        vm.Configure("comp", "Comp", store,
+            liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
+
+        vm.CanRecalculate.ShouldBeTrue();
+        await vm.RecalculateSMatrixCommand.ExecuteAsync(null);
+
+        store.ShouldContainKey("comp");
+        store["comp"].Wavelengths.ShouldContainKey("1550");
+        vm.SolverStatus.ShouldContain("FDTD done");
+        vm.IsComputing.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RecalculateSMatrix_OnFailure_SurfacesHintAndStoresNothing()
+    {
+        var service = new Mock<IFdtdSMatrixService>();
+        service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(FdtdSMatrixResult.Fail("image build failed", missingDependency: "docker"));
+        var store = new Dictionary<string, ComponentSMatrixData>();
+
+        var vm = new ComponentSettingsDialogViewModel(
+            Mock.Of<IFileDialogService>(),
+            fdtdService: service.Object,
+            fdtdRequestFactory: FakeFactory());
+        vm.Configure("comp", "Comp", store,
+            liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
+
+        await vm.RecalculateSMatrixCommand.ExecuteAsync(null);
+
+        store.ShouldNotContainKey("comp");
+        vm.SolverStatus.ShouldContain("docker");
+    }
+}

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
@@ -50,7 +50,7 @@ public class ComponentSettingsDialogFdtdTests
     public async Task RecalculateSMatrix_OnSuccess_StoresDataAndReportsStatus()
     {
         var service = new Mock<IFdtdSMatrixService>();
-        service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<CancellationToken>()))
+        service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
                .ReturnsAsync(SuccessResult());
         var store = new Dictionary<string, ComponentSMatrixData>();
 
@@ -74,7 +74,7 @@ public class ComponentSettingsDialogFdtdTests
     public async Task RecalculateSMatrix_OnFailure_SurfacesHintAndStoresNothing()
     {
         var service = new Mock<IFdtdSMatrixService>();
-        service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<CancellationToken>()))
+        service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
                .ReturnsAsync(FdtdSMatrixResult.Fail("image build failed", missingDependency: "docker"));
         var store = new Dictionary<string, ComponentSMatrixData>();
 

--- a/UnitTests/Solvers/Fdtd/ComponentFdtdRequestFactoryTests.cs
+++ b/UnitTests/Solvers/Fdtd/ComponentFdtdRequestFactoryTests.cs
@@ -1,0 +1,58 @@
+using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Solvers.Fdtd;
+
+/// <summary>
+/// Verifies the geometry/port mapping the FDTD request factory applies to a
+/// Nazca preview render (layer filtering and pin → port mapping).
+/// </summary>
+public class ComponentFdtdRequestFactoryTests
+{
+    private static NazcaPreviewPolygon Poly(int layer) => new()
+    {
+        Layer = layer,
+        Vertices = new[] { (0.0, 0.0), (1.0, 0.0), (1.0, 1.0) },
+    };
+
+    [Fact]
+    public void BuildPolygons_KeepsOnlyOpticalLayer()
+    {
+        var polys = new[] { Poly(1), Poly(1), Poly(20), Poly(1003) };
+
+        var result = ComponentFdtdRequestFactory.BuildPolygons(polys, siliconLayer: 1);
+
+        result.Count.ShouldBe(2);
+        result.ShouldAllBe(p => p.Layer == 1);
+    }
+
+    [Fact]
+    public void BuildPolygons_FallsBackToAllLayers_WhenNoneMatch()
+    {
+        var polys = new[] { Poly(2), Poly(501) };
+
+        var result = ComponentFdtdRequestFactory.BuildPolygons(polys, siliconLayer: 1);
+
+        result.Count.ShouldBe(2); // no layer-1 polygons → keep everything rather than render nothing
+    }
+
+    [Fact]
+    public void BuildPorts_MapsPinAngleToOrientation()
+    {
+        var pins = new[]
+        {
+            new NazcaPreviewPin { Name = "a0", X = 0, Y = 0, Angle = 180 },
+            new NazcaPreviewPin { Name = "b0", X = 80, Y = 2, Angle = 0 },
+        };
+
+        var ports = ComponentFdtdRequestFactory.BuildPorts(pins, portWidthUm: 2.0);
+
+        ports.Count.ShouldBe(2);
+        ports[0].Name.ShouldBe("a0");
+        ports[0].Orientation.ShouldBe(180);
+        ports[1].X.ShouldBe(80);
+        ports[1].Width.ShouldBe(2.0);
+    }
+}

--- a/UnitTests/Solvers/Fdtd/DockerFdtdShmTests.cs
+++ b/UnitTests/Solvers/Fdtd/DockerFdtdShmTests.cs
@@ -1,0 +1,23 @@
+using CAP.Avalonia.Services.Solvers;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Solvers.Fdtd;
+
+/// <summary>
+/// Verifies the dynamic /dev/shm sizing that scales with the MPI rank count
+/// (which itself scales with the host's cores), clamped to a floor and ceiling.
+/// </summary>
+public class DockerFdtdShmTests
+{
+    [Theory]
+    [InlineData(1, 2048)]    // tiny machine → floor
+    [InlineData(4, 2048)]    // 4×256=1024 → still floor
+    [InlineData(16, 4096)]   // 16×256 → scales
+    [InlineData(24, 6144)]   // 24×256 → scales
+    [InlineData(128, 16384)] // huge machine → ceiling
+    public void ResolveShmMb_ScalesWithCores_WithinFloorAndCeiling(int cores, int expectedMb)
+    {
+        DockerFdtdSMatrixService.ResolveShmMb(cores).ShouldBe(expectedMb);
+    }
+}

--- a/UnitTests/Solvers/Fdtd/DockerFdtdShmTests.cs
+++ b/UnitTests/Solvers/Fdtd/DockerFdtdShmTests.cs
@@ -20,4 +20,15 @@ public class DockerFdtdShmTests
     {
         DockerFdtdSMatrixService.ResolveShmMb(cores).ShouldBe(expectedMb);
     }
+
+    [Fact]
+    public void CleanProgressLine_StripsTqdmBarArt()
+    {
+        var raw = " 50%|███▉     | 3/4 [00:03<00:01, 1.2it/s]";
+
+        var clean = DockerFdtdSMatrixService.CleanProgressLine(raw);
+
+        clean.ShouldBe("50% 3/4 [00:03<00:01, 1.2it/s]");
+        clean.ShouldNotContain("█");
+    }
 }

--- a/UnitTests/Solvers/Fdtd/FdtdSMatrixContractTests.cs
+++ b/UnitTests/Solvers/Fdtd/FdtdSMatrixContractTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Solvers.Fdtd;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Solvers.Fdtd;
+
+/// <summary>
+/// Verifies <see cref="FdtdJsonContract"/> round-trips the JSON contract of
+/// <c>scripts/fdtd_sparams.py</c> without spawning Docker or Meep.
+/// </summary>
+public class FdtdSMatrixContractTests
+{
+    private const string SuccessJson =
+        """
+        {"success":true,"is_3d":false,"resolution":20,"ports":["o1","o2"],"wavelengths":[1.5,1.55,1.6],"s":{"o2@0,o1@0":[[0.1,0.2],[0.3,0.4],[0.5,-0.6]],"o1@0,o1@0":[[0.0,0.0],[0.01,0.0],[0.0,0.0]]},"energy_sum_per_input":{"o1@0":0.98}}
+        """;
+
+    [Fact]
+    public void ParseOutput_SuccessJson_ReturnsEntriesAndWavelengths()
+    {
+        var result = FdtdJsonContract.ParseOutput(SuccessJson);
+
+        result.Success.ShouldBeTrue();
+        result.Is3D.ShouldBeFalse();
+        result.Wavelengths.Count.ShouldBe(3);
+        result.Entries.Count.ShouldBe(2);
+
+        var t = result.Entries.First(e => e.Key == "o2@0,o1@0");
+        t.Values.Count.ShouldBe(3);
+        t.Values[0].Real.ShouldBe(0.1, 1e-9);
+        t.Values[2].Imaginary.ShouldBe(-0.6, 1e-9);
+        result.EnergySumPerInput["o1@0"].ShouldBe(0.98, 1e-9);
+    }
+
+    [Fact]
+    public void ParseOutput_LeadingChatter_UsesTrailingJsonLine()
+    {
+        var stdout = "INFO: loading meep...\nWARNING: no GPU\n" + SuccessJson;
+
+        var result = FdtdJsonContract.ParseOutput(stdout);
+
+        result.Success.ShouldBeTrue();
+        result.Entries.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ParseOutput_FailureJson_SurfacesErrorAndMissingDependency()
+    {
+        const string json =
+            """{"success":false,"error":"FDTD backend missing","missing_backend":"gdsfactory"}""";
+
+        var result = FdtdJsonContract.ParseOutput(json, stderr: "ModuleNotFoundError: gdsfactory");
+
+        result.Success.ShouldBeFalse();
+        result.Error.ShouldContain("backend missing");
+        result.MissingDependency.ShouldBe("gdsfactory");
+        result.RawStderr.ShouldContain("ModuleNotFoundError");
+    }
+
+    [Fact]
+    public void ParseOutput_EmptyStdout_ReturnsFailure()
+    {
+        var result = FdtdJsonContract.ParseOutput("");
+
+        result.Success.ShouldBeFalse();
+        result.Error.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ParseOutput_NoJsonInOutput_ReturnsFailure()
+    {
+        var result = FdtdJsonContract.ParseOutput("Traceback (most recent call last):\nSyntaxError\n");
+
+        result.Success.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void SerialiseRequest_IncludesPortsLayerAndSettings()
+    {
+        var request = new FdtdSMatrixRequest
+        {
+            GdsPath = @"C:\tmp\comp.gds",
+            Ports = new[]
+            {
+                new FdtdPort { Name = "o1", X = 0, Y = 0, Orientation = 180, Width = 0.5 },
+                new FdtdPort { Name = "o2", X = 12, Y = 0, Orientation = 0, Width = 0.5 },
+            },
+            LayerNumber = 1,
+            LayerDatatype = 0,
+            WavelengthPoints = 7,
+            Is3D = true,
+        };
+
+        var json = FdtdJsonContract.SerialiseRequest(request, "/data/comp.gds");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        root.GetProperty("gds_path").GetString().ShouldBe("/data/comp.gds");
+        root.GetProperty("is_3d").GetBoolean().ShouldBeTrue();
+        root.GetProperty("wavelength_points").GetInt32().ShouldBe(7);
+        root.GetProperty("ports").GetArrayLength().ShouldBe(2);
+        root.GetProperty("ports")[0].GetProperty("name").GetString().ShouldBe("o1");
+        root.GetProperty("ports")[1].GetProperty("orientation").GetDouble().ShouldBe(0);
+        root.GetProperty("layer")[0].GetInt32().ShouldBe(1);
+    }
+}

--- a/UnitTests/Solvers/Fdtd/FdtdSMatrixConverterTests.cs
+++ b/UnitTests/Solvers/Fdtd/FdtdSMatrixConverterTests.cs
@@ -1,0 +1,65 @@
+using System.Numerics;
+using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Solvers.Fdtd;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Solvers.Fdtd;
+
+/// <summary>
+/// Verifies <see cref="FdtdSMatrixConverter"/> maps the solver's "out@m,in@m"
+/// keyed result into the row-major per-wavelength matrices the dialog stores.
+/// </summary>
+public class FdtdSMatrixConverterTests
+{
+    [Fact]
+    public void ToComponentSMatrixData_PlacesEntriesAtOutInIndicesPerWavelength()
+    {
+        var result = new FdtdSMatrixResult
+        {
+            Success = true,
+            Ports = new[] { "o1", "o2" },
+            Wavelengths = new[] { 1.55 },
+            Entries = new[]
+            {
+                new FdtdSEntry { Key = "o2@0,o1@0", Values = new[] { new Complex(0.9, 0.1) } },
+                new FdtdSEntry { Key = "o1@0,o1@0", Values = new[] { new Complex(0.02, -0.03) } },
+            },
+        };
+
+        var data = FdtdSMatrixConverter.ToComponentSMatrixData(result, "FDTD Meep 2D");
+
+        data.SourceNote.ShouldBe("FDTD Meep 2D");
+        data.Wavelengths.ShouldContainKey("1550");
+
+        var entry = data.Wavelengths["1550"];
+        entry.Rows.ShouldBe(2);
+        entry.Cols.ShouldBe(2);
+        entry.PortNames.ShouldBe(new[] { "o1", "o2" });
+
+        // "o2@0,o1@0" => out=o2 (row 1), in=o1 (col 0) => flat = 1*2 + 0 = 2
+        entry.Real[2].ShouldBe(0.9, 1e-9);
+        entry.Imag[2].ShouldBe(0.1, 1e-9);
+        // "o1@0,o1@0" => row 0, col 0 => flat 0
+        entry.Real[0].ShouldBe(0.02, 1e-9);
+        entry.Imag[0].ShouldBe(-0.03, 1e-9);
+        // Unset element (o1<-o2, flat 1) stays zero
+        entry.Real[1].ShouldBe(0.0, 1e-9);
+    }
+
+    [Fact]
+    public void ToComponentSMatrixData_RoundsWavelengthMicronsToNanometreKey()
+    {
+        var result = new FdtdSMatrixResult
+        {
+            Success = true,
+            Ports = new[] { "o1" },
+            Wavelengths = new[] { 1.31 },
+            Entries = new[] { new FdtdSEntry { Key = "o1@0,o1@0", Values = new[] { Complex.One } } },
+        };
+
+        var data = FdtdSMatrixConverter.ToComponentSMatrixData(result, "x");
+
+        data.Wavelengths.Keys.ShouldContain("1310");
+    }
+}

--- a/scripts/fdtd/Dockerfile
+++ b/scripts/fdtd/Dockerfile
@@ -1,0 +1,27 @@
+# Pinned open-source FDTD image for Lunima's "Recalculate S-Matrix": Meep (MPI)
+# + gdsfactory + gplugins. Built on first use by DockerFdtdSMatrixService.
+#
+# Build context is the scripts/ directory (small) so the bridge script can be
+# COPYed without shipping the whole repo to the Docker daemon:
+#   docker build -f scripts/fdtd/Dockerfile -t lunima-meep:1 scripts
+#
+# Recipe notes (each cost real time to discover, see issue #569):
+#  - Meep is conda-only (no PyPI, no native Windows) -> conda-forge.
+#  - pymeep has no Python 3.12 build (only 3.11 / 3.13) -> pin python=3.13.
+#  - Install into a SEPARATE env, not base: upgrading base mid-solve breaks
+#    mamba's own libxml2 (exit 127).
+#  - Pin the mpi_mpich build + mpich so Meep runs multi-core under mpirun
+#    instead of the single-core 'nompi' default.
+FROM condaforge/miniforge3:24.9.2-0
+
+RUN mamba create -y -n mp -c conda-forge python=3.13 \
+        "pymeep=*=mpi_mpich_*" pymeep-extras mpich \
+    && mamba clean -afy
+
+ENV PATH=/opt/conda/envs/mp/bin:$PATH
+
+# Meep is not pip-installable, so do NOT use the gplugins[meep] extra.
+RUN pip install --no-cache-dir "gdsfactory" "gplugins"
+
+WORKDIR /work
+COPY fdtd_sparams.py /work/fdtd_sparams.py

--- a/scripts/fdtd_sparams.py
+++ b/scripts/fdtd_sparams.py
@@ -1,0 +1,162 @@
+"""
+fdtd_sparams.py - open-source FDTD S-matrix bridge for Lunima.
+
+Reads a JSON spec from stdin describing a component's exported GDS plus its
+ports (Lunima knows its pin positions, so it passes them explicitly rather than
+having us reconstruct them from the GDS), runs Meep FDTD via gplugins, and
+writes an S-matrix JSON to stdout. Intended to run inside the pinned
+`lunima-meep` Docker image (Meep is conda-only and has no native Windows build).
+
+Input JSON (stdin):
+    {
+      "gds_path":    "/work/component.gds",
+      "ports": [ {"name":"o1","x":0.0,"y":0.0,"orientation":180,"width":0.5},
+                 {"name":"o2","x":12.0,"y":0.0,"orientation":0,"width":0.5} ],
+      "layer":       [1, 0],          # silicon layer/datatype (default [1,0])
+      "wavelength_start": 1.5,         # um
+      "wavelength_stop":  1.6,
+      "wavelength_points": 11,
+      "resolution":  20,               # pixels/um
+      "is_3d":       false,
+      "ymargin":     2.0,
+      "xmargin":     2.0
+    }
+
+Output JSON (stdout) - success:
+    { "success": true, "is_3d": false, "resolution": 20,
+      "ports": ["o1","o2"], "wavelengths": [...],
+      "s": { "o2@0,o1@0": [[re,im], ...], ... },
+      "energy_sum_per_input": { "o1@0": 0.996, ... } }
+
+Output JSON (stdout) - failure:
+    { "success": false, "error": "...", "missing_backend": "gdsfactory"|null }
+
+Only the MPI master rank emits the JSON, so the output is identical whether run
+as `python fdtd_sparams.py` or `mpirun -np N python fdtd_sparams.py`.
+"""
+
+import sys
+import json
+
+
+def _is_master():
+    try:
+        import meep as mp
+        return mp.am_master()
+    except Exception:
+        return True
+
+
+def _emit(obj):
+    if _is_master():
+        print(json.dumps(obj))
+
+
+def _fail(message, missing_backend=None):
+    _emit({"success": False, "error": message, "missing_backend": missing_backend})
+    sys.exit(0 if missing_backend else 1)
+
+
+def build_component(spec):
+    """
+    Build the component geometry and attach the ports supplied by Lunima.
+
+    Geometry comes from explicit polygons when present (e.g. the Nazca preview
+    render), otherwise from a GDS file. Ports are always supplied explicitly
+    because Lunima knows its own pin positions.
+    """
+    import gdsfactory as gf
+    import gdsfactory.gpdk as gpdk
+    gpdk.PDK.activate()
+
+    layer = tuple(spec.get("layer", [1, 0]))
+    polygons = spec.get("polygons") or []
+
+    c = gf.Component()
+    if polygons:
+        for poly in polygons:
+            pts = [(float(x), float(y)) for x, y in poly["points"]]
+            c.add_polygon(pts, layer=(int(poly.get("layer", layer[0])), 0))
+    else:
+        c << gf.import_gds(spec["gds_path"])
+
+    for p in spec["ports"]:
+        c.add_port(
+            p["name"],
+            center=(float(p["x"]), float(p["y"])),
+            width=float(p["width"]),
+            orientation=float(p["orientation"]),
+            layer=layer,
+        )
+    return c
+
+
+def run(spec):
+    try:
+        from gplugins.gmeep import write_sparameters_meep
+    except ImportError as e:
+        missing = "gdsfactory" if "gdsfactory" in str(e) else "gplugins"
+        _fail(f"FDTD backend missing ({e}). Install with: pip install gplugins", missing)
+
+    component = build_component(spec)
+
+    sp = write_sparameters_meep(
+        component=component,
+        is_3d=bool(spec.get("is_3d", False)),
+        resolution=int(spec.get("resolution", 20)),
+        ymargin=float(spec.get("ymargin", 2.0)),
+        xmargin=float(spec.get("xmargin", 2.0)),
+        wavelength_start=float(spec.get("wavelength_start", 1.5)),
+        wavelength_stop=float(spec.get("wavelength_stop", 1.6)),
+        wavelength_points=int(spec.get("wavelength_points", 11)),
+        overwrite=True,
+    )
+    return component, sp
+
+
+def serialise(component, sp, spec):
+    import numpy as np
+
+    keys = [k for k in sp if "@" in k]
+    s_out, energy_sum = {}, {}
+    for k in keys:
+        arr = np.asarray(sp[k])
+        s_out[k] = [[float(z.real), float(z.imag)] for z in arr]
+        inp = k.split(",")[1]
+        energy_sum[inp] = energy_sum.get(inp, 0.0) + float(abs(arr[len(arr) // 2]) ** 2)
+
+    return {
+        "success": True,
+        "is_3d": bool(spec.get("is_3d", False)),
+        "resolution": int(spec.get("resolution", 20)),
+        "ports": [p.name for p in component.ports],
+        "wavelengths": [float(x) for x in np.asarray(sp["wavelengths"])],
+        "s": s_out,
+        "energy_sum_per_input": energy_sum,
+    }
+
+
+def _load_spec():
+    """Read the JSON spec from a --spec=PATH file (robust under mpirun) or stdin."""
+    for a in sys.argv[1:]:
+        if a.startswith("--spec="):
+            with open(a.split("=", 1)[1]) as f:
+                return json.load(f)
+    return json.loads(sys.stdin.read())
+
+
+def main():
+    spec = _load_spec()
+    component, sp = run(spec)
+    _emit(serialise(component, sp, spec))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:
+        import traceback
+        _emit({"success": False, "error": str(e), "trace": traceback.format_exc()[-1500:]})
+        sys.exit(1)


### PR DESCRIPTION
Closes #569.

Recompute a component's S-matrix from its geometry using the open-source **Meep**
FDTD solver in **Docker** — no commercial tool. Built on current `main` (v0.7.0).

## What you get
- **"Recalculate S-matrix (FDTD)…"** button in the Component Settings dialog,
  next to "Load S-matrix from file" — instead of importing, it computes the
  S-matrix from the component geometry and feeds it through the same
  store-and-apply path as an import.
- **Live status**: an elapsed-time heartbeat + streamed Meep progress (handles the
  one-time image build phase too).
- **Self-provisioning**: builds the pinned `lunima-meep` image on first use
  (`docker image inspect` → `build`).
- **Robust**: memory-safe MPI rank count, dynamic `/dev/shm` sizing, and reliable
  container cleanup on cancel / app-exit / orphan-reap (a bare `docker run` would
  otherwise leave the container running when the app is closed).

## How it works
`component → NazcaComponentPreviewService render (polygons + pins) → FdtdSMatrixRequest → docker run mpirun write_sparameters_meep → S-matrix JSON → ComponentSMatrixData (existing override path)`

Architecture mirrors the subprocess + stdin/stdout-JSON + structured-error pattern;
geometry can come from polygons (default, from the preview) or a GDS file.

## Validated
- Real demo-PDK `mmi1x2_sh` (Nazca found via the interpreter finder): render →
  polygons+pins → 3×3 S-matrix, end to end.
- Straight waveguide is energy-conserving (|S21|²=0.995; 3D energy sum=1.0002).
- 20 FDTD tests + 119 ComponentSettings tests pass; build clean.

## Known limitation (follow-up #570)
Physical **calibration** is pending: the solver currently uses generic SOI material
indices, while a real PDK may be e.g. InP — so absolute magnitudes aren't yet
trustworthy (energy ≈ 0.37 on the InP MMI). The energy-conservation value shown in
the status tells you whether to trust a given run. #570 (PDK process model: per-PDK
materials/layer-stack/widths) supplies the real indices and makes the values
physically meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)