### PR TITLE
(+) macOS update: Gatekeeper 'Open Anyway' guidance + downloaded-file fallback (#613)

### DIFF
--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -9,7 +9,7 @@ namespace CAP.Avalonia.ViewModels.Update;
 
 /// <summary>
 /// ViewModel for the software update panel.
-/// Handles checking GitHub releases for newer versions, downloading the MSI,
+/// Handles checking GitHub releases for newer versions, downloading the platform installer,
 /// and installing it with graceful application shutdown.
 /// </summary>
 public partial class UpdateViewModel : ObservableObject
@@ -132,8 +132,7 @@ public partial class UpdateViewModel : ObservableObject
             StatusText = "Opening GitHub releases page in browser...";
             try
             {
-                var releaseUrl = $"https://github.com/aignermax/Lunima/releases/tag/{_availableRelease.TagName}";
-                _urlLauncher.Open(releaseUrl);
+                _urlLauncher.Open(BuildReleaseUrl(_availableRelease.TagName));
             }
             catch (Exception ex)
             {
@@ -159,16 +158,21 @@ public partial class UpdateViewModel : ObservableObject
 
             StatusText = "Download complete. Opening installer...";
             _urlLauncher.OpenFileOrDirectory(installerPath);
-
-            // On Windows the MSI installer replaces the running app; quit cleanly first.
-            // On macOS the user mounts the .dmg and drags to Applications — keep the app running.
-            // On Linux the user extracts the archive manually — keep the app running.
-            if (OperatingSystem.IsWindows())
-                ShutdownApplication();
+            ShowPostDownloadGuidance();
         }
         catch (Exception ex)
         {
-            StatusText = $"Download failed: {ex.Message}";
+            // Never leave the update banner as a dead button: fall back to the releases page
+            // so the user always has a way to finish updating manually.
+            StatusText = $"Download failed: {ex.Message}. Opening the releases page instead...";
+            try
+            {
+                _urlLauncher.Open(BuildReleaseUrl(_availableRelease.TagName));
+            }
+            catch
+            {
+                StatusText = $"Download failed: {ex.Message}";
+            }
         }
         finally
         {
@@ -247,6 +251,29 @@ public partial class UpdateViewModel : ObservableObject
             IsChecking = false;
         }
     }
+
+    /// <summary>
+    /// After the installer is opened, either quits (Windows, where msiexec replaces the running
+    /// binary) or leaves the app running with platform-specific guidance. The macOS build is not
+    /// yet Apple-notarized, so Gatekeeper blocks a normal double-click launch; the user must
+    /// right-click the app and choose Open once to bypass it.
+    /// </summary>
+    private void ShowPostDownloadGuidance()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            ShutdownApplication();
+            return;
+        }
+
+        StatusText = OperatingSystem.IsMacOS()
+            ? "Update downloaded. In the disk image, right-click Lunima and choose Open "
+              + "(first launch only — the app is not code-signed yet), then drag it to Applications."
+            : "Update downloaded. Extract the archive and replace your installation to finish updating.";
+    }
+
+    private static string BuildReleaseUrl(string tagName) =>
+        $"https://github.com/aignermax/Lunima/releases/tag/{tagName}";
 
     private static SemanticVersion ResolveCurrentVersion()
     {

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -145,6 +145,7 @@ public partial class UpdateViewModel : ObservableObject
         DownloadProgress = 0;
         StatusText = "Downloading update...";
 
+        string installerPath;
         try
         {
             var progress = new Progress<double>(p =>
@@ -153,30 +154,54 @@ public partial class UpdateViewModel : ObservableObject
                 StatusText = $"Downloading... {p:P0}";
             });
 
-            var installerPath = await _downloader.DownloadInstallerAsync(
+            installerPath = await _downloader.DownloadInstallerAsync(
                 platformAsset.BrowserDownloadUrl, platformAsset.Size, progress);
-
-            StatusText = "Download complete. Opening installer...";
-            _urlLauncher.OpenFileOrDirectory(installerPath);
-            ShowPostDownloadGuidance();
         }
         catch (Exception ex)
         {
-            // Never leave the update banner as a dead button: fall back to the releases page
-            // so the user always has a way to finish updating manually.
-            StatusText = $"Download failed: {ex.Message}. Opening the releases page instead...";
-            try
-            {
-                _urlLauncher.Open(BuildReleaseUrl(_availableRelease.TagName));
-            }
-            catch
-            {
-                StatusText = $"Download failed: {ex.Message}";
-            }
+            // A failed download has no side effects — the user can simply click Install again.
+            StatusText = $"Download failed: {ex.Message}";
+            return;
         }
         finally
         {
             IsDownloading = false;
+        }
+
+        StatusText = "Download complete. Opening installer...";
+        OpenDownloadedInstaller(installerPath);
+    }
+
+    /// <summary>
+    /// Opens the downloaded installer. When opening fails, the file is already on disk, so the
+    /// user is pointed at it (status text + reveal in file manager) instead of being sent to
+    /// re-download it from the releases page.
+    /// </summary>
+    private void OpenDownloadedInstaller(string installerPath)
+    {
+        try
+        {
+            _urlLauncher.OpenFileOrDirectory(installerPath);
+        }
+        catch (Exception)
+        {
+            StatusText = $"The update was downloaded to {installerPath} but could not be opened "
+                + "automatically. Run it from there to finish updating.";
+            TryRevealInstaller(installerPath);
+            return;
+        }
+        ShowPostDownloadGuidance();
+    }
+
+    private void TryRevealInstaller(string installerPath)
+    {
+        try
+        {
+            _urlLauncher.RevealInFileManager(installerPath);
+        }
+        catch (Exception)
+        {
+            // The status line already names the full path, so the user can still find the file.
         }
     }
 
@@ -254,9 +279,7 @@ public partial class UpdateViewModel : ObservableObject
 
     /// <summary>
     /// After the installer is opened, either quits (Windows, where msiexec replaces the running
-    /// binary) or leaves the app running with platform-specific guidance. The macOS build is not
-    /// yet Apple-notarized, so Gatekeeper blocks a normal double-click launch; the user must
-    /// right-click the app and choose Open once to bypass it.
+    /// binary) or leaves the app running with platform-specific guidance.
     /// </summary>
     private void ShowPostDownloadGuidance()
     {
@@ -266,11 +289,23 @@ public partial class UpdateViewModel : ObservableObject
             return;
         }
 
-        StatusText = OperatingSystem.IsMacOS()
-            ? "Update downloaded. In the disk image, right-click Lunima and choose Open "
-              + "(first launch only — the app is not code-signed yet), then drag it to Applications."
-            : "Update downloaded. Extract the archive and replace your installation to finish updating.";
+        StatusText = BuildPostDownloadGuidance(OperatingSystem.IsMacOS());
     }
+
+    /// <summary>
+    /// Guidance shown after the installer was opened on non-Windows platforms. The macOS build
+    /// is not yet Apple-notarized, and macOS 15+ no longer offers the right-click → Open
+    /// Gatekeeper override, so the unsigned app must be approved via System Settings →
+    /// Privacy &amp; Security → "Open Anyway". Approval must happen on the copy in Applications
+    /// because the quarantine attribute travels with the app when dragged out of the disk image.
+    /// </summary>
+    internal static string BuildPostDownloadGuidance(bool isMacOS) =>
+        isMacOS
+            ? "Update downloaded. Drag Lunima from the disk image to Applications and open it "
+              + "once — macOS will block the unsigned app. Allow it under System Settings → "
+              + "Privacy & Security → 'Open Anyway' (on macOS 14 and older, right-click the app "
+              + "and choose Open instead)."
+            : "Update downloaded. Extract the archive and replace your installation to finish updating.";
 
     private static string BuildReleaseUrl(string tagName) =>
         $"https://github.com/aignermax/Lunima/releases/tag/{tagName}";

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -42,6 +42,22 @@ public class UpdateViewModelTests
         }
         """;
 
+    /// <summary>Release carrying an installer for every OS, so FindPlatformAsset resolves on any runner.</summary>
+    private const string AllPlatformsReleaseJson = """
+        {
+          "tag_name": "v99.0.0",
+          "name": "Version 99.0.0",
+          "body": "Cross-platform release.",
+          "prerelease": false,
+          "published_at": "2099-01-01T00:00:00Z",
+          "assets": [
+            { "name": "Lunima-99.0.0.msi",    "browser_download_url": "https://example.com/Lunima-99.0.0.msi",    "size": 8, "content_type": "application/x-msi" },
+            { "name": "Lunima-99.0.0.dmg",    "browser_download_url": "https://example.com/Lunima-99.0.0.dmg",    "size": 8, "content_type": "application/octet-stream" },
+            { "name": "Lunima-99.0.0.tar.gz", "browser_download_url": "https://example.com/Lunima-99.0.0.tar.gz", "size": 8, "content_type": "application/gzip" }
+          ]
+        }
+        """;
+
     private static UpdateViewModel CreateViewModel(
         string responseJson,
         HttpStatusCode statusCode = HttpStatusCode.OK,
@@ -239,6 +255,43 @@ public class UpdateViewModelTests
         urlLauncher.LastOpenedUrl.ShouldBe("https://github.com/aignermax/Lunima/releases/tag/v99.0.0");
     }
 
+    [Fact]
+    public async Task InstallUpdate_PlatformAssetPresent_OpensInstallerWithGuidanceAndKeepsAppAliveOnNonWindows()
+    {
+        // #613: after downloading, the installer is opened via the launcher and the user gets
+        // actionable guidance. On macOS that guidance is the Gatekeeper right-click → Open hint
+        // (the build is not code-signed), so the update banner never dead-ends.
+        // A repeating handler is required: this exercises TWO requests (metadata + download),
+        // and a single shared response can only be read once.
+        var launcher = new FakeUrlLauncher();
+        var httpClient = new HttpClient(new RepeatingHttpMessageHandler(AllPlatformsReleaseJson));
+        var vm = new UpdateViewModel(
+            new UpdateChecker(httpClient, "owner", "repo"),
+            new UpdateDownloader(httpClient),
+            new UserPreferencesService(Path.GetTempFileName()),
+            launcher);
+        await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+        vm.UpdateAvailable.ShouldBeTrue();
+
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+        try
+        {
+            launcher.LastOpenedPath.ShouldNotBeNull();   // installer opened through the abstraction
+            vm.StatusText.ShouldNotBeNullOrEmpty();       // user is never left without direction
+
+            if (OperatingSystem.IsMacOS())
+                vm.StatusText.ShouldContain("right-click");
+            else if (!OperatingSystem.IsWindows())
+                vm.StatusText.ShouldContain("Extract the archive");
+        }
+        finally
+        {
+            if (launcher.LastOpenedPath != null && File.Exists(launcher.LastOpenedPath))
+                File.Delete(launcher.LastOpenedPath);
+        }
+    }
+
     private sealed class FakeUrlLauncher : IUrlLauncher
     {
         public string? LastOpenedUrl { get; private set; }
@@ -426,6 +479,27 @@ public class UpdateViewModelTests
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(_response);
+        }
+    }
+
+    /// <summary>Returns a fresh response with the same body on every request, so the same body
+    /// can be consumed by more than one call (metadata fetch followed by installer download).</summary>
+    private sealed class RepeatingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+
+        public RepeatingHttpMessageHandler(string body)
+        {
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_body)
+            });
         }
     }
 }

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -80,6 +80,16 @@ public class UpdateViewModelTests
         return new UpdateViewModel(checker, downloader, prefs, urlLauncher ?? new FakeUrlLauncher());
     }
 
+    private static UpdateViewModel CreateViewModel(HttpMessageHandler handler, IUrlLauncher urlLauncher)
+    {
+        var httpClient = new HttpClient(handler);
+        return new UpdateViewModel(
+            new UpdateChecker(httpClient, "owner", "repo"),
+            new UpdateDownloader(httpClient),
+            new UserPreferencesService(Path.GetTempFileName()),
+            urlLauncher);
+    }
+
     [Fact]
     public async Task CheckForUpdates_NewerVersionExists_SetsUpdateAvailableTrue()
     {
@@ -259,17 +269,12 @@ public class UpdateViewModelTests
     public async Task InstallUpdate_PlatformAssetPresent_OpensInstallerWithGuidanceAndKeepsAppAliveOnNonWindows()
     {
         // #613: after downloading, the installer is opened via the launcher and the user gets
-        // actionable guidance. On macOS that guidance is the Gatekeeper right-click → Open hint
-        // (the build is not code-signed), so the update banner never dead-ends.
+        // actionable guidance (per-platform wording is covered by the BuildPostDownloadGuidance
+        // tests below), so the update banner never dead-ends.
         // A repeating handler is required: this exercises TWO requests (metadata + download),
         // and a single shared response can only be read once.
         var launcher = new FakeUrlLauncher();
-        var httpClient = new HttpClient(new RepeatingHttpMessageHandler(AllPlatformsReleaseJson));
-        var vm = new UpdateViewModel(
-            new UpdateChecker(httpClient, "owner", "repo"),
-            new UpdateDownloader(httpClient),
-            new UserPreferencesService(Path.GetTempFileName()),
-            launcher);
+        var vm = CreateViewModel(StubHttpMessageHandler.RepeatingOk(AllPlatformsReleaseJson), launcher);
         await vm.CheckForUpdatesCommand.ExecuteAsync(null);
         vm.UpdateAvailable.ShouldBeTrue();
 
@@ -281,7 +286,7 @@ public class UpdateViewModelTests
             vm.StatusText.ShouldNotBeNullOrEmpty();       // user is never left without direction
 
             if (OperatingSystem.IsMacOS())
-                vm.StatusText.ShouldContain("right-click");
+                vm.StatusText.ShouldContain("Open Anyway");
             else if (!OperatingSystem.IsWindows())
                 vm.StatusText.ShouldContain("Extract the archive");
         }
@@ -292,11 +297,83 @@ public class UpdateViewModelTests
         }
     }
 
+    [Fact]
+    public async Task InstallUpdate_DownloadFails_ShowsRetryableErrorWithoutOpeningBrowser()
+    {
+        // A failed download has no side effects — the user can simply click Install again.
+        // In particular it must not hijack focus with a browser tab on every (possibly
+        // transient) network error.
+        var launcher = new FakeUrlLauncher();
+        var handler = new StubHttpMessageHandler(request =>
+            request.RequestUri!.Host == "example.com"
+                ? new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("") }
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(AllPlatformsReleaseJson) });
+        var vm = CreateViewModel(handler, launcher);
+        await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+        vm.UpdateAvailable.ShouldBeTrue();
+
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+        vm.StatusText.ShouldContain("Download failed");
+        launcher.LastOpenedUrl.ShouldBeNull();    // no browser fallback for a retryable failure
+        launcher.LastOpenedPath.ShouldBeNull();   // nothing was opened
+        vm.IsDownloading.ShouldBeFalse();         // the Install button is usable again
+    }
+
+    [Fact]
+    public async Task InstallUpdate_OpeningInstallerFails_RevealsDownloadedFileInsteadOfClaimingDownloadFailed()
+    {
+        // The download succeeded; only opening the file failed. The status must not claim
+        // "Download failed", and instead of sending the user to re-download ~100MB from the
+        // releases page, the already-downloaded installer is revealed in the file manager.
+        var launcher = new FakeUrlLauncher { ThrowOnOpenFileOrDirectory = true };
+        var vm = CreateViewModel(StubHttpMessageHandler.RepeatingOk(AllPlatformsReleaseJson), launcher);
+        await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+        vm.UpdateAvailable.ShouldBeTrue();
+
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+        try
+        {
+            vm.StatusText.ShouldNotContain("Download failed");
+            launcher.LastRevealedPath.ShouldNotBeNull();          // user is pointed at the file on disk
+            vm.StatusText.ShouldContain(launcher.LastRevealedPath!);
+            launcher.LastOpenedUrl.ShouldBeNull();                // no browser detour to re-download
+        }
+        finally
+        {
+            if (launcher.LastRevealedPath != null && File.Exists(launcher.LastRevealedPath))
+                File.Delete(launcher.LastRevealedPath);
+        }
+    }
+
+    [Fact]
+    public void PostDownloadGuidance_MacOS_PointsToSystemSettingsOpenAnyway()
+    {
+        // macOS 15 (Sequoia) removed the Control-click → Open Gatekeeper override for
+        // unsigned apps; the surviving path is System Settings → Privacy & Security →
+        // "Open Anyway", and approval must happen on the copy in /Applications (the
+        // quarantine attribute travels with the app when it is dragged out of the dmg).
+        var guidance = UpdateViewModel.BuildPostDownloadGuidance(isMacOS: true);
+
+        guidance.ShouldContain("Applications");
+        guidance.ShouldContain("Open Anyway");
+        guidance.ShouldContain("right-click");   // still works on macOS 14 and older
+    }
+
+    [Fact]
+    public void PostDownloadGuidance_NonMacOS_TellsUserToExtractArchive()
+    {
+        UpdateViewModel.BuildPostDownloadGuidance(isMacOS: false)
+            .ShouldContain("Extract the archive");
+    }
+
     private sealed class FakeUrlLauncher : IUrlLauncher
     {
         public string? LastOpenedUrl { get; private set; }
         public string? LastOpenedPath { get; private set; }
         public string? LastRevealedPath { get; private set; }
+        public bool ThrowOnOpenFileOrDirectory { get; init; }
 
         public void Open(string url)
         {
@@ -305,6 +382,8 @@ public class UpdateViewModelTests
 
         public void OpenFileOrDirectory(string path)
         {
+            if (ThrowOnOpenFileOrDirectory)
+                throw new InvalidOperationException($"No application is associated with {path}.");
             LastOpenedPath = path;
         }
 
@@ -482,24 +561,25 @@ public class UpdateViewModelTests
         }
     }
 
-    /// <summary>Returns a fresh response with the same body on every request, so the same body
-    /// can be consumed by more than one call (metadata fetch followed by installer download).</summary>
-    private sealed class RepeatingHttpMessageHandler : HttpMessageHandler
+    /// <summary>Builds a fresh response per request via a delegate, so a body can be consumed
+    /// by more than one call (metadata fetch followed by installer download) and responses can
+    /// differ per URL (e.g. metadata succeeds while the asset download fails).</summary>
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
     {
-        private readonly string _body;
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
 
-        public RepeatingHttpMessageHandler(string body)
+        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
         {
-            _body = body;
+            _respond = respond;
         }
+
+        public static StubHttpMessageHandler RepeatingOk(string body) =>
+            new(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) });
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(_body)
-            });
+            return Task.FromResult(_respond(request));
         }
     }
 }


### PR DESCRIPTION
Closes #613. Follow-up to the macOS update fix (#612).

## Problem
#612 fixed the core bug (macOS downloaded the Windows `.msi`, quit, never installed). But the build is **not yet Apple-notarized**, so after the `.dmg` is opened the user hits the *"developer cannot be verified"* Gatekeeper wall — with no on-screen guidance on how to get past it. The post-download status still read `Opening installer...`.

## What this PR does
`UpdateViewModel.InstallUpdate` now shows platform-specific guidance after opening the installer (new `ShowPostDownloadGuidance` / `BuildPostDownloadGuidance` helpers):

- **macOS** — *"drag Lunima to Applications and open it once — macOS will block the unsigned app; allow it under System Settings → Privacy & Security → 'Open Anyway'"* (right-click → Open is kept as the hint for macOS 14 and older, since macOS 15 removed that override). Approval is described on the copy in Applications because the quarantine attribute travels with the app.
- **Linux** — *"extract the archive and replace your installation to finish updating."*
- **Windows** — unchanged: auto-quit so `msiexec` can replace the running binary.

**Failure handling (split by cause, so the banner never dead-ends but also never lies):**
- **Download fails** (e.g. transient network error) → status shows `Download failed: …`; the user simply clicks Install again. No browser tab is opened.
- **Download succeeded but opening the installer fails** (e.g. no app associated with the file type) → status names the downloaded file's location and it is revealed in the file manager — the user is *not* sent to the releases page to re-download ~100 MB that already sits on disk.
- **No platform asset in the release** → unchanged: opens the GitHub releases page.

## Tests
- `BuildPostDownloadGuidance` is `internal static`, so the per-platform wording (incl. the macOS 15 "Open Anyway" path) is asserted on every CI runner, not only on a Mac.
- New `InstallUpdate_DownloadFails_ShowsRetryableErrorWithoutOpeningBrowser` and `InstallUpdate_OpeningInstallerFails_RevealsDownloadedFileInsteadOfClaimingDownloadFailed` cover both failure paths.
- `InstallUpdate_PlatformAssetPresent_OpensInstallerWithGuidanceAndKeepsAppAliveOnNonWindows` exercises the real download → open path via a delegate-based `StubHttpMessageHandler` (fresh response per request; also used to simulate metadata-OK/download-fails).
- Full suite green locally: **2578 passed, 5 skipped, 0 failed**; `dotnet build` clean (no new warnings).

## Scope notes
- No code-signing / notarization work here — that's a separate, larger effort. This only closes the UX gap for the current unsigned build.
- Guidance text originally suggested by @TyMcMan in #611, updated for macOS 15+ where the right-click override no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)