### PR TITLE
Agent: macOS: clicking Download on the update banner quits the app and never installs the update

### DIFF
--- a/CAP.Avalonia/Services/UpdateDownloader.cs
+++ b/CAP.Avalonia/Services/UpdateDownloader.cs
@@ -1,11 +1,10 @@
-using System.Diagnostics;
 using System.Net.Http;
 using CAP_Core.Update;
 
 namespace CAP.Avalonia.Services;
 
 /// <summary>
-/// Downloads an MSI installer from a GitHub release asset URL with progress reporting.
+/// Downloads a platform-appropriate installer from a GitHub release asset URL with progress reporting.
 /// </summary>
 public class UpdateDownloader
 {
@@ -24,7 +23,7 @@ public class UpdateDownloader
     /// The temporary file extension is derived from the asset filename in <paramref name="downloadUrl"/>.
     /// </summary>
     /// <returns>Local file path to the downloaded installer.</returns>
-    public async Task<string> DownloadMsiAsync(
+    public async Task<string> DownloadInstallerAsync(
         string downloadUrl,
         long expectedSize,
         IProgress<double> progress,
@@ -57,46 +56,6 @@ public class UpdateDownloader
         }
 
         return tempPath;
-    }
-
-    /// <summary>
-    /// Launches the downloaded installer.
-    /// <list type="bullet">
-    ///   <item><description>Windows — invokes <c>msiexec /i &lt;path&gt;</c> via <see cref="ProcessStartInfo.ArgumentList"/>.</description></item>
-    ///   <item><description>macOS — opens the <c>.dmg</c> or <c>.pkg</c> with <c>open</c> for manual installation.</description></item>
-    ///   <item><description>Other platforms — no-op (caller should redirect to the releases page).</description></item>
-    /// </list>
-    /// </summary>
-    /// <param name="installerPath">Full path to the downloaded installer file.</param>
-    public static void LaunchInstaller(string installerPath)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            var psi = new ProcessStartInfo
-            {
-                FileName = "msiexec.exe",
-                UseShellExecute = true,
-            };
-            psi.ArgumentList.Add("/i");
-            psi.ArgumentList.Add(installerPath);
-            Process.Start(psi);
-            return;
-        }
-
-        if (OperatingSystem.IsMacOS())
-        {
-            // Open the .dmg / .pkg for the user — they complete the install manually.
-            var psi = new ProcessStartInfo
-            {
-                FileName = "open",
-                UseShellExecute = false,
-            };
-            psi.ArgumentList.Add(installerPath);
-            Process.Start(psi);
-            return;
-        }
-
-        // Linux and other platforms: no automated installer launch — caller should open browser.
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -116,18 +116,19 @@ public partial class UpdateViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Downloads the MSI from the available release and launches the installer,
-    /// then shuts down the application.
+    /// Downloads the platform-appropriate installer from the available release and opens it,
+    /// then shuts down the application on Windows (where msiexec replaces the running binary).
+    /// On macOS and Linux the app stays open so the user can complete the manual install step.
     /// </summary>
     [RelayCommand]
     private async Task InstallUpdate()
     {
         if (_availableRelease == null || IsDownloading) return;
 
-        var msiAsset = UpdateChecker.FindMsiAsset(_availableRelease);
-        if (msiAsset == null)
+        var platformAsset = UpdateChecker.FindPlatformAsset(_availableRelease);
+        if (platformAsset == null)
         {
-            // No MSI found - open GitHub releases page in browser
+            // No platform installer found — open GitHub releases page in browser
             StatusText = "Opening GitHub releases page in browser...";
             try
             {
@@ -153,13 +154,17 @@ public partial class UpdateViewModel : ObservableObject
                 StatusText = $"Downloading... {p:P0}";
             });
 
-            var msiPath = await _downloader.DownloadMsiAsync(
-                msiAsset.BrowserDownloadUrl, msiAsset.Size, progress);
+            var installerPath = await _downloader.DownloadInstallerAsync(
+                platformAsset.BrowserDownloadUrl, platformAsset.Size, progress);
 
-            StatusText = "Download complete. Launching installer...";
-            UpdateDownloader.LaunchInstaller(msiPath);
+            StatusText = "Download complete. Opening installer...";
+            _urlLauncher.OpenFileOrDirectory(installerPath);
 
-            ShutdownApplication();
+            // On Windows the MSI installer replaces the running app; quit cleanly first.
+            // On macOS the user mounts the .dmg and drags to Applications — keep the app running.
+            // On Linux the user extracts the archive manually — keep the app running.
+            if (OperatingSystem.IsWindows())
+                ShutdownApplication();
         }
         catch (Exception ex)
         {

--- a/UnitTests/Architecture/CrossPlatformProcessLaunchTests.cs
+++ b/UnitTests/Architecture/CrossPlatformProcessLaunchTests.cs
@@ -51,7 +51,6 @@ public class CrossPlatformProcessLaunchTests
         "Connect-A-Pic-Core/Export/ProcessLaunchFactory.cs",
         "CAP.Avalonia/Services/PlatformShellLauncher.cs",
         // 2. Grandfathered platform-aware launchers (pre-existing — do NOT add new entries here)
-        "CAP.Avalonia/Services/UpdateDownloader.cs",
         "CAP.Avalonia/Services/PythonResolution.cs",
         "CAP.Avalonia/Services/Solvers/PythonModeSolverService.cs",
     };

--- a/UnitTests/Update/UpdateCheckerTests.cs
+++ b/UnitTests/Update/UpdateCheckerTests.cs
@@ -97,6 +97,64 @@ public class UpdateCheckerTests
         UpdateChecker.FindMsiAsset(release).ShouldBeNull();
     }
 
+    [Fact]
+    public void FindPlatformAsset_AllPlatformAssetsPresent_ReturnsCorrectAssetForCurrentOS()
+    {
+        var release = new GitHubReleaseInfo
+        {
+            TagName = "v1.5.0",
+            Assets = new List<GitHubReleaseAsset>
+            {
+                new() { Name = "Lunima-1.5.0.msi",    BrowserDownloadUrl = "https://example.com/Lunima.msi" },
+                new() { Name = "Lunima-1.5.0.dmg",    BrowserDownloadUrl = "https://example.com/Lunima.dmg" },
+                new() { Name = "Lunima-1.5.0.tar.gz", BrowserDownloadUrl = "https://example.com/Lunima.tar.gz" },
+            }
+        };
+
+        var asset = UpdateChecker.FindPlatformAsset(release);
+
+        asset.ShouldNotBeNull();
+        if (OperatingSystem.IsWindows())
+            asset!.Name.ShouldEndWith(".msi");
+        else if (OperatingSystem.IsMacOS())
+            asset!.Name.ShouldEndWith(".dmg");
+        else
+            asset!.Name.ShouldEndWith(".tar.gz");
+    }
+
+    [Fact]
+    public void FindPlatformAsset_EmptyAssets_ReturnsNull()
+    {
+        var release = new GitHubReleaseInfo
+        {
+            TagName = "v1.0.0",
+            Assets = new List<GitHubReleaseAsset>()
+        };
+
+        UpdateChecker.FindPlatformAsset(release).ShouldBeNull();
+    }
+
+    [Fact]
+    public void FindPlatformAsset_OnlyMsiAvailable_ReturnsNullOnNonWindows()
+    {
+        // Regression test: FindPlatformAsset must NOT return a .msi on macOS/Linux.
+        // Root cause of the macOS "downloads .msi instead of .dmg" bug (issue #610):
+        // the ViewModel was calling FindMsiAsset (always .msi) instead of FindPlatformAsset.
+        var release = new GitHubReleaseInfo
+        {
+            TagName = "v1.0.0",
+            Assets = new List<GitHubReleaseAsset>
+            {
+                new() { Name = "Lunima-1.0.0.msi", BrowserDownloadUrl = "https://example.com/Lunima.msi" },
+            }
+        };
+
+        if (OperatingSystem.IsWindows())
+            UpdateChecker.FindPlatformAsset(release).ShouldNotBeNull();
+        else
+            UpdateChecker.FindPlatformAsset(release).ShouldBeNull();
+    }
+
     [Theory]
     [InlineData("v1.5.0", "1.4.0", true)]   // release newer
     [InlineData("v1.5.0", "1.5.0", false)]  // same version


### PR DESCRIPTION
Automated implementation for #610

All done. Here's a summary of what was changed and why:

---

## Fix: macOS update downloads wrong installer (#610)

**Root causes fixed:**

### 1. Wrong asset selected (`UpdateViewModel.cs`)
`InstallUpdate()` called `FindMsiAsset()` (always returns `.msi`) instead of `FindPlatformAsset()` (returns `.dmg` on macOS, `.tar.gz` on Linux). One-line fix.

### 2. Direct `Process.Start("open")` on macOS (`UpdateDownloader.cs`)
`LaunchInstaller` bypassed the `IUrlLauncher` abstraction, hardcoding `open` for macOS. The ViewModel already holds `_urlLauncher`, so the fix routes the launch through `_urlLauncher.OpenFileOrDirectory(installerPath)` instead. `LaunchInstaller` was removed and `UpdateDownloader.cs` was removed from the allowlist in the architecture test (shrinking the grandfathered list as intended).

### 3. Premature shutdown on macOS (`UpdateViewModel.cs`)
`ShutdownApplication()` was called unconditionally after launching the installer. On macOS, the user still needs the app to be alive while they mount the `.dmg` and drag to Applications — quitting immediately makes it look like a crash. The shutdown is now gated to `OperatingSystem.IsWindows()` only (where msiexec replaces the running binary).

### 4. Method rename
`DownloadMsiAsync` → `DownloadInstallerAsync` since it now downloads any platform installer type.

### Tests added (`UpdateCheckerTests.cs`)
- `FindPlatformAsset_AllPlatformAssetsPresent_ReturnsCorrectAssetForCurrentOS` — verifies correct extension per OS
- `FindPlatformAsset_EmptyAssets_ReturnsNull`
- `FindPlatformAsset_OnlyMsiAvailable_ReturnsNullOnNonWindows` — explicit regression for the bug: `.msi` must not be selected on macOS/Linux


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 1,548,360
- **Estimated cost:** $0.8671 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*