### PR TITLE
(=) Installer: bundle FDTD bridge script + Dockerfile (#569)

### DIFF
--- a/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
+++ b/CAP.Avalonia/Services/Solvers/DockerFdtdSMatrixService.cs
@@ -308,5 +308,32 @@ public class DockerFdtdSMatrixService : IFdtdSMatrixService
         return System.Text.RegularExpressions.Regex.Replace(noBlocks, @"\s{2,}", " ").Trim();
     }
 
+    private const string DockerInstallUrl = "https://www.docker.com/products/docker-desktop/";
+
+    /// <inheritdoc/>
+    public async Task<FdtdAvailability> CheckAvailabilityAsync(CancellationToken ct = default)
+    {
+        // `docker version --format {{.Server.Version}}` prints the engine version
+        // when the daemon is reachable; it fails (non-zero) if Docker is installed
+        // but the engine isn't running, and won't start at all if Docker is absent.
+        var si = new ProcessStartInfo { FileName = _dockerExe };
+        si.ArgumentList.Add("version");
+        si.ArgumentList.Add("--format");
+        si.ArgumentList.Add("{{.Server.Version}}");
+
+        var run = await SubprocessJsonRunner.RunAsync(si, string.Empty, TimeSpan.FromSeconds(20), ct);
+
+        if (run.Outcome == SubprocessJsonRunner.Outcome.StartFailed)
+            return FdtdAvailability.Unavailable(
+                $"Docker is not installed (or not on PATH). FDTD needs Docker Desktop — install it from {DockerInstallUrl}, then retry.");
+
+        if (run.Outcome == SubprocessJsonRunner.Outcome.Completed && run.ExitCode == 0
+            && !string.IsNullOrWhiteSpace(run.Stdout))
+            return FdtdAvailability.Available($"Docker engine {run.Stdout.Trim()} ready.");
+
+        return FdtdAvailability.Unavailable(
+            "Docker is installed but the engine isn't running. Start Docker Desktop and try again.");
+    }
+
     private static string ToDockerPath(string path) => path.Replace('\\', '/');
 }

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
@@ -60,11 +60,21 @@ public partial class ComponentSettingsDialogViewModel
             return;
 
         IsComputing = true;
-        SolverStatus = "Preparing component geometry…";
         _recalcCts = new CancellationTokenSource();
 
         try
         {
+            // Fail fast with an actionable message if Docker isn't ready, before
+            // exporting geometry / building images.
+            SolverStatus = "Checking the FDTD solver (Docker)…";
+            var availability = await _fdtdService.CheckAvailabilityAsync(_recalcCts.Token);
+            if (!availability.IsAvailable)
+            {
+                SolverStatus = availability.Message;
+                return;
+            }
+
+            SolverStatus = "Preparing component geometry…";
             var request = await _fdtdRequestFactory(_liveComponent, _recalcCts.Token);
             if (request == null)
             {

--- a/CAP.Desktop/CAP.Desktop.csproj
+++ b/CAP.Desktop/CAP.Desktop.csproj
@@ -31,4 +31,21 @@
              CopyToOutputDirectory="PreserveNewest"
              CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <!-- FDTD S-matrix solver bridge (issue #569). DockerFdtdSMatrixService /
+       FindFdtdDockerfile() look for `<baseDir>/scripts/fdtd/Dockerfile`, and that
+       Dockerfile COPYs `fdtd_sparams.py` relative to its build context (the
+       scripts/ folder). Both must ship next to the binary in that exact layout,
+       or "Recalculate S-matrix (FDTD)" can't build its Docker image on a fresh
+       install. (Docker itself is a user prerequisite — not bundled.) -->
+  <ItemGroup>
+    <Content Include="..\scripts\fdtd_sparams.py"
+             Link="scripts\fdtd_sparams.py"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="..\scripts\fdtd\Dockerfile"
+             Link="scripts\fdtd\Dockerfile"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/Connect-A-Pic-Core/Solvers/Fdtd/FdtdAvailability.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/FdtdAvailability.cs
@@ -1,0 +1,23 @@
+namespace CAP_Core.Solvers.Fdtd;
+
+/// <summary>
+/// Result of a quick "can the FDTD solver run here?" probe — checked before the
+/// (long) solve so the user gets immediate, actionable feedback instead of a
+/// failure deep into the run.
+/// </summary>
+public class FdtdAvailability
+{
+    /// <summary>True when the solver backend (e.g. Docker engine) is ready to use.</summary>
+    public bool IsAvailable { get; init; }
+
+    /// <summary>Human-readable status / how to fix it when not available.</summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>Creates an available result.</summary>
+    public static FdtdAvailability Available(string message) =>
+        new() { IsAvailable = true, Message = message };
+
+    /// <summary>Creates an unavailable result with an actionable message.</summary>
+    public static FdtdAvailability Unavailable(string message) =>
+        new() { IsAvailable = false, Message = message };
+}

--- a/Connect-A-Pic-Core/Solvers/Fdtd/IFdtdSMatrixService.cs
+++ b/Connect-A-Pic-Core/Solvers/Fdtd/IFdtdSMatrixService.cs
@@ -18,4 +18,10 @@ public interface IFdtdSMatrixService
     /// <param name="ct">Cancellation token.</param>
     Task<FdtdSMatrixResult> SolveAsync(
         FdtdSMatrixRequest request, IProgress<string>? progress = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Quickly probes whether the solver backend is ready (e.g. the Docker engine is
+    /// installed and running), so the UI can warn before starting a long solve.
+    /// </summary>
+    Task<FdtdAvailability> CheckAvailabilityAsync(CancellationToken ct = default);
 }

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
@@ -50,6 +50,8 @@ public class ComponentSettingsDialogFdtdTests
     public async Task RecalculateSMatrix_OnSuccess_StoresDataAndReportsStatus()
     {
         var service = new Mock<IFdtdSMatrixService>();
+        service.Setup(s => s.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(FdtdAvailability.Available("ready"));
         service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
                .ReturnsAsync(SuccessResult());
         var store = new Dictionary<string, ComponentSMatrixData>();
@@ -74,6 +76,8 @@ public class ComponentSettingsDialogFdtdTests
     public async Task RecalculateSMatrix_OnFailure_SurfacesHintAndStoresNothing()
     {
         var service = new Mock<IFdtdSMatrixService>();
+        service.Setup(s => s.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(FdtdAvailability.Available("ready"));
         service.Setup(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
                .ReturnsAsync(FdtdSMatrixResult.Fail("image build failed", missingDependency: "docker"));
         var store = new Dictionary<string, ComponentSMatrixData>();
@@ -89,5 +93,29 @@ public class ComponentSettingsDialogFdtdTests
 
         store.ShouldNotContainKey("comp");
         vm.SolverStatus.ShouldContain("docker");
+    }
+
+    [Fact]
+    public async Task RecalculateSMatrix_WhenDockerUnavailable_ShowsHintAndDoesNotSolve()
+    {
+        var service = new Mock<IFdtdSMatrixService>();
+        service.Setup(s => s.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+               .ReturnsAsync(FdtdAvailability.Unavailable("Docker is not installed. Install Docker Desktop."));
+        var store = new Dictionary<string, ComponentSMatrixData>();
+
+        var vm = new ComponentSettingsDialogViewModel(
+            Mock.Of<IFileDialogService>(),
+            fdtdService: service.Object,
+            fdtdRequestFactory: FakeFactory());
+        vm.Configure("comp", "Comp", store,
+            liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
+
+        await vm.RecalculateSMatrixCommand.ExecuteAsync(null);
+
+        vm.SolverStatus.ShouldContain("Docker Desktop");
+        store.ShouldNotContainKey("comp");
+        vm.IsComputing.ShouldBeFalse();
+        // The solver must not be invoked when the backend isn't available.
+        service.Verify(s => s.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }


### PR DESCRIPTION
The FDTD "Recalculate S-matrix" feature (#569) shipped without its support files.
Only `render_component_preview.py` was declared as `Content` in
`CAP.Desktop.csproj`, so `scripts/fdtd_sparams.py` and `scripts/fdtd/Dockerfile`
were **not** in the publish output → not harvested into the MSI → on a fresh
install `FindFdtdDockerfile()` found nothing and the Docker image build failed.

Fix: add both as `Content` (`CopyToOutputDirectory` + `CopyToPublishDirectory`)
in the exact `scripts/` layout the Docker build context expects (the Dockerfile
COPYs `fdtd_sparams.py` relative to `scripts/`). Verified they land at
`bin/.../scripts/fdtd/Dockerfile` and `bin/.../scripts/fdtd_sparams.py`.

**Docker Desktop remains a user prerequisite** — it is not (and shouldn't be)
bundled. When Docker is absent the app already surfaces a clear "docker required"
message instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)