### PR TITLE
(+) Single-PDK enforcement + process model persistence (issue #570)

### DIFF
--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -221,6 +221,11 @@ public partial class MainViewModel : ObservableObject
             Selection.NazcaOverridePropagator.Propagate(
                 identifierMap, FileOperations.StoredNazcaOverrides);
 
+        // Single-PDK enforcement (issue #570): let the canvas interaction read and update
+        // the active chip PDK from the file-operations layer.
+        CanvasInteraction.GetActivePdkName = () => FileOperations.ActivePdkName;
+        CanvasInteraction.OnComponentPlaced = pdkSource => FileOperations.NotifyComponentPlaced(pdkSource);
+
         // Wire rename from hierarchy panel through undo-aware command manager
         LeftPanel.HierarchyPanel.RenameComponent = (component, newName) =>
         {
@@ -723,6 +728,14 @@ public class DesignFileData
     /// Null for files saved before chip-size support was added (defaults to 5000 μm on load).
     /// </summary>
     public double? ChipHeightMicrometers { get; set; }
+
+    /// <summary>
+    /// The PDK this design is locked to (issue #570 — one process per chip).
+    /// Set on first save after a user-PDK component is placed, or inferred from the
+    /// dominant PDK on load of legacy files that lack this field.
+    /// Null means no user-PDK component has been placed yet; the design is open to any PDK.
+    /// </summary>
+    public string? ActivePdkName { get; set; }
 }
 
 /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -8,6 +8,7 @@ using CAP.Avalonia.Commands;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.Services;
+using CAP_Core.Components.Process;
 
 namespace CAP.Avalonia.ViewModels.Panels;
 
@@ -89,6 +90,20 @@ public partial class CanvasInteractionViewModel : ObservableObject
     /// Wired by <c>MainViewModel</c> to propagate <c>StoredNazcaOverrides</c>.
     /// </summary>
     public Action<IReadOnlyDictionary<string, string>>? OnComponentsPasted { get; set; }
+
+    /// <summary>
+    /// Returns the active chip PDK name (null = no user-PDK component placed yet).
+    /// Wired by <c>MainViewModel</c> to <c>FileOperationsViewModel.ActivePdkName</c>.
+    /// Used to enforce the single-PDK-per-design rule (issue #570).
+    /// </summary>
+    public Func<string?>? GetActivePdkName { get; set; }
+
+    /// <summary>
+    /// Invoked after a component is successfully placed to allow the host to update
+    /// the active chip PDK. Wired by <c>MainViewModel</c> to
+    /// <c>FileOperationsViewModel.NotifyComponentPlaced</c>.
+    /// </summary>
+    public Action<string?>? OnComponentPlaced { get; set; }
 
     public CanvasInteractionViewModel(
         DesignCanvasViewModel canvas,
@@ -305,6 +320,17 @@ public partial class CanvasInteractionViewModel : ObservableObject
     {
         if (SelectedTemplate == null) return;
 
+        // Single-PDK enforcement (issue #570): block if the template's PDK differs from the
+        // design's active PDK. Built-in components (null PdkSource) are always allowed.
+        var (isAllowed, blockReason) = SinglePdkPolicy.CheckPlacement(
+            GetActivePdkName?.Invoke(),
+            SelectedTemplate.PdkSource);
+        if (!isAllowed)
+        {
+            UpdateStatus?.Invoke(blockReason ?? "PDK mismatch — cannot place component.");
+            return;
+        }
+
         double centeredX = x - SelectedTemplate.WidthMicrometers / 2;
         double centeredY = y - SelectedTemplate.HeightMicrometers / 2;
 
@@ -316,6 +342,7 @@ public partial class CanvasInteractionViewModel : ObservableObject
         }
 
         _commandManager.ExecuteCommand(cmd);
+        OnComponentPlaced?.Invoke(SelectedTemplate.PdkSource);
         UpdateStatus?.Invoke($"Placed {SelectedTemplate.Name} at ({x:F0}, {y:F0})µm");
     }
 

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -15,6 +15,7 @@ using CAP.Avalonia.ViewModels.Converters;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Export;
 using CAP_Core.Export;
+using CAP_Core.Components.Process;
 
 namespace CAP.Avalonia.ViewModels.Panels;
 
@@ -45,6 +46,13 @@ public partial class FileOperationsViewModel : ObservableObject
     /// and other user-set fields survive a save-over-reload cycle.
     /// </summary>
     private DesignMetadata? _loadedMetadata;
+
+    /// <summary>
+    /// The PDK this design is locked to (issue #570 — one process per chip).
+    /// Null until the first user-PDK component is placed, or after a new design is started.
+    /// Persisted in the .lun file and migrated from legacy files on load.
+    /// </summary>
+    public string? ActivePdkName { get; private set; }
 
     /// <summary>
     /// Per-component S-matrix overrides loaded from the PIR section of the .lun file,
@@ -324,6 +332,7 @@ public partial class FileOperationsViewModel : ObservableObject
                 designData.NazcaOverrides = new Dictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>(StoredNazcaOverrides);
             designData.ChipWidthMicrometers  = _canvas.ChipMaxX;
             designData.ChipHeightMicrometers = _canvas.ChipMaxY;
+            designData.ActivePdkName = ResolveActivePdkForSave();
 
             var json = JsonSerializer.Serialize(designData, new JsonSerializerOptions
             {
@@ -572,6 +581,62 @@ public partial class FileOperationsViewModel : ObservableObject
         };
     }
 
+    /// <summary>
+    /// Called by <see cref="CAP.Avalonia.ViewModels.Panels.CanvasInteractionViewModel"/> after
+    /// successfully placing a user-PDK component. Locks the design to that PDK on the
+    /// first placement.
+    /// </summary>
+    public void NotifyComponentPlaced(string? pdkSource)
+    {
+        if (!string.IsNullOrWhiteSpace(pdkSource) && string.IsNullOrWhiteSpace(ActivePdkName))
+            ActivePdkName = pdkSource;
+    }
+
+    /// <summary>
+    /// Returns the active PDK name to persist on save.
+    /// Re-computes from placed components so that placing the first user-PDK component
+    /// automatically locks the design on the next save.
+    /// </summary>
+    private string? ResolveActivePdkForSave()
+    {
+        var pdkSources = _canvas.Components
+            .Select(vm => vm.TemplatePdkSource ?? FindTemplatePdkSource(vm.Component));
+        var computed = SinglePdkPolicy.DetermineActivePdk(pdkSources);
+        // Keep the previously stored name if the canvas is empty (e.g., new design).
+        return computed ?? ActivePdkName;
+    }
+
+    /// <summary>
+    /// Restores <see cref="ActivePdkName"/> after loading a file.
+    /// Prefers the value stored in the file; falls back to the dominant PDK
+    /// inferred from loaded components (migration path for legacy files).
+    /// Logs a warning when the file is silent but multiple PDKs are present.
+    /// </summary>
+    private string? RestoreActivePdk(DesignFileData designData)
+    {
+        if (!string.IsNullOrWhiteSpace(designData.ActivePdkName))
+            return designData.ActivePdkName;
+
+        // Legacy file: infer from loaded components.
+        var pdkSources = designData.Components
+            .Select(c => c.PdkSource)
+            .Concat(designData.Groups?.SelectMany(g =>
+                g.ChildComponents.Select(ch => ch.PdkSource)) ?? Enumerable.Empty<string?>());
+
+        var dominant = SinglePdkPolicy.DetermineActivePdk(pdkSources);
+        if (dominant == null) return null;
+
+        var conflicts = SinglePdkPolicy.FindConflictingPdks(pdkSources, dominant);
+        if (conflicts.Count > 0)
+            _errorConsole?.LogWarning(
+                $"Legacy design contains components from multiple PDKs. " +
+                $"Locked to dominant PDK '{dominant}'. " +
+                $"Other PDKs present: {string.Join(", ", conflicts)}. " +
+                "Remove conflicting components or start a new design.");
+
+        return dominant;
+    }
+
     private string FindTemplateName(Component component)
     {
         // Check if the component has a VM on the canvas with a template name
@@ -748,6 +813,10 @@ public partial class FileOperationsViewModel : ObservableObject
                 // Preserve PIR metadata so Created date survives subsequent saves
                 _loadedMetadata = designData.Metadata;
 
+                // Restore or migrate the active chip PDK (issue #570).
+                // Legacy files have no ActivePdkName → infer it from the dominant PDK.
+                ActivePdkName = RestoreActivePdk(designData);
+
                 // Restore imported S-matrices from PIR section
                 StoredSMatrices.Clear();
                 if (designData.SMatrices != null)
@@ -878,6 +947,7 @@ public partial class FileOperationsViewModel : ObservableObject
 
         _currentFilePath = null;
         _loadedMetadata = null;
+        ActivePdkName = null;
         HasUnsavedChanges = false;
         UpdateStatus?.Invoke("New project created");
 

--- a/Connect-A-Pic-Core/Components/Process/SinglePdkPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/SinglePdkPolicy.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CAP_Core.Components.Process;
+
+/// <summary>
+/// Enforces the single-PDK-per-design rule (issue #570).
+/// A monolithic chip is fabricated in exactly one process, so all components
+/// placed on the canvas must originate from the same PDK.
+/// Built-in components (null/empty <c>pdkSource</c>) are exempt from the check —
+/// they are process-agnostic adapters (lasers, detectors, …).
+/// </summary>
+public static class SinglePdkPolicy
+{
+    /// <summary>
+    /// Examines the PDK sources of all components currently in a design and returns
+    /// the "active" chip PDK — the one with the most placements. Returns <c>null</c>
+    /// when no user PDK component has been placed yet (only built-ins, or empty design).
+    /// Used during migration: existing designs without an <c>activePdkName</c> field
+    /// acquire one automatically on their next load/save.
+    /// </summary>
+    /// <param name="pdkSources">
+    ///   Sequence of <c>PdkSource</c> values from all loaded components (may contain
+    ///   <c>null</c> or empty strings for built-in components).
+    /// </param>
+    public static string? DetermineActivePdk(IEnumerable<string?> pdkSources)
+    {
+        var counts = pdkSources
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .GroupBy(s => s!, StringComparer.OrdinalIgnoreCase)
+            .Select(g => (Name: g.Key, Count: g.Count()))
+            .OrderByDescending(t => t.Count)
+            .ToList();
+
+        return counts.Count == 0 ? null : counts[0].Name;
+    }
+
+    /// <summary>
+    /// Returns the set of PDK names that appear in the design but differ from
+    /// <paramref name="activePdkName"/>. An empty set means the design is uniform.
+    /// Used after migration to report which PDK sources were demoted.
+    /// </summary>
+    public static IReadOnlyList<string> FindConflictingPdks(
+        IEnumerable<string?> pdkSources,
+        string activePdkName)
+    {
+        return pdkSources
+            .Where(s => !string.IsNullOrWhiteSpace(s)
+                        && !s!.Equals(activePdkName, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Checks whether a new component may be placed on a design whose active PDK is
+    /// <paramref name="activePdkName"/>.
+    /// </summary>
+    /// <param name="activePdkName">
+    ///   The design's locked PDK, or <c>null</c> if no PDK has been locked yet.
+    ///   When <c>null</c> the first user-PDK component that is placed will lock the design.
+    /// </param>
+    /// <param name="newComponentPdkSource">
+    ///   The PDK source of the component to be placed, or <c>null</c> / empty for built-in
+    ///   process-agnostic components.
+    /// </param>
+    /// <returns>
+    ///   <c>(IsAllowed: true, BlockReason: null)</c> when placement is permitted;
+    ///   <c>(IsAllowed: false, BlockReason: "…")</c> with a user-readable message otherwise.
+    /// </returns>
+    public static (bool IsAllowed, string? BlockReason) CheckPlacement(
+        string? activePdkName,
+        string? newComponentPdkSource)
+    {
+        // Built-in / process-agnostic components are always allowed.
+        if (string.IsNullOrWhiteSpace(newComponentPdkSource))
+            return (true, null);
+
+        // No PDK locked yet — first user-PDK component locks the design.
+        if (string.IsNullOrWhiteSpace(activePdkName))
+            return (true, null);
+
+        if (activePdkName.Equals(newComponentPdkSource, StringComparison.OrdinalIgnoreCase))
+            return (true, null);
+
+        return (false,
+            $"This component belongs to '{newComponentPdkSource}', but the chip is locked to '{activePdkName}'. " +
+            "A monolithic design can only use components from one PDK. " +
+            "Start a new design to mix PDKs.");
+    }
+}

--- a/UnitTests/Components/SinglePdkPolicyTests.cs
+++ b/UnitTests/Components/SinglePdkPolicyTests.cs
@@ -1,0 +1,117 @@
+using CAP_Core.Components.Process;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Verifies the single-PDK-per-design enforcement policy (issue #570).
+/// </summary>
+public class SinglePdkPolicyTests
+{
+    // ── DetermineActivePdk ────────────────────────────────────────────────────
+
+    [Fact]
+    public void DetermineActivePdk_EmptyList_ReturnsNull()
+    {
+        SinglePdkPolicy.DetermineActivePdk(Array.Empty<string?>()).ShouldBeNull();
+    }
+
+    [Fact]
+    public void DetermineActivePdk_AllNullOrEmpty_ReturnsNull()
+    {
+        SinglePdkPolicy.DetermineActivePdk(new string?[] { null, "", "  " }).ShouldBeNull();
+    }
+
+    [Fact]
+    public void DetermineActivePdk_SinglePdk_ReturnsThatPdk()
+    {
+        var result = SinglePdkPolicy.DetermineActivePdk(new[] { "AMF-Si", "AMF-Si", null });
+        result.ShouldBe("AMF-Si");
+    }
+
+    [Fact]
+    public void DetermineActivePdk_DominantPdk_ReturnsMostFrequent()
+    {
+        var sources = new[] { "HHI-InP", "AMF-Si", "HHI-InP", "HHI-InP", "AMF-Si" };
+        SinglePdkPolicy.DetermineActivePdk(sources).ShouldBe("HHI-InP");
+    }
+
+    // ── FindConflictingPdks ───────────────────────────────────────────────────
+
+    [Fact]
+    public void FindConflictingPdks_UniformDesign_ReturnsEmpty()
+    {
+        var conflicts = SinglePdkPolicy.FindConflictingPdks(
+            new[] { "AMF-Si", "AMF-Si", null }, "AMF-Si");
+        conflicts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindConflictingPdks_MixedDesign_ReturnsForeignPdks()
+    {
+        var sources = new string?[] { "HHI-InP", "AMF-Si", "AMF-Si", null };
+        var conflicts = SinglePdkPolicy.FindConflictingPdks(sources, "AMF-Si");
+        conflicts.Count.ShouldBe(1);
+        conflicts[0].ShouldBe("HHI-InP");
+    }
+
+    [Fact]
+    public void FindConflictingPdks_IsCaseInsensitive()
+    {
+        var sources = new string?[] { "amf-si", "AMF-Si" };
+        SinglePdkPolicy.FindConflictingPdks(sources, "AMF-Si").ShouldBeEmpty();
+    }
+
+    // ── CheckPlacement ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckPlacement_NoActivePdk_AllowsAnyComponent()
+    {
+        var (ok, reason) = SinglePdkPolicy.CheckPlacement(null, "AMF-Si");
+        ok.ShouldBeTrue();
+        reason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CheckPlacement_BuiltInComponent_AlwaysAllowed()
+    {
+        var (ok, _) = SinglePdkPolicy.CheckPlacement("AMF-Si", null);
+        ok.ShouldBeTrue();
+
+        (ok, _) = SinglePdkPolicy.CheckPlacement("AMF-Si", "");
+        ok.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CheckPlacement_SamePdk_IsAllowed()
+    {
+        var (ok, reason) = SinglePdkPolicy.CheckPlacement("AMF-Si", "AMF-Si");
+        ok.ShouldBeTrue();
+        reason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CheckPlacement_DifferentPdk_IsBlocked()
+    {
+        var (ok, reason) = SinglePdkPolicy.CheckPlacement("AMF-Si", "HHI-InP");
+        ok.ShouldBeFalse();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("HHI-InP");
+        reason.ShouldContain("AMF-Si");
+    }
+
+    [Fact]
+    public void CheckPlacement_IsCaseInsensitive()
+    {
+        var (ok, _) = SinglePdkPolicy.CheckPlacement("amf-si", "AMF-Si");
+        ok.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CheckPlacement_BothNull_IsAllowed()
+    {
+        var (ok, _) = SinglePdkPolicy.CheckPlacement(null, null);
+        ok.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #570 — implements the **single-PDK-per-design enforcement** (step 4 of the issue's build order). The process-block data model (`ProcessDefinition`, importers, `ProcessManagementViewModel`) was already merged in earlier PRs; this PR adds the active-chip-PDK tracking and the hard placement block.

### What changed

- **`SinglePdkPolicy`** (new, `Connect-A-Pic-Core/Components/Process/`): pure stateless helpers:
  - `DetermineActivePdk` — counts PDK sources and returns the dominant one (migration helper for legacy files).
  - `FindConflictingPdks` — returns PDKs that differ from the active one (for migration warnings).
  - `CheckPlacement` — returns `(IsAllowed, BlockReason)`. Built-in/process-agnostic components always pass; a user-PDK component is blocked if its PDK differs from the active chip PDK.

- **`DesignFileData.ActivePdkName`** (new nullable field): persisted in `.lun` files. Null until the first user-PDK component is placed.

- **`FileOperationsViewModel`**:
  - Exposes `ActivePdkName { get; private set; }`.
  - `NotifyComponentPlaced(pdkSource)` locks the design to the first placed user-PDK.
  - Save: `ResolveActivePdkForSave()` re-computes from canvas components.
  - Load: `RestoreActivePdk()` reads the stored field; for legacy files without the field it infers the dominant PDK and logs a one-time warning when mixed PDKs are present (migration option 1).
  - File → New resets `ActivePdkName` to null.

- **`CanvasInteractionViewModel`**:
  - `GetActivePdkName` / `OnComponentPlaced` callback properties (same pattern as `UpdateStatus`).
  - `PlaceComponentAt` checks `SinglePdkPolicy.CheckPlacement` before issuing the undo command — blocked placements surface a clear status-bar message without touching the undo stack.

- **`MainViewModel`**: wires the two new callbacks.

### Tests

13 new tests in `UnitTests/Components/SinglePdkPolicyTests.cs` covering all policy branches (null active PDK, built-in exemption, same-PDK pass, cross-PDK block, case insensitivity, dominant-PDK selection, conflict detection).

## Test plan

- [ ] All 13 `SinglePdkPolicyTests` pass ✅
- [ ] Full test suite: 325 pass, 2 pre-existing failures unrelated to this PR (`PdkJsonSaverRoundTrip` — git worktree root detection; `NazcaEditorPreview` — live Python/Nazca dependency)
- [ ] Build: zero errors, zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)