### PR TITLE
Tests: run Avalonia-control tests on UI thread via [AvaloniaFact] (CI stability)

### DIFF
--- a/UnitTests/Behaviors/ScrollPositionBehaviorTests.cs
+++ b/UnitTests/Behaviors/ScrollPositionBehaviorTests.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
 using CAP.Avalonia.Behaviors;
 using Shouldly;
 using Xunit;
@@ -13,7 +14,7 @@ namespace UnitTests.Behaviors;
 /// </summary>
 public class ScrollPositionBehaviorTests
 {
-    [Fact]
+    [AvaloniaFact]
     public void VerticalOffset_DefaultsToZero()
     {
         var scrollViewer = new ScrollViewer();
@@ -23,7 +24,7 @@ public class ScrollPositionBehaviorTests
         offset.ShouldBe(0.0);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void SetVerticalOffset_UpdatesProperty()
     {
         var scrollViewer = new ScrollViewer();
@@ -34,7 +35,7 @@ public class ScrollPositionBehaviorTests
         offset.ShouldBe(100.5);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void GetVerticalOffset_ReturnsCorrectValue()
     {
         var scrollViewer = new ScrollViewer();
@@ -45,7 +46,7 @@ public class ScrollPositionBehaviorTests
         result.ShouldBe(250.75);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void VerticalOffset_SupportsMultipleUpdates()
     {
         var scrollViewer = new ScrollViewer();

--- a/UnitTests/Controls/DesignCanvasRefreshTests.cs
+++ b/UnitTests/Controls/DesignCanvasRefreshTests.cs
@@ -1,3 +1,4 @@
+using Avalonia.Headless.XUnit;
 using CAP.Avalonia.Controls;
 using CAP.Avalonia.ViewModels.Canvas;
 using Shouldly;
@@ -11,7 +12,7 @@ namespace UnitTests.Controls;
 /// </summary>
 public class DesignCanvasRefreshTests
 {
-    [Fact]
+    [AvaloniaFact]
     public void DesignCanvas_SetsRepaintCallback_WhenViewModelAssigned()
     {
         // Arrange
@@ -25,7 +26,7 @@ public class DesignCanvasRefreshTests
         viewModel.RepaintRequested.ShouldNotBeNull("RepaintRequested callback should be set when ViewModel is assigned");
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void DesignCanvas_ClearsRepaintCallback_WhenViewModelRemoved()
     {
         // Arrange
@@ -43,7 +44,7 @@ public class DesignCanvasRefreshTests
         viewModel.RepaintRequested.ShouldBeNull("RepaintRequested callback should be cleared when ViewModel is removed");
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void DesignCanvas_CanHandleMultipleViewModelChanges()
     {
         // Arrange
@@ -63,7 +64,7 @@ public class DesignCanvasRefreshTests
         viewModel2.RepaintRequested.ShouldNotBeNull("New ViewModel's callback should be set");
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void DesignCanvasViewModel_ComponentsClear_DoesNotThrow()
     {
         // Arrange
@@ -84,7 +85,7 @@ public class DesignCanvasRefreshTests
         viewModel.Components.Count.ShouldBe(0);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void DesignCanvasViewModel_ConnectionsClear_DoesNotThrow()
     {
         // Arrange

--- a/UnitTests/Visualization/GroupPowerFlowIntegrationTests.cs
+++ b/UnitTests/Visualization/GroupPowerFlowIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Avalonia.Headless.XUnit;
 using CAP.Avalonia.Visualization;
 using CAP_Core.Components;
 using CAP_Core.Components.Connections;
@@ -180,7 +181,7 @@ public class GroupPowerFlowIntegrationTests
     /// the same signal that was visible in ungrouped connections should remain
     /// visible (non-zero) in frozen paths after grouping.
     /// </summary>
-    [Fact]
+    [AvaloniaFact]
     public void UpdateFromSimulation_AfterGrouping_PreservesPowerVisualization()
     {
         // Arrange


### PR DESCRIPTION
## Problem
The Avalonia 11.3.13 bump in #572 made `Dispatcher.VerifyAccess()` strict. ~10 `[Fact]` tests that construct real Avalonia controls (`DesignCanvas`, `ScrollViewer`, `PowerFlowVisualizer`/`Pen`) started throwing `System.InvalidOperationException: Call from invalid thread` in CI — **order-dependently**, once the headless Avalonia app (added by #572) initializes the UI thread. `main` was passing by luck; #564's added tests perturbed ordering and exposed it.

## Fix
Convert exactly those tests to `[AvaloniaFact]` so they run on the Avalonia UI thread. Pure test-attribute change — **no production code touched**.

- `DesignCanvasRefreshTests` (5 tests)
- `ScrollPositionBehaviorTests` (4 of 6 — the `ScrollViewer`-constructing ones)
- `GroupPowerFlowIntegrationTests` (1 test)

## Verification
Build clean; converted classes pass locally (5/5, 6/6, 7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)