### PR TITLE
(c) CI: stop xUnit running twice (limit push trigger to main)

### DIFF
--- a/.github/workflows/xUnitTests.yaml
+++ b/.github/workflows/xUnitTests.yaml
@@ -1,7 +1,11 @@
 name: 🔍 xUnit Tests
 
+# Run on PRs (the required check for branch protection) and on pushes to main
+# only. Previously `push:` had no branch filter, so a push to a branch that also
+# had an open PR triggered BOTH events → the suite ran twice.
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
**Symptom:** the `🔍 xUnit Tests` workflow runs twice on every PR push.

**Cause:** the trigger was
```yaml
on:
  push:
  pull_request:
```
`push:` with no branch filter fires on every push to any branch. When a feature
branch has an open PR, a push triggers **both** `push` and `pull_request` → the
suite runs twice.

**Fix:** limit `push` to `main`:
```yaml
on:
  push:
    branches: [main]
  pull_request:
```
- Feature branch + PR → only `pull_request` runs (once) — still the branch-protection
  required check.
- `main` after merge → one `push` run.

No more duplicate runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)