### PR TITLE
(=) Canvas: right-click keeps an existing multi-selection (Create Group)

### DIFF
--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -344,12 +344,34 @@ public partial class CanvasInteractionViewModel : ObservableObject
     /// </summary>
     public void SelectComponentAt(double canvasX, double canvasY)
     {
+        var hit = ComponentAt(canvasX, canvasY);
+
+        // Right-clicking one of several already-selected components keeps the whole
+        // multi-selection (so "Create Group" stays available) and just makes the
+        // clicked one the primary for the context menu / component settings.
+        // Right-clicking outside the selection (or with only one selected) selects
+        // just that component, exactly like a left-click would.
+        if (hit != null && _canvas.Selection.HasMultipleSelected && _canvas.Selection.SelectedComponents.Contains(hit))
+        {
+            SelectedComponent = hit;
+            _canvas.SelectedComponent = hit;
+            SelectedWaveguideConnection = null;
+            UpdateStatus?.Invoke($"Selected: {hit.Name} ({_canvas.Selection.SelectedComponents.Count} selected)");
+            return;
+        }
+
         SelectAt(canvasX, canvasY);
         if (SelectedComponent != null)
             _canvas.Selection.SelectSingle(SelectedComponent);
         else
             _canvas.Selection.ClearSelection();
     }
+
+    /// <summary>Returns the topmost component whose bounds contain the point, or null.</summary>
+    private ComponentViewModel? ComponentAt(double x, double y) =>
+        _canvas.Components
+            .Where(c => x >= c.X && x <= c.X + c.Width && y >= c.Y && y <= c.Y + c.Height)
+            .LastOrDefault();
 
     private void SelectAt(double x, double y)
     {
@@ -364,9 +386,7 @@ public partial class CanvasInteractionViewModel : ObservableObject
         }
 
         // Find component at position
-        var component = _canvas.Components
-            .Where(c => x >= c.X && x <= c.X + c.Width && y >= c.Y && y <= c.Y + c.Height)
-            .LastOrDefault();
+        var component = ComponentAt(x, y);
 
         if (component != null)
         {

--- a/UnitTests/ViewModels/CanvasContextMenuComponentSettingsTests.cs
+++ b/UnitTests/ViewModels/CanvasContextMenuComponentSettingsTests.cs
@@ -102,6 +102,44 @@ public class CanvasContextMenuComponentSettingsTests
     }
 
     [Fact]
+    public void SelectComponentAt_OnAlreadySelectedComponent_KeepsMultiSelection_ForCreateGroup()
+    {
+        var (interaction, canvas) = CreateInteraction();
+        var a = AddComponentAt(canvas, x: 0, y: 0);
+        var b = AddComponentAt(canvas, x: 200, y: 200);
+        canvas.Selection.AddToSelection(a);
+        canvas.Selection.AddToSelection(b);
+
+        // Right-click one of the already-selected components.
+        interaction.SelectComponentAt(10, 10);
+
+        // The multi-selection must survive so "Create Group" stays available…
+        canvas.Selection.SelectedComponents.Count.ShouldBe(2);
+        canvas.Selection.SelectedComponents.ShouldContain(a);
+        canvas.Selection.SelectedComponents.ShouldContain(b);
+        interaction.CreateGroupCommand.CanExecute(null).ShouldBeTrue();
+        // …and the clicked component becomes the primary for the context menu.
+        interaction.SelectedComponent.ShouldBe(a);
+    }
+
+    [Fact]
+    public void SelectComponentAt_OnComponentOutsideMultiSelection_CollapsesToThatOne()
+    {
+        var (interaction, canvas) = CreateInteraction();
+        var a = AddComponentAt(canvas, x: 0, y: 0);
+        var b = AddComponentAt(canvas, x: 200, y: 200);
+        var c = AddComponentAt(canvas, x: 400, y: 400);
+        canvas.Selection.AddToSelection(a);
+        canvas.Selection.AddToSelection(b);
+
+        // Right-click a component that is NOT part of the current selection.
+        interaction.SelectComponentAt(410, 410);
+
+        canvas.Selection.SelectedComponents.ShouldHaveSingleItem().ShouldBe(c);
+        interaction.SelectedComponent.ShouldBe(c);
+    }
+
+    [Fact]
     public void SelectComponentAt_EmptySpace_ClearsSelection()
     {
         var (interaction, canvas) = CreateInteraction();


### PR DESCRIPTION
**Bug:** select several components, right-click one of them → all the others get
deselected, so "Create Group" is no longer available. Right-click ran
`SelectComponentAt → SelectSingle`, collapsing the multi-selection to the single
clicked component.

**Fix — the rule you'd expect:**
- Right-click a component that is **already part of a multi-selection** → keep the
  whole selection; the clicked one just becomes the **primary** (for the context
  menu / Component Settings). → "Create Group" stays enabled.
- Right-click a component **outside** the selection (or with only one selected) →
  select just that one, exactly like a left-click.

`CanCreateGroup` = `SelectedComponents.Count >= 2`, so keeping the set keeps the
command enabled.

Tests: 2 added (multi-selection preserved + collapse-on-outside-click); the
existing "switch to the right-clicked component" single-select test is unchanged
(10/10 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)