### PR TITLE
(=) Release: full-history checkout for complete changelog

### DIFF
--- a/.github/workflows/Build_Exe.yaml
+++ b/.github/workflows/Build_Exe.yaml
@@ -260,6 +260,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.sha || github.ref }}
+          # Full history (not a shallow depth-1 clone) so the changelog step's
+          # `git log <prev-tag>..<curr-tag>` can see every commit in the range.
+          # With the default shallow checkout only the tip commit is present, so
+          # the v0.9.0 notes listed a single commit instead of the whole release.
+          fetch-depth: 0
 
       - name: Compute release info
         id: info


### PR DESCRIPTION
The release job's ctions/checkout@v4 used the default shallow depth-1 clone, so the Generate-Changelog step's git log <prev>..<curr> only saw the tip commit. The v0.9.0 notes therefore listed a single commit instead of the 22 in v0.8.0..v0.9.0.

Fix: etch-depth: 0 on the release-job checkout → future releases get the full changelog automatically.

(The published v0.9.0 body was already corrected manually via gh release edit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)