### PR TITLE
Fix macOS update: download the .dmg, not the Windows .msi (#610)

### DIFF
--- a/CAP.Avalonia/Services/UpdateDownloader.cs
+++ b/CAP.Avalonia/Services/UpdateDownloader.cs
@@ -60,43 +60,26 @@ public class UpdateDownloader
     }
 
     /// <summary>
-    /// Launches the downloaded installer.
-    /// <list type="bullet">
-    ///   <item><description>Windows — invokes <c>msiexec /i &lt;path&gt;</c> via <see cref="ProcessStartInfo.ArgumentList"/>.</description></item>
-    ///   <item><description>macOS — opens the <c>.dmg</c> or <c>.pkg</c> with <c>open</c> for manual installation.</description></item>
-    ///   <item><description>Other platforms — no-op (caller should redirect to the releases page).</description></item>
-    /// </list>
+    /// Runs the downloaded Windows MSI via <c>msiexec /i &lt;path&gt;</c>. The caller shuts the
+    /// application down afterwards so the installer can replace the running files.
+    /// No-op on non-Windows platforms — macOS/Linux open the downloaded installer through
+    /// <see cref="IUrlLauncher"/>, which resolves the launch command even on a PATH-less
+    /// Finder/Dock launch.
     /// </summary>
-    /// <param name="installerPath">Full path to the downloaded installer file.</param>
+    /// <param name="installerPath">Full path to the downloaded MSI.</param>
     public static void LaunchInstaller(string installerPath)
     {
-        if (OperatingSystem.IsWindows())
-        {
-            var psi = new ProcessStartInfo
-            {
-                FileName = "msiexec.exe",
-                UseShellExecute = true,
-            };
-            psi.ArgumentList.Add("/i");
-            psi.ArgumentList.Add(installerPath);
-            Process.Start(psi);
+        if (!OperatingSystem.IsWindows())
             return;
-        }
 
-        if (OperatingSystem.IsMacOS())
+        var psi = new ProcessStartInfo
         {
-            // Open the .dmg / .pkg for the user — they complete the install manually.
-            var psi = new ProcessStartInfo
-            {
-                FileName = "open",
-                UseShellExecute = false,
-            };
-            psi.ArgumentList.Add(installerPath);
-            Process.Start(psi);
-            return;
-        }
-
-        // Linux and other platforms: no automated installer launch — caller should open browser.
+            FileName = "msiexec.exe",
+            UseShellExecute = true,
+        };
+        psi.ArgumentList.Add("/i");
+        psi.ArgumentList.Add(installerPath);
+        Process.Start(psi);
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -173,8 +173,11 @@ public partial class UpdateViewModel : ObservableObject
                 // bare `open` that has no shell PATH under a Finder/Dock launch) is what made the
                 // previous flow read as a crash (#610).
                 _urlLauncher.OpenFileOrDirectory(installerPath);
-                StatusText = "Update downloaded — opening the installer. "
-                    + "Quit Lunima, then drag the new version into your Applications folder.";
+                // Builds are unsigned (no Apple Developer ID yet), so first launch trips Gatekeeper.
+                // Guide the user through the right-click → Open bypass rather than leaving them at the wall.
+                StatusText = "Update downloaded — the installer is opening. Quit Lunima and drag the new "
+                    + "version into Applications. It's unsigned, so on first launch right-click it and "
+                    + "choose Open to get past macOS's \"developer cannot be verified\" warning.";
             }
         }
         catch (Exception ex)

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -124,10 +124,12 @@ public partial class UpdateViewModel : ObservableObject
     {
         if (_availableRelease == null || IsDownloading) return;
 
-        var msiAsset = UpdateChecker.FindMsiAsset(_availableRelease);
-        if (msiAsset == null)
+        // Platform-aware: .dmg on macOS, .msi on Windows, .tar.gz on Linux.
+        // (FindMsiAsset is platform-blind and would hand macOS the Windows .msi — see #610.)
+        var installerAsset = UpdateChecker.FindPlatformAsset(_availableRelease);
+        if (installerAsset == null)
         {
-            // No MSI found - open GitHub releases page in browser
+            // No installer for this platform - open GitHub releases page in browser
             StatusText = "Opening GitHub releases page in browser...";
             try
             {
@@ -153,11 +155,11 @@ public partial class UpdateViewModel : ObservableObject
                 StatusText = $"Downloading... {p:P0}";
             });
 
-            var msiPath = await _downloader.DownloadMsiAsync(
-                msiAsset.BrowserDownloadUrl, msiAsset.Size, progress);
+            var installerPath = await _downloader.DownloadMsiAsync(
+                installerAsset.BrowserDownloadUrl, installerAsset.Size, progress);
 
             StatusText = "Download complete. Launching installer...";
-            UpdateDownloader.LaunchInstaller(msiPath);
+            UpdateDownloader.LaunchInstaller(installerPath);
 
             ShutdownApplication();
         }

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -116,8 +116,9 @@ public partial class UpdateViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Downloads the MSI from the available release and launches the installer,
-    /// then shuts down the application.
+    /// Downloads the platform installer from the available release. On Windows it runs the MSI
+    /// and shuts the app down so the installer can replace it; on macOS/Linux it opens the
+    /// downloaded installer for the user to complete the install and leaves the app running.
     /// </summary>
     [RelayCommand]
     private async Task InstallUpdate()
@@ -158,10 +159,23 @@ public partial class UpdateViewModel : ObservableObject
             var installerPath = await _downloader.DownloadMsiAsync(
                 installerAsset.BrowserDownloadUrl, installerAsset.Size, progress);
 
-            StatusText = "Download complete. Launching installer...";
-            UpdateDownloader.LaunchInstaller(installerPath);
-
-            ShutdownApplication();
+            if (OperatingSystem.IsWindows())
+            {
+                // Windows: run the MSI, which needs the running app to close so it can replace it.
+                StatusText = "Download complete. Launching installer...";
+                UpdateDownloader.LaunchInstaller(installerPath);
+                ShutdownApplication();
+            }
+            else
+            {
+                // macOS/Linux: open the .dmg/.tar.gz via the PATH-safe launcher and leave the app
+                // running — the user completes the install manually. Auto-quitting here (and the
+                // bare `open` that has no shell PATH under a Finder/Dock launch) is what made the
+                // previous flow read as a crash (#610).
+                _urlLauncher.OpenFileOrDirectory(installerPath);
+                StatusText = "Update downloaded — opening the installer. "
+                    + "Quit Lunima, then drag the new version into your Applications folder.";
+            }
         }
         catch (Exception ex)
         {

--- a/UnitTests/Update/UpdateCheckerTests.cs
+++ b/UnitTests/Update/UpdateCheckerTests.cs
@@ -97,6 +97,51 @@ public class UpdateCheckerTests
         UpdateChecker.FindMsiAsset(release).ShouldBeNull();
     }
 
+    [Fact]
+    public void FindPlatformAsset_MultiPlatformRelease_PicksCurrentOsInstaller()
+    {
+        var release = ReleaseWithAllPlatformAssets();
+
+        var asset = UpdateChecker.FindPlatformAsset(release);
+
+        asset.ShouldNotBeNull();
+        if (OperatingSystem.IsWindows())
+            asset!.Name.EndsWith(".msi").ShouldBeTrue();
+        else if (OperatingSystem.IsMacOS())
+            asset!.Name.EndsWith(".dmg").ShouldBeTrue();
+        else
+            asset!.Name.EndsWith(".tar.gz").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FindPlatformAsset_OnNonWindows_NeverReturnsTheWindowsMsi()
+    {
+        // Regression for #610: on macOS/Linux the updater used the platform-blind
+        // FindMsiAsset, which matched the Windows .msi shipped alongside the .dmg/.tar.gz.
+        // It downloaded that .msi, handed it to the OS (which cannot install it), and quit
+        // the app — presenting as a crash with the update never applied.
+        if (OperatingSystem.IsWindows()) return;
+
+        var asset = UpdateChecker.FindPlatformAsset(ReleaseWithAllPlatformAssets());
+
+        asset.ShouldNotBeNull();
+        asset!.Name.EndsWith(".msi").ShouldBeFalse();
+    }
+
+    /// <summary>Mirrors a real Lunima release: a Windows .msi, a Windows portable .zip,
+    /// a macOS .dmg, and a Linux .tar.gz, all present at once.</summary>
+    private static GitHubReleaseInfo ReleaseWithAllPlatformAssets() => new()
+    {
+        TagName = "v0.9.0",
+        Assets = new List<GitHubReleaseAsset>
+        {
+            new() { Name = "Lunima-0.9.0-linux-x64.tar.gz", BrowserDownloadUrl = "https://example.com/Lunima-0.9.0-linux-x64.tar.gz" },
+            new() { Name = "Lunima-0.9.0-osx-arm64.dmg",    BrowserDownloadUrl = "https://example.com/Lunima-0.9.0-osx-arm64.dmg" },
+            new() { Name = "Lunima-0.9.0-win-x64.zip",      BrowserDownloadUrl = "https://example.com/Lunima-0.9.0-win-x64.zip" },
+            new() { Name = "Lunima-Setup-0.9.0.msi",        BrowserDownloadUrl = "https://example.com/Lunima-Setup-0.9.0.msi" },
+        }
+    };
+
     [Theory]
     [InlineData("v1.5.0", "1.4.0", true)]   // release newer
     [InlineData("v1.5.0", "1.5.0", false)]  // same version

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -239,6 +239,78 @@ public class UpdateViewModelTests
         urlLauncher.LastOpenedUrl.ShouldBe("https://github.com/aignermax/Lunima/releases/tag/v99.0.0");
     }
 
+    [Fact]
+    public async Task InstallUpdate_OnMacOrLinux_OpensDownloadedInstallerViaLauncher()
+    {
+        // #610: on macOS/Linux the update downloads the platform installer (.dmg/.tar.gz) and
+        // opens it through the PATH-safe launcher — it must not fall back to the browser, and
+        // (unlike Windows) it must not auto-quit the app.
+        if (OperatingSystem.IsWindows()) return; // the Windows branch runs msiexec; not exercised on the Linux CI runner
+
+        var urlLauncher = new FakeUrlLauncher();
+        var vm = CreateViewModelForDownload(MultiPlatformReleaseJson, urlLauncher);
+
+        await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+        vm.UpdateAvailable.ShouldBeTrue();
+
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+        urlLauncher.LastOpenedPath.ShouldNotBeNull();   // installer opened via the launcher
+        urlLauncher.LastOpenedUrl.ShouldBeNull();       // not the browser fallback
+        var expectedExtension = OperatingSystem.IsMacOS() ? ".dmg" : ".tar.gz";
+        urlLauncher.LastOpenedPath!.EndsWith(expectedExtension).ShouldBeTrue();
+
+        if (File.Exists(urlLauncher.LastOpenedPath!))
+            File.Delete(urlLauncher.LastOpenedPath!);
+    }
+
+    private const string MultiPlatformReleaseJson = """
+        {
+          "tag_name": "v99.0.0",
+          "name": "Version 99.0.0",
+          "body": "Major update.",
+          "prerelease": false,
+          "published_at": "2099-01-01T00:00:00Z",
+          "assets": [
+            { "name": "Lunima-99.0.0-osx-arm64.dmg", "browser_download_url": "https://example.com/Lunima-99.0.0-osx-arm64.dmg", "size": 4, "content_type": "application/octet-stream" },
+            { "name": "Lunima-99.0.0-linux-x64.tar.gz", "browser_download_url": "https://example.com/Lunima-99.0.0-linux-x64.tar.gz", "size": 4, "content_type": "application/gzip" },
+            { "name": "Lunima-Setup-99.0.0.msi", "browser_download_url": "https://example.com/Lunima-Setup-99.0.0.msi", "size": 4, "content_type": "application/x-msi" }
+          ]
+        }
+        """;
+
+    private static UpdateViewModel CreateViewModelForDownload(string releaseJson, IUrlLauncher urlLauncher)
+    {
+        var httpClient = new HttpClient(new ReleaseThenBinaryHandler(releaseJson));
+        return new UpdateViewModel(
+            new UpdateChecker(httpClient, "owner", "repo"),
+            new UpdateDownloader(httpClient),
+            new UserPreferencesService(Path.GetTempFileName()),
+            urlLauncher);
+    }
+
+    /// <summary>Returns the release JSON for the GitHub API call and a few bytes for any other
+    /// (asset download) URL, with a fresh response each call so the download stream is readable.</summary>
+    private sealed class ReleaseThenBinaryHandler : HttpMessageHandler
+    {
+        private readonly string _releaseJson;
+
+        public ReleaseThenBinaryHandler(string releaseJson) => _releaseJson = releaseJson;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var isApi = request.RequestUri!.Host.Contains("api.github.com");
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = isApi
+                    ? new StringContent(_releaseJson)
+                    : new ByteArrayContent(new byte[] { 1, 2, 3, 4 }),
+            };
+            return Task.FromResult(response);
+        }
+    }
+
     private sealed class FakeUrlLauncher : IUrlLauncher
     {
         public string? LastOpenedUrl { get; private set; }


### PR DESCRIPTION
**Draft / work-in-progress.** Addresses #610. The reported crash is fixed and the macOS strategy is decided; one optional hardening item remains.

## The bug (verified)

On macOS, clicking **Download** in the update banner downloaded ~12 MB, then the app quit ("crash"), and the update was never applied — the banner returned on every relaunch.

Root cause: the v0.9.0 release ships **all** platform installers at once —

```
Lunima-0.9.0-linux-x64.tar.gz
Lunima-0.9.0-osx-arm64.dmg
Lunima-0.9.0-osx-x64.dmg
Lunima-0.9.0-win-x64.zip
Lunima-Setup-0.9.0.msi      ← Windows installer
```

`InstallUpdate` picked the asset with `UpdateChecker.FindMsiAsset`, which matches **any** `.msi` regardless of OS. So on macOS it grabbed the Windows `.msi`, downloaded it, ran `open` on it (macOS can't install an `.msi`), then called `ShutdownApplication()`. The app vanishing mid-update reads as a crash; nothing installs, the version never changes, so the banner comes back.

## What this PR does

1. **Platform-aware asset selection.** Use `UpdateChecker.FindPlatformAsset` (`.dmg` on macOS, `.msi` on Windows, `.tar.gz` on Linux) instead of `FindMsiAsset`. That method already existed — added with macOS support in #596 — but `InstallUpdate` was never switched to it.
2. **PATH-safe launch + correct shutdown timing.** On macOS/Linux the downloaded installer is opened through `IUrlLauncher.OpenFileOrDirectory` — the abstraction that resolves the launch command even when the app was started from Finder/Dock with no shell `PATH` — and the app is **left running** so the user can finish the install. Only Windows (where `msiexec` must replace the running binary) auto-quits. `UpdateDownloader.LaunchInstaller` is now Windows-only; its fragile bare `open` path is gone.
3. **Unsigned-build Gatekeeper guidance.** Decision: no Apple Developer ID / code-signing yet, so the "developer cannot be verified" warning is expected and bypassed manually. The macOS post-download status now tells the user to right-click the new app and choose **Open** on first launch, rather than leaving them at the wall.

**Tests:** `FindPlatformAsset` selects the current-OS installer from a mixed release and never hands non-Windows the `.msi`; a non-Windows `InstallUpdate` test asserts the installer is opened via the launcher (not the browser) and the app is not quit. `dotnet build` clean; UpdateChecker (15), UpdateViewModel (17), and the cross-platform launch architecture test all pass.

## Remaining

- **Optional hardening:** a guaranteed fallback if a download/open step throws — open the releases page or reveal the file in Finder — so the banner never becomes a dead button.
- **Real-Mac verification:** the logic is unit-tested, but the end-to-end (click Download → `.dmg` mounts → right-click Open) hasn't been exercised on a real Mac (CI is Linux).

## Smaller cleanups noticed (out of scope unless wanted)

- DI registers the update checker with `repo: "Connect-A-PIC-Pro"` while the repo is now `Lunima`; it works today only because GitHub redirects the old name.
- `UpdateDownloader.DownloadMsiAsync` / `FindMsiAsset` are now misnomers (they handle `.dmg`/`.tar.gz` too); `FindMsiAsset` is no longer used in production after this PR.
