### PR TITLE
(=) Update banner: clear current → latest headline, drop redundant version echo

### DIFF
--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -37,6 +37,11 @@ public partial class UpdateViewModel : ObservableObject
     [ObservableProperty]
     private bool _updateAvailable;
 
+    /// <summary>
+    /// Headline shown in the update banner, contrasting both versions once each —
+    /// "Update available: v{current} → v{latest}". Avoids the previous redundancy
+    /// where the new version was restated in a second status line.
+    /// </summary>
     [ObservableProperty]
     private string _latestVersionText = "";
 
@@ -93,10 +98,12 @@ public partial class UpdateViewModel : ObservableObject
             // Manual check: always show updates, even if previously skipped
             // (User explicitly wants to check, so honor that intent)
             _availableRelease = release;
-            LatestVersionText = $"New version: v{releaseVersion}";
+            LatestVersionText = $"Update available: v{_currentVersion} → v{releaseVersion}";
             ReleaseNotes = TruncateReleaseNotes(release.Body);
             UpdateAvailable = true;
-            StatusText = $"Update available: v{releaseVersion}";
+            // The headline already states the version transition; keep the live status line
+            // empty here so it isn't a redundant echo (it carries download progress later).
+            StatusText = string.Empty;
         }
         catch (Exception ex)
         {
@@ -221,10 +228,10 @@ public partial class UpdateViewModel : ObservableObject
             if (skipped != null && release.ParsedVersion != null && skipped >= release.ParsedVersion) return;
 
             _availableRelease = release;
-            LatestVersionText = $"New version: v{release.ParsedVersion}";
+            LatestVersionText = $"Update available: v{_currentVersion} → v{release.ParsedVersion}";
             ReleaseNotes = TruncateReleaseNotes(release.Body);
             UpdateAvailable = true;
-            StatusText = $"Update available: v{release.ParsedVersion}";
+            StatusText = string.Empty;
         }
         catch
         {

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -77,6 +77,22 @@ public class UpdateViewModelTests
     }
 
     [Fact]
+    public async Task CheckForUpdates_Available_HeadlineShowsBothVersions_NoRedundantStatusEcho()
+    {
+        // Banner clarity fix: a single headline contrasts current → latest (each version once),
+        // and the live status line is not a redundant restatement of the same version.
+        var vm = CreateViewModel(NewerReleaseJson);
+
+        await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+
+        vm.UpdateAvailable.ShouldBeTrue();
+        vm.LatestVersionText.ShouldStartWith("Update available: v");
+        vm.LatestVersionText.ShouldContain("→");      // both versions, contrasted
+        vm.LatestVersionText.ShouldContain("99.0.0"); // the latest (online) version
+        vm.StatusText.ShouldBeNullOrEmpty();          // no redundant version echo
+    }
+
+    [Fact]
     public async Task CheckForUpdates_CurrentIsLatest_UpdateAvailableIsFalse()
     {
         var vm = CreateViewModel(OlderReleaseJson);


### PR DESCRIPTION
## What
The software-update banner now shows **one clear headline contrasting both versions**:

> **Update available: v0.8.0 → v0.9.0**

instead of restating the new version across two lines and never showing the current version.

## Why
Reported: the banner showed the same version repeatedly and didn't clearly surface "your version vs the version found online". Root of the redundancy (confirmed in code):
- `LatestVersionText` = `"New version: v{latest}"` **and** `StatusText` = `"Update available: v{latest}"` both restated the **online** version, and
- the **current** version was only shown on the Settings page, never in the banner — so there was no side-by-side contrast.

(Note: a literal "own version three times" couldn't be reproduced from the code — the banner only ever bound the online version — so this change focuses on the confirmable redundancy + missing current-version contrast. If anything still looks off at runtime, a screenshot will pin it down.)

## How
- `UpdateViewModel.LatestVersionText` → `"Update available: v{current} → v{latest}"` (both versions, each once), set in both the manual-check and startup-check paths.
- On update-found, `StatusText` is cleared instead of echoing the version; it still carries live **download progress / errors** (and the "you are up to date" message on the no-update path is unchanged).
- No AXAML changes needed — the banner's bold line already binds `LatestVersionText`; the now-empty `StatusText` sub-line simply collapses until download starts.

## Verification
- `dotnet build` ✓
- `smart_test.py UpdateViewModel` → 16/16 ✓ (incl. a new test asserting the headline contains both versions and `StatusText` isn't a redundant echo)

## Manual test
Trigger the update banner (or the Settings → Software Updates section) with an available release: the headline should read "Update available: v{your version} → v{new version}", with no duplicate version line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
