### PR TITLE
(c) Bump version to 0.8.0 for release

### DIFF
--- a/CAP.Desktop/CAP.Desktop.csproj
+++ b/CAP.Desktop/CAP.Desktop.csproj
@@ -7,7 +7,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <!-- Lunima application icon (embedded in the .exe) -->
     <ApplicationIcon>LunimaIcon.ico</ApplicationIcon>
   </PropertyGroup>


### PR DESCRIPTION
Version bump 0.7.0 → 0.8.0 ahead of the v0.8.0 release tag.

New since v0.7.0: GDS geometry preview in library thumbnails (+ persistent disk cache), left-panel restructure into resizable rubrics, FDTD dialog UX (cancel-on-close, live status, serialised solves, orphan-gating) + Docker availability check, canvas right-click multi-selection, scrollable Component Settings dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)