### PR TITLE
(c) Bump version to 0.9.0 for release

### DIFF
--- a/CAP.Desktop/CAP.Desktop.csproj
+++ b/CAP.Desktop/CAP.Desktop.csproj
@@ -13,7 +13,7 @@
     <BuiltInComInteropSupport Condition="'$(RuntimeIdentifier)' == '' Or $(RuntimeIdentifier.StartsWith('win'))">true</BuiltInComInteropSupport>
     <!-- Add macOS ARM64 and x64 support alongside Windows and Linux -->
     <RuntimeIdentifiers>win-x64;linux-x64;osx-arm64;osx-x64</RuntimeIdentifiers>
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
     <!-- Windows icon (embedded in the .exe; macOS uses the .icns inside the bundle) -->
     <ApplicationIcon Condition="'$(RuntimeIdentifier)' == '' Or $(RuntimeIdentifier.StartsWith('win'))">LunimaIcon.ico</ApplicationIcon>
   </PropertyGroup>


### PR DESCRIPTION
Version bump 0.8.0 → 0.9.0 to cut the v0.9.0 release.

Includes since v0.8.0: macOS support (#596), geometry-scoped S-matrix overrides (#597), GDS preview thumbnails (#589), vertical-slice DI (#595), update-banner headline fix (#605), corrected release-notes generation (#606).

After merge: tag \0.9.0\ triggers the Build & Publish workflow (MSI + macOS .dmg + Linux tar.gz) and creates the GitHub release with the corrected notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)