### PR TITLE
(=) CI: build macOS x64 slice on Apple-Silicon runner (cross-compile)

### DIFF
--- a/.github/workflows/Build_Exe.yaml
+++ b/.github/workflows/Build_Exe.yaml
@@ -189,10 +189,14 @@ jobs:
     strategy:
       matrix:
         include:
-          # Apple Silicon runner builds the arm64 slice; the macos-13 Intel runner builds x64.
+          # Both slices build on the Apple-Silicon runner. The x64 slice is cross-compiled
+          # via `dotnet publish -r osx-x64` (the bundle script never runs the produced binary,
+          # and hdiutil/.dmg packaging is arch-agnostic). This avoids the macos-13 Intel
+          # runners, which are scarce/deprecated — the x64 job previously queued 24h with no
+          # runner and was auto-cancelled, skipping the release.
           - os: macos-latest
             rid: osx-arm64
-          - os: macos-13
+          - os: macos-latest
             rid: osx-x64
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Why
The v0.9.0 release run was cancelled: the \Build macOS .dmg (osx-x64)\ job ran on \macos-13\ (Intel), but those runners are scarce/deprecated — it queued ~24h with no runner and GitHub auto-cancelled it. Because \Create Release\ \
eeds\ all build jobs, the release was skipped (no v0.9.0 release published).

## Fix
Build the \osx-x64\ slice on \macos-latest\ (Apple Silicon) and cross-compile via \dotnet publish -r osx-x64\. Verified safe: \uild_macos_bundle.sh\ never executes the produced binary, and .dmg packaging (\hdiutil\) is arch-agnostic. arm64 already built successfully on macos-latest.

## After merge
Move the \0.9.0\ tag to the commit including this fix to re-trigger the release with both macOS slices on available runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)