### PR TITLE
(=) Fix StatusText tests broken by #587 (main is red)

### DIFF
--- a/UnitTests/ViewModels/ComponentLibraryViewModelTests.cs
+++ b/UnitTests/ViewModels/ComponentLibraryViewModelTests.cs
@@ -116,13 +116,18 @@ public class ComponentLibraryViewModelTests : IDisposable
         var template2 = _libraryManager.SaveTemplate(group2, "Group 2", null, "User");
         _viewModel.LoadGroupsCommand.Execute(null);
 
-        _viewModel.StatusText.ShouldBe("2 user group(s), 0 PDK macro(s)");
+        // Counts are no longer surfaced in StatusText (the section labels + lists show
+        // them); StatusText is empty while groups exist and only carries the empty hint.
+        _viewModel.StatusText.ShouldBeEmpty();
 
         // Act
         _viewModel.RemoveTemplateCommand.Execute(template1);
+        _viewModel.StatusText.ShouldBeEmpty();   // one group still present
+
+        _viewModel.RemoveTemplateCommand.Execute(template2);
 
         // Assert
-        _viewModel.StatusText.ShouldBe("1 user group(s), 0 PDK macro(s)");
+        _viewModel.StatusText.ShouldBe("No saved groups");   // empty → hint
     }
 
     [Fact]
@@ -140,7 +145,7 @@ public class ComponentLibraryViewModelTests : IDisposable
         // Assert
         _viewModel.UserGroups.Count.ShouldBe(1);
         _viewModel.UserGroups[0].Template.ShouldBe(template);
-        _viewModel.StatusText.ShouldBe("1 user group(s), 0 PDK macro(s)");
+        _viewModel.StatusText.ShouldBeEmpty();   // counts not surfaced once a group exists
     }
 
     [Fact]
@@ -158,7 +163,7 @@ public class ComponentLibraryViewModelTests : IDisposable
         // Assert
         _viewModel.PdkGroups.Count.ShouldBe(1);
         _viewModel.PdkGroups[0].Template.ShouldBe(template);
-        _viewModel.StatusText.ShouldBe("0 user group(s), 1 PDK macro(s)");
+        _viewModel.StatusText.ShouldBeEmpty();   // counts not surfaced once a group exists
     }
 
     [Fact]
@@ -233,7 +238,7 @@ public class ComponentLibraryViewModelTests : IDisposable
     }
 
     [Fact]
-    public void StatusText_ReflectsMixedUserAndPdkGroups()
+    public void StatusText_IsEmptyWhenGroupsPresent()
     {
         // Arrange
         var userGroup = CreateTestGroup("UserGroup", 1);
@@ -244,8 +249,8 @@ public class ComponentLibraryViewModelTests : IDisposable
         // Act
         _viewModel.LoadGroupsCommand.Execute(null);
 
-        // Assert
-        _viewModel.StatusText.ShouldBe("1 user group(s), 1 PDK macro(s)");
+        // Assert — counts live in the section labels + lists now, not in StatusText
+        _viewModel.StatusText.ShouldBeEmpty();
     }
 
     [Fact]

--- a/UnitTests/ViewModels/GroupLibraryIntegrationTests.cs
+++ b/UnitTests/ViewModels/GroupLibraryIntegrationTests.cs
@@ -95,8 +95,7 @@ public class GroupLibraryIntegrationTests : IDisposable
         // Assert
         _libraryViewModel.UserGroups.Count.ShouldBe(1);
         _libraryViewModel.PdkGroups.Count.ShouldBe(1);
-        _libraryViewModel.StatusText.ShouldContain("1 user group");
-        _libraryViewModel.StatusText.ShouldContain("1 PDK macro");
+        _libraryViewModel.StatusText.ShouldBeEmpty();   // counts shown by labels/lists, not StatusText
     }
 
     [Fact]
@@ -162,28 +161,27 @@ public class GroupLibraryIntegrationTests : IDisposable
     }
 
     [Fact]
-    public void StatusText_UpdatesWithGroupCounts()
+    public void StatusText_EmptyWhenGroupsPresent_HintWhenEmpty()
     {
         // Arrange - empty library
         _libraryViewModel.LoadGroupsCommand.Execute(null);
         _libraryViewModel.StatusText.ShouldBe("No saved groups");
 
-        // Act - add user groups
+        // Act - add a user group
         var group1 = CreateTestGroup("Group1", 1);
         _libraryManager.SaveTemplate(group1, "User Group 1");
         _libraryViewModel.LoadGroupsCommand.Execute(null);
 
-        // Assert
-        _libraryViewModel.StatusText.ShouldContain("1 user group");
+        // Assert - once groups exist StatusText is empty (counts shown by labels/lists)
+        _libraryViewModel.StatusText.ShouldBeEmpty();
 
-        // Act - add PDK group
+        // Act - add a PDK group
         var group2 = CreateTestGroup("Group2", 1);
         _libraryManager.SaveTemplate(group2, "PDK Macro 1", null, "PDK");
         _libraryViewModel.LoadGroupsCommand.Execute(null);
 
-        // Assert
-        _libraryViewModel.StatusText.ShouldContain("1 user group");
-        _libraryViewModel.StatusText.ShouldContain("1 PDK macro");
+        // Assert - still empty
+        _libraryViewModel.StatusText.ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
`main` is currently **red**: PR #587 changed `ComponentLibraryViewModel.UpdateStatus()` so `StatusText` is **empty while groups exist** (the section labels + lists already carry the counts) and only shows `"No saved groups"` when empty. But 6 existing tests still asserted the old `"X user group(s), Y PDK macro(s)"` format.

This slipped onto main because #587 was admin-merged without checking the (red) CI run — my mistake.

## Fix
Update the 6 tests to the new, intended behaviour:
- `StatusText` empty when groups are present
- `"No saved groups"` when the library is empty

No production code changes. Full suite green locally (2384 passed / 0 failed / 10 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)