### PR TITLE
(=) Component Settings dialog: scrollable so short windows don't clip the S-matrix/wavelength list

### DIFF
--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -15,6 +15,12 @@
         Background="#1e1e1e"
         WindowStartupLocation="CenterOwner">
 
+    <!-- The dialog can be resized quite short; without an outer scroll the
+         lower DockPanel sections (effective S-matrix + wavelength list) get
+         clipped instead of becoming reachable. Wrapping the whole content in a
+         ScrollViewer keeps every section accessible at any window height. -->
+    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Disabled">
     <DockPanel Margin="16">
 
         <!-- Title -->
@@ -436,4 +442,5 @@
         </ScrollViewer>
 
     </DockPanel>
+    </ScrollViewer>
 </Window>


### PR DESCRIPTION
## Problem
The Component Settings window can be resized quite short. When it is, the lower `DockPanel` sections — **Currently effective S-matrix** and the **wavelength/entry list** — get clipped with no way to scroll to them.

## Fix
Wrap the whole dialog content in a `ScrollViewer` (vertical auto, horizontal disabled). Every section stays reachable at any window height; when the window is tall enough no scrollbar appears.

UI-only change, no logic touched. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)