### PR TITLE
Enable autonomous QA: .agent.toml + headless UI screenshot harness

### DIFF
--- a/.agent.toml
+++ b/.agent.toml
@@ -1,6 +1,6 @@
 build_cmd = "dotnet build"
 test_cmd = "dotnet test UnitTests/UnitTests.csproj"
-ui_test_cmd = ""
+ui_test_cmd = "dotnet test UnitTests/UnitTests.csproj --filter Category=UiScreenshots"
 tech_stack = ["csharp", "avalonia", "dotnet"]
 agents_enabled = ["coder", "reviewer", "qa"]
 command_timeout_sec = 1800

--- a/.agent.toml
+++ b/.agent.toml
@@ -1,0 +1,7 @@
+build_cmd = "dotnet build"
+test_cmd = "dotnet test UnitTests/UnitTests.csproj"
+ui_test_cmd = ""
+tech_stack = ["csharp", "avalonia", "dotnet"]
+agents_enabled = ["coder", "reviewer", "qa"]
+command_timeout_sec = 1800
+qa_review_enabled = true

--- a/UnitTests/UI/ScreenshotTestApp.cs
+++ b/UnitTests/UI/ScreenshotTestApp.cs
@@ -1,0 +1,41 @@
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Themes.Fluent;
+
+[assembly: AvaloniaTestApplication(typeof(UnitTests.UI.ScreenshotTestAppBuilder))]
+
+namespace UnitTests.UI;
+
+/// <summary>
+/// Minimal Avalonia application for headless screenshot tests.
+/// Loads only Fluent theme — intentionally avoids production App.cs DI setup
+/// so tests control all ViewModel construction themselves.
+/// </summary>
+internal class ScreenshotTestApp : Application
+{
+    public override void Initialize()
+    {
+        RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Dark;
+        Styles.Add(new FluentTheme());
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        base.OnFrameworkInitializationCompleted();
+    }
+}
+
+/// <summary>
+/// Configures Avalonia with Skia rendering so that <c>CaptureRenderedFrame()</c> produces
+/// real pixel data. UseHeadlessDrawing = false is required — true throws NotSupportedException.
+/// Skia 11.3.13 is pinned in UnitTests.csproj to resolve the version conflict with
+/// CAP.Avalonia's Avalonia.Skia 11.2.1 reference.
+/// </summary>
+public class ScreenshotTestAppBuilder
+{
+    /// <summary>Entry point called by <see cref="AvaloniaTestApplicationAttribute"/>.</summary>
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<ScreenshotTestApp>()
+            .UseSkia()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false });
+}

--- a/UnitTests/UI/ScreenshotTestApp.cs
+++ b/UnitTests/UI/ScreenshotTestApp.cs
@@ -18,11 +18,6 @@ internal class ScreenshotTestApp : Application
         RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Dark;
         Styles.Add(new FluentTheme());
     }
-
-    public override void OnFrameworkInitializationCompleted()
-    {
-        base.OnFrameworkInitializationCompleted();
-    }
 }
 
 /// <summary>

--- a/UnitTests/UI/UiScreenshotTests.cs
+++ b/UnitTests/UI/UiScreenshotTests.cs
@@ -1,6 +1,8 @@
+using System.Runtime.InteropServices;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using CAP.Avalonia.Views;
 using CAP.Avalonia.Views.Panels;
@@ -21,20 +23,26 @@ namespace UnitTests.UI;
 [Trait("Category", "UiScreenshots")]
 public class UiScreenshotTests
 {
+    // A solid-color blank frame samples to 1 distinct color; anti-aliased edges may add a
+    // handful. A real rendered UI yields dozens-to-hundreds. 10 is the fail-fast floor.
+    private const int MinDistinctSampledColors = 10;
+
     /// <summary>
     /// Captures all target Views in one pass. Uses a single MainViewModel so panel bindings
     /// that navigate through RightPanel/LeftPanel sub-properties resolve correctly.
-    /// Each panel is wrapped in its own Window; failures are caught and logged so one bad
-    /// panel does not block the rest.
+    /// Each panel is wrapped in its own Window; per-panel construction failures are caught
+    /// and logged so one bad panel does not block the rest, but a blank/near-blank render
+    /// FAILS the test loudly (false confidence is worse than no image).
     /// </summary>
     [AvaloniaFact]
     public void CaptureAllUiScreenshots()
     {
         var outputDir = ResolveOutputDirectory();
+        ClearStalePngs(outputDir);
         Directory.CreateDirectory(outputDir);
 
         var vm = MainViewModelTestHelper.CreateMainViewModel();
-        var captured = new List<string>();
+        var captured = new List<(string Path, int DistinctColors)>();
         var skipped = new List<(string Name, string Reason)>();
 
         // All panels use x:DataType="vm:MainViewModel", so pass the full VM as DataContext.
@@ -48,18 +56,15 @@ public class UiScreenshotTests
         foreach (var (name, reason) in skipped)
             Console.WriteLine($"[SKIPPED] {name}: {reason}");
 
-        foreach (var path in captured)
-            Console.WriteLine($"[OK] {path} ({new FileInfo(path).Length:N0} bytes)");
+        foreach (var (path, colors) in captured)
+            Console.WriteLine($"[OK] {path} ({new FileInfo(path).Length:N0} bytes, {colors} distinct sampled colors)");
 
-        foreach (var path in captured)
+        foreach (var (path, colors) in captured)
         {
-            var info = new FileInfo(path);
-            info.Exists.ShouldBeTrue($"Screenshot file must exist: {path}");
-            // 2 KB min: a fully blank 450×600 solid-color PNG compresses to ~600 bytes,
-            // so >2 KB confirms the renderer produced real pixels with actual content.
-            info.Length.ShouldBeGreaterThan(2000,
-                $"Screenshot must be non-trivial (>2 KB) — a blank/empty render means " +
-                $"UseHeadlessDrawing was not set to false or UseSkia() is missing: {path}");
+            new FileInfo(path).Exists.ShouldBeTrue($"Screenshot file must exist: {path}");
+            colors.ShouldBeGreaterThan(MinDistinctSampledColors,
+                $"Near-blank render — only {colors} distinct sampled colors in {path}. " +
+                "Likely UseSkia() is missing or UseHeadlessDrawing != false.");
         }
 
         captured.Count.ShouldBeGreaterThan(0, "At least one screenshot must be captured");
@@ -72,8 +77,8 @@ public class UiScreenshotTests
         int height,
         string outputDir,
         string filename,
-        List<string> captured,
-        List<(string, string)> skipped)
+        List<(string Path, int DistinctColors)> captured,
+        List<(string Name, string Reason)> skipped)
     {
         try
         {
@@ -92,6 +97,7 @@ public class UiScreenshotTests
 
             var bitmap = window.CaptureRenderedFrame();
             window.Close();
+            Dispatcher.UIThread.RunJobs();
 
             if (bitmap == null)
             {
@@ -100,16 +106,60 @@ public class UiScreenshotTests
             }
 
             var path = Path.Combine(outputDir, filename);
+            int distinctColors;
             using (bitmap)
             {
+                distinctColors = CountDistinctSampledColors(bitmap);
                 bitmap.Save(path);
             }
 
-            captured.Add(path);
+            captured.Add((path, distinctColors));
         }
         catch (Exception ex)
         {
             skipped.Add((filename, $"{ex.GetType().Name}: {ex.Message}"));
+        }
+    }
+
+    // 64×64 = 4096 samples: dense enough to land hits on sparse panels (e.g. a single
+    // anti-aliased label on a mostly-black background) yet still O(ms) per bitmap.
+    private const int SampleGridSize = 64;
+
+    /// <summary>
+    /// Samples a <see cref="SampleGridSize"/>×<see cref="SampleGridSize"/> grid of pixels
+    /// from the bitmap and returns the count of distinct 32-bit ARGB values. Works for any
+    /// 4-byte-per-pixel format (Bgra8888, Rgba8888) — the call only counts diversity, not
+    /// color semantics.
+    /// </summary>
+    private static int CountDistinctSampledColors(WriteableBitmap bitmap)
+    {
+        using var fb = bitmap.Lock();
+        int width = fb.Size.Width;
+        int height = fb.Size.Height;
+        if (width <= 0 || height <= 0) return 0;
+
+        int stepX = Math.Max(1, width / SampleGridSize);
+        int stepY = Math.Max(1, height / SampleGridSize);
+        var colors = new HashSet<int>();
+        for (int y = 0; y < height; y += stepY)
+        {
+            var rowAddr = fb.Address + y * fb.RowBytes;
+            for (int x = 0; x < width; x += stepX)
+                colors.Add(Marshal.ReadInt32(rowAddr, x * 4));
+        }
+        return colors.Count;
+    }
+
+    /// <summary>
+    /// Deletes any pre-existing *.png in the output directory. Prevents stale screenshots
+    /// from a previous successful run from masking a current silent capture failure.
+    /// </summary>
+    private static void ClearStalePngs(string dir)
+    {
+        if (!Directory.Exists(dir)) return;
+        foreach (var f in Directory.GetFiles(dir, "*.png"))
+        {
+            try { File.Delete(f); } catch (IOException) { /* file locked — best-effort */ }
         }
     }
 

--- a/UnitTests/UI/UiScreenshotTests.cs
+++ b/UnitTests/UI/UiScreenshotTests.cs
@@ -1,0 +1,136 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using CAP.Avalonia.Views;
+using CAP.Avalonia.Views.Panels;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.UI;
+
+/// <summary>
+/// Headless screenshot harness — renders key Avalonia Views offscreen via Skia and writes PNGs
+/// to <c>artifacts/ui-screenshots/</c> in the repo root for downstream QA visual inspection.
+/// </summary>
+/// <remarks>
+/// Run with: <c>dotnet test UnitTests/UnitTests.csproj --filter Category=UiScreenshots</c>
+/// Output directory override: set env var <c>UI_SHOT_DIR</c> to an absolute path.
+/// </remarks>
+[Trait("Category", "UiScreenshots")]
+public class UiScreenshotTests
+{
+    /// <summary>
+    /// Captures all target Views in one pass. Uses a single MainViewModel so panel bindings
+    /// that navigate through RightPanel/LeftPanel sub-properties resolve correctly.
+    /// Each panel is wrapped in its own Window; failures are caught and logged so one bad
+    /// panel does not block the rest.
+    /// </summary>
+    [AvaloniaFact]
+    public void CaptureAllUiScreenshots()
+    {
+        var outputDir = ResolveOutputDirectory();
+        Directory.CreateDirectory(outputDir);
+
+        var vm = MainViewModelTestHelper.CreateMainViewModel();
+        var captured = new List<string>();
+        var skipped = new List<(string Name, string Reason)>();
+
+        // All panels use x:DataType="vm:MainViewModel", so pass the full VM as DataContext.
+        TryCapture(() => new MainView(), vm, 1280, 900, outputDir, "MainView.png", captured, skipped);
+        TryCapture(() => new DesignChecksPanel(), vm, 450, 700, outputDir, "DesignChecksPanel.png", captured, skipped);
+        TryCapture(() => new AiAssistantPanel(), vm, 450, 800, outputDir, "AiAssistantPanel.png", captured, skipped);
+        TryCapture(() => new LayoutCompressionPanel(), vm, 450, 600, outputDir, "LayoutCompressionPanel.png", captured, skipped);
+        TryCapture(() => new RoutingDiagnosticsPanel(), vm, 600, 700, outputDir, "RoutingDiagnosticsPanel.png", captured, skipped);
+        TryCapture(() => new SelectedComponentPropertiesPanel(), vm, 450, 600, outputDir, "SelectedComponentPropertiesPanel.png", captured, skipped);
+
+        foreach (var (name, reason) in skipped)
+            Console.WriteLine($"[SKIPPED] {name}: {reason}");
+
+        foreach (var path in captured)
+            Console.WriteLine($"[OK] {path} ({new FileInfo(path).Length:N0} bytes)");
+
+        foreach (var path in captured)
+        {
+            var info = new FileInfo(path);
+            info.Exists.ShouldBeTrue($"Screenshot file must exist: {path}");
+            // 2 KB min: a fully blank 450×600 solid-color PNG compresses to ~600 bytes,
+            // so >2 KB confirms the renderer produced real pixels with actual content.
+            info.Length.ShouldBeGreaterThan(2000,
+                $"Screenshot must be non-trivial (>2 KB) — a blank/empty render means " +
+                $"UseHeadlessDrawing was not set to false or UseSkia() is missing: {path}");
+        }
+
+        captured.Count.ShouldBeGreaterThan(0, "At least one screenshot must be captured");
+    }
+
+    private static void TryCapture(
+        Func<Control> createView,
+        object dataContext,
+        int width,
+        int height,
+        string outputDir,
+        string filename,
+        List<string> captured,
+        List<(string, string)> skipped)
+    {
+        try
+        {
+            var view = createView();
+            view.DataContext = dataContext;
+
+            var window = new Window
+            {
+                Width = width,
+                Height = height,
+                Content = view
+            };
+
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var bitmap = window.CaptureRenderedFrame();
+            window.Close();
+
+            if (bitmap == null)
+            {
+                skipped.Add((filename, "CaptureRenderedFrame returned null — likely a render miss"));
+                return;
+            }
+
+            var path = Path.Combine(outputDir, filename);
+            using (bitmap)
+            {
+                bitmap.Save(path);
+            }
+
+            captured.Add(path);
+        }
+        catch (Exception ex)
+        {
+            skipped.Add((filename, $"{ex.GetType().Name}: {ex.Message}"));
+        }
+    }
+
+    /// <summary>
+    /// Resolves the output directory. Checks <c>UI_SHOT_DIR</c> env var first, then walks up
+    /// from the test binary to find the repo root (directory containing a <c>.sln</c> file).
+    /// </summary>
+    private static string ResolveOutputDirectory()
+    {
+        var envDir = Environment.GetEnvironmentVariable("UI_SHOT_DIR");
+        if (!string.IsNullOrEmpty(envDir))
+            return envDir;
+
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (dir.GetFiles("*.sln").Length > 0)
+                return Path.Combine(dir.FullName, "artifacts", "ui-screenshots");
+            dir = dir.Parent;
+        }
+
+        return Path.Combine(AppContext.BaseDirectory, "artifacts", "ui-screenshots");
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -14,6 +14,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Avalonia 11.3.13 packages pinned to resolve the version conflict:
+         CAP.Avalonia references Avalonia.Skia 11.2.1, but Avalonia.Headless.XUnit 11.3.13
+         requires 11.3.x Skia APIs. Explicitly upgrading here forces NuGet to place
+         11.3.x DLLs in the test output so UseSkia() + UseHeadlessDrawing=false work. -->
+    <PackageReference Include="Avalonia" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Skia" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
     <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.70" />


### PR DESCRIPTION
Two changes that let the Autonomous Issue Agent's QA role verify this repo:

### 1. `.agent.toml`
Declares build/test commands and enables the QA review pass. Verified: `dotnet build` (0 errors), `dotnet test` (2339 passed).

### 2. Headless UI screenshot harness
New `UnitTests/UI/` harness using the already-present `Avalonia.Headless.XUnit` to render key Views (MainView + 5 panels) offscreen to real PNGs via Skia. Wires `ui_test_cmd` to `dotnet test --filter Category=UiScreenshots`. Screenshots land in `artifacts/ui-screenshots/` (gitignored) for visual QA.

- Resolved a Skia 11.2/11.3 version conflict in the test project only.
- All 6 PNGs verified as real renders (180-629 distinct colors).

_Built by Claude Code, verified by Hermes._