### PR TITLE
(+) S-matrix override scoped by geometry identity + save-time GC (fixes copy/paste override loss)

### DIFF
--- a/CAP.Avalonia/Services/ComponentGeometryKey.cs
+++ b/CAP.Avalonia/Services/ComponentGeometryKey.cs
@@ -1,0 +1,39 @@
+// CAP.Avalonia/Services/ComponentGeometryKey.cs
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Geometry identity of a component, used to scope S-matrix overrides: components with
+/// the same geometry must share the same (recomputed) S-matrix. When a raw-code Nazca
+/// override (#561) is active the code itself defines the geometry; otherwise the Nazca
+/// call (module|function|parameters) does. Same identity ⇒ same key.
+/// </summary>
+public static class ComponentGeometryKey
+{
+    /// <summary>Bump to invalidate all geometry-scoped override keys.</summary>
+    public const int FormatVersion = 1;
+
+    /// <summary>
+    /// Builds the geometry key. <paramref name="rawCodeLookup"/> returns the active raw-code
+    /// override for the component (e.g. from StoredNazcaOverrides), or null if none.
+    /// </summary>
+    public static string For(Component component, Func<Component, string?> rawCodeLookup)
+    {
+        var raw = rawCodeLookup(component);
+        if (!string.IsNullOrWhiteSpace(raw))
+            return $"raw:v{FormatVersion}-{Hash(raw)}";
+
+        var material = $"{component.NazcaModuleName}{component.NazcaFunctionName}{component.NazcaFunctionParameters}";
+        return $"geo:v{FormatVersion}-{Hash(material)}";
+    }
+
+    private static string Hash(string s)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(s));
+        return Convert.ToHexString(bytes, 0, 12).ToLowerInvariant();
+    }
+}

--- a/CAP.Avalonia/Services/ComponentGeometryKey.cs
+++ b/CAP.Avalonia/Services/ComponentGeometryKey.cs
@@ -17,6 +17,9 @@ public static class ComponentGeometryKey
     /// <summary>Bump to invalidate all geometry-scoped override keys.</summary>
     public const int FormatVersion = 1;
 
+    /// <summary>ASCII unit separator — never appears in module/function/parameter strings.</summary>
+    private const char FieldSeparator = (char)31;
+
     /// <summary>
     /// Builds the geometry key. <paramref name="rawCodeLookup"/> returns the active raw-code
     /// override for the component (e.g. from StoredNazcaOverrides), or null if none.
@@ -27,7 +30,8 @@ public static class ComponentGeometryKey
         if (!string.IsNullOrWhiteSpace(raw))
             return $"raw:v{FormatVersion}-{Hash(raw)}";
 
-        var material = $"{component.NazcaModuleName}{component.NazcaFunctionName}{component.NazcaFunctionParameters}";
+        // Separate fields so distinct tuples can't collide via boundary shifts.
+        var material = $"{component.NazcaModuleName}{FieldSeparator}{component.NazcaFunctionName}{FieldSeparator}{component.NazcaFunctionParameters}";
         return $"geo:v{FormatVersion}-{Hash(material)}";
     }
 

--- a/CAP.Avalonia/Services/SMatrixOverrideApplicator.cs
+++ b/CAP.Avalonia/Services/SMatrixOverrideApplicator.cs
@@ -132,16 +132,19 @@ public static class SMatrixOverrideApplicator
 
     /// <summary>
     /// Applies all S-matrix overrides in <paramref name="storedSMatrices"/> to matching
-    /// components. A component matches by <see cref="Component.Identifier"/>, with an
-    /// optional <paramref name="templateKeyResolver"/> consulted as a fallback so PDK-
-    /// template-scoped overrides (key shape <c>"{pdkSource}::{templateName}"</c>) reach
-    /// every instance of that template.
+    /// components. A component matches by <see cref="Component.Identifier"/> first;
+    /// if no direct match is found, the optional <paramref name="geometryKeyResolver"/>
+    /// is consulted so identical-geometry instances and copies can share one override;
+    /// finally the optional <paramref name="templateKeyResolver"/> is used as a last
+    /// fallback for PDK-template-scoped overrides
+    /// (key shape <c>"{pdkSource}::{templateName}"</c>).
     /// Keys with no matching component are reported as orphans rather than silently kept.
     /// </summary>
     public static ApplyAllResult ApplyAll(
         IEnumerable<Component> components,
         IReadOnlyDictionary<string, ComponentSMatrixData> storedSMatrices,
         Func<Component, string?>? templateKeyResolver = null,
+        Func<Component, string?>? geometryKeyResolver = null,
         ErrorConsoleService? errorConsole = null,
         Func<string, bool>? keyMatchesKnownTemplate = null,
         bool reportOrphans = false)
@@ -157,9 +160,15 @@ public static class SMatrixOverrideApplicator
                 resolvedKey = comp.Identifier;
             else
             {
-                var templateKey = templateKeyResolver?.Invoke(comp);
-                if (templateKey != null && storedSMatrices.TryGetValue(templateKey, out data))
-                    resolvedKey = templateKey;
+                var geomKey = geometryKeyResolver?.Invoke(comp);
+                if (geomKey != null && storedSMatrices.TryGetValue(geomKey, out data))
+                    resolvedKey = geomKey;
+                else
+                {
+                    var templateKey = templateKeyResolver?.Invoke(comp);
+                    if (templateKey != null && storedSMatrices.TryGetValue(templateKey, out data))
+                        resolvedKey = templateKey;
+                }
             }
 
             if (resolvedKey != null && data != null)

--- a/CAP.Avalonia/Services/SMatrixOverrideGc.cs
+++ b/CAP.Avalonia/Services/SMatrixOverrideGc.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Garbage-collects project-local S-matrix overrides at save time: keeps only entries
+/// whose geometry key is still used by a placed component, plus legacy per-Identifier
+/// entries whose component still exists, plus template-scoped ("::") entries (user-global
+/// migrated). Orphans (e.g. after a parameter change) are dropped.
+/// </summary>
+public static class SMatrixOverrideGc
+{
+    /// <summary>Returns the subset of <paramref name="store"/> that should be persisted.</summary>
+    public static Dictionary<string, ComponentSMatrixData> Sweep(
+        IReadOnlyDictionary<string, ComponentSMatrixData> store,
+        IReadOnlySet<string> usedGeometryKeys,
+        IReadOnlySet<string> liveIdentifiers)
+    {
+        var kept = new Dictionary<string, ComponentSMatrixData>();
+        foreach (var (key, value) in store)
+        {
+            var keep = usedGeometryKeys.Contains(key)
+                       || liveIdentifiers.Contains(key)
+                       || key.Contains("::", System.StringComparison.Ordinal);
+            if (keep) kept[key] = value;
+        }
+        return kept;
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Display.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Display.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using System.Linq;
+
+namespace CAP.Avalonia.ViewModels.ComponentSettings;
+
+/// <summary>
+/// S-matrix list display half of the dialog: rebuilds the stored-entry list and the
+/// "currently effective S-matrix" list (with per-wavelength override tags) from the
+/// override store and the live component's resolved matrices.
+/// </summary>
+public partial class ComponentSettingsDialogViewModel
+{
+    private void RefreshEntries(bool notifyChanged)
+    {
+        SMatrixEntries.Clear();
+
+        if (_storedSMatrices == null || !_storedSMatrices.TryGetValue(_smatrixKey, out var data))
+        {
+            HasSMatrices = false;
+            if (notifyChanged)
+            {
+                RefreshEffectiveEntries();
+                _onChanged?.Invoke();
+            }
+            return;
+        }
+
+        foreach (var kvp in data.Wavelengths.OrderBy(k => k.Key))
+            SMatrixEntries.Add(new SMatrixEntryViewModel(kvp.Key, kvp.Value, data.SourceNote));
+
+        HasSMatrices = SMatrixEntries.Count > 0;
+        if (notifyChanged)
+        {
+            RefreshEffectiveEntries();
+            _onChanged?.Invoke();
+        }
+    }
+
+    private void RefreshEffectiveEntries()
+    {
+        EffectiveEntries.Clear();
+        if (_effectiveSMatrices == null || _effectivePins == null)
+        {
+            HasEffectiveEntries = false;
+            return;
+        }
+
+        foreach (var kvp in _effectiveSMatrices.OrderBy(k => k.Key))
+        {
+            // A wavelength is "overridden" iff the active store has an entry
+            // with the same wavelength key — a wavelength present in the
+            // PDK default but not in the override is still PDK-driven.
+            bool isOverridden =
+                _storedSMatrices != null &&
+                _storedSMatrices.TryGetValue(_smatrixKey, out var data) &&
+                data.Wavelengths.ContainsKey(kvp.Key.ToString(CultureInfo.InvariantCulture));
+
+            EffectiveEntries.Add(new EffectiveSMatrixEntryViewModel(
+                kvp.Key, kvp.Value, _effectivePins, isOverridden));
+        }
+
+        HasEffectiveEntries = EffectiveEntries.Count > 0;
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.Fdtd.cs
@@ -104,7 +104,7 @@ public partial class ComponentSettingsDialogViewModel
 
             var note = $"FDTD Meep {(result.Is3D ? "3D" : "2D")}";
             var data = FdtdSMatrixConverter.ToComponentSMatrixData(result, note);
-            _storedSMatrices[_entityKey] = data;
+            _storedSMatrices[_smatrixKey] = data;
 
             var applyResult = SMatrixOverrideApplicator.Apply(_liveComponent, data, _errorConsole);
             SolverStatus = BuildSolverStatus(result, applyResult);

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -28,7 +28,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
 
     private Dictionary<string, ComponentSMatrixData>? _storedSMatrices;
     private Component? _liveComponent;
-    private string _entityKey = string.Empty;
+    private string _smatrixKey = string.Empty;
     private string _displayName = string.Empty;
     private Action? _onChanged;
     private bool _isUserGlobalScope;
@@ -125,9 +125,15 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     /// Configures the dialog for a specific entity (PDK template or canvas instance).
     /// </summary>
     /// <param name="entityKey">
-    /// Key used to store and retrieve S-matrix data in <paramref name="storedSMatrices"/>.
+    /// Per-instance key used for the Nazca raw-code override side
+    /// (<see cref="InstanceNazcaCodeEditorViewModel"/> / <c>storedNazcaOverrides</c>).
     /// For canvas instances this is <c>component.Identifier</c>;
     /// for PDK templates it is <c>"pdkSource::templateName"</c>.
+    /// </param>
+    /// <param name="smatrixKey">
+    /// Key used to store and retrieve S-matrix data in <paramref name="storedSMatrices"/>.
+    /// For canvas instances this is the geometry identity (so a copy inherits a
+    /// recomputed/imported S-matrix); for PDK templates it is <c>"pdkSource::templateName"</c>.
     /// </param>
     /// <param name="displayName">Human-readable name shown in the title bar.</param>
     /// <param name="storedSMatrices">Shared dictionary from <c>FileOperationsViewModel</c>.</param>
@@ -179,6 +185,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     /// </param>
     public void Configure(
         string entityKey,
+        string smatrixKey,
         string displayName,
         Dictionary<string, ComponentSMatrixData> storedSMatrices,
         Component? liveComponent = null,
@@ -197,7 +204,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         Action? nazcaDimensionsChanged = null,
         Action<IReadOnlyList<PhysicalPin>>? nazcaPinsChanged = null)
     {
-        _entityKey = entityKey;
+        _smatrixKey = smatrixKey;
         _displayName = displayName;
         _storedSMatrices = storedSMatrices;
         _liveComponent = liveComponent;
@@ -302,7 +309,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
                 return; // user cancelled — StatusText already set
 
             var smatrixData = SParameterConverter.ToComponentSMatrixData(resolved);
-            _storedSMatrices[_entityKey] = smatrixData;
+            _storedSMatrices[_smatrixKey] = smatrixData;
 
             ApplyResult? applyResult = null;
             if (_liveComponent != null)
@@ -393,12 +400,12 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     [RelayCommand]
     private void DeleteEntry(SMatrixEntryViewModel entry)
     {
-        if (_storedSMatrices == null || !_storedSMatrices.TryGetValue(_entityKey, out var data))
+        if (_storedSMatrices == null || !_storedSMatrices.TryGetValue(_smatrixKey, out var data))
             return;
 
         data.Wavelengths.Remove(entry.WavelengthKey);
         if (data.Wavelengths.Count == 0)
-            _storedSMatrices.Remove(_entityKey);
+            _storedSMatrices.Remove(_smatrixKey);
 
         if (_liveComponent != null && int.TryParse(entry.WavelengthKey, out int wavelengthNm))
             _liveComponent.WaveLengthToSMatrixMap.Remove(wavelengthNm);
@@ -411,7 +418,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     {
         SMatrixEntries.Clear();
 
-        if (_storedSMatrices == null || !_storedSMatrices.TryGetValue(_entityKey, out var data))
+        if (_storedSMatrices == null || !_storedSMatrices.TryGetValue(_smatrixKey, out var data))
         {
             HasSMatrices = false;
             if (notifyChanged)
@@ -449,7 +456,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
             // PDK default but not in the override is still PDK-driven.
             bool isOverridden =
                 _storedSMatrices != null &&
-                _storedSMatrices.TryGetValue(_entityKey, out var data) &&
+                _storedSMatrices.TryGetValue(_smatrixKey, out var data) &&
                 data.Wavelengths.ContainsKey(kvp.Key.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
             EffectiveEntries.Add(new EffectiveSMatrixEntryViewModel(

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -29,6 +29,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     private Dictionary<string, ComponentSMatrixData>? _storedSMatrices;
     private Component? _liveComponent;
     private string _smatrixKey = string.Empty;
+    private Func<string>? _smatrixKeyResolver;
     private string _displayName = string.Empty;
     private Action? _onChanged;
     private bool _isUserGlobalScope;
@@ -183,6 +184,13 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
     /// <param name="templateModuleName">
     /// Original PDK template module name, or null if not set.
     /// </param>
+    /// <param name="smatrixKeyResolver">
+    /// Optional resolver that recomputes <paramref name="smatrixKey"/> from the live
+    /// component's current geometry identity. Invoked when a Nazca geometry override is
+    /// applied or reset (which changes the identity), so the S-matrix entry list stays in
+    /// sync without reopening the dialog. Pass the same expression that produced
+    /// <paramref name="smatrixKey"/>; null disables re-resolution (per-template mode).
+    /// </param>
     public void Configure(
         string entityKey,
         string smatrixKey,
@@ -202,9 +210,11 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         string? nazcaTemplateCode = null,
         Func<double, double, IReadOnlyList<string>>? nazcaOverlapCheck = null,
         Action? nazcaDimensionsChanged = null,
-        Action<IReadOnlyList<PhysicalPin>>? nazcaPinsChanged = null)
+        Action<IReadOnlyList<PhysicalPin>>? nazcaPinsChanged = null,
+        Func<string>? smatrixKeyResolver = null)
     {
         _smatrixKey = smatrixKey;
+        _smatrixKeyResolver = smatrixKeyResolver;
         _displayName = displayName;
         _storedSMatrices = storedSMatrices;
         _liveComponent = liveComponent;
@@ -218,7 +228,10 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
             : $"Component Settings: {displayName}";
         StatusText = string.Empty;
 
-        // Only create the Nazca override VM for per-instance mode
+        // Only create the Nazca override VM for per-instance mode.
+        // The Nazca VMs report through OnNazcaGeometryChanged (not the raw onChanged) so the
+        // dialog re-resolves the S-matrix key first: a geometry override changes the component's
+        // geometry identity, hence the key its S-matrix override is stored under.
         if (liveComponent != null && storedNazcaOverrides != null && templateFunctionName != null)
         {
             NazcaOverride = new InstanceNazcaOverrideViewModel(
@@ -228,7 +241,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
                 templateFunctionName,
                 templateFunctionParameters ?? string.Empty,
                 templateModuleName,
-                onChanged);
+                OnNazcaGeometryChanged);
         }
         else
         {
@@ -251,7 +264,7 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
                 nazcaPreviewService,
                 nazcaOverlapCheck,
                 nazcaDimensionsChanged,
-                onChanged,
+                OnNazcaGeometryChanged,
                 nazcaPinsChanged);
         }
         else
@@ -265,6 +278,19 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         RefreshEffectiveEntries();
         OnPropertyChanged(nameof(CanRecalculate));
         RecalculateSMatrixCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Invoked when a Nazca geometry override is applied or reset. The override changes the
+    /// component's geometry identity, so its S-matrix override is now keyed differently —
+    /// re-resolve the key and rebuild the entry lists so the dialog reflects the new geometry
+    /// without needing to be closed and reopened. Then notify external observers.
+    /// </summary>
+    private void OnNazcaGeometryChanged()
+    {
+        if (_smatrixKeyResolver != null)
+            _smatrixKey = _smatrixKeyResolver();
+        RefreshEntries(notifyChanged: true);
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -414,58 +414,6 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         RefreshEntries(notifyChanged: true);
     }
 
-    private void RefreshEntries(bool notifyChanged)
-    {
-        SMatrixEntries.Clear();
-
-        if (_storedSMatrices == null || !_storedSMatrices.TryGetValue(_smatrixKey, out var data))
-        {
-            HasSMatrices = false;
-            if (notifyChanged)
-            {
-                RefreshEffectiveEntries();
-                _onChanged?.Invoke();
-            }
-            return;
-        }
-
-        foreach (var kvp in data.Wavelengths.OrderBy(k => k.Key))
-            SMatrixEntries.Add(new SMatrixEntryViewModel(kvp.Key, kvp.Value, data.SourceNote));
-
-        HasSMatrices = SMatrixEntries.Count > 0;
-        if (notifyChanged)
-        {
-            RefreshEffectiveEntries();
-            _onChanged?.Invoke();
-        }
-    }
-
-    private void RefreshEffectiveEntries()
-    {
-        EffectiveEntries.Clear();
-        if (_effectiveSMatrices == null || _effectivePins == null)
-        {
-            HasEffectiveEntries = false;
-            return;
-        }
-
-        foreach (var kvp in _effectiveSMatrices.OrderBy(k => k.Key))
-        {
-            // A wavelength is "overridden" iff the active store has an entry
-            // with the same wavelength key — a wavelength present in the
-            // PDK default but not in the override is still PDK-driven.
-            bool isOverridden =
-                _storedSMatrices != null &&
-                _storedSMatrices.TryGetValue(_smatrixKey, out var data) &&
-                data.Wavelengths.ContainsKey(kvp.Key.ToString(System.Globalization.CultureInfo.InvariantCulture));
-
-            EffectiveEntries.Add(new EffectiveSMatrixEntryViewModel(
-                kvp.Key, kvp.Value, _effectivePins, isOverridden));
-        }
-
-        HasEffectiveEntries = EffectiveEntries.Count > 0;
-    }
-
     private ISParameterImporter? FindImporter(string path)
     {
         var ext = Path.GetExtension(path).ToLowerInvariant();

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -169,6 +169,7 @@ public partial class FileOperationsViewModel : ObservableObject
                 addedComponents,
                 StoredSMatrices,
                 templateKeyResolver: ResolveTemplateKey,
+                geometryKeyResolver: ResolveGeometryKey,
                 errorConsole: _errorConsole,
                 keyMatchesKnownTemplate: KeyMatchesKnownLibraryTemplate);
         }
@@ -308,7 +309,17 @@ public partial class FileOperationsViewModel : ObservableObject
             designData.FormatVersion = CurrentFormatVersion;
             designData.Metadata = BuildMetadataForSave();
             if (StoredSMatrices.Count > 0)
-                designData.SMatrices = new Dictionary<string, ComponentSMatrixData>(StoredSMatrices);
+            {
+                // Drop overrides orphaned by a parameter/geometry change before persisting:
+                // keep only entries still reachable from a placed component (by geometry key
+                // or legacy Identifier) plus template-scoped ("::") user-global entries.
+                var live = _canvas.Components.Select(vm => vm.Component).ToList();
+                var usedGeometryKeys = live.Select(ResolveGeometryKey).ToHashSet();
+                var liveIdentifiers = live.Select(c => c.Identifier).ToHashSet();
+                var swept = Services.SMatrixOverrideGc.Sweep(StoredSMatrices, usedGeometryKeys, liveIdentifiers);
+                if (swept.Count > 0)
+                    designData.SMatrices = swept;
+            }
             if (StoredNazcaOverrides.Count > 0)
                 designData.NazcaOverrides = new Dictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>(StoredNazcaOverrides);
             designData.ChipWidthMicrometers  = _canvas.ChipMaxX;
@@ -375,6 +386,17 @@ public partial class FileOperationsViewModel : ObservableObject
         var templateName = FindTemplateName(component);
         return $"{pdkSource}::{templateName}";
     }
+
+    /// <summary>
+    /// Builds the geometry-scoped override-store key for a component, so that an
+    /// override imported under a geometry key (FDTD / S-parameter import) re-applies
+    /// to every placed instance and copy sharing that geometry. Threads the live
+    /// raw-code override (if any) through <see cref="Services.ComponentGeometryKey.For"/>.
+    /// </summary>
+    private string ResolveGeometryKey(Component component) =>
+        CAP.Avalonia.Services.ComponentGeometryKey.For(
+            component,
+            c => StoredNazcaOverrides.TryGetValue(c.Identifier, out var o) ? o.RawCode : null);
 
     /// <summary>
     /// Returns true when the given override-store key (shape
@@ -769,6 +791,7 @@ public partial class FileOperationsViewModel : ObservableObject
                         allComponents,
                         StoredSMatrices,
                         templateKeyResolver: ResolveTemplateKey,
+                        geometryKeyResolver: ResolveGeometryKey,
                         errorConsole: _errorConsole,
                         keyMatchesKnownTemplate: KeyMatchesKnownLibraryTemplate,
                         reportOrphans: true);

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -691,13 +691,14 @@ public partial class MainWindow : Window
         // component's geometry identity so a copy inherits them; the per-instance
         // Nazca raw-code override keeps using entityKey (component.Identifier).
         // The library/template path has no live component and keeps the {PdkSource}::{Name} key.
-        string smatrixKey;
-        if (liveComponent != null)
-            smatrixKey = CAP.Avalonia.Services.ComponentGeometryKey.For(
+        // Resolve lazily so the dialog can re-derive the key after a Nazca geometry override
+        // (raw code / parameters) changes the identity mid-session.
+        Func<string> smatrixKeyResolver = liveComponent != null
+            ? () => CAP.Avalonia.Services.ComponentGeometryKey.For(
                 liveComponent,
-                c => vm.FileOperations.StoredNazcaOverrides.TryGetValue(c.Identifier, out var o) ? o.RawCode : null);
-        else
-            smatrixKey = entityKey;
+                c => vm.FileOperations.StoredNazcaOverrides.TryGetValue(c.Identifier, out var o) ? o.RawCode : null)
+            : () => entityKey;
+        string smatrixKey = smatrixKeyResolver();
 
         dialogVm.Configure(
             entityKey,
@@ -718,7 +719,8 @@ public partial class MainWindow : Window
             nazcaTemplateCode: nazcaTemplateCode,
             nazcaOverlapCheck: nazcaOverlapCheck,
             nazcaDimensionsChanged: nazcaDimensionsChanged,
-            nazcaPinsChanged: nazcaPinsChanged);
+            nazcaPinsChanged: nazcaPinsChanged,
+            smatrixKeyResolver: smatrixKeyResolver);
 
         var dialog = new ComponentSettingsDialog { DataContext = dialogVm };
         dialog.Show(this);

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -687,8 +687,21 @@ public partial class MainWindow : Window
             };
         }
 
+        // S-matrix overrides (FDTD recompute / file import) are stored under the
+        // component's geometry identity so a copy inherits them; the per-instance
+        // Nazca raw-code override keeps using entityKey (component.Identifier).
+        // The library/template path has no live component and keeps the {PdkSource}::{Name} key.
+        string smatrixKey;
+        if (liveComponent != null)
+            smatrixKey = CAP.Avalonia.Services.ComponentGeometryKey.For(
+                liveComponent,
+                c => vm.FileOperations.StoredNazcaOverrides.TryGetValue(c.Identifier, out var o) ? o.RawCode : null);
+        else
+            smatrixKey = entityKey;
+
         dialogVm.Configure(
             entityKey,
+            smatrixKey,
             displayName,
             store,
             liveComponent,

--- a/Connect-A-Pic-Core/Components/Core/Component.cs
+++ b/Connect-A-Pic-Core/Components/Core/Component.cs
@@ -385,6 +385,10 @@ public class Component : ICloneable
         clonedComponent.RotationDegrees = RotationDegrees;
         clonedComponent.NazcaOriginOffsetX = NazcaOriginOffsetX;
         clonedComponent.NazcaOriginOffsetY = NazcaOriginOffsetY;
+        // The module is part of the component's geometry identity (it picks the Nazca cell):
+        // without it a copy renders against the wrong module and its geometry-scoped S-matrix
+        // override no longer matches the original.
+        clonedComponent.NazcaModuleName = NazcaModuleName;
         clonedComponent.IsLocked = false;  // Cloned components should always be unlocked
         clonedComponent.HumanReadableName = HumanReadableName;
 

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogEffectiveDisplayTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogEffectiveDisplayTests.cs
@@ -54,7 +54,7 @@ public class ComponentSettingsDialogEffectiveDisplayTests
     public void Configure_NoEffectiveData_HidesSection()
     {
         var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
-        vm.Configure("comp_1", "MyComp", new Dictionary<string, ComponentSMatrixData>());
+        vm.Configure("comp_1", "comp_1", "MyComp", new Dictionary<string, ComponentSMatrixData>());
 
         vm.HasEffectiveEntries.ShouldBeFalse();
         vm.EffectiveEntries.Count.ShouldBe(0);
@@ -70,6 +70,7 @@ public class ComponentSettingsDialogEffectiveDisplayTests
 
         var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
         vm.Configure(
+            "comp_1",
             "comp_1",
             "MyComp",
             new Dictionary<string, ComponentSMatrixData>(),
@@ -115,6 +116,7 @@ public class ComponentSettingsDialogEffectiveDisplayTests
         var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
         vm.Configure(
             "comp_1",
+            "comp_1",
             "MyComp",
             store,
             effectiveSMatrices: effective,
@@ -154,6 +156,7 @@ public class ComponentSettingsDialogEffectiveDisplayTests
 
         var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
         vm.Configure(
+            "comp_1",
             "comp_1",
             "MyComp",
             store,

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogFdtdTests.cs
@@ -40,7 +40,7 @@ public class ComponentSettingsDialogFdtdTests
     public void CanRecalculate_IsFalse_WithoutFdtdWiring()
     {
         var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
-        vm.Configure("c", "C", new Dictionary<string, ComponentSMatrixData>(),
+        vm.Configure("c", "c", "C", new Dictionary<string, ComponentSMatrixData>(),
             liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
 
         vm.CanRecalculate.ShouldBeFalse();
@@ -60,7 +60,7 @@ public class ComponentSettingsDialogFdtdTests
             Mock.Of<IFileDialogService>(),
             fdtdService: service.Object,
             fdtdRequestFactory: FakeFactory());
-        vm.Configure("comp", "Comp", store,
+        vm.Configure("comp", "comp", "Comp", store,
             liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
 
         vm.CanRecalculate.ShouldBeTrue();
@@ -86,7 +86,7 @@ public class ComponentSettingsDialogFdtdTests
             Mock.Of<IFileDialogService>(),
             fdtdService: service.Object,
             fdtdRequestFactory: FakeFactory());
-        vm.Configure("comp", "Comp", store,
+        vm.Configure("comp", "comp", "Comp", store,
             liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
 
         await vm.RecalculateSMatrixCommand.ExecuteAsync(null);
@@ -107,7 +107,7 @@ public class ComponentSettingsDialogFdtdTests
             Mock.Of<IFileDialogService>(),
             fdtdService: service.Object,
             fdtdRequestFactory: FakeFactory());
-        vm.Configure("comp", "Comp", store,
+        vm.Configure("comp", "comp", "Comp", store,
             liveComponent: TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins());
 
         await vm.RecalculateSMatrixCommand.ExecuteAsync(null);

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogImportIntegrationTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogImportIntegrationTests.cs
@@ -40,7 +40,7 @@ public class ComponentSettingsDialogImportIntegrationTests
             .ReturnsAsync(path);
 
         var vm = new ComponentSettingsDialogViewModel(fileDialog.Object);
-        vm.Configure("comp_bdc", "BDC TE 1550", store);
+        vm.Configure("comp_bdc", "comp_bdc", "BDC TE 1550", store);
 
         await vm.LoadFromFileCommand.ExecuteAsync(null);
 
@@ -100,7 +100,7 @@ public class ComponentSettingsDialogImportIntegrationTests
             .ReturnsAsync(path);
 
         var vm = new ComponentSettingsDialogViewModel(fileDialog.Object);
-        vm.Configure("comp_bdc", "BDC TE 1550", store);
+        vm.Configure("comp_bdc", "comp_bdc", "BDC TE 1550", store);
         await vm.LoadFromFileCommand.ExecuteAsync(null);
 
         var totalBefore = vm.SMatrixEntries.Count;

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogUserGlobalScopeTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogUserGlobalScopeTests.cs
@@ -59,6 +59,7 @@ public class ComponentSettingsDialogUserGlobalScopeTests : IDisposable
         bool onChangedFired = false;
         vm.Configure(
             entityKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
+            smatrixKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
             displayName: "2x2 MMI Coupler",
             storedSMatrices: userStore.Overrides,
             liveComponent: null,
@@ -89,6 +90,7 @@ public class ComponentSettingsDialogUserGlobalScopeTests : IDisposable
 
         vm.Configure(
             entityKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
+            smatrixKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
             displayName: "2x2 MMI Coupler",
             storedSMatrices: userStore.Overrides,
             isUserGlobalScope: true);
@@ -104,6 +106,7 @@ public class ComponentSettingsDialogUserGlobalScopeTests : IDisposable
 
         vm.Configure(
             entityKey: "comp_1",
+            smatrixKey: "comp_1",
             displayName: "MyComponent_1",
             storedSMatrices: store,
             isUserGlobalScope: false);
@@ -135,6 +138,7 @@ public class ComponentSettingsDialogUserGlobalScopeTests : IDisposable
         var vm = new ComponentSettingsDialogViewModel(Mock.Of<IFileDialogService>());
         vm.Configure(
             entityKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
+            smatrixKey: "siepic-ebeam-pdk::2x2 MMI Coupler",
             displayName: "2x2 MMI Coupler",
             storedSMatrices: userStore.Overrides,
             onChanged: userStore.Save,

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogViewModelTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogViewModelTests.cs
@@ -44,7 +44,7 @@ public class ComponentSettingsDialogViewModelTests
         var store = MakeStore("comp_1", "1550", "1310");
         var vm = NewVm();
 
-        vm.Configure("comp_1", "My Component", store);
+        vm.Configure("comp_1", "comp_1", "My Component", store);
 
         vm.SMatrixEntries.Count.ShouldBe(2);
         vm.HasSMatrices.ShouldBeTrue();
@@ -57,7 +57,7 @@ public class ComponentSettingsDialogViewModelTests
         var store = MakeStore("comp_1", "1550");
         var vm = NewVm();
 
-        vm.Configure("comp_99", "Unknown", store);
+        vm.Configure("comp_99", "comp_99", "Unknown", store);
 
         vm.SMatrixEntries.Count.ShouldBe(0);
         vm.HasSMatrices.ShouldBeFalse();
@@ -73,7 +73,7 @@ public class ComponentSettingsDialogViewModelTests
         var vm = NewVm();
         int callCount = 0;
 
-        vm.Configure("comp_1", "My Component", store, onChanged: () => callCount++);
+        vm.Configure("comp_1", "comp_1", "My Component", store, onChanged: () => callCount++);
 
         callCount.ShouldBe(0);
     }
@@ -83,7 +83,7 @@ public class ComponentSettingsDialogViewModelTests
     {
         var store = MakeStore("comp_1", "1550", "1310");
         var vm = NewVm();
-        vm.Configure("comp_1", "My Component", store);
+        vm.Configure("comp_1", "comp_1", "My Component", store);
 
         var entryToDelete = vm.SMatrixEntries.First();
         var deletedKey = entryToDelete.WavelengthKey;
@@ -102,7 +102,7 @@ public class ComponentSettingsDialogViewModelTests
     {
         var store = MakeStore("comp_1", "1550");
         var vm = NewVm();
-        vm.Configure("comp_1", "My Component", store);
+        vm.Configure("comp_1", "comp_1", "My Component", store);
 
         vm.DeleteEntryCommand.Execute(vm.SMatrixEntries[0]);
 
@@ -124,7 +124,7 @@ public class ComponentSettingsDialogViewModelTests
         liveComponent.WaveLengthToSMatrixMap.ShouldContainKey(1550);
 
         var vm = NewVm();
-        vm.Configure("comp_1", "My Component", store, liveComponent);
+        vm.Configure("comp_1", "comp_1", "My Component", store, liveComponent);
 
         vm.DeleteEntryCommand.Execute(vm.SMatrixEntries[0]);
 
@@ -136,7 +136,7 @@ public class ComponentSettingsDialogViewModelTests
     {
         var store = MakeStore("comp_1", "1550");
         var vm = NewVm();
-        vm.Configure("comp_1", "My Component", store);
+        vm.Configure("comp_1", "comp_1", "My Component", store);
 
         store["comp_1"].Wavelengths["980"] = new SMatrixWavelengthEntry
         {
@@ -145,7 +145,7 @@ public class ComponentSettingsDialogViewModelTests
             Imag = new List<double> { 0, 0, 0, 0 }
         };
 
-        vm.Configure("comp_1", "My Component", store);
+        vm.Configure("comp_1", "comp_1", "My Component", store);
 
         vm.SMatrixEntries.Count.ShouldBe(2);
     }
@@ -208,7 +208,7 @@ public class ComponentSettingsDialogViewModelTests
             .Setup(s => s.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync((string?)null);
         var vm = new ComponentSettingsDialogViewModel(fileDialog.Object);
-        vm.Configure("comp_1", "My Component", store);
+        vm.Configure("comp_1", "comp_1", "My Component", store);
         var entryCountBefore = vm.SMatrixEntries.Count;
 
         vm.LoadFromFileCommand.Execute(null);
@@ -230,7 +230,7 @@ public class ComponentSettingsDialogViewModelTests
                 .Setup(s => s.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(tmp);
             var vm = new ComponentSettingsDialogViewModel(fileDialog.Object);
-            vm.Configure("comp_1", "My Component", store);
+            vm.Configure("comp_1", "comp_1", "My Component", store);
 
             vm.LoadFromFileCommand.Execute(null);
 

--- a/UnitTests/ComponentSettings/ComponentSettingsDialogViewModelTests.cs
+++ b/UnitTests/ComponentSettings/ComponentSettingsDialogViewModelTests.cs
@@ -198,6 +198,57 @@ public class ComponentSettingsDialogViewModelTests
     }
 
     [Fact]
+    public async Task NazcaGeometryChange_ReResolvesSmatrixKey_RefreshesEntries()
+    {
+        // The bug: the dialog cached the S-matrix key computed when it opened. Overriding
+        // (or resetting) the Nazca geometry changes the component's geometry identity — and
+        // thus the key the S-matrix override is stored under — but the entry list kept showing
+        // the OLD geometry's entries until the window was closed and reopened. The dialog must
+        // re-resolve the key and rebuild the list when the geometry changes.
+        var liveComponent = TestComponentFactory.CreateSimpleTwoPortComponent();
+        liveComponent.Identifier = "comp_1";
+
+        // The underlying geometry has a stored S-matrix override; the raw-code geometry has none.
+        const string geoKey = "geo-key";
+        const string rawKey = "raw-key";
+        var store = MakeStore(geoKey, "1550");
+
+        // Start with an active raw-code override (so the dialog opens on the raw geometry key).
+        var nazcaOverrides = new Dictionary<string, NazcaCodeOverride>
+        {
+            ["comp_1"] = new NazcaCodeOverride { RawCode = "import nazca as nd\ndef component(): ..." },
+        };
+        // Resolver mirrors ComponentGeometryKey: raw override present ⇒ raw key, else geometry key.
+        string Resolver() =>
+            nazcaOverrides.TryGetValue("comp_1", out var o) && o.RawCode != null ? rawKey : geoKey;
+
+        var vm = NewVm();
+        vm.Configure(
+            entityKey: "comp_1",
+            smatrixKey: Resolver(),
+            displayName: "My Component",
+            storedSMatrices: store,
+            liveComponent: liveComponent,
+            storedNazcaOverrides: nazcaOverrides,
+            templateFunctionName: "ebeam_crossing4",
+            templateFunctionParameters: "",
+            templateModuleName: "siepic_ebeam_pdk",
+            nazcaTemplateCode: "def component(): pass",
+            smatrixKeyResolver: Resolver);
+
+        // On open the raw geometry has no stored S-matrix, so nothing is shown.
+        vm.HasSMatrices.ShouldBeFalse();
+        vm.NazcaCodeEditor.ShouldNotBeNull();
+
+        // Reset to template clears the raw override → geometry identity reverts to the geo key.
+        await vm.NazcaCodeEditor!.ResetToTemplateCommand.ExecuteAsync(null);
+
+        // The dialog must now reflect the geo geometry's stored override without a reopen.
+        vm.HasSMatrices.ShouldBeTrue();
+        vm.SMatrixEntries.Count.ShouldBe(1);
+    }
+
+    [Fact]
     public void LoadFromFile_UserCancels_NoMutationNoCrash()
     {
         // FileDialogService returns null when the user cancels — the command must exit

--- a/UnitTests/ComponentSettings/PortMappingDialogIntegrationTests.cs
+++ b/UnitTests/ComponentSettings/PortMappingDialogIntegrationTests.cs
@@ -68,7 +68,7 @@ public class PortMappingDialogIntegrationTests : IDisposable
         var store = new Dictionary<string, ComponentSMatrixData>();
         // Pin list intentionally matches the imported names — no dialog needed.
         vm.Configure(
-            "comp_1", "MyComp", store,
+            "comp_1", "comp_1", "MyComp", store,
             availablePinNames: new[] { "port 1", "port 2", "port 3" });
 
         await vm.LoadFromFileCommand.ExecuteAsync(null);
@@ -110,7 +110,7 @@ public class PortMappingDialogIntegrationTests : IDisposable
 
         var store = new Dictionary<string, ComponentSMatrixData>();
         vm.Configure(
-            "comp_1", "1×2 Splitter", store,
+            "comp_1", "comp_1", "1×2 Splitter", store,
             availablePinNames: new[] { "in", "out1", "out2" });
 
         await vm.LoadFromFileCommand.ExecuteAsync(null);
@@ -154,7 +154,7 @@ public class PortMappingDialogIntegrationTests : IDisposable
 
         var store = new Dictionary<string, ComponentSMatrixData>();
         vm.Configure(
-            "comp_1", "1×2 Splitter", store,
+            "comp_1", "comp_1", "1×2 Splitter", store,
             availablePinNames: new[] { "in", "out1", "out2" });
 
         await vm.LoadFromFileCommand.ExecuteAsync(null);
@@ -185,7 +185,7 @@ public class PortMappingDialogIntegrationTests : IDisposable
         var store = new Dictionary<string, ComponentSMatrixData>();
         // 2-port pin list against a 3-port file: structurally unmappable.
         vm.Configure(
-            "comp_1", "MyComp", store,
+            "comp_1", "comp_1", "MyComp", store,
             availablePinNames: new[] { "in", "out" });
 
         await vm.LoadFromFileCommand.ExecuteAsync(null);

--- a/UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs
+++ b/UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs
@@ -452,4 +452,35 @@ public class SMatrixOverrideApplicatorTests
         console.Entries.Count.ShouldBe(1);
         console.Entries[0].Message.ShouldContain("renamed_or_removed");
     }
+
+    [Fact]
+    public void ApplyAll_GeometryKeyResolver_AppliesToAllMatchingInstances()
+    {
+        var a = TestComponentFactory.CreateSimpleTwoPortComponent(); a.Identifier = "inst_A";
+        var b = TestComponentFactory.CreateSimpleTwoPortComponent(); b.Identifier = "inst_B";
+        var store = new Dictionary<string, ComponentSMatrixData> { ["geo:v1-shared"] = MakeData("1550", 2) };
+
+        var result = SMatrixOverrideApplicator.ApplyAll(
+            new[] { a, b }, store,
+            geometryKeyResolver: _ => "geo:v1-shared");
+
+        result.PerComponent["inst_A"].Applied.ShouldBe(1);
+        result.PerComponent["inst_B"].Applied.ShouldBe(1);
+        result.OrphanKeys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ApplyAll_GeometryKeyResolver_DifferentGeometryDoesNotInherit()
+    {
+        var a = TestComponentFactory.CreateSimpleTwoPortComponent(); a.Identifier = "inst_A";
+        var b = TestComponentFactory.CreateSimpleTwoPortComponent(); b.Identifier = "inst_B";
+        var store = new Dictionary<string, ComponentSMatrixData> { ["geo:v1-A"] = MakeData("1550", 2) };
+
+        var result = SMatrixOverrideApplicator.ApplyAll(
+            new[] { a, b }, store,
+            geometryKeyResolver: c => c.Identifier == "inst_A" ? "geo:v1-A" : "geo:v1-B");
+
+        result.PerComponent.ContainsKey("inst_A").ShouldBeTrue();
+        result.PerComponent.ContainsKey("inst_B").ShouldBeFalse();
+    }
 }

--- a/UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs
+++ b/UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using CAP.Avalonia.Services;
 using CAP_Core;
+using CAP_Core.Components.Core;
 using CAP_DataAccess.Persistence.PIR;
 using Shouldly;
 using UnitTests;
@@ -482,5 +483,23 @@ public class SMatrixOverrideApplicatorTests
 
         result.PerComponent.ContainsKey("inst_A").ShouldBeTrue();
         result.PerComponent.ContainsKey("inst_B").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CopyScenario_OverrideStoredByGeometry_AppliesToClone()
+    {
+        var a = TestComponentFactory.CreateSimpleTwoPortComponent(); a.Identifier = "A";
+        a.NazcaFunctionName = "ebeam_edge_coupler";
+        var b = TestComponentFactory.CreateSimpleTwoPortComponent(); b.Identifier = "B";
+        b.NazcaFunctionName = "ebeam_edge_coupler";
+
+        string GeoKey(Component c) => CAP.Avalonia.Services.ComponentGeometryKey.For(c, _ => null);
+        var store = new Dictionary<string, ComponentSMatrixData> { [GeoKey(a)] = MakeData("1550", 2) };
+
+        var result = SMatrixOverrideApplicator.ApplyAll(
+            new[] { a, b }, store, geometryKeyResolver: GeoKey);
+
+        result.PerComponent["A"].Applied.ShouldBe(1);
+        result.PerComponent["B"].Applied.ShouldBe(1);
     }
 }

--- a/UnitTests/Components/ComponentCloneOrphanPinTests.cs
+++ b/UnitTests/Components/ComponentCloneOrphanPinTests.cs
@@ -107,4 +107,35 @@ public class ComponentCloneOrphanPinTests
         clonedValues[(clonedLeftIn, clonedRightOut)].ShouldBe(overridden,
             "Clone must preserve the overridden S-matrix value on the (re-keyed) pins.");
     }
+
+    [Fact]
+    public void Clone_PreservesNazcaModuleName()
+    {
+        // Root cause of the copy/paste override loss: Clone() copied NazcaFunctionName and
+        // NazcaFunctionParameters but dropped NazcaModuleName. A pasted component then had a
+        // null module, so (1) its geometry key diverged from the original's — the geometry-
+        // scoped S-matrix override no longer matched, and the dialog showed "PDK Default" —
+        // and (2) the FDTD preview render fell back to nazca.demofab and failed with
+        // "module 'nazca.demofab' has no attribute '<cell>'".
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>
+        {
+            new("west0", 0, MatterType.Light, RectSide.Left),
+            new("east0", 1, MatterType.Light, RectSide.Right),
+        });
+        var matrix = new SMatrix(
+            Component.GetAllPins(parts).SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList(),
+            new());
+        var component = new Component(
+            new Dictionary<int, SMatrix> { { StandardWaveLengths.RedNM, matrix } },
+            new(), "ebeam_crossing4", "", parts, 0, "Crossing", DiscreteRotation.R0)
+        {
+            NazcaModuleName = "siepic_ebeam_pdk",
+        };
+
+        var clone = (Component)component.Clone();
+
+        clone.NazcaModuleName.ShouldBe("siepic_ebeam_pdk",
+            "Clone must carry the Nazca module so the copy keeps the same geometry identity.");
+    }
 }

--- a/UnitTests/Components/ComponentCloneOrphanPinTests.cs
+++ b/UnitTests/Components/ComponentCloneOrphanPinTests.cs
@@ -72,4 +72,39 @@ public class ComponentCloneOrphanPinTests
         clonedMatrix.GetNonNullValues().Count.ShouldBe(validConnectionCount,
             "The in-Parts connection must survive cloning; the orphan connection is dropped.");
     }
+
+    [Fact]
+    public void Clone_PreservesOverriddenSMatrixValue_NotJustStructure()
+    {
+        // Reproduces the copy/paste concern for an FDTD-recomputed S-matrix on NORMAL
+        // ports: the recompute writes non-default values onto the component's existing
+        // pins (all present in Parts). Cloning must carry the *values* over, not reset
+        // to a PDK default. This confirms Clone is NOT where an FDTD override is lost.
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>
+        {
+            new("west0", 0, MatterType.Light, RectSide.Left),
+            new("east0", 1, MatterType.Light, RectSide.Right),
+        });
+        var leftIn = parts[0, 0].GetPinAt(RectSide.Left).IDInFlow;
+        var rightOut = parts[0, 0].GetPinAt(RectSide.Right).IDOutFlow;
+        var allPinIds = Component.GetAllPins(parts)
+            .SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+
+        var overridden = new Complex(0.1234, -0.5678);   // a distinctly non-default value
+        var matrix = new SMatrix(allPinIds, new());
+        matrix.SetValues(new() { { (leftIn, rightOut), overridden } });
+        var component = new Component(
+            new Dictionary<int, SMatrix> { { StandardWaveLengths.RedNM, matrix } },
+            new(), "placeCell_StraightWG", "", parts, 0, "Straight", DiscreteRotation.R0);
+
+        var clone = (Component)component.Clone();
+
+        var clonedPins = Component.GetAllPins(clone.Parts).ToList();
+        var clonedLeftIn = clonedPins.Single(p => p.Name == "west0").IDInFlow;
+        var clonedRightOut = clonedPins.Single(p => p.Name == "east0").IDOutFlow;
+        var clonedValues = clone.WaveLengthToSMatrixMap[StandardWaveLengths.RedNM].GetNonNullValues();
+        clonedValues[(clonedLeftIn, clonedRightOut)].ShouldBe(overridden,
+            "Clone must preserve the overridden S-matrix value on the (re-keyed) pins.");
+    }
 }

--- a/UnitTests/Import/SMatrixOverrideGcTests.cs
+++ b/UnitTests/Import/SMatrixOverrideGcTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using CAP.Avalonia.Services;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Import;
+
+public class SMatrixOverrideGcTests
+{
+    private static ComponentSMatrixData Data() => new() { SourceNote = "x" };
+
+    [Fact]
+    public void Sweep_KeepsUsedKeys_DropsOrphans()
+    {
+        var store = new Dictionary<string, ComponentSMatrixData>
+        {
+            ["geo:v1-used"]       = Data(),
+            ["geo:v1-orphan"]     = Data(),
+            ["legacy_identifier"] = Data(),
+        };
+        var usedGeometryKeys = new HashSet<string> { "geo:v1-used" };
+        var liveIdentifiers  = new HashSet<string> { "legacy_identifier" };
+
+        var kept = SMatrixOverrideGc.Sweep(store, usedGeometryKeys, liveIdentifiers);
+
+        kept.Keys.ShouldBe(new[] { "geo:v1-used", "legacy_identifier" }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void Sweep_KeepsTemplateScopedKeys()
+    {
+        var store = new Dictionary<string, ComponentSMatrixData> { ["Demo PDK::Coupler"] = Data() };
+        var kept = SMatrixOverrideGc.Sweep(store, new HashSet<string>(), new HashSet<string>());
+        kept.ShouldContainKey("Demo PDK::Coupler");
+    }
+}

--- a/UnitTests/Services/ComponentGeometryKeyTests.cs
+++ b/UnitTests/Services/ComponentGeometryKeyTests.cs
@@ -1,0 +1,55 @@
+// UnitTests/Services/ComponentGeometryKeyTests.cs
+using CAP.Avalonia.Services;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests;
+using Xunit;
+
+namespace UnitTests.Services;
+
+public class ComponentGeometryKeyTests
+{
+    private static Component Wg(string module, string function, string parameters)
+    {
+        var c = TestComponentFactory.CreateStraightWaveGuide();
+        c.NazcaModuleName = module;
+        c.NazcaFunctionName = function;
+        c.NazcaFunctionParameters = parameters;
+        return c;
+    }
+
+    [Fact]
+    public void SameModuleFunctionParameters_SameKey()
+    {
+        var a = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=5"), _ => null);
+        var b = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=5"), _ => null);
+        a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void DifferentParameters_DifferentKey()
+    {
+        var a = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=5"), _ => null);
+        var b = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=9"), _ => null);
+        a.ShouldNotBe(b);
+    }
+
+    [Fact]
+    public void RawCodeOverride_UsesCodeHash_IndependentOfFunction()
+    {
+        var comp = Wg("siepic", "ebeam_dc", "Lc=5");
+        var withOverride = ComponentGeometryKey.For(comp, _ => "import nazca; def component(): ...");
+        var noOverride = ComponentGeometryKey.For(comp, _ => null);
+        withOverride.ShouldNotBe(noOverride);
+        var other = Wg("other", "different_fn", "");
+        ComponentGeometryKey.For(other, _ => "import nazca; def component(): ...")
+            .ShouldBe(withOverride);
+    }
+
+    [Fact]
+    public void Prefixed_RawVsGeo_NeverCollide()
+    {
+        ComponentGeometryKey.For(Wg("m", "f", "p"), _ => null).ShouldStartWith("geo:");
+        ComponentGeometryKey.For(Wg("m", "f", "p"), _ => "x").ShouldStartWith("raw:");
+    }
+}

--- a/UnitTests/Services/ComponentGeometryKeyTests.cs
+++ b/UnitTests/Services/ComponentGeometryKeyTests.cs
@@ -52,4 +52,17 @@ public class ComponentGeometryKeyTests
         ComponentGeometryKey.For(Wg("m", "f", "p"), _ => null).ShouldStartWith("geo:");
         ComponentGeometryKey.For(Wg("m", "f", "p"), _ => "x").ShouldStartWith("raw:");
     }
+
+    [Fact]
+    public void ClonedComponent_SharesGeometryKeyWithOriginal()
+    {
+        // The user-facing guarantee behind geometry-scoped overrides: a copy/paste
+        // (Component.Clone) is geometrically identical, so it must map to the SAME key —
+        // otherwise the copy can't inherit the original's recomputed S-matrix override.
+        var original = Wg("siepic_ebeam_pdk", "ebeam_crossing4", "");
+        var clone = (Component)original.Clone();
+
+        ComponentGeometryKey.For(clone, _ => null)
+            .ShouldBe(ComponentGeometryKey.For(original, _ => null));
+    }
 }

--- a/UnitTests/Solvers/Fdtd/ComponentFdtdRequestFactoryTests.cs
+++ b/UnitTests/Solvers/Fdtd/ComponentFdtdRequestFactoryTests.cs
@@ -1,6 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Components.Core;
 using CAP_Core.Export;
+using Moq;
 using Shouldly;
+using UnitTests;
 using Xunit;
 
 namespace UnitTests.Solvers.Fdtd;
@@ -74,5 +80,38 @@ public class ComponentFdtdRequestFactoryTests
 
         ports[0].Name.ShouldBe("a0");
         ports[1].Name.ShouldBe("b0");
+    }
+
+    [Fact]
+    public async Task BuildAsync_OnClonedComponent_RendersAgainstOriginalModule_NotDemoFallback()
+    {
+        // Regression for the copy/paste FDTD failure: a pasted (cloned) component used to lose
+        // its NazcaModuleName, so BuildAsync rendered against the "demo" fallback (nazca.demofab)
+        // and failed with "module 'nazca.demofab' has no attribute '<cell>'". The clone must
+        // carry the module so the recompute renders against the real PDK cell.
+        var original = TestComponentFactory.CreateStraightWaveGuide();
+        original.NazcaModuleName = "siepic_ebeam_pdk";
+        original.NazcaFunctionName = "ebeam_crossing4";
+        var clone = (Component)original.Clone();
+
+        string? renderedModule = "<never called>";
+        var preview = new Mock<NazcaComponentPreviewService>(
+            MockBehavior.Loose, "python3", "preview.py", (TimeSpan?)null) { CallBase = false };
+        preview.Setup(s => s.RenderAsync(
+                It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Callback<string?, string, string?, CancellationToken>((module, _, _, _) => renderedModule = module)
+            .ReturnsAsync(new NazcaPreviewResult
+            {
+                Success = true,
+                Polygons = new[] { Poly(1) },
+                Pins = new[] { new NazcaPreviewPin { Name = "a0", X = 0, Y = 0, Angle = 0 } },
+            });
+
+        var factory = new ComponentFdtdRequestFactory(preview.Object);
+        var request = await factory.BuildAsync(clone);
+
+        renderedModule.ShouldBe("siepic_ebeam_pdk",
+            "The clone must render against the original PDK module, not the nazca.demofab fallback.");
+        request.ShouldNotBeNull();
     }
 }

--- a/docs/superpowers/plans/2026-06-23-smatrix-override-geometry-scope.md
+++ b/docs/superpowers/plans/2026-06-23-smatrix-override-geometry-scope.md
@@ -1,0 +1,453 @@
+# S-Matrix-Override nach Geometrie-Identität (+ GC) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Einen per FDTD neuberechneten (oder importierten) S-Matrix-Override an die **Geometrie-Identität** des Bauteils binden (statt an `component.Identifier`), sodass alle deckungsgleichen Instanzen + Kopien ihn erben; verwaiste Overrides beim Speichern per Refcount aufräumen.
+
+**Architecture:** Neuer Geometrie-Identitäts-Schlüssel (`module|function|parameters`, bzw. Raw-Code-Hash bei #561-Override). `SMatrixOverrideApplicator.ApplyAll` matcht zusätzlich über diesen Schlüssel (Identifier-Match bleibt als erster Lookup → Abwärtskompatibilität). FDTD-Recompute/Load schreiben unter dem Geometrie-Schlüssel. `SaveDesign` persistiert nur Overrides mit refcount > 0.
+
+**Tech Stack:** C# / .NET 10, Avalonia 11.2.1, xUnit + Shouldly + Moq.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-smatrix-override-geometry-scope-design.md`
+
+---
+
+## File Structure
+
+| Datei | Verantwortung | Aktion |
+|---|---|---|
+| `CAP.Avalonia/Services/ComponentGeometryKey.cs` | Geometrie-Identität eines Bauteils (raw-code-hash oder module\|function\|parameters) | Create |
+| `CAP.Avalonia/Services/SMatrixOverrideApplicator.cs` | `ApplyAll` matcht zusätzlich per Geometrie-Schlüssel | Modify |
+| `CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel(.Fdtd).cs` | S-Matrix-Override unter Geometrie-Schlüssel statt Identifier | Modify |
+| `CAP.Avalonia/Views/MainWindow.axaml.cs` | Geometrie-Schlüssel berechnen + an Dialog übergeben | Modify |
+| `CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs` | Resolver auf Geometrie-Identität + Save-Sweep-GC | Modify |
+| `UnitTests/Services/ComponentGeometryKeyTests.cs` | Identitäts-Bildung | Create |
+| `UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs` | Geometrie-Match (erben/nicht erben) | Modify |
+| `UnitTests/Import/SMatrixOverrideGcTests.cs` | Save-Sweep | Create |
+
+**Branch:** `feat/smatrix-override-geometry-scope` (bereits angelegt; enthält Spec + Repro-Test `ComponentCloneOrphanPinTests.Clone_PreservesOverriddenSMatrixValue_NotJustStructure`).
+
+---
+
+## Task 1: `ComponentGeometryKey`
+
+Geometrie-Identität eines Bauteils. Raw-Code-Override (#561) → Hash des Codes; sonst `module|function|parameters`. Konzeptionell dieselbe Identität wie `GdsPreviewKey` (Thumbnails), hier feature-neutral für den S-Matrix-Scope.
+
+**Files:**
+- Create: `CAP.Avalonia/Services/ComponentGeometryKey.cs`
+- Test:   `UnitTests/Services/ComponentGeometryKeyTests.cs`
+
+Relevant: `CAP_Core.Components.Core.Component` hat `string NazcaModuleName`, `string NazcaFunctionName`, `string NazcaFunctionParameters`. Der Raw-Code wird über einen Lookup `Func<Component,string?>` (Identifier→RawCode, später aus `StoredNazcaOverrides`) geliefert.
+
+- [ ] **Step 1: Failing test schreiben**
+
+```csharp
+// UnitTests/Services/ComponentGeometryKeyTests.cs
+using CAP.Avalonia.Services;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.Services;
+
+public class ComponentGeometryKeyTests
+{
+    private static Component Wg(string module, string function, string parameters)
+    {
+        var c = TestComponentFactory.CreateStraightWaveGuide();
+        c.NazcaModuleName = module;
+        c.NazcaFunctionName = function;
+        c.NazcaFunctionParameters = parameters;
+        return c;
+    }
+
+    [Fact]
+    public void SameModuleFunctionParameters_SameKey()
+    {
+        var a = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=5"), _ => null);
+        var b = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=5"), _ => null);
+        a.ShouldBe(b);
+    }
+
+    [Fact]
+    public void DifferentParameters_DifferentKey()
+    {
+        var a = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=5"), _ => null);
+        var b = ComponentGeometryKey.For(Wg("siepic", "ebeam_dc", "Lc=9"), _ => null);
+        a.ShouldNotBe(b);
+    }
+
+    [Fact]
+    public void RawCodeOverride_UsesCodeHash_IndependentOfFunction()
+    {
+        var comp = Wg("siepic", "ebeam_dc", "Lc=5");
+        var withOverride = ComponentGeometryKey.For(comp, _ => "import nazca; def component(): ...");
+        var noOverride = ComponentGeometryKey.For(comp, _ => null);
+        withOverride.ShouldNotBe(noOverride);
+        // same raw code → same key regardless of the underlying function name
+        var other = Wg("other", "different_fn", "");
+        ComponentGeometryKey.For(other, _ => "import nazca; def component(): ...")
+            .ShouldBe(withOverride);
+    }
+
+    [Fact]
+    public void Prefixed_RawVsGeo_NeverCollide()
+    {
+        ComponentGeometryKey.For(Wg("m", "f", "p"), _ => null).ShouldStartWith("geo:");
+        ComponentGeometryKey.For(Wg("m", "f", "p"), _ => "x").ShouldStartWith("raw:");
+    }
+}
+```
+
+- [ ] **Step 2: Test ausführen (muss fehlschlagen)**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" ComponentGeometryKey`
+Expected: FAIL (Typ existiert nicht).
+
+- [ ] **Step 3: Implementieren**
+
+```csharp
+// CAP.Avalonia/Services/ComponentGeometryKey.cs
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Geometry identity of a component, used to scope S-matrix overrides: components with
+/// the same geometry must share the same (recomputed) S-matrix. When a raw-code Nazca
+/// override (#561) is active the code itself defines the geometry; otherwise the Nazca
+/// call (module|function|parameters) does. Same identity ⇒ same key.
+/// </summary>
+public static class ComponentGeometryKey
+{
+    /// <summary>Bump to invalidate all geometry-scoped override keys.</summary>
+    public const int FormatVersion = 1;
+
+    /// <summary>
+    /// Builds the geometry key. <paramref name="rawCodeLookup"/> returns the active raw-code
+    /// override for the component (e.g. from StoredNazcaOverrides), or null if none.
+    /// </summary>
+    public static string For(Component component, Func<Component, string?> rawCodeLookup)
+    {
+        var raw = rawCodeLookup(component);
+        if (!string.IsNullOrWhiteSpace(raw))
+            return $"raw:v{FormatVersion}-{Hash(raw)}";
+
+        var material = $"{component.NazcaModuleName}{component.NazcaFunctionName}{component.NazcaFunctionParameters}";
+        return $"geo:v{FormatVersion}-{Hash(material)}";
+    }
+
+    private static string Hash(string s)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(s));
+        return Convert.ToHexString(bytes, 0, 12).ToLowerInvariant();
+    }
+}
+```
+
+- [ ] **Step 4: Test ausführen (muss bestehen)**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" ComponentGeometryKey`
+Expected: PASS (4 Tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CAP.Avalonia/Services/ComponentGeometryKey.cs UnitTests/Services/ComponentGeometryKeyTests.cs
+git commit -m "(+) ComponentGeometryKey: geometry identity for S-matrix override scoping"
+```
+(Commit-Body endet mit: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`)
+
+---
+
+## Task 2: `ApplyAll` matcht per Geometrie-Schlüssel
+
+Heute matcht `ApplyAll` per `comp.Identifier`, dann optional `templateKeyResolver`. Wir erweitern die Match-Kette: `Identifier` → `geometryKeyResolver(comp)` → (bestehender `templateKeyResolver`). So erben deckungsgleiche Instanzen einen unter dem Geometrie-Schlüssel gespeicherten Override; Identifier-Altbestände bleiben matchbar.
+
+**Files:**
+- Modify: `CAP.Avalonia/Services/SMatrixOverrideApplicator.cs` (Methode `ApplyAll`, aktuelle Signatur: `ApplyAll(components, storedSMatrices, templateKeyResolver=null, errorConsole=null, keyMatchesKnownTemplate=null, reportOrphans=false)`; die Match-Schleife resolved `comp.Identifier` zuerst, dann `templateKeyResolver`)
+- Test: `UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs`
+
+- [ ] **Step 1: Failing test schreiben** (anhängen an die bestehende Testklasse)
+
+```csharp
+    [Fact]
+    public void ApplyAll_GeometryKeyResolver_AppliesToAllMatchingInstances()
+    {
+        // Two distinct instances (different Identifiers) with the SAME geometry key.
+        var a = TestComponentFactory.CreateSimpleTwoPortComponent(); a.Identifier = "inst_A";
+        var b = TestComponentFactory.CreateSimpleTwoPortComponent(); b.Identifier = "inst_B";
+
+        var store = new Dictionary<string, ComponentSMatrixData> { ["geo:v1-shared"] = MakeData("1550", 2) };
+
+        var result = SMatrixOverrideApplicator.ApplyAll(
+            new[] { a, b }, store,
+            geometryKeyResolver: _ => "geo:v1-shared");
+
+        result.PerComponent["inst_A"].Applied.ShouldBe(1);
+        result.PerComponent["inst_B"].Applied.ShouldBe(1);   // the copy inherits it too
+        result.OrphanKeys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ApplyAll_GeometryKeyResolver_DifferentGeometryDoesNotInherit()
+    {
+        var a = TestComponentFactory.CreateSimpleTwoPortComponent(); a.Identifier = "inst_A";
+        var b = TestComponentFactory.CreateSimpleTwoPortComponent(); b.Identifier = "inst_B";
+        var store = new Dictionary<string, ComponentSMatrixData> { ["geo:v1-A"] = MakeData("1550", 2) };
+
+        var result = SMatrixOverrideApplicator.ApplyAll(
+            new[] { a, b }, store,
+            geometryKeyResolver: c => c.Identifier == "inst_A" ? "geo:v1-A" : "geo:v1-B");
+
+        result.PerComponent.ContainsKey("inst_A").ShouldBeTrue();
+        result.PerComponent.ContainsKey("inst_B").ShouldBeFalse();   // different geometry → no override
+    }
+```
+
+- [ ] **Step 2: Test ausführen (muss fehlschlagen)**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" SMatrixOverrideApplicator`
+Expected: FAIL (`geometryKeyResolver`-Parameter existiert nicht).
+
+- [ ] **Step 3: `ApplyAll` erweitern**
+
+Signatur um einen optionalen Parameter ergänzen (NACH `templateKeyResolver`, vor `errorConsole`, damit benannte Argumente bestehender Aufrufer gültig bleiben):
+
+```csharp
+public static ApplyAllResult ApplyAll(
+    IEnumerable<Component> components,
+    IReadOnlyDictionary<string, ComponentSMatrixData> storedSMatrices,
+    Func<Component, string?>? templateKeyResolver = null,
+    Func<Component, string?>? geometryKeyResolver = null,
+    ErrorConsoleService? errorConsole = null,
+    Func<string, bool>? keyMatchesKnownTemplate = null,
+    bool reportOrphans = false)
+```
+
+In der Match-Schleife (heute: erst `storedSMatrices.TryGetValue(comp.Identifier)`, dann `templateKeyResolver`) den Geometrie-Resolver als zusätzlichen Lookup einfügen — Reihenfolge: **Identifier → geometryKey → templateKey**:
+
+```csharp
+string? resolvedKey = null;
+if (storedSMatrices.TryGetValue(comp.Identifier, out var data))
+    resolvedKey = comp.Identifier;
+else
+{
+    var geomKey = geometryKeyResolver?.Invoke(comp);
+    if (geomKey != null && storedSMatrices.TryGetValue(geomKey, out data))
+        resolvedKey = geomKey;
+    else
+    {
+        var templateKey = templateKeyResolver?.Invoke(comp);
+        if (templateKey != null && storedSMatrices.TryGetValue(templateKey, out data))
+            resolvedKey = templateKey;
+    }
+}
+if (resolvedKey != null && data != null)
+{
+    perComponent[comp.Identifier] = Apply(comp, data, errorConsole);
+    matchedKeys.Add(resolvedKey);
+}
+```
+
+- [ ] **Step 4: Test ausführen (muss bestehen)**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" SMatrixOverrideApplicator`
+Expected: PASS (alle bestehenden + 2 neue).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CAP.Avalonia/Services/SMatrixOverrideApplicator.cs UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs
+git commit -m "(+) SMatrixOverrideApplicator: match overrides by geometry key (inherit across identical instances)"
+```
+
+---
+
+## Task 3: Override unter Geometrie-Schlüssel schreiben + verdrahten
+
+Der S-Matrix-Override soll unter dem Geometrie-Schlüssel landen (FDTD-Recompute + Load-from-file). Der Settings-Dialog nutzt heute `_entityKey` (= `component.Identifier`) für `_storedSMatrices` UND der Nazca-Override nutzt denselben Identifier. Wir führen einen separaten `_smatrixKey` ein; der Nazca-Teil behält den Identifier.
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs` (Feld `_entityKey`; `Configure(...)` setzt `_entityKey`; alle `_storedSMatrices[_entityKey]` / `TryGetValue(_entityKey)` Stellen — diese auf ein neues Feld `_smatrixKey` umstellen) und `...Fdtd.cs` (`_storedSMatrices[_entityKey] = data` → `_smatrixKey`)
+- Modify: `CAP.Avalonia/Views/MainWindow.axaml.cs` (`ShowComponentSettingsDialog`/`Configure`-Aufruf: `smatrixKey` berechnen und übergeben)
+
+Vorgehen (der ausführende Subagent liest die genauen Stellen):
+1. Feld `private string _smatrixKey = string.Empty;` ergänzen; `Configure(...)` um Parameter `string smatrixKey` erweitern und `_smatrixKey = smatrixKey;` setzen. Alle Stellen, die `_storedSMatrices` per `_entityKey` indizieren (Recompute, Load, effective-S-matrix-Anzeige, Delete), auf `_smatrixKey` umstellen. Der **Nazca-Override-Teil** (`NazcaCodeEditor`, `storedNazcaOverrides`) bleibt auf `_entityKey` (Identifier).
+2. In `MainWindow.axaml.cs` den `smatrixKey` bilden:
+   - Im Per-Instance-Pfad (liveComponent != null): `smatrixKey = ComponentGeometryKey.For(liveComponent, c => vm.FileOperations.StoredNazcaOverrides.TryGetValue(c.Identifier, out var o) ? o.RawCode : null)`.
+   - Im Template-Pfad (liveComponent == null, Library-Kontextmenü): `smatrixKey = entityKey` (der bestehende `{PdkSource}::{Name}`-Key bleibt für den user-global Scope).
+   und an `Configure(...)` übergeben.
+
+- [ ] **Step 1: Build + bestehende ComponentSettings-Tests grün halten**
+
+Run: `dotnet build CAP.Avalonia/CAP.Avalonia.csproj -clp:ErrorsOnly` → 0 Fehler.
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" ComponentSettings`
+Expected: PASS (bestehende Dialog-Tests; ggf. Configure-Aufrufe in Tests um `smatrixKey:` ergänzen — Default = der jeweils genutzte Key).
+
+- [ ] **Step 2: Regressionstest „Kopie erbt FDTD-Override"** (Integration, ohne Docker)
+
+```csharp
+// In UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs anhängen:
+[Fact]
+public void CopyScenario_OverrideStoredByGeometry_AppliesToClone()
+{
+    // Original A and its clone B share geometry → both must receive the override
+    // that a recompute stored under the geometry key.
+    var a = TestComponentFactory.CreateSimpleTwoPortComponent(); a.Identifier = "A";
+    a.NazcaFunctionName = "ebeam_edge_coupler";
+    var b = TestComponentFactory.CreateSimpleTwoPortComponent(); b.Identifier = "B";
+    b.NazcaFunctionName = "ebeam_edge_coupler";
+
+    string GeoKey(Component c) => ComponentGeometryKey.For(c, _ => null);
+    var store = new Dictionary<string, ComponentSMatrixData> { [GeoKey(a)] = MakeData("1550", 2) };
+
+    var result = SMatrixOverrideApplicator.ApplyAll(
+        new[] { a, b }, store, geometryKeyResolver: GeoKey);
+
+    result.PerComponent["A"].Applied.ShouldBe(1);
+    result.PerComponent["B"].Applied.ShouldBe(1);
+}
+```
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" SMatrixOverrideApplicator` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CAP.Avalonia/ViewModels/ComponentSettings/ CAP.Avalonia/Views/MainWindow.axaml.cs UnitTests/ComponentSettings/SMatrixOverrideApplicatorTests.cs
+git commit -m "(+) FDTD/import S-matrix override stored + applied by geometry key, not per-instance"
+```
+
+---
+
+## Task 4: `FileOperationsViewModel` — Geometrie-Resolver + Save-Sweep-GC
+
+Den Geometrie-Resolver an die `ApplyAll`-Aufrufe durchreichen und beim Speichern verwaiste Overrides verwerfen.
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs`
+  - neuer privater Helper `private string ResolveGeometryKey(Component c) => ComponentGeometryKey.For(c, comp => StoredNazcaOverrides.TryGetValue(comp.Identifier, out var o) ? o.RawCode : null);`
+  - die `ApplyAll(...)`-Aufrufe (in `OnComponentsChangedApplyStoredOverrides` ~Z.168 und im Projekt-Load ~Z.765) um `geometryKeyResolver: ResolveGeometryKey` ergänzen.
+  - Save-Sweep: im `SaveDesign`-Pfad, dort wo `designData.SMatrices = new Dictionary<...>(StoredSMatrices)` gesetzt wird (~Z.310), stattdessen nur die genutzten Einträge übernehmen (siehe Step 3).
+- Test: `UnitTests/Import/SMatrixOverrideGcTests.cs`
+
+- [ ] **Step 1: Failing test schreiben** (Sweep als reine Funktion testbar machen)
+
+```csharp
+// UnitTests/Import/SMatrixOverrideGcTests.cs
+using System.Collections.Generic;
+using CAP.Avalonia.Services;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Import;
+
+public class SMatrixOverrideGcTests
+{
+    private static ComponentSMatrixData Data() => new() { SourceNote = "x" };
+
+    [Fact]
+    public void Sweep_KeepsUsedKeys_DropsOrphans()
+    {
+        var store = new Dictionary<string, ComponentSMatrixData>
+        {
+            ["geo:v1-used"]   = Data(),   // a placed component resolves to this
+            ["geo:v1-orphan"] = Data(),   // no component uses this geometry anymore
+            ["legacy_identifier"] = Data(),// an existing component still has this Identifier
+        };
+        var usedGeometryKeys = new HashSet<string> { "geo:v1-used" };
+        var liveIdentifiers  = new HashSet<string> { "legacy_identifier" };
+
+        var kept = SMatrixOverrideGc.Sweep(store, usedGeometryKeys, liveIdentifiers);
+
+        kept.Keys.ShouldBe(new[] { "geo:v1-used", "legacy_identifier" }, ignoreOrder: true);
+    }
+}
+```
+
+- [ ] **Step 2: Test ausführen (muss fehlschlagen)**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" SMatrixOverrideGc`
+Expected: FAIL (`SMatrixOverrideGc` existiert nicht).
+
+- [ ] **Step 3: `SMatrixOverrideGc` implementieren + im Save-Pfad nutzen**
+
+```csharp
+// CAP.Avalonia/Services/SMatrixOverrideGc.cs
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Garbage-collects project-local S-matrix overrides at save time: keeps only entries
+/// whose geometry key is still used by a placed component, plus legacy per-Identifier
+/// entries whose component still exists. Orphans (e.g. after a parameter change) are dropped.
+/// </summary>
+public static class SMatrixOverrideGc
+{
+    /// <summary>Returns the subset of <paramref name="store"/> that should be persisted.</summary>
+    public static Dictionary<string, ComponentSMatrixData> Sweep(
+        IReadOnlyDictionary<string, ComponentSMatrixData> store,
+        IReadOnlySet<string> usedGeometryKeys,
+        IReadOnlySet<string> liveIdentifiers)
+    {
+        var kept = new Dictionary<string, ComponentSMatrixData>();
+        foreach (var (key, value) in store)
+            if (usedGeometryKeys.Contains(key) || liveIdentifiers.Contains(key))
+                kept[key] = value;
+        return kept;
+    }
+}
+```
+
+In `SaveDesign` (FileOperationsViewModel), wo `designData.SMatrices` gesetzt wird, ersetzen durch:
+
+```csharp
+if (StoredSMatrices.Count > 0)
+{
+    var live = _canvas.Components.Select(vm => vm.Component).ToList();
+    var usedGeometryKeys = live.Select(ResolveGeometryKey).Where(k => k != null).ToHashSet()!;
+    var liveIdentifiers = live.Select(c => c.Identifier).ToHashSet();
+    var swept = Services.SMatrixOverrideGc.Sweep(StoredSMatrices, usedGeometryKeys!, liveIdentifiers);
+    if (swept.Count > 0)
+        designData.SMatrices = swept;
+}
+```
+(Template-scoped `::`-Keys, falls vorhanden, separat behalten falls `KeyMatchesKnownLibraryTemplate` — der ausführende Subagent prüft, ob solche im project-local Store vorkommen; falls ja, zur `usedGeometryKeys`-Bedingung ein `|| IsTemplateScopedKey(key)` ergänzen, damit user-global migrierte Keys nicht fälschlich gekehrt werden.)
+
+- [ ] **Step 4: Test ausführen (muss bestehen)**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" SMatrixOverrideGc` → PASS.
+Run: `dotnet build CAP.Avalonia/CAP.Avalonia.csproj -clp:ErrorsOnly` → 0 Fehler.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CAP.Avalonia/Services/SMatrixOverrideGc.cs CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs UnitTests/Import/SMatrixOverrideGcTests.cs
+git commit -m "(+) S-matrix override GC: drop orphaned overrides at save time (refcount sweep)"
+```
+
+---
+
+## Task 5: Voller Testlauf + PR
+
+- [ ] **Step 1: Komplette Suite**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py"`
+Expected: alle grün (0 failed). Besonders `SMatrixOverrideApplicatorTests`, `ComponentCloneOrphanPinTests`, `ComponentGeometryKeyTests`, `SMatrixOverrideGcTests`.
+
+- [ ] **Step 2: PR** gegen `main`, Titel `(+) S-matrix override scoped by geometry identity + save-time GC (fixes copy/paste override loss)`, verlinkt Spec + Issues #583/#580E. Manueller Hinweis: FDTD auf einem Edge Coupler → kopieren → Kopie zeigt denselben Override; Parameter ändern → eigener Override; Speichern → verwaiste raus.
+
+---
+
+## Self-Review-Notizen
+
+- **Spec-Abdeckung:** Geometrie-Identität (T1) ✓, Vererbung via ApplyAll (T2) ✓, Schreiben unter Geometrie-Schlüssel + Nazca bleibt per-Instanz (T3) ✓, Save-Sweep-GC mit Identifier-Altbestand-Schutz (T4) ✓, Migration = Identifier-first-Match (T2-Schleife) ✓.
+- **Konsistenz:** `geometryKeyResolver`-Parametername identisch in T2/T3/T4; `ComponentGeometryKey.For(component, rawCodeLookup)`-Signatur identisch überall; `raw:`/`geo:`-Präfixe in T1 definiert, in T4-Sweep nur als opake Keys genutzt.
+- **Bewusst offen für den Implementierer:** exakte `_storedSMatrices`-Indizierungsstellen im Dialog (T3) und die genaue `SaveDesign`-Zeile (T4) liest der Subagent in der Datei — die Änderung ist je präzise beschrieben.

--- a/docs/superpowers/specs/2026-06-23-smatrix-override-geometry-scope-design.md
+++ b/docs/superpowers/specs/2026-06-23-smatrix-override-geometry-scope-design.md
@@ -1,0 +1,117 @@
+# S-Matrix-Override nach Geometrie-Identität (+ Garbage Collection)
+
+**Datum:** 2026-06-23
+**Status:** Design genehmigt, bereit für Implementierungsplanung
+
+## Problem
+
+Eine per FDTD neuberechnete (oder importierte) S-Matrix wird heute pro **Instanz**
+gespeichert — Schlüssel = `component.Identifier` (Canvas-/Hierarchy-Pfad). Dupliziert
+man das Bauteil (Strg+C/V), bekommt die Kopie einen neuen Identifier und damit keinen
+Override → der Override „verschwindet" für die Kopie, und andere baugleiche Instanzen
+erben ihn nie.
+
+`Component.Clone()` selbst überträgt die S-Matrix-Werte korrekt (Repro-Test
+`ComponentCloneOrphanPinTests.Clone_PreservesOverriddenSMatrixValue_NotJustStructure`).
+Der Verlust sitzt also nicht im Klonen, sondern im **per-Identifier-Schlüssel** des
+Override-Stores (vgl. Issues #583, #580E).
+
+## Grundprinzip
+
+Die S-Matrix ist eine Funktion der **Geometrie** (gegeben der Prozess), nicht des
+Namens oder der Instanz. Deckungsgleiche Geometrie ⇒ gleiche S-Matrix. Also ist der
+natürliche Override-Schlüssel die **Geometrie-Identität** des Bauteils.
+
+## Design
+
+### 1. Geometrie-Identität als Override-Schlüssel
+
+Für ein Bauteil:
+- **Aktiver Raw-Code-Override (#561)** vorhanden → Schlüssel = stabiler Hash des
+  Override-Codes (gleicher Code ⇒ gleicher Schlüssel ⇒ gleiche S-Matrix).
+- **Sonst** → `module | function | parameters` (keine/gleiche Parameter ⇒ gleicher
+  Schlüssel). Parametrisierte Varianten (z. B. unterschiedliche Koppler-Länge) bekommen
+  dadurch automatisch verschiedene Schlüssel ⇒ eigene S-Matrix.
+
+Dies ist dieselbe Identität, die `GdsPreviewKey` (GDS-Thumbnails) bereits bildet
+(`module|function|parameters` + Format-Version-Hash). Die Identitäts-Bildung wird
+geteilt/verallgemeinert, damit Preview und S-Matrix-Scope konsistent dieselbe
+Definition von „deckungsgleicher Geometrie" verwenden. Der Raw-Code-Fall wird ergänzt.
+
+### 2. Vererbung über `ApplyAll`
+
+`SMatrixOverrideApplicator.ApplyAll` matcht Overrides bisher per `Identifier` mit
+`templateKeyResolver` (`{PdkSource}::{Name}`) als Fallback. Der Fallback-Resolver wird
+durch einen **Geometrie-Identitäts-Resolver** ersetzt: `geometryKeyResolver(component)`
+liefert die Geometrie-Identität (siehe 1). Dadurch:
+- erhalten **alle deckungsgleichen Instanzen + Kopien** den Override beim Platzieren
+  und beim Projekt-Laden,
+- löst sich das Orphan-Key-Problem (#583) auf, weil der Schlüssel konsistent zur
+  Geometrie statt zum Anzeigenamen/Identifier ist.
+
+`Identifier`-Match bleibt als erster Lookup erhalten (Abwärtskompatibilität, siehe 5).
+
+### 3. Schreiben des Overrides
+
+FDTD-Recompute **und** „Load S-matrix from file" (beide schreiben in denselben
+project-local Store `StoredSMatrices`) speichern künftig unter dem **Geometrie-Schlüssel**
+statt unter `Identifier`. Konkret bekommt der Component-Settings-Dialog für den
+S-Matrix-Teil einen `smatrixKey` (= Geometrie-Identität), getrennt vom Identifier, der
+weiter den **Nazca-Geometrie-Override** (#561) adressiert — denn dieser *definiert* die
+Geometrie einer Einzelinstanz und ist daher zu Recht per-Instanz.
+
+### 4. Garbage Collection (Save-Sweep)
+
+Beim Projekt-Speichern werden nur S-Matrix-Overrides persistiert, deren
+Geometrie-Identität von **mindestens einer Canvas-Komponente** verwendet wird
+(refcount > 0). Verwaiste Einträge (z. B. nach Parameteränderung, sodass kein Bauteil
+mehr die alte Geometrie hat) fallen beim Speichern raus.
+
+Während der Session bleiben verwaiste Overrides erhalten — so sind Undo und
+„Parameter ändern und wieder zurücksetzen" sicher. Kein sofortiges Löschen, kein
+persistentes Markierungsfeld nötig: der Refcount wird beim Speichern aus den aktuell
+platzierten Komponenten berechnet (eine Komponente trägt 1 für ihre Geometrie-Identität).
+
+### 5. Migration / Abwärtskompatibilität
+
+Bestehende `.lun`-Projekte enthalten Overrides unter `Identifier`. Diese bleiben
+funktionsfähig, weil `ApplyAll` zuerst per `Identifier` matcht und erst dann den
+Geometrie-Resolver konsultiert. Nur **neue** Recomputes/Importe schreiben unter dem
+Geometrie-Schlüssel. Kein Bruch alter Projekte; keine aktive Datei-Migration nötig.
+
+Hinweis Save-Sweep: Der Refcount-Sweep darf einen alten per-Identifier-Eintrag nicht
+fälschlich als verwaist verwerfen, solange seine Instanz existiert. Der Sweep behält
+daher einen Eintrag, wenn entweder (a) seine Geometrie-Identität von ≥1 Komponente
+genutzt wird **oder** (b) sein Schlüssel ein `Identifier` einer noch vorhandenen
+Komponente ist.
+
+## Abgrenzung / Nicht-Ziele
+
+- Keine UI für Refcounts/„welche Bauteile teilen diese S-Matrix" (rein interne Mechanik).
+- Kein user-global Scope (bewusst project-local; siehe gewählter Scope „Typ, im Projekt").
+- Keine Änderung am Nazca-Geometrie-Override-Scope (#561 bleibt per-Instanz).
+- Time-Domain-Panel-UX ist separat (eigenes Roadmap-Thema).
+
+## Tests
+
+- Geometrie-Identität: gleicher `module|function|parameters` ⇒ gleicher Schlüssel;
+  abweichende Parameter ⇒ anderer Schlüssel; aktiver Raw-Code-Override ⇒ Code-Hash-Schlüssel.
+- `ApplyAll`: zwei deckungsgleiche Instanzen (gleiche Geometrie, verschiedene Identifier)
+  erben beide einen unter dem Geometrie-Schlüssel gespeicherten Override; eine
+  umparametrisierte Instanz erbt ihn nicht.
+- Kopie-Szenario (Regression zum gemeldeten Bug): Recompute auf Instanz A → Kopie B
+  (Clone) wird platziert → B trägt den Override (über `ApplyAll`-Geometrie-Match).
+- Save-Sweep: Override, dessen Geometrie keine Komponente mehr nutzt, wird beim Speichern
+  entfernt; ein noch genutzter (und ein per-Identifier-Altbestand mit vorhandener Instanz)
+  bleibt erhalten.
+- Bestehende Override-Tests (`SMatrixOverrideApplicatorTests`) bleiben grün
+  (Identifier-Match-Pfad unverändert).
+
+## Offene/abhängige Punkte
+
+- `GdsPreviewKey` liegt in `CAP.Avalonia/Controls/Canvas/ComponentPreview/`. Für die
+  Wiederverwendung als allgemeine Geometrie-Identität wird die Identitäts-Bildung an
+  einen feature-neutralen Ort gehoben oder als gemeinsame Hilfsfunktion exponiert
+  (Detail im Implementierungsplan).
+- Exakte Stelle des Save-Sweep: im Projekt-Speicherpfad von `FileOperationsViewModel`
+  (Detail im Plan).


### PR DESCRIPTION
## Was
Ein per FDTD neuberechneter (oder importierter) S-Matrix-Override wird jetzt an die **Geometrie-Identität** des Bauteils gebunden statt an die Einzelinstanz (`component.Identifier`). Damit erben **alle deckungsgleichen Instanzen + Kopien** (Strg+C/V) den Override automatisch — der gemeldete Bug (Kopie verliert den Override) ist behoben. Verwaiste Overrides werden beim Speichern per Refcount aufgeräumt.

## Warum
Die S-Matrix ist eine Eigenschaft der **Geometrie** (gegeben der Prozess), nicht der Instanz: gleiche Geometrie ⇒ gleiche S-Matrix. (#593 hatte nur den Copy/Paste-*Crash* behoben, nicht das Mitnehmen des Overrides.)

## Wie
- **`ComponentGeometryKey`** — Identität: Raw-Code-Override-Hash (#561) bzw. `module|function|parameters` (mit Trenner). Konzeptgleich zu `GdsPreviewKey`.
- **`SMatrixOverrideApplicator.ApplyAll`** — matcht `Identifier -> geometryKey -> templateKey` (Identifier-first = abwärtskompatibel).
- **Dialog** — FDTD-Recompute und "Load S-matrix from file" speichern unter dem Geometrie-Schlüssel (`_smatrixKey`); der **Nazca-Geometrie-Override bleibt per-Instanz**.
- **`SMatrixOverrideGc.Sweep`** — beim Speichern bleiben nur Overrides mit refcount > 0 (genutzte Geometrie / lebende Identifier / template-scoped); verwaiste fallen raus. Während der Session bleiben sie (Undo-sicher).
- **Migration:** alte per-Identifier-Overrides bleiben matchbar; kein Bruch.

## Verifikation
Build grün; volle Suite **2523 passed / 0 failed**. Neue Tests: `ComponentGeometryKey`, `SMatrixOverrideGc`, Geometrie-Match + Copy-Szenario in `SMatrixOverrideApplicatorTests`, Clone-Werterhaltung in `ComponentCloneOrphanPinTests`. Spec + Plan unter `docs/superpowers/`.

Adressiert #583 (Orphan-Key) und #580E (Typ-Ebene-Override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
