### PR TITLE
(+) Transient waveform plot: power-vs-time oscilloscope view (#601)

### DIFF
--- a/CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs
@@ -8,7 +8,12 @@ using CAP_Core.LightCalculation;
 using CAP_Core.LightCalculation.TimeDomainSimulation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Analysis.TimeTrace;
 using CAP.Avalonia.ViewModels.Canvas;
+using OxyPlot;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 namespace CAP.Avalonia.ViewModels.Analysis;
 
@@ -50,9 +55,28 @@ public partial class TimeDomainViewModel : ObservableObject
     [ObservableProperty]
     private string _resultText = "";
 
+    /// <summary>
+    /// OxyPlot model for the transient waveform plot (power vs time, one series
+    /// per output pin). Bound to the panel's <c>PlotView</c>. Reuses the ONA
+    /// charting approach (#526) — zoom/pan come from OxyPlot's default axes.
+    /// </summary>
+    [ObservableProperty]
+    private PlotModel _plotModel = TimeTracePlotBuilder.CreateEmptyPlotModel();
+
+    /// <summary>
+    /// Legend / per-pin visibility toggles. Each entry maps to one output-pin
+    /// trace; toggling <see cref="TimeTraceSeriesViewModel.IsVisible"/> rebuilds
+    /// the plot.
+    /// </summary>
+    public ObservableCollection<TimeTraceSeriesViewModel> Series { get; } = new();
+
+    /// <summary>True once a completed transient result is available to plot/export.</summary>
+    public bool HasResult => _lastResult != null;
+
     private readonly CAP_Core.ErrorConsoleService? _errorConsole;
     private DesignCanvasViewModel? _canvas;
     private TimeDomainResult? _lastResult;
+    private Dictionary<Guid, string> _pinNameMap = new();
 
     /// <summary>Initializes a new instance of <see cref="TimeDomainViewModel"/>.</summary>
     /// <param name="errorConsole">Optional service for error logging.</param>
@@ -71,6 +95,7 @@ public partial class TimeDomainViewModel : ObservableObject
         ResultText = "";
         StatusText = "";
         _lastResult = null;
+        ClearPlot();
     }
 
     /// <summary>Runs the time-domain simulation pipeline.</summary>
@@ -88,12 +113,16 @@ public partial class TimeDomainViewModel : ObservableObject
         StatusText = "Building impulse responses…";
         ResultText = "";
         _lastResult = null;
+        ClearPlot();
 
         try
         {
+            _pinNameMap = BuildPinNameMap();
             var result = await Task.Run(() => RunSimulationCore());
             _lastResult = result;
             ResultText = TimeDomainResultFormatter.FormatResult(result);
+            BuildPlot(result);
+            OnPropertyChanged(nameof(HasResult));
             StatusText = $"Done — {result.PinTraces.Count} output pin(s)";
         }
         catch (InvalidOperationException ex)
@@ -213,4 +242,71 @@ public partial class TimeDomainViewModel : ObservableObject
         return signals;
     }
 
+    /// <summary>
+    /// Maps each logical pin Guid (both in- and out-flow) to a "Component.Pin" label so the
+    /// plot legend shows readable names instead of Guids. Built on the UI thread from the
+    /// current canvas before the simulation runs.
+    /// </summary>
+    private Dictionary<Guid, string> BuildPinNameMap()
+    {
+        var map = new Dictionary<Guid, string>();
+        if (_canvas == null) return map;
+
+        foreach (var compVm in _canvas.Components)
+        {
+            var component = compVm.Component;
+            var componentName = component.HumanReadableName ?? component.Identifier;
+            foreach (var pin in component.PhysicalPins)
+            {
+                if (pin.LogicalPin == null) continue;
+                var label = $"{componentName}.{pin.Name}";
+                // The result keys traces by the output pin's flow id; map both so the
+                // label resolves regardless of which flow direction the trace carries.
+                map[pin.LogicalPin.IDInFlow] = label;
+                map[pin.LogicalPin.IDOutFlow] = label;
+            }
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// Builds the legend items and plot model from a completed result, and subscribes to
+    /// each series so toggling its visibility rebuilds the plot.
+    /// </summary>
+    private void BuildPlot(TimeDomainResult result)
+    {
+        DetachSeries();
+        Series.Clear();
+
+        var items = TimeTracePlotBuilder.BuildSeriesItems(
+            result, pinId => _pinNameMap.TryGetValue(pinId, out var name) ? name : null);
+        foreach (var item in items)
+        {
+            item.PropertyChanged += OnSeriesVisibilityChanged;
+            Series.Add(item);
+        }
+
+        PlotModel = TimeTracePlotBuilder.BuildPlotModel(result, items);
+    }
+
+    /// <summary>Resets the plot and legend to the empty state (e.g. on reconfigure or re-run).</summary>
+    private void ClearPlot()
+    {
+        DetachSeries();
+        Series.Clear();
+        PlotModel = TimeTracePlotBuilder.CreateEmptyPlotModel();
+        OnPropertyChanged(nameof(HasResult));
+    }
+
+    private void DetachSeries()
+    {
+        foreach (var series in Series)
+            series.PropertyChanged -= OnSeriesVisibilityChanged;
+    }
+
+    private void OnSeriesVisibilityChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TimeTraceSeriesViewModel.IsVisible) && _lastResult != null)
+            PlotModel = TimeTracePlotBuilder.BuildPlotModel(_lastResult, Series);
+    }
 }

--- a/CAP.Avalonia/ViewModels/Analysis/TimeTrace/TimeTracePlotBuilder.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/TimeTrace/TimeTracePlotBuilder.cs
@@ -1,0 +1,139 @@
+using CAP_Core.LightCalculation.TimeDomainSimulation;
+using CAP.Avalonia.Controls.Plotting;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Legends;
+
+namespace CAP.Avalonia.ViewModels.Analysis.TimeTrace;
+
+/// <summary>
+/// Pure mapping helpers that turn a <see cref="TimeDomainResult"/> into an
+/// OxyPlot <see cref="PlotModel"/> of power-vs-time traces (one series per
+/// output pin) and into the legend/toggle items that drive visibility.
+/// Mirrors the ONA spectrum charting approach (#526) for consistency.
+/// Kept free of ViewModel/UI state so the result→series mapping is unit-testable.
+/// </summary>
+internal static class TimeTracePlotBuilder
+{
+    /// <summary>Seconds-to-picoseconds factor for the time axis.</summary>
+    private const double SecondsToPicoseconds = 1e12;
+
+    /// <summary>Power below this (field-units²) is treated as "no signal" and the pin is skipped.</summary>
+    private const double SignalFloor = 1e-12;
+
+    private const double SeriesStrokeThickness = 1.5;
+
+    // Light colours readable on the dark (#1e1e1e) panel background. Matches
+    // the palette feel of the ONA chart while staying distinct per series.
+    private static readonly OxyColor[] Palette =
+    {
+        OxyColor.Parse("#4FC3F7"), OxyColor.Parse("#FF8A65"),
+        OxyColor.Parse("#81C784"), OxyColor.Parse("#BA68C8"),
+        OxyColor.Parse("#FFD54F"), OxyColor.Parse("#4DD0E1"),
+        OxyColor.Parse("#F06292"), OxyColor.Parse("#AED581"),
+    };
+
+    private static readonly OxyColor PlotForeground = OxyColor.Parse("#E0E0E0");
+    private static readonly OxyColor PlotGridline = OxyColor.Parse("#404040");
+    private static readonly OxyColor PlotAxisline = OxyColor.Parse("#808080");
+
+    /// <summary>
+    /// Builds the legend/toggle items for a result: one per output pin that
+    /// carries a non-negligible signal. Each gets a stable palette colour and a
+    /// resolved display label. Pins are ordered by descending peak power so the
+    /// strongest traces appear first.
+    /// </summary>
+    /// <param name="result">The transient result to map.</param>
+    /// <param name="resolveLabel">Maps a pin Guid to a display label; may return null.</param>
+    public static IReadOnlyList<TimeTraceSeriesViewModel> BuildSeriesItems(
+        TimeDomainResult result, Func<Guid, string?> resolveLabel)
+    {
+        var ordered = result.PinTraces
+            .Where(kv => kv.Value.Length > 0 && kv.Value.Max() >= SignalFloor)
+            .OrderByDescending(kv => kv.Value.Max())
+            .ToList();
+
+        var items = new List<TimeTraceSeriesViewModel>(ordered.Count);
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            var pinId = ordered[i].Key;
+            var label = resolveLabel(pinId) ?? $"Pin {pinId.ToString("N")[..6]}";
+            items.Add(new TimeTraceSeriesViewModel(pinId, label, Palette[i % Palette.Length]));
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="PlotModel"/> from the result, drawing one line series
+    /// per <paramref name="seriesItems"/> entry whose
+    /// <see cref="TimeTraceSeriesViewModel.IsVisible"/> is true. The X axis is
+    /// time in picoseconds; the Y axis is power |E(t)|². Zoom/pan are enabled by
+    /// OxyPlot's default linear-axis behaviour.
+    /// </summary>
+    /// <param name="result">The transient result supplying the time axis and traces.</param>
+    /// <param name="seriesItems">Legend items (identity + colour + visibility).</param>
+    public static PlotModel BuildPlotModel(
+        TimeDomainResult result, IReadOnlyList<TimeTraceSeriesViewModel> seriesItems)
+    {
+        var model = CreateEmptyPlotModel();
+        var timePs = result.TimeAxis.Select(t => t * SecondsToPicoseconds).ToArray();
+
+        foreach (var item in seriesItems)
+        {
+            if (!item.IsVisible) continue;
+            if (!result.PinTraces.TryGetValue(item.PinId, out var trace)) continue;
+
+            var series = new XTrackingLineSeries
+            {
+                Title = item.Label,
+                Color = item.Color,
+                StrokeThickness = SeriesStrokeThickness,
+                CanTrackerInterpolatePoints = true,
+                TrackerTextProvider = dp => $"{item.Label}\nt = {dp.X:0.000} ps\nP = {dp.Y:0.000e0}",
+            };
+
+            int count = Math.Min(timePs.Length, trace.Length);
+            for (int n = 0; n < count; n++)
+                series.Points.Add(new DataPoint(timePs[n], trace[n]));
+
+            model.Series.Add(series);
+        }
+
+        model.InvalidatePlot(true);
+        return model;
+    }
+
+    /// <summary>Creates an empty, dark-themed time-trace plot model with labelled axes.</summary>
+    public static PlotModel CreateEmptyPlotModel()
+    {
+        var model = new PlotModel
+        {
+            Title = "Transient — Power vs Time",
+            Background = OxyColors.Transparent,
+            TextColor = PlotForeground,
+            TitleColor = PlotForeground,
+            PlotAreaBorderColor = PlotAxisline,
+        };
+        model.Legends.Add(new Legend
+        {
+            LegendPosition = LegendPosition.RightTop,
+            LegendTextColor = PlotForeground,
+        });
+        model.Axes.Add(CreateAxis(AxisPosition.Bottom, "Time (ps)"));
+        model.Axes.Add(CreateAxis(AxisPosition.Left, "Power |E(t)|²"));
+        return model;
+    }
+
+    private static LinearAxis CreateAxis(AxisPosition position, string title) => new()
+    {
+        Position = position,
+        Title = title,
+        MajorGridlineStyle = LineStyle.Dot,
+        MajorGridlineColor = PlotGridline,
+        TextColor = PlotForeground,
+        TitleColor = PlotForeground,
+        TicklineColor = PlotAxisline,
+        AxislineColor = PlotAxisline,
+        AxislineStyle = LineStyle.Solid,
+    };
+}

--- a/CAP.Avalonia/ViewModels/Analysis/TimeTrace/TimeTraceSeriesViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/TimeTrace/TimeTraceSeriesViewModel.cs
@@ -1,0 +1,44 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using OxyPlot;
+
+namespace CAP.Avalonia.ViewModels.Analysis.TimeTrace;
+
+/// <summary>
+/// One entry in the transient-plot legend: a single output-pin trace.
+/// Carries the pin identity, its display label, the colour used to draw it,
+/// and a user-toggleable visibility flag. The owning ViewModel observes
+/// <see cref="ObservableObject.PropertyChanged"/> to rebuild the plot when
+/// <see cref="IsVisible"/> changes.
+/// </summary>
+public partial class TimeTraceSeriesViewModel : ObservableObject
+{
+    /// <summary>Outflow pin Guid this series was built from.</summary>
+    public Guid PinId { get; }
+
+    /// <summary>Human-readable label shown in the legend (e.g. "MMI.out1").</summary>
+    public string Label { get; }
+
+    /// <summary>Colour used for both the legend swatch and the plotted line.</summary>
+    public OxyColor Color { get; }
+
+    /// <summary>Hex string of <see cref="Color"/> for AXAML brush binding.</summary>
+    public string ColorHex => Color.ToString();
+
+    /// <summary>
+    /// Whether this trace is drawn. Toggling it triggers a plot rebuild in the
+    /// owning ViewModel via property-changed notification.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isVisible = true;
+
+    /// <summary>Initializes a new legend entry for one output-pin trace.</summary>
+    /// <param name="pinId">Outflow pin Guid.</param>
+    /// <param name="label">Display label for the legend.</param>
+    /// <param name="color">Series colour.</param>
+    public TimeTraceSeriesViewModel(Guid pinId, string label, OxyColor color)
+    {
+        PinId = pinId;
+        Label = label;
+        Color = color;
+    }
+}

--- a/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
@@ -1,8 +1,19 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:CAP.Avalonia.ViewModels"
+             xmlns:trace="using:CAP.Avalonia.ViewModels.Analysis.TimeTrace"
+             xmlns:oxy="using:OxyPlot.Avalonia"
              x:Class="CAP.Avalonia.Views.Panels.TimeDomainPanel"
              x:DataType="vm:MainViewModel">
+
+    <UserControl.Styles>
+        <!-- Dark hover-tracker so its text is readable on the dark theme,
+             mirroring the ONA window's tracker style. -->
+        <Style Selector="oxy|TrackerControl">
+            <Setter Property="Background" Value="#2D2D2D"/>
+            <Setter Property="LineStroke" Value="#A0A0A0"/>
+        </Style>
+    </UserControl.Styles>
 
     <StackPanel>
         <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
@@ -86,8 +97,35 @@
                    IsVisible="{Binding RightPanel.TimeDomain.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                    TextWrapping="Wrap"/>
 
-        <!-- Result table -->
-        <ScrollViewer MaxHeight="180" Margin="0,4,0,0"
+        <!-- Waveform plot: power vs time, one series per output pin.
+             Zoom/pan via OxyPlot default axes; cursor read-out via tracker. -->
+        <Border Background="#1a1a1a" BorderBrush="#3d3d3d" BorderThickness="1"
+                Height="220" Margin="0,4,0,0"
+                IsVisible="{Binding RightPanel.TimeDomain.HasResult}">
+            <oxy:PlotView Model="{Binding RightPanel.TimeDomain.PlotModel}" Background="Transparent"/>
+        </Border>
+
+        <!-- Per-pin visibility toggles (legend). -->
+        <ItemsControl ItemsSource="{Binding RightPanel.TimeDomain.Series}"
+                      Margin="0,4,0,0"
+                      IsVisible="{Binding RightPanel.TimeDomain.HasResult}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate x:DataType="trace:TimeTraceSeriesViewModel">
+                    <CheckBox IsChecked="{Binding IsVisible}" Margin="0,0,0,1">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <Border Width="12" Height="12" CornerRadius="2"
+                                    VerticalAlignment="Center"
+                                    Background="{Binding ColorHex}"/>
+                            <TextBlock Text="{Binding Label}" Foreground="LightGray"
+                                       FontSize="10" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </CheckBox>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <!-- Peak-power summary table (kept from the original text output). -->
+        <ScrollViewer MaxHeight="120" Margin="0,4,0,0"
                       IsVisible="{Binding RightPanel.TimeDomain.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
             <TextBlock Text="{Binding RightPanel.TimeDomain.ResultText}"
                        Foreground="Plum" FontFamily="Consolas" FontSize="10"
@@ -98,7 +136,7 @@
         <Button Content="Export CSV"
                 Command="{Binding RightPanel.TimeDomain.ExportCsvCommand}"
                 Width="110" Margin="0,5,0,0" Background="#3d3d5d"
-                IsVisible="{Binding RightPanel.TimeDomain.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                IsVisible="{Binding RightPanel.TimeDomain.HasResult}"/>
         </StackPanel><!-- end Time-Domain controls -->
     </StackPanel>
 

--- a/UnitTests/Analysis/TimeTrace/TimeTracePlotBuilderTests.cs
+++ b/UnitTests/Analysis/TimeTrace/TimeTracePlotBuilderTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CAP_Core.LightCalculation.TimeDomainSimulation;
+using CAP.Avalonia.ViewModels.Analysis.TimeTrace;
+using OxyPlot.Series;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.TimeTrace;
+
+/// <summary>
+/// Tests the result→series mapping and visibility-toggle logic that drives the
+/// transient waveform plot (Issue #601).
+/// </summary>
+public class TimeTracePlotBuilderTests
+{
+    private static TimeDomainResult MakeResult(
+        double[] timeAxis, params (Guid pin, double[] trace)[] traces)
+    {
+        var dict = traces.ToDictionary(t => t.pin, t => t.trace);
+        return new TimeDomainResult(timeAxis, dict);
+    }
+
+    [Fact]
+    public void BuildSeriesItems_CreatesOneItemPerSignalCarryingPin()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var result = MakeResult(
+            new[] { 0.0, 1e-12, 2e-12 },
+            (a, new[] { 0.0, 0.5, 0.2 }),
+            (b, new[] { 0.0, 0.9, 0.1 }));
+
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+
+        items.Count.ShouldBe(2);
+        items.Select(i => i.PinId).ShouldBe(new[] { a, b }, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void BuildSeriesItems_SkipsPinsBelowSignalFloor()
+    {
+        var loud = Guid.NewGuid();
+        var silent = Guid.NewGuid();
+        var result = MakeResult(
+            new[] { 0.0, 1e-12 },
+            (loud, new[] { 0.0, 0.5 }),
+            (silent, new[] { 0.0, 1e-15 }));
+
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+
+        items.Count.ShouldBe(1);
+        items[0].PinId.ShouldBe(loud);
+    }
+
+    [Fact]
+    public void BuildSeriesItems_OrdersByDescendingPeakPower()
+    {
+        var weak = Guid.NewGuid();
+        var strong = Guid.NewGuid();
+        var result = MakeResult(
+            new[] { 0.0, 1e-12 },
+            (weak, new[] { 0.0, 0.2 }),
+            (strong, new[] { 0.0, 0.9 }));
+
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+
+        items[0].PinId.ShouldBe(strong);
+        items[1].PinId.ShouldBe(weak);
+    }
+
+    [Fact]
+    public void BuildSeriesItems_UsesResolvedLabelWhenAvailable()
+    {
+        var pin = Guid.NewGuid();
+        var result = MakeResult(new[] { 0.0, 1e-12 }, (pin, new[] { 0.0, 0.5 }));
+
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => "MMI.out1");
+
+        items[0].Label.ShouldBe("MMI.out1");
+    }
+
+    [Fact]
+    public void BuildSeriesItems_FallsBackToShortGuidLabel()
+    {
+        var pin = Guid.NewGuid();
+        var result = MakeResult(new[] { 0.0, 1e-12 }, (pin, new[] { 0.0, 0.5 }));
+
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+
+        items[0].Label.ShouldStartWith("Pin ");
+    }
+
+    [Fact]
+    public void BuildPlotModel_ConvertsTimeAxisToPicoseconds()
+    {
+        var pin = Guid.NewGuid();
+        var result = MakeResult(new[] { 0.0, 1e-12, 2e-12 }, (pin, new[] { 0.0, 0.5, 0.2 }));
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+
+        var model = TimeTracePlotBuilder.BuildPlotModel(result, items);
+
+        var series = model.Series.OfType<LineSeries>().Single();
+        series.Points.Count.ShouldBe(3);
+        // 2e-12 s == 2 ps on the X axis.
+        series.Points[2].X.ShouldBe(2.0, 1e-9);
+        series.Points[1].Y.ShouldBe(0.5, 1e-9);
+    }
+
+    [Fact]
+    public void BuildPlotModel_OmitsHiddenSeries()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var result = MakeResult(
+            new[] { 0.0, 1e-12 },
+            (a, new[] { 0.0, 0.5 }),
+            (b, new[] { 0.0, 0.9 }));
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+
+        items[0].IsVisible = false; // hide the strongest
+
+        var model = TimeTracePlotBuilder.BuildPlotModel(result, items);
+
+        model.Series.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void BuildPlotModel_AllHidden_ProducesNoSeries()
+    {
+        var pin = Guid.NewGuid();
+        var result = MakeResult(new[] { 0.0, 1e-12 }, (pin, new[] { 0.0, 0.5 }));
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+        items[0].IsVisible = false;
+
+        var model = TimeTracePlotBuilder.BuildPlotModel(result, items);
+
+        model.Series.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CreateEmptyPlotModel_HasTimeAndPowerAxes()
+    {
+        var model = TimeTracePlotBuilder.CreateEmptyPlotModel();
+
+        model.Axes.Count.ShouldBe(2);
+        model.Series.Count.ShouldBe(0);
+        model.Axes.Any(a => a.Title.Contains("Time")).ShouldBeTrue();
+        model.Axes.Any(a => a.Title.Contains("Power")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DistinctPalette_AssignedToSeparatePins()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var result = MakeResult(
+            new[] { 0.0, 1e-12 },
+            (a, new[] { 0.0, 0.9 }),
+            (b, new[] { 0.0, 0.5 }));
+
+        var items = TimeTracePlotBuilder.BuildSeriesItems(result, _ => null);
+
+        items[0].Color.ShouldNotBe(items[1].Color);
+    }
+}


### PR DESCRIPTION
Closes #601.

## What
Replaces the transient panel's text/CSV-only output with an **interactive power-vs-time plot** (oscilloscope view): one line series per output pin, a per-pin legend with visibility toggles, zoom/pan and a cursor read-out. CSV export is retained.

## Why
The transient engine (#527) already produces per-pin time traces, but they were only shown as a text table — you couldn't *see* the waveform. This is the "make transient usable, not just CSV" step of the transient → optical-link epic (#599), and the foundation the eye-diagram view (#535) will sit on.

## How
- Reuses the **existing ONA charting stack** (`OxyPlot.Avalonia` + `CAP.Avalonia/Controls/Plotting/XTrackingLineSeries`) — **no new dependency**.
- `TimeTracePlotBuilder` (pure, unit-tested): maps a `TimeDomainResult` → legend items + `PlotModel`. Skips pins below a signal floor, orders by descending peak power, assigns a distinct palette colour, converts the time axis to picoseconds.
- `TimeTraceSeriesViewModel`: one legend entry (pin id, label, colour, `IsVisible`).
- `TimeDomainViewModel`: owns `PlotModel` + `Series`; resolves pin Guids to "Component.Pin" labels; rebuilds the plot when a series is toggled; `HasResult` gates the plot/legend/export.
- `TimeDomainPanel.axaml`: `PlotView` + legend `ItemsControl`; the original peak-power text table is kept as a compact summary.

## Scope
Waveform plotting only. Eye diagram + BER is #535; signal sources / sample-mode driver is #600; active components are #529 — none of those are touched here.

## Verification
- `dotnet build` ✓
- `smart_test.py TimeTrace` → 10/10 ✓ (result→series mapping, signal floor, ordering, label resolution, ps conversion, hidden-series, palette)
- `smart_test.py TimeDomain` → 28/28 ✓ (no regression)

## Manual test
Load a circuit with a coupler light source → enable Transient mode → **Run Transient**. The panel now shows the power-vs-time traces; toggle pins in the legend; hover for t/P read-out; Export CSV still works.

## Provenance / review note
Implemented by a background agent; the agent's run was cut off by a transient API error before it could finish, leaving 3 referenced helper methods undefined. I completed those (`BuildPinNameMap` / `BuildPlot` / `ClearPlot` + the toggle-rebuild wiring), then verified build + tests. Worth a careful look at the pin-Guid→label mapping (`BuildPinNameMap` maps both in/out flow ids) and the OxyPlot theming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
