### PR TITLE
(=) FDTD: key recomputed S-matrix by component pin names (#569)

### DIFF
--- a/CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs
+++ b/CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs
@@ -49,10 +49,12 @@ public class ComponentFdtdRequestFactory
         if (!preview.Success || preview.Polygons.Count == 0 || preview.Pins.Count == 0)
             return null;
 
+        var componentPinNames = component.PhysicalPins?.Select(p => p.Name).ToList() ?? new List<string>();
+
         return new FdtdSMatrixRequest
         {
             Polygons = BuildPolygons(preview.Polygons, _siliconLayer),
-            Ports = BuildPorts(preview.Pins, _portWidthUm),
+            Ports = BuildPorts(preview.Pins, componentPinNames, _portWidthUm),
             LayerNumber = _siliconLayer,
             Is3D = false, // 2D for a quick recompute; a 3D/accuracy toggle can come later
         };
@@ -74,14 +76,29 @@ public class ComponentFdtdRequestFactory
         }).ToList();
     }
 
-    /// <summary>Maps Nazca pin stubs to FDTD ports (orientation = pin angle).</summary>
-    internal static IReadOnlyList<FdtdPort> BuildPorts(IReadOnlyList<NazcaPreviewPin> pins, double portWidthUm) =>
-        pins.Select(pin => new FdtdPort
+    /// <summary>
+    /// Builds FDTD ports from the rendered Nazca pin stubs. Positions and angles
+    /// come from the preview (same coordinate frame as the polygons), but the port
+    /// <b>names</b> come from the component's own pins so the resulting S-matrix is
+    /// keyed by the names the simulator expects (e.g. "port 1"), not the Nazca cell
+    /// pin names ("a0"/"pin1"). Without this the override can't be mapped onto the
+    /// component and every wavelength is skipped.
+    ///
+    /// Pins are matched by index (a PDK's pin order matches its Nazca cell's pin
+    /// order). If the counts differ we keep the preview names rather than guess —
+    /// the override will then report the mismatch instead of mislabelling ports.
+    /// </summary>
+    internal static IReadOnlyList<FdtdPort> BuildPorts(
+        IReadOnlyList<NazcaPreviewPin> pins, IReadOnlyList<string> componentPinNames, double portWidthUm)
+    {
+        bool useComponentNames = componentPinNames.Count == pins.Count;
+        return pins.Select((pin, i) => new FdtdPort
         {
-            Name = pin.Name,
+            Name = useComponentNames ? componentPinNames[i] : pin.Name,
             X = pin.X,
             Y = pin.Y,
             Orientation = pin.Angle,
             Width = portWidthUm,
         }).ToList();
+    }
 }

--- a/UnitTests/Solvers/Fdtd/ComponentFdtdRequestFactoryTests.cs
+++ b/UnitTests/Solvers/Fdtd/ComponentFdtdRequestFactoryTests.cs
@@ -39,7 +39,7 @@ public class ComponentFdtdRequestFactoryTests
     }
 
     [Fact]
-    public void BuildPorts_MapsPinAngleToOrientation()
+    public void BuildPorts_UsesComponentPinNames_KeepsPreviewPositions()
     {
         var pins = new[]
         {
@@ -47,12 +47,32 @@ public class ComponentFdtdRequestFactoryTests
             new NazcaPreviewPin { Name = "b0", X = 80, Y = 2, Angle = 0 },
         };
 
-        var ports = ComponentFdtdRequestFactory.BuildPorts(pins, portWidthUm: 2.0);
+        // Component pin names differ from the Nazca cell pin names — these must win,
+        // matched by index, while positions/angles stay from the preview.
+        var ports = ComponentFdtdRequestFactory.BuildPorts(pins, new[] { "port 1", "port 2" }, portWidthUm: 2.0);
 
         ports.Count.ShouldBe(2);
-        ports[0].Name.ShouldBe("a0");
+        ports[0].Name.ShouldBe("port 1");
         ports[0].Orientation.ShouldBe(180);
+        ports[0].X.ShouldBe(0);
+        ports[1].Name.ShouldBe("port 2");
         ports[1].X.ShouldBe(80);
         ports[1].Width.ShouldBe(2.0);
+    }
+
+    [Fact]
+    public void BuildPorts_FallsBackToPreviewNames_OnCountMismatch()
+    {
+        var pins = new[]
+        {
+            new NazcaPreviewPin { Name = "a0", X = 0, Y = 0, Angle = 180 },
+            new NazcaPreviewPin { Name = "b0", X = 80, Y = 2, Angle = 0 },
+        };
+
+        // Only one component name for two pins → can't safely match → keep preview names.
+        var ports = ComponentFdtdRequestFactory.BuildPorts(pins, new[] { "port 1" }, portWidthUm: 2.0);
+
+        ports[0].Name.ShouldBe("a0");
+        ports[1].Name.ShouldBe("b0");
     }
 }

--- a/UnitTests/Solvers/Fdtd/FdtdRecomputeIntegrationTests.cs
+++ b/UnitTests/Solvers/Fdtd/FdtdRecomputeIntegrationTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.Solvers;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Export;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace UnitTests.Solvers.Fdtd;
+
+/// <summary>
+/// End-to-end integration test for "Recalculate S-matrix (FDTD)" on a real PDK
+/// component (SiEPIC EBeam <c>ebeam_DC_2-1_te895</c> — one of the smallest, so it
+/// solves quickly): render → request factory → Docker/Meep solve → convert →
+/// apply, asserting the recomputed S-matrix maps onto the component's pins
+/// (the #578 fix — no skipped wavelengths).
+///
+/// HEAVY + opt-in: it builds/runs the Meep Docker image and renders via Nazca,
+/// so it only runs when <c>LUNIMA_FDTD_INTEGRATION=1</c> AND Docker + a working
+/// render Python are present. Otherwise it no-ops (keeps CI fast/green).
+/// </summary>
+[Trait("Category", "FdtdIntegration")]
+public class FdtdRecomputeIntegrationTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public FdtdRecomputeIntegrationTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public async Task Recompute_SiepicDc21_AppliesToAllPorts_WithoutSkippedWavelengths()
+    {
+        if (Environment.GetEnvironmentVariable("LUNIMA_FDTD_INTEGRATION") != "1")
+        {
+            _output.WriteLine("skip: set LUNIMA_FDTD_INTEGRATION=1 to run (needs Docker + SiEPIC render deps).");
+            return;
+        }
+
+        var python = FindWorkingPython3();
+        if (python == null) { _output.WriteLine("skip: no working python3 for the Nazca render."); return; }
+
+        var dockerfile = FindUp(Path.Combine("scripts", "fdtd", "Dockerfile"));
+        var previewScript = FindUp(Path.Combine("scripts", "render_component_preview.py"));
+        if (dockerfile == null || previewScript == null)
+        {
+            _output.WriteLine("skip: scripts/fdtd/Dockerfile or render_component_preview.py not found.");
+            return;
+        }
+
+        if (!DockerAvailable())
+        {
+            _output.WriteLine("skip: Docker engine not available.");
+            return;
+        }
+
+        var buildContext = Directory.GetParent(Path.GetDirectoryName(dockerfile)!)!.FullName; // scripts/
+        var fdtd = new DockerFdtdSMatrixService("lunima-meep:1", dockerfile, buildContext);
+
+        // Real SiEPIC DC 2-1 component (its pins are "port 1".."port 4").
+        var templates = TestPdkLoader.LoadFromPdk("siepic-ebeam-pdk.json");
+        var dcTemplate = templates.FirstOrDefault(t => t.NazcaFunctionName == "ebeam_DC_2-1_te895")
+                         ?? templates.FirstOrDefault(t => t.Name == "DC 2-1 TE 895");
+        dcTemplate.ShouldNotBeNull("SiEPIC DC 2-1 template not found in siepic-ebeam-pdk.json");
+        var component = ComponentTemplates.CreateFromTemplate(dcTemplate!, 0, 0);
+
+        var preview = new NazcaComponentPreviewService(python, previewScript);
+        var factory = new ComponentFdtdRequestFactory(preview);
+
+        var request = await factory.BuildAsync(component);
+        request.ShouldNotBeNull("render/factory produced no request — SiEPIC render deps (klayout/siepic) present?");
+
+        var result = await fdtd.SolveAsync(request!);
+        result.Success.ShouldBeTrue($"FDTD failed: {result.Error}\n{result.RawStderr}");
+
+        var data = FdtdSMatrixConverter.ToComponentSMatrixData(result, "FDTD integration test");
+        var apply = SMatrixOverrideApplicator.Apply(component, data, errorConsole: null);
+
+        // The core of #578: ports are named after the component pins, so the
+        // override maps onto every wavelength rather than being skipped.
+        apply.Skipped.ShouldBeEmpty("port-name mismatch would skip wavelengths");
+        apply.Applied.ShouldBeGreaterThan(0);
+
+        // Loose passivity sanity only — absolute accuracy needs material calibration
+        // (#570 stage 3); uncalibrated SOI defaults are lossy, not near 1.
+        foreach (var energy in result.EnergySumPerInput.Values)
+            energy.ShouldBeLessThanOrEqualTo(1.05);
+
+        _output.WriteLine($"OK: applied {apply.Applied} wavelength(s); " +
+                          $"max energy Σ|S|² = {result.EnergySumPerInput.Values.DefaultIfEmpty(0).Max():F3}");
+    }
+
+    private static string? FindUp(string relative)
+    {
+        var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static bool DockerAvailable()
+    {
+        try
+        {
+            using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "docker",
+                Arguments = "version --format {{.Server.Version}}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            if (p == null) return false;
+            p.WaitForExit(20000);
+            return p.HasExited && p.ExitCode == 0;
+        }
+        catch { return false; }
+    }
+
+    private static string? FindWorkingPython3()
+    {
+        var envOverride = Environment.GetEnvironmentVariable("LUNIMA_TEST_PYTHON3");
+        var candidates = !string.IsNullOrWhiteSpace(envOverride)
+            ? new[] { envOverride, "python3", "py", "python" }
+            : new[] { "/usr/bin/python3", "/usr/local/bin/python3", "python3", "py", "python" };
+        foreach (var c in candidates)
+        {
+            try
+            {
+                using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = c,
+                    Arguments = "-c \"print('ok')\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                });
+                if (p == null) continue;
+                p.WaitForExit(10000);
+                if (p.HasExited && p.ExitCode == 0) return c;
+            }
+            catch { /* try next candidate */ }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
**Problem (the blocker):** after "Recalculate S-matrix (FDTD)", applying it to the
ONA analyzer logged a wall of warnings and used nothing:
`port name 'pin1' not found on component (available: port 1, port 2, port 3, port 4)`
(and `'a0' not found ... available: fiber, waveguide`).

**Cause:** the recompute stored the S-matrix keyed by the **Nazca cell** pin names
(`a0`/`pin1`), but components expose their own pin names. The override applicator
couldn't map them → every wavelength skipped.

**Fix:** FDTD ports now take **positions/angles from the rendered preview pins**
(same frame as the geometry) and their **names from the component's pins**, matched
by index (a PDK's pin order matches its Nazca cell's pin order). On a count mismatch
it keeps the preview names rather than mislabelling. Unit-tested.

**Please verify** on the real components (the SiEPIC DC and the edge coupler): the
"port name … not found" warnings should be gone and the recomputed S-matrix should
actually drive the ONA sweep. If a specific component's pin *order* doesn't line up,
that's the case to report (the index assumption).

First of several small follow-ups addressing the FDTD review feedback
(next: cancel-on-close + container stop, status-line cleanup, override visibility, instance-vs-type scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)