### PR TITLE
Fix copy/paste crash: Component.Clone() with override-replaced pins

### DIFF
--- a/Connect-A-Pic-Core/Components/Core/Component.cs
+++ b/Connect-A-Pic-Core/Components/Core/Component.cs
@@ -354,8 +354,14 @@ public class Component : ICloneable
             // now recreate the nonLinearConnections and assign them to the Matrix
             foreach (var nonLin in oldMatrix.NonLinearConnections)
             {
+                // Skip non-linear connections on pins absent from the cloned set (see the
+                // linear-connection note above): an override may have replaced the ports.
+                if (!oldToNewPinIds.TryGetValue(nonLin.Key.PinIdStart, out var nlStart) ||
+                    !oldToNewPinIds.TryGetValue(nonLin.Key.PinIdEnd, out var nlEnd))
+                    continue;
+
                 // convert the old Key to the new one.
-                var newKey = (oldToNewPinIds[nonLin.Key.PinIdStart], oldToNewPinIds[nonLin.Key.PinIdEnd]);
+                var newKey = (nlStart, nlEnd);
                 // recreate the non linear function with the new Pins.
                 var newFunction = MathExpressionReader.ConvertToDelegate(nonLin.Value.ConnectionsFunctionRaw, clonedPins, clonedSliderMap.Values.ToList());
                 // assign the new Pin and new function to our dictionary
@@ -437,8 +443,15 @@ public class Component : ICloneable
         var newConnections = new Dictionary<(Guid, Guid), Complex>();
         foreach (var oldConnection in oldMatrix.GetNonNullValues())
         {
-            var newKey = (oldToNewPinIds[oldConnection.Key.PinIdStart], oldToNewPinIds[oldConnection.Key.PinIdEnd]);
-            newConnections.Add(newKey, oldConnection.Value);
+            // Skip connections whose pins are no longer part of the component. A raw-code
+            // override (#561) can replace the ports while leaving stale S-matrix entries on
+            // the old pin IDs; those have no counterpart in the cloned pin set, so dropping
+            // them is the only sound option (cloning must not throw — issue: copy/paste crash).
+            if (!oldToNewPinIds.TryGetValue(oldConnection.Key.PinIdStart, out var newStart) ||
+                !oldToNewPinIds.TryGetValue(oldConnection.Key.PinIdEnd, out var newEnd))
+                continue;
+
+            newConnections.Add((newStart, newEnd), oldConnection.Value);
         }
         return newConnections;
     }

--- a/UnitTests/Components/ComponentCloneOrphanPinTests.cs
+++ b/UnitTests/Components/ComponentCloneOrphanPinTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Regression tests for <see cref="Component.Clone"/> when the S-matrix references pin IDs
+/// that are no longer present in the component's Parts — the situation a raw-code Nazca
+/// override creates when it replaces the component's ports (#561). Cloning (copy/paste)
+/// must not throw a <see cref="KeyNotFoundException"/>; orphaned connections are dropped.
+/// </summary>
+public class ComponentCloneOrphanPinTests
+{
+    private static Component CreateComponentWithOrphanSMatrixPin(out int validConnectionCount)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>
+        {
+            new("west0", 0, MatterType.Light, RectSide.Left),
+            new("east0", 1, MatterType.Light, RectSide.Right),
+        });
+
+        var leftIn = parts[0, 0].GetPinAt(RectSide.Left).IDInFlow;
+        var rightOut = parts[0, 0].GetPinAt(RectSide.Right).IDOutFlow;
+
+        // Pins that exist in the S-matrix but NOT in Parts — simulates a raw-code override
+        // having replaced the ports while a stale S-matrix entry still references the old pin.
+        var orphanIn = Guid.NewGuid();
+        var orphanOut = Guid.NewGuid();
+
+        var partPinIds = Component.GetAllPins(parts)
+            .SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow });
+        var allPinIds = partPinIds.Concat(new[] { orphanIn, orphanOut }).ToList();
+
+        var matrix = new SMatrix(allPinIds, new());
+        matrix.SetValues(new()
+        {
+            { (leftIn, rightOut), Complex.One },   // valid: both pins in Parts
+            { (orphanIn, orphanOut), 0.5 },        // orphan: pins absent from Parts
+        });
+
+        var connections = new Dictionary<int, SMatrix> { { StandardWaveLengths.RedNM, matrix } };
+        validConnectionCount = 1;
+        return new Component(connections, new(), "placeCell_StraightWG", "", parts, 0, "Straight", DiscreteRotation.R0);
+    }
+
+    [Fact]
+    public void Clone_SMatrixReferencesPinAbsentFromParts_DoesNotThrow()
+    {
+        var component = CreateComponentWithOrphanSMatrixPin(out _);
+
+        Should.NotThrow(() => component.Clone());
+    }
+
+    [Fact]
+    public void Clone_DropsOrphanConnection_ButKeepsValidOne()
+    {
+        var component = CreateComponentWithOrphanSMatrixPin(out var validConnectionCount);
+
+        var clone = (Component)component.Clone();
+
+        var clonedMatrix = clone.WaveLengthToSMatrixMap[StandardWaveLengths.RedNM];
+        clonedMatrix.GetNonNullValues().Count.ShouldBe(validConnectionCount,
+            "The in-Parts connection must survive cloning; the orphan connection is dropped.");
+    }
+}


### PR DESCRIPTION
## Problem
Copy/pasting a component whose ports were replaced by a raw-code Nazca override (#561) crashed the app (`exit 134`) on Ctrl+V:

```
KeyNotFoundException: key '…' not present in dictionary
  at Component.CreateConnectionsWithUpdatedPins  Component.cs:440
  at Component.Clone()                           Component.cs:351
  at ComponentClipboard.Paste(...)
```

`Component.Clone()` remaps each S-matrix connection's pin IDs through `oldToNewPinIds` (built from the component's **Parts**). An override leaves stale S-matrix entries on the **old** pin IDs, which are absent from the new pin set → the direct dictionary index threw.

## Fix
Both the linear (`CreateConnectionsWithUpdatedPins`) and non-linear connection remapping now **skip** connections whose pins are not in the cloned pin set — orphaned entries that have no counterpart in the clone anyway. Valid in-Parts connections are unchanged.

## Tests
`ComponentCloneOrphanPinTests` reproduces the crash (S-matrix referencing a pin absent from Parts) and asserts:
- cloning does not throw,
- the orphan connection is dropped while the valid one survives.

Local: new tests 2/2, existing copy/paste 24/24, full suite 2501 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)