### PR TITLE
(+) Settings: Python-Environments-Seite, Nazca-Kandidaten im GDS-Export + Install-Guard beim Export

### DIFF
--- a/CAP.Avalonia/DI/ExportFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/ExportFeatureExtensions.cs
@@ -1,6 +1,8 @@
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager;
 using CAP_Core.Export;
+using CAP_Core.Export.PythonEnvironmentManager;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CAP.Avalonia.DI;
@@ -26,6 +28,22 @@ internal static class ExportFeatureExtensions
             var prefs = sp.GetRequiredService<UserPreferencesService>();
             vm.Initialize(prefs.GetCustomPythonPath());
             vm.OnPythonPathChanged = path => prefs.SetCustomPythonPath(path);
+
+            // Managed-environment integration (lazy resolution — the registry and the
+            // env-manager ViewModel are resolved when the delegate fires, not at build time).
+            vm.ManagedEnvironmentsProvider = () =>
+                sp.GetRequiredService<PythonEnvironmentRegistry>().GetAll()
+                    .Where(e => e.IsHealthy)
+                    .Select(e => new ManagedEnvCandidate(
+                        e.Name,
+                        e.PythonExecutable,
+                        $"Managed · {e.Name} · Python {e.PythonVersion ?? "?"} · Nazca {e.NazcaVersion ?? "?"}"))
+                    .ToList();
+            vm.ActivateManagedEnvironment = name =>
+                sp.GetRequiredService<PythonEnvironmentRegistry>().SetActive(name);
+            vm.RequestNazcaInstall = () =>
+                _ = sp.GetRequiredService<PythonEnvironmentManagerViewModel>()
+                    .StartDefaultNazcaInstallAsync();
             return vm;
         });
 

--- a/CAP.Avalonia/DI/SettingsFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/SettingsFeatureExtensions.cs
@@ -19,6 +19,7 @@ internal static class SettingsFeatureExtensions
         services.AddTransient<ISettingsPage, GridSnapSettingsPage>();
         services.AddTransient<ISettingsPage, UpdateSettingsPage>();
         services.AddTransient<ISettingsPage, GdsExportSettingsPage>();
+        services.AddTransient<ISettingsPage, PythonEnvironmentsSettingsPage>();
         services.AddTransient<ISettingsPage, ChipSizeSettingsPage>();
         services.AddTransient<ISettingsPage, AiAssistantSettingsPage>();
         services.AddTransient<SettingsWindowViewModel>();

--- a/CAP.Avalonia/Services/IMessageBoxService.cs
+++ b/CAP.Avalonia/Services/IMessageBoxService.cs
@@ -23,4 +23,13 @@ public interface IMessageBoxService
     /// <param name="title">Dialog title</param>
     /// <returns>User's choice</returns>
     Task<SavePromptResult> ShowSavePromptAsync(string message, string title);
+
+    /// <summary>
+    /// Shows a dialog with one button per entry in <paramref name="buttonLabels"/>.
+    /// </summary>
+    /// <param name="message">Message to display.</param>
+    /// <param name="title">Dialog title.</param>
+    /// <param name="buttonLabels">Button captions, left to right.</param>
+    /// <returns>Index of the clicked button, or -1 if the dialog was closed.</returns>
+    Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels);
 }

--- a/CAP.Avalonia/Services/MessageBoxService.cs
+++ b/CAP.Avalonia/Services/MessageBoxService.cs
@@ -119,4 +119,60 @@ public class MessageBoxService : IMessageBoxService
 
         return result ?? SavePromptResult.Cancel;
     }
+
+    /// <inheritdoc/>
+    public async Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels)
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop
+            || desktop.MainWindow == null)
+            return -1;
+
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 480,
+            SizeToContent = SizeToContent.Height,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Background = new SolidColorBrush(Color.Parse("#2d2d2d"))
+        };
+
+        var stackPanel = new StackPanel { Margin = new Thickness(20) };
+        stackPanel.Children.Add(new TextBlock
+        {
+            Text = message,
+            Margin = new Thickness(0, 10, 0, 20),
+            Foreground = Brushes.White,
+            TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+            FontSize = 14
+        });
+
+        var buttonPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 10
+        };
+
+        var result = -1;
+        for (var i = 0; i < buttonLabels.Count; i++)
+        {
+            var index = i;
+            var button = new Button
+            {
+                Content = buttonLabels[i],
+                Height = 32,
+                Padding = new Thickness(12, 0),
+                Background = new SolidColorBrush(Color.Parse(i == 0 ? "#0d6efd" : "#3d3d3d")),
+                Foreground = Brushes.White
+            };
+            button.Click += (_, _) => { result = index; dialog.Close(); };
+            buttonPanel.Children.Add(button);
+        }
+
+        stackPanel.Children.Add(buttonPanel);
+        dialog.Content = stackPanel;
+        await dialog.ShowDialog(desktop.MainWindow);
+        return result;
+    }
 }

--- a/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
@@ -54,6 +54,12 @@ public partial class GdsExportViewModel : ObservableObject
     [ObservableProperty]
     private bool _showNazcaInstallOffer;
 
+    [ObservableProperty]
+    private ObservableCollection<InterpreterOption> _interpreterOptions = new();
+
+    [ObservableProperty]
+    private bool _showCreateEnvironmentButton;
+
     /// <summary>
     /// True if both Python and Nazca are available and ready.
     /// </summary>
@@ -175,6 +181,66 @@ public partial class GdsExportViewModel : ObservableObject
             ManagedCandidates.Add(candidate);
 
         ShowNazcaInstallOffer = !NazcaAvailable && ManagedCandidates.Count == 0;
+        // The one-click create stays available whenever no managed environment exists,
+        // even if a system Python happens to carry Nazca.
+        ShowCreateEnvironmentButton = ManagedCandidates.Count == 0;
+        RebuildInterpreterOptions();
+    }
+
+    /// <summary>
+    /// Rebuilds the unified interpreter list (managed environments first, then discovered
+    /// system Pythons), marking the entry that matches the configured interpreter path.
+    /// </summary>
+    private void RebuildInterpreterOptions()
+    {
+        InterpreterOptions.Clear();
+        foreach (var candidate in ManagedCandidates)
+            InterpreterOptions.Add(new InterpreterOption(
+                candidate.DisplayText,
+                candidate.PythonExecutable,
+                IsConfiguredPath(candidate.PythonExecutable),
+                candidate.Name));
+
+        foreach (var python in AvailablePythons)
+            InterpreterOptions.Add(new InterpreterOption(
+                $"{python.Source} · Python {python.PythonVersion ?? "?"} · Nazca {python.NazcaVersion ?? "—"}",
+                python.Path,
+                IsConfiguredPath(python.Path),
+                ManagedName: null));
+    }
+
+    private bool IsConfiguredPath(string path) =>
+        string.Equals(path, CustomPythonPath, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Selects an interpreter from the unified list: managed environments are activated
+    /// through the registry (persists + updates the running pipeline), system Pythons via
+    /// the classic path selection. Both re-check the environment afterwards.
+    /// </summary>
+    /// <param name="option">The interpreter the user clicked.</param>
+    [RelayCommand]
+    public async Task SelectInterpreter(InterpreterOption option)
+    {
+        if (option.ManagedName != null)
+        {
+            ActivateManagedEnvironment?.Invoke(option.ManagedName);
+            await CheckEnvironmentAsync();
+            return;
+        }
+
+        await SetPythonPathAsync(option.Path);
+    }
+
+    /// <summary>
+    /// One-stop refresh for the settings page: discovers system Pythons with Nazca
+    /// (auto-selecting the first hit when nothing is configured yet — the "first start"
+    /// default), then re-checks the configured interpreter and rebuilds the list.
+    /// </summary>
+    [RelayCommand]
+    public async Task RefreshInterpretersAsync()
+    {
+        await SearchForPythonAsync();
+        await CheckEnvironmentAsync();
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
@@ -194,6 +194,31 @@ public partial class GdsExportViewModel : ObservableObject
     public void InstallNazca() => RequestNazcaInstall?.Invoke();
 
     /// <summary>
+    /// Decides how to proceed with GDS generation based on the current environment
+    /// state. Callers refresh the state (<see cref="CheckEnvironmentAsync"/>) first;
+    /// this method only maps state + user choice to a decision.
+    /// </summary>
+    /// <param name="messageBox">Dialog service; null (headless) proceeds like before.</param>
+    public async Task<GdsPreflightDecision> PreflightGdsAsync(Services.IMessageBoxService? messageBox)
+    {
+        if (!GenerateGdsEnabled || IsEnvironmentReady || messageBox == null)
+            return GdsPreflightDecision.Proceed;
+
+        var choice = await messageBox.ShowChoicePromptAsync(
+            "Nazca is required to generate a GDS file, but no Python environment with Nazca is available. "
+            + "The Nazca Python script itself has been exported.",
+            "Nazca required",
+            new[] { "Install Nazca now", "Open Settings", "Skip GDS" });
+
+        return choice switch
+        {
+            0 => GdsPreflightDecision.InstallRequested,
+            1 => GdsPreflightDecision.OpenSettingsRequested,
+            _ => GdsPreflightDecision.SkipGds,
+        };
+    }
+
+    /// <summary>
     /// Exports a Python script to GDS (if enabled and environment is ready).
     /// </summary>
     /// <param name="scriptPath">Path to the exported Python script.</param>

--- a/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
@@ -320,19 +320,33 @@ public partial class GdsExportViewModel : ObservableObject
         return result;
     }
 
+    private int _searchGeneration;
+
+    /// <summary>
+    /// Runs the actual interpreter discovery. Virtual so tests can substitute a
+    /// controllable discovery to exercise overlapping-search behavior.
+    /// </summary>
+    protected virtual Task<List<PythonDiscoveryService.PythonInstallation>> DiscoverPythonsAsync() =>
+        _discoveryService.DiscoverPythonWithNazcaAsync();
+
     /// <summary>
     /// Searches for Python installations with Nazca and updates the available list.
+    /// Starting a new search supersedes any still-running one: the stale run discards
+    /// its results, so rapid page switches can never duplicate the list.
     /// </summary>
     [RelayCommand]
     public async Task SearchForPythonAsync()
     {
+        var generation = ++_searchGeneration;
         IsSearching = true;
-        AvailablePythons.Clear();
 
         try
         {
-            var found = await _discoveryService.DiscoverPythonWithNazcaAsync();
+            var found = await DiscoverPythonsAsync();
+            if (generation != _searchGeneration)
+                return;   // a newer search owns the list now
 
+            AvailablePythons.Clear();
             foreach (var installation in found)
             {
                 AvailablePythons.Add(installation);
@@ -354,12 +368,16 @@ public partial class GdsExportViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            _errorConsole?.LogError($"Python discovery failed: {ex.Message}", ex);
-            PythonStatus = $"✗ Search failed: {ex.Message}";
+            if (generation == _searchGeneration)
+            {
+                _errorConsole?.LogError($"Python discovery failed: {ex.Message}", ex);
+                PythonStatus = $"✗ Search failed: {ex.Message}";
+            }
         }
         finally
         {
-            IsSearching = false;
+            if (generation == _searchGeneration)
+                IsSearching = false;
         }
     }
 

--- a/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
@@ -95,9 +95,11 @@ public partial class GdsExportViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Initializes the ViewModel with saved preferences.
+    /// Initializes the ViewModel with saved preferences. A null path clears the
+    /// configuration (e.g. the active managed environment was deleted) so a stale
+    /// interpreter path never lingers; the next refresh picks a fallback.
     /// </summary>
-    /// <param name="savedPythonPath">Previously saved Python path from preferences.</param>
+    /// <param name="savedPythonPath">Previously saved Python path, or null to clear.</param>
     public void Initialize(string? savedPythonPath)
     {
         if (!string.IsNullOrEmpty(savedPythonPath))
@@ -105,7 +107,12 @@ public partial class GdsExportViewModel : ObservableObject
             CustomPythonPath = savedPythonPath;
             _exportService.SetCustomPythonPath(savedPythonPath);
             PythonPathSource = "Custom";
+            return;
         }
+
+        CustomPythonPath = string.Empty;
+        _exportService.SetCustomPythonPath(null);
+        PythonPathSource = string.Empty;
     }
 
     /// <summary>
@@ -241,6 +248,23 @@ public partial class GdsExportViewModel : ObservableObject
     {
         await SearchForPythonAsync();
         await CheckEnvironmentAsync();
+        await TrySelectFallbackInterpreterAsync();
+    }
+
+    /// <summary>
+    /// When no interpreter is configured — or the configured one no longer exists on
+    /// disk (e.g. its managed environment was deleted) — falls back to the first
+    /// available candidate (managed environments come first) instead of showing
+    /// "not found" while working alternatives sit in the list.
+    /// </summary>
+    public async Task TrySelectFallbackInterpreterAsync()
+    {
+        var configuredIsUsable = !string.IsNullOrEmpty(CustomPythonPath) && File.Exists(CustomPythonPath);
+        if (configuredIsUsable) return;
+
+        var fallback = InterpreterOptions.FirstOrDefault();
+        if (fallback != null)
+            await SelectInterpreter(fallback);
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs
@@ -48,6 +48,12 @@ public partial class GdsExportViewModel : ObservableObject
     [ObservableProperty]
     private string _pythonPathSource = string.Empty;
 
+    [ObservableProperty]
+    private ObservableCollection<ManagedEnvCandidate> _managedCandidates = new();
+
+    [ObservableProperty]
+    private bool _showNazcaInstallOffer;
+
     /// <summary>
     /// True if both Python and Nazca are available and ready.
     /// </summary>
@@ -57,6 +63,18 @@ public partial class GdsExportViewModel : ObservableObject
     /// Callback to save Python path to preferences when changed.
     /// </summary>
     public Action<string?>? OnPythonPathChanged { get; set; }
+
+    /// <summary>
+    /// Supplies the managed environments that carry Nazca (wired by the DI layer;
+    /// the GDS-export slice never references the environment-manager slice directly).
+    /// </summary>
+    public Func<IReadOnlyList<ManagedEnvCandidate>>? ManagedEnvironmentsProvider { get; set; }
+
+    /// <summary>Activates a managed environment by name (wired by the DI layer).</summary>
+    public Action<string>? ActivateManagedEnvironment { get; set; }
+
+    /// <summary>Starts the default Nazca environment installation (wired by the DI layer).</summary>
+    public Action? RequestNazcaInstall { get; set; }
 
     private readonly ErrorConsoleService? _errorConsole;
 
@@ -127,6 +145,7 @@ public partial class GdsExportViewModel : ObservableObject
             }
 
             OnPropertyChanged(nameof(IsEnvironmentReady));
+            RefreshManagedCandidates();
         }
         catch (Exception ex)
         {
@@ -136,12 +155,43 @@ public partial class GdsExportViewModel : ObservableObject
             NazcaStatus = "✗ Check failed";
             _errorConsole?.LogError($"Python environment check failed: {ex.Message}", ex);
             OnPropertyChanged(nameof(IsEnvironmentReady));
+            RefreshManagedCandidates();
         }
         finally
         {
             IsChecking = false;
         }
     }
+
+    /// <summary>
+    /// Rebuilds <see cref="ManagedCandidates"/> from <see cref="ManagedEnvironmentsProvider"/>
+    /// and recomputes whether the "install Nazca" offer should be shown (no Nazca in the
+    /// active interpreter AND no managed environment to switch to).
+    /// </summary>
+    public void RefreshManagedCandidates()
+    {
+        ManagedCandidates.Clear();
+        foreach (var candidate in ManagedEnvironmentsProvider?.Invoke() ?? Array.Empty<ManagedEnvCandidate>())
+            ManagedCandidates.Add(candidate);
+
+        ShowNazcaInstallOffer = !NazcaAvailable && ManagedCandidates.Count == 0;
+    }
+
+    /// <summary>
+    /// Activates a managed environment: the registry callback (DI layer) persists the
+    /// interpreter and pushes it into this ViewModel, then the status is re-checked.
+    /// </summary>
+    /// <param name="candidate">The managed environment to activate.</param>
+    [RelayCommand]
+    public async Task SelectManagedEnvironment(ManagedEnvCandidate candidate)
+    {
+        ActivateManagedEnvironment?.Invoke(candidate.Name);
+        await CheckEnvironmentAsync();
+    }
+
+    /// <summary>Requests creation + installation of the default Nazca environment.</summary>
+    [RelayCommand]
+    public void InstallNazca() => RequestNazcaInstall?.Invoke();
 
     /// <summary>
     /// Exports a Python script to GDS (if enabled and environment is ready).

--- a/CAP.Avalonia/ViewModels/Export/GdsPreflightDecision.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsPreflightDecision.cs
@@ -1,0 +1,17 @@
+namespace CAP.Avalonia.ViewModels.Export;
+
+/// <summary>Outcome of the pre-flight check before generating a GDS file.</summary>
+public enum GdsPreflightDecision
+{
+    /// <summary>Environment is ready (or GDS generation is disabled/headless) — continue.</summary>
+    Proceed,
+
+    /// <summary>User chose to skip the GDS step; the Nazca script export stands alone.</summary>
+    SkipGds,
+
+    /// <summary>User asked to install Nazca now (open settings + start default install).</summary>
+    InstallRequested,
+
+    /// <summary>User asked to open the settings without installing.</summary>
+    OpenSettingsRequested,
+}

--- a/CAP.Avalonia/ViewModels/Export/InterpreterOption.cs
+++ b/CAP.Avalonia/ViewModels/Export/InterpreterOption.cs
@@ -1,0 +1,12 @@
+namespace CAP.Avalonia.ViewModels.Export;
+
+/// <summary>
+/// One selectable interpreter in the unified list on the GDS-Export settings page —
+/// either a managed environment or a discovered system Python. The interpreter path
+/// is shown as a label so entries with equal names stay distinguishable.
+/// </summary>
+/// <param name="DisplayText">Primary line, e.g. "Managed · nazca · Python 3.11 · Nazca 0.6.1".</param>
+/// <param name="Path">Full path to the interpreter executable (secondary label).</param>
+/// <param name="IsActive">True when this interpreter is the currently configured one.</param>
+/// <param name="ManagedName">Registry name when this is a managed environment; null for system Pythons.</param>
+public sealed record InterpreterOption(string DisplayText, string Path, bool IsActive, string? ManagedName);

--- a/CAP.Avalonia/ViewModels/Export/ManagedEnvCandidate.cs
+++ b/CAP.Avalonia/ViewModels/Export/ManagedEnvCandidate.cs
@@ -1,0 +1,13 @@
+namespace CAP.Avalonia.ViewModels.Export;
+
+/// <summary>
+/// A managed Python environment offered as an interpreter candidate on the
+/// GDS-Export settings page. Deliberately a plain DTO: the GDS-export slice
+/// never imports the environment-manager slice — the DI layer maps registry
+/// entries into this type. Packages beyond Nazca (e.g. gdsfactory, #581)
+/// extend <see cref="DisplayText"/> later without UI changes.
+/// </summary>
+/// <param name="Name">Registry name of the environment (activation key).</param>
+/// <param name="PythonExecutable">Full path to the environment's interpreter.</param>
+/// <param name="DisplayText">Human-readable list entry, e.g. "Managed · nazca · Python 3.11 · Nazca 0.6.1".</param>
+public sealed record ManagedEnvCandidate(string Name, string PythonExecutable, string DisplayText);

--- a/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
@@ -58,6 +58,31 @@ public partial class PythonEnvironmentManagerViewModel : ObservableObject
         RefreshList();
     }
 
+    /// <summary>Name of the environment created by the one-click "install Nazca" offers.</summary>
+    public const string DefaultEnvironmentName = "nazca";
+
+    /// <summary>
+    /// One-click entry point used by the GDS-export fallback and the export guard:
+    /// creates the default Nazca environment with default settings. No-ops (with an
+    /// explanatory status) when an environment of that name already exists, and does
+    /// nothing while another operation runs.
+    /// </summary>
+    public async Task StartDefaultNazcaInstallAsync()
+    {
+        if (IsBusy) return;
+
+        if (_registry.Exists(DefaultEnvironmentName))
+        {
+            ProgressText = $"Environment '{DefaultEnvironmentName}' already exists — "
+                + "select it below or use Repair if it is broken.";
+            return;
+        }
+
+        NewEnvironmentName = DefaultEnvironmentName;
+        PythonVersion = UvBootstrapper.DefaultPythonVersion;
+        await CreateAndInstallCommand.ExecuteAsync(null);
+    }
+
     /// <summary>Creates a new venv and installs Nazca + pyclipper into it.</summary>
     [RelayCommand]
     private async Task CreateAndInstallAsync()

--- a/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
@@ -31,6 +31,14 @@ public partial class PythonEnvironmentManagerViewModel : ObservableObject
     [ObservableProperty]
     private string _pythonVersion = UvBootstrapper.DefaultPythonVersion;
 
+    /// <summary>
+    /// Python versions offered in the create-environment dropdown. Limited to versions
+    /// with known-good Nazca/pyclipper support (3.14+ currently breaks numpy/nazca);
+    /// the default is <see cref="UvBootstrapper.DefaultPythonVersion"/>.
+    /// </summary>
+    public IReadOnlyList<string> PythonVersionChoices { get; } =
+        new[] { "3.10", "3.11", "3.12", "3.13" };
+
     [ObservableProperty]
     private bool _isBusy;
 

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -199,6 +199,14 @@ public partial class MainViewModel : ObservableObject
         ViewportControl.UpdateStatus = UpdateStatusText;
         LeftPanel.UpdateStatus = UpdateStatusText;
 
+        // Let the export guard open the Settings window (e.g. on the Python-Environments
+        // page when Nazca is missing); ShowSettingsWindowAsync is wired later by MainWindow.
+        FileOperations.ShowSettingsWindow = async pageType =>
+        {
+            if (ShowSettingsWindowAsync != null)
+                await ShowSettingsWindowAsync(pageType);
+        };
+
         // Wire up canvas status updates to bottom panel
         _canvas.PropertyChanged += (s, e) =>
         {

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -1277,6 +1277,20 @@ public partial class FileOperationsViewModel : ObservableObject
 
         if (filePath != null)
         {
+            // A script named like a Python module it imports (e.g. re.py, numpy.py)
+            // shadows that module and fails with a cryptic circular-import error —
+            // refuse the name up front instead of letting the Nazca run explode.
+            var stem = Path.GetFileNameWithoutExtension(filePath);
+            if (PythonModuleShadowing.ShadowsPythonModule(stem))
+            {
+                var warning = $"'{Path.GetFileName(filePath)}' shadows the Python module '{stem.ToLowerInvariant()}' "
+                    + "— the exported script could not import Nazca. Please choose a different file name (e.g. chip1.py).";
+                if (MessageBoxService != null)
+                    await MessageBoxService.ShowChoicePromptAsync(warning, "Invalid script name", new[] { "OK" });
+                UpdateStatus?.Invoke(warning);
+                return;
+            }
+
             try
             {
                 // Export Python script

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -112,6 +112,12 @@ public partial class FileOperationsViewModel : ObservableObject
     /// </summary>
     public IMessageBoxService? MessageBoxService { get; set; }
 
+    /// <summary>
+    /// Opens the Settings window, optionally pre-selecting a page by type.
+    /// Wired by <see cref="MainViewModel"/>; null in headless contexts.
+    /// </summary>
+    public Func<Type?, Task>? ShowSettingsWindow { get; set; }
+
     /// <summary>Initializes a new instance of <see cref="FileOperationsViewModel"/>.</summary>
     public FileOperationsViewModel(
         DesignCanvasViewModel canvas,
@@ -1277,6 +1283,18 @@ public partial class FileOperationsViewModel : ObservableObject
                 var nazcaCode = _nazcaExporter.Export(_canvas, overrides: StoredNazcaOverrides);
                 await File.WriteAllTextAsync(filePath, nazcaCode);
 
+                // GDS pre-flight: refresh a stale "not ready" verdict once, then ask the
+                // user how to proceed when Nazca is genuinely unavailable.
+                if (GdsExport.GenerateGdsEnabled && !GdsExport.IsEnvironmentReady)
+                    await GdsExport.CheckEnvironmentAsync();
+
+                var decision = await GdsExport.PreflightGdsAsync(MessageBoxService);
+                if (decision != Export.GdsPreflightDecision.Proceed)
+                {
+                    await HandleSkippedGdsAsync(decision, filePath);
+                    return;
+                }
+
                 // Attempt GDS generation if enabled
                 var result = await GdsExport.ExportScriptToGdsAsync(filePath);
 
@@ -1306,6 +1324,29 @@ public partial class FileOperationsViewModel : ObservableObject
                 UpdateStatus?.Invoke($"Export failed: {ex.Message}");
             }
         }
+    }
+
+    /// <summary>
+    /// Handles the non-Proceed pre-flight outcomes: the Nazca script is already on disk,
+    /// only the GDS step is skipped. Install/settings choices open the Settings window on
+    /// the Python-Environments page (the install progress is visible there).
+    /// </summary>
+    private async Task HandleSkippedGdsAsync(Export.GdsPreflightDecision decision, string scriptPath)
+    {
+        if (decision == Export.GdsPreflightDecision.InstallRequested)
+        {
+            GdsExport.InstallNazcaCommand.Execute(null);
+            if (ShowSettingsWindow != null)
+                await ShowSettingsWindow(typeof(Settings.PythonEnvironmentsSettingsPage));
+            UpdateStatus?.Invoke($"Exported {Path.GetFileName(scriptPath)} — GDS skipped (installing Nazca)");
+            return;
+        }
+
+        if (decision == Export.GdsPreflightDecision.OpenSettingsRequested
+            && ShowSettingsWindow != null)
+            await ShowSettingsWindow(typeof(Settings.PythonEnvironmentsSettingsPage));
+
+        UpdateStatus?.Invoke($"Exported {Path.GetFileName(scriptPath)} — GDS skipped (Nazca not available)");
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
@@ -7,7 +7,6 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Converters;
 using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Export;
-using CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager;
 using CAP.Avalonia.ViewModels.Properties;
 using CAP.Avalonia.Services;
 using System.ComponentModel;
@@ -114,11 +113,6 @@ public partial class RightPanelViewModel : ObservableObject
     /// </summary>
     public TimeDomainViewModel TimeDomain { get; }
 
-    /// <summary>
-    /// ViewModel for the Python Environment Manager panel (create/install/manage Python venvs).
-    /// </summary>
-    public PythonEnvironmentManagerViewModel PythonEnvManager { get; }
-
     private readonly ComponentEditorFactory _editorFactory;
     private readonly DesignCanvasViewModel _canvas;
 
@@ -155,8 +149,7 @@ public partial class RightPanelViewModel : ObservableObject
         AiAssistantViewModel aiAssistant,
         OnaSweepViewModel onaAnalysis,
         ComponentEditorFactory editorFactory,
-        TimeDomainViewModel timeDomain,
-        PythonEnvironmentManagerViewModel pythonEnvManager)
+        TimeDomainViewModel timeDomain)
     {
         _preferencesService = preferencesService;
         _editorFactory = editorFactory;
@@ -175,7 +168,6 @@ public partial class RightPanelViewModel : ObservableObject
         AiAssistant = aiAssistant;
         TimeDomain = timeDomain;
         OnaAnalysis = onaAnalysis;
-        PythonEnvManager = pythonEnvManager;
 
         // Configure ViewModels that need canvas reference
         RoutingDiagnostics.Configure(canvas);

--- a/CAP.Avalonia/ViewModels/Settings/GdsExportSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/GdsExportSettingsPage.cs
@@ -31,4 +31,11 @@ public class GdsExportSettingsPage : ISettingsPage
     {
         ViewModel = gdsExportViewModel;
     }
+
+    /// <summary>
+    /// Navigating to this page refreshes the interpreter list automatically —
+    /// no manual "check environment" click needed.
+    /// </summary>
+    public void OnSelected() =>
+        ((GdsExportViewModel)ViewModel).RefreshInterpretersCommand.Execute(null);
 }

--- a/CAP.Avalonia/ViewModels/Settings/ISettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/ISettingsPage.cs
@@ -19,4 +19,10 @@ public interface ISettingsPage
 
     /// <summary>The ViewModel rendered inside the content area when this page is selected.</summary>
     object ViewModel { get; }
+
+    /// <summary>
+    /// Invoked by the Settings window whenever this page becomes the selected page.
+    /// Default: no-op. Override to refresh page data on navigation.
+    /// </summary>
+    void OnSelected() { }
 }

--- a/CAP.Avalonia/ViewModels/Settings/PythonEnvironmentsSettingsPage.cs
+++ b/CAP.Avalonia/ViewModels/Settings/PythonEnvironmentsSettingsPage.cs
@@ -1,0 +1,30 @@
+using CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Settings page hosting the managed Python environment manager (create, install
+/// Nazca, health-check, repair, remove, set active). Lives in Settings — not the
+/// Properties sidebar — because environments are application-wide configuration.
+/// </summary>
+public class PythonEnvironmentsSettingsPage : ISettingsPage
+{
+    /// <inheritdoc/>
+    public string Title => "Python Environments";
+
+    /// <inheritdoc/>
+    public string Icon => "📦";
+
+    /// <inheritdoc/>
+    public string? Category => "Export";
+
+    /// <inheritdoc/>
+    public object ViewModel { get; }
+
+    /// <summary>Initializes a new instance of <see cref="PythonEnvironmentsSettingsPage"/>.</summary>
+    /// <param name="viewModel">The shared environment-manager ViewModel from DI.</param>
+    public PythonEnvironmentsSettingsPage(PythonEnvironmentManagerViewModel viewModel)
+    {
+        ViewModel = viewModel;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs
@@ -26,4 +26,16 @@ public partial class SettingsWindowViewModel : ObservableObject
         Pages = pages.ToList();
         SelectedPage = Pages.FirstOrDefault();
     }
+
+    /// <summary>
+    /// Selects the page whose runtime type matches <paramref name="pageType"/>;
+    /// keeps the current selection when no such page is registered.
+    /// </summary>
+    /// <param name="pageType">Runtime type of the <see cref="ISettingsPage"/> to select.</param>
+    public void SelectPage(Type pageType)
+    {
+        var page = Pages.FirstOrDefault(p => p.GetType() == pageType);
+        if (page != null)
+            SelectedPage = page;
+    }
 }

--- a/CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs
@@ -17,6 +17,8 @@ public partial class SettingsWindowViewModel : ObservableObject
     [ObservableProperty]
     private ISettingsPage? _selectedPage;
 
+    partial void OnSelectedPageChanged(ISettingsPage? value) => value?.OnSelected();
+
     /// <summary>
     /// Initializes a new instance of <see cref="SettingsWindowViewModel"/>.
     /// </summary>

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -732,9 +732,6 @@
                     <!-- Time-Domain (Transient) Simulation Panel -->
                     <panels:TimeDomainPanel/>
 
-                    <!-- Python Environment Manager Panel -->
-                    <panels:PythonEnvironmentManagerPanel/>
-
                     <!-- Element Lock Panel -->
                     <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
                     <TextBlock Text="Lock Elements:" Foreground="Gold" Margin="0,0,0,5" FontWeight="SemiBold"/>

--- a/CAP.Avalonia/Views/Panels/PythonEnvironmentManagerPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/PythonEnvironmentManagerPanel.axaml
@@ -1,11 +1,10 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:vm="using:CAP.Avalonia.ViewModels"
+             xmlns:vm="using:CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager"
              x:Class="CAP.Avalonia.Views.Panels.PythonEnvironmentManagerPanel"
-             x:DataType="vm:MainViewModel">
+             x:DataType="vm:PythonEnvironmentManagerViewModel">
 
     <StackPanel>
-        <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
         <TextBlock Text="Python Environment Manager:" Foreground="LightSkyBlue"
                    Margin="0,0,0,5" FontWeight="SemiBold"/>
         <TextBlock Foreground="Gray" FontSize="10" Margin="0,0,0,8" TextWrapping="Wrap">
@@ -14,8 +13,8 @@
         </TextBlock>
 
         <!-- Environments list -->
-        <ListBox ItemsSource="{Binding RightPanel.PythonEnvManager.Environments}"
-                 SelectedItem="{Binding RightPanel.PythonEnvManager.SelectedEnvironment}"
+        <ListBox ItemsSource="{Binding Environments}"
+                 SelectedItem="{Binding SelectedEnvironment}"
                  MaxHeight="160" Margin="0,0,0,6" Background="#1e1e1e" BorderBrush="#3d3d3d"
                  BorderThickness="1">
             <ListBox.ItemTemplate>
@@ -41,28 +40,28 @@
         </ListBox>
 
         <!-- Action buttons for selected environment -->
-        <StackPanel IsVisible="{Binding RightPanel.PythonEnvManager.SelectedEnvironment,
+        <StackPanel IsVisible="{Binding SelectedEnvironment,
                                         Converter={x:Static ObjectConverters.IsNotNull}}">
             <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,4">
                 <Button Content="Set Active"
-                        Command="{Binding RightPanel.PythonEnvManager.SetActiveCommand}"
+                        Command="{Binding SetActiveCommand}"
                         Width="80" Background="#3d5d3d" FontSize="11"
-                        IsEnabled="{Binding RightPanel.PythonEnvManager.IsBusy,
+                        IsEnabled="{Binding IsBusy,
                                             Converter={x:Static BoolConverters.Not}}"/>
                 <Button Content="Check Health"
-                        Command="{Binding RightPanel.PythonEnvManager.CheckHealthCommand}"
+                        Command="{Binding CheckHealthCommand}"
                         Width="90" Background="#3d4d5d" FontSize="11"
-                        IsEnabled="{Binding RightPanel.PythonEnvManager.IsBusy,
+                        IsEnabled="{Binding IsBusy,
                                             Converter={x:Static BoolConverters.Not}}"/>
                 <Button Content="Repair"
-                        Command="{Binding RightPanel.PythonEnvManager.RepairCommand}"
+                        Command="{Binding RepairCommand}"
                         Width="70" Background="#5d4d3d" FontSize="11"
-                        IsEnabled="{Binding RightPanel.PythonEnvManager.IsBusy,
+                        IsEnabled="{Binding IsBusy,
                                             Converter={x:Static BoolConverters.Not}}"/>
                 <Button Content="Remove"
-                        Command="{Binding RightPanel.PythonEnvManager.RemoveCommand}"
+                        Command="{Binding RemoveCommand}"
                         Width="70" Background="#5d3d3d" FontSize="11"
-                        IsEnabled="{Binding RightPanel.PythonEnvManager.IsBusy,
+                        IsEnabled="{Binding IsBusy,
                                             Converter={x:Static BoolConverters.Not}}"/>
             </StackPanel>
         </StackPanel>
@@ -74,38 +73,38 @@
         <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,4">
             <TextBlock Text="Name:" Foreground="Gray" FontSize="11"
                        VerticalAlignment="Center" Width="50"/>
-            <TextBox Text="{Binding RightPanel.PythonEnvManager.NewEnvironmentName}"
+            <TextBox Text="{Binding NewEnvironmentName}"
                      Width="150" FontSize="11" Watermark="e.g. nazca-env"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,4">
             <TextBlock Text="Python:" Foreground="Gray" FontSize="11"
                        VerticalAlignment="Center" Width="50"/>
-            <TextBox Text="{Binding RightPanel.PythonEnvManager.PythonVersion}"
+            <TextBox Text="{Binding PythonVersion}"
                      Width="80" FontSize="11" Watermark="3.11"/>
         </StackPanel>
         <Button Content="Create + Install Nazca"
-                Command="{Binding RightPanel.PythonEnvManager.CreateAndInstallCommand}"
+                Command="{Binding CreateAndInstallCommand}"
                 Width="160" Background="#3d5d7d" FontSize="11" Margin="0,0,0,6"
-                IsEnabled="{Binding RightPanel.PythonEnvManager.IsBusy,
+                IsEnabled="{Binding IsBusy,
                                     Converter={x:Static BoolConverters.Not}}"/>
 
         <!-- Progress and cancel -->
-        <StackPanel IsVisible="{Binding RightPanel.PythonEnvManager.IsBusy}"
+        <StackPanel IsVisible="{Binding IsBusy}"
                     Margin="0,0,0,4">
             <StackPanel Orientation="Horizontal" Spacing="8">
-                <TextBlock Text="{Binding RightPanel.PythonEnvManager.ProgressText}"
+                <TextBlock Text="{Binding ProgressText}"
                            Foreground="LightSkyBlue" FontSize="10" TextWrapping="Wrap"/>
                 <Button Content="Cancel"
-                        Command="{Binding RightPanel.PythonEnvManager.CancelCommand}"
+                        Command="{Binding CancelCommand}"
                         FontSize="10" Padding="6,2" Background="#5d3d3d"
-                        IsEnabled="{Binding RightPanel.PythonEnvManager.CanCancel}"/>
+                        IsEnabled="{Binding CanCancel}"/>
             </StackPanel>
         </StackPanel>
 
         <!-- Status (idle) -->
-        <TextBlock Text="{Binding RightPanel.PythonEnvManager.ProgressText}"
+        <TextBlock Text="{Binding ProgressText}"
                    Foreground="Gray" FontSize="10" TextWrapping="Wrap"
-                   IsVisible="{Binding RightPanel.PythonEnvManager.IsBusy,
+                   IsVisible="{Binding IsBusy,
                                        Converter={x:Static BoolConverters.Not}}"
                    Margin="0,0,0,4"/>
     </StackPanel>

--- a/CAP.Avalonia/Views/Panels/PythonEnvironmentManagerPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/PythonEnvironmentManagerPanel.axaml
@@ -79,8 +79,9 @@
         <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,0,0,4">
             <TextBlock Text="Python:" Foreground="Gray" FontSize="11"
                        VerticalAlignment="Center" Width="50"/>
-            <TextBox Text="{Binding PythonVersion}"
-                     Width="80" FontSize="11" Watermark="3.11"/>
+            <ComboBox ItemsSource="{Binding PythonVersionChoices}"
+                      SelectedItem="{Binding PythonVersion}"
+                      Width="90" FontSize="11"/>
         </StackPanel>
         <Button Content="Create + Install Nazca"
                 Command="{Binding CreateAndInstallCommand}"

--- a/CAP.Avalonia/Views/SettingsWindow.axaml
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml
@@ -10,7 +10,7 @@
         x:Class="CAP.Avalonia.Views.SettingsWindow"
         x:DataType="settings:SettingsWindowViewModel"
         Title="Settings"
-        Width="820" Height="560"
+        Width="820" Height="680"
         WindowStartupLocation="CenterOwner"
         Background="#1e1e1e"
         Foreground="White">
@@ -178,47 +178,55 @@
                                 <TextBlock Text="{Binding NazcaStatus}" Foreground="White"/>
                             </StackPanel>
 
-                            <!-- Unified interpreter list: managed environments + discovered system Pythons -->
-                            <ItemsControl ItemsSource="{Binding InterpreterOptions}"
-                                          Margin="0,6,0,0"
-                                          x:Name="InterpreterOptionsList"
+                            <!-- Unified interpreter list: managed environments + discovered system
+                                 Pythons. Scrolls beyond ~5 entries instead of growing unbounded. -->
+                            <ScrollViewer MaxHeight="240" Margin="0,6,0,0"
+                                          VerticalScrollBarVisibility="Auto"
                                           IsVisible="{Binding InterpreterOptions.Count}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Button Command="{Binding #InterpreterOptionsList.DataContext.SelectInterpreterCommand}"
-                                                CommandParameter="{Binding}"
-                                                HorizontalAlignment="Stretch"
-                                                HorizontalContentAlignment="Left"
-                                                Margin="0,2,0,0" Padding="6,4"
-                                                Background="#2d2d2d" FontSize="11">
-                                            <StackPanel>
-                                                <StackPanel Orientation="Horizontal" Spacing="6">
-                                                    <TextBlock Text="✓" Foreground="Gold" FontWeight="Bold"
-                                                               IsVisible="{Binding IsActive}"/>
-                                                    <TextBlock Text="{Binding DisplayText}" Foreground="LightGray"/>
+                                <ItemsControl ItemsSource="{Binding InterpreterOptions}"
+                                              x:Name="InterpreterOptionsList">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Button Command="{Binding #InterpreterOptionsList.DataContext.SelectInterpreterCommand}"
+                                                    CommandParameter="{Binding}"
+                                                    HorizontalAlignment="Stretch"
+                                                    HorizontalContentAlignment="Left"
+                                                    Margin="0,2,4,0" Padding="6,3"
+                                                    Background="#2d2d2d" FontSize="11">
+                                                <StackPanel>
+                                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                                        <TextBlock Text="✓" Foreground="Gold" FontWeight="Bold"
+                                                                   IsVisible="{Binding IsActive}"/>
+                                                        <TextBlock Text="{Binding DisplayText}" Foreground="LightGray"/>
+                                                    </StackPanel>
+                                                    <TextBlock Text="{Binding Path}" Foreground="Gray" FontSize="10"
+                                                               TextWrapping="Wrap"/>
                                                 </StackPanel>
-                                                <TextBlock Text="{Binding Path}" Foreground="Gray" FontSize="10"
-                                                           TextWrapping="Wrap"/>
-                                            </StackPanel>
-                                        </Button>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
+                                            </Button>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
 
                             <!-- No managed environment yet: offer the one-click create (warning text
                                  only when Nazca is missing everywhere) -->
                             <Border IsVisible="{Binding ShowCreateEnvironmentButton}"
                                     Background="#2a2a20" CornerRadius="4" Padding="10" Margin="0,10,0,0">
-                                <StackPanel Spacing="6">
-                                    <TextBlock Text="No Nazca environment found."
-                                               Foreground="#e8c872" FontWeight="SemiBold" FontSize="12"
-                                               IsVisible="{Binding ShowNazcaInstallOffer}"/>
-                                    <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap"
-                                               Text="Lunima can create a managed Python environment and install Nazca into it automatically."/>
-                                    <Button Content="Create + install Nazca now"
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <StackPanel Grid.Column="0" Spacing="4" VerticalAlignment="Center"
+                                                Margin="0,0,10,0">
+                                        <TextBlock Text="No Nazca environment found."
+                                                   Foreground="#e8c872" FontWeight="SemiBold" FontSize="12"
+                                                   IsVisible="{Binding ShowNazcaInstallOffer}"/>
+                                        <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap"
+                                                   Text="Lunima can create a managed Python environment with Nazca automatically."/>
+                                    </StackPanel>
+                                    <Button Grid.Column="1" Content="Install new"
                                             Click="OnCreateNazcaEnvironmentClick"
-                                            Background="#3d5d3d" HorizontalAlignment="Left"/>
-                                </StackPanel>
+                                            ToolTip.Tip="Create a managed Python environment and install Nazca into it"
+                                            Background="#3d5d3d" FontSize="11" Padding="10,2"
+                                            MinHeight="0" VerticalAlignment="Center"/>
+                                </Grid>
                             </Border>
                         </StackPanel>
                     </DataTemplate>

--- a/CAP.Avalonia/Views/SettingsWindow.axaml
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml
@@ -153,30 +153,21 @@
                             <TextBlock Text="Python Environment" FontSize="14" FontWeight="SemiBold" Foreground="LightGray"/>
                             <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,4">
                                 Python interpreter used to run the exported Nazca script.
-                                Leave the path blank to use auto-detection.
+                                Pick one from the list below — the selection is remembered.
                             </TextBlock>
 
-                            <TextBlock Text="Python Path:" Foreground="Gray" FontSize="12" Margin="0,4,0,3"/>
+                            <TextBlock Text="Active interpreter:" Foreground="Gray" FontSize="12" Margin="0,4,0,3"/>
                             <Grid ColumnDefinitions="*,Auto">
                                 <TextBox Grid.Column="0"
                                          Text="{Binding CustomPythonPath}"
-                                         Watermark="Auto-detect or enter path..."
+                                         IsReadOnly="True"
+                                         Watermark="No interpreter selected yet"
                                          Margin="0,0,6,0"/>
-                                <Button Grid.Column="1" Content="🔍" Width="32" Padding="4"
-                                        Command="{Binding SearchForPythonCommand}"
-                                        ToolTip.Tip="Search for Python with Nazca"
+                                <Button Grid.Column="1" Content="🔄" Width="32" Padding="4"
+                                        Command="{Binding RefreshInterpretersCommand}"
+                                        ToolTip.Tip="Refresh: discover Pythons with Nazca and re-check the environment"
                                         IsEnabled="{Binding IsSearching, Converter={x:Static BoolConverters.Not}}"/>
                             </Grid>
-
-                            <TextBlock Text="{Binding PythonPathSource}"
-                                       Foreground="Gray" FontSize="10"
-                                       IsVisible="{Binding PythonPathSource, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
-
-                            <Button Content="Check Environment"
-                                    Command="{Binding CheckEnvironmentCommand}"
-                                    Width="150" Margin="0,8,0,0" Background="#3d5d5d"
-                                    HorizontalAlignment="Left"
-                                    IsEnabled="{Binding IsChecking, Converter={x:Static BoolConverters.Not}}"/>
 
                             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                                 <TextBlock Text="Python: " Foreground="Gray" Width="70"/>
@@ -187,47 +178,41 @@
                                 <TextBlock Text="{Binding NazcaStatus}" Foreground="White"/>
                             </StackPanel>
 
-                            <ItemsControl ItemsSource="{Binding AvailablePythons}"
+                            <!-- Unified interpreter list: managed environments + discovered system Pythons -->
+                            <ItemsControl ItemsSource="{Binding InterpreterOptions}"
                                           Margin="0,6,0,0"
-                                          x:Name="AvailablePythonsList"
-                                          IsVisible="{Binding AvailablePythons.Count}">
+                                          x:Name="InterpreterOptionsList"
+                                          IsVisible="{Binding InterpreterOptions.Count}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Button Content="{Binding DisplayText}"
-                                                Command="{Binding #AvailablePythonsList.DataContext.SelectPythonCommand}"
+                                        <Button Command="{Binding #InterpreterOptionsList.DataContext.SelectInterpreterCommand}"
                                                 CommandParameter="{Binding}"
                                                 HorizontalAlignment="Stretch"
                                                 HorizontalContentAlignment="Left"
                                                 Margin="0,2,0,0" Padding="6,4"
-                                                Background="#2d2d2d" FontSize="11"/>
+                                                Background="#2d2d2d" FontSize="11">
+                                            <StackPanel>
+                                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                                    <TextBlock Text="✓" Foreground="Gold" FontWeight="Bold"
+                                                               IsVisible="{Binding IsActive}"/>
+                                                    <TextBlock Text="{Binding DisplayText}" Foreground="LightGray"/>
+                                                </StackPanel>
+                                                <TextBlock Text="{Binding Path}" Foreground="Gray" FontSize="10"
+                                                           TextWrapping="Wrap"/>
+                                            </StackPanel>
+                                        </Button>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
 
-                            <!-- Managed environments with Nazca (from the environment manager) -->
-                            <ItemsControl ItemsSource="{Binding ManagedCandidates}"
-                                          Margin="0,6,0,0"
-                                          x:Name="ManagedCandidatesList"
-                                          IsVisible="{Binding ManagedCandidates.Count}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <Button Content="{Binding DisplayText}"
-                                                Command="{Binding #ManagedCandidatesList.DataContext.SelectManagedEnvironmentCommand}"
-                                                CommandParameter="{Binding}"
-                                                HorizontalAlignment="Stretch"
-                                                HorizontalContentAlignment="Left"
-                                                Margin="0,2,0,0" Padding="6,4"
-                                                Background="#2d3d2d" FontSize="11"/>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-
-                            <!-- Fallback: no Nazca anywhere -->
-                            <Border IsVisible="{Binding ShowNazcaInstallOffer}"
-                                    Background="#3d3320" CornerRadius="4" Padding="10" Margin="0,10,0,0">
+                            <!-- No managed environment yet: offer the one-click create (warning text
+                                 only when Nazca is missing everywhere) -->
+                            <Border IsVisible="{Binding ShowCreateEnvironmentButton}"
+                                    Background="#2a2a20" CornerRadius="4" Padding="10" Margin="0,10,0,0">
                                 <StackPanel Spacing="6">
                                     <TextBlock Text="No Nazca environment found."
-                                               Foreground="#e8c872" FontWeight="SemiBold" FontSize="12"/>
+                                               Foreground="#e8c872" FontWeight="SemiBold" FontSize="12"
+                                               IsVisible="{Binding ShowNazcaInstallOffer}"/>
                                     <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap"
                                                Text="Lunima can create a managed Python environment and install Nazca into it automatically."/>
                                     <Button Content="Create + install Nazca now"

--- a/CAP.Avalonia/Views/SettingsWindow.axaml
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml
@@ -5,6 +5,8 @@
         xmlns:vmUpdate="using:CAP.Avalonia.ViewModels.Update"
         xmlns:vmExport="using:CAP.Avalonia.ViewModels.Export"
         xmlns:vmAi="using:CAP.Avalonia.ViewModels.AI"
+        xmlns:vmPyEnv="using:CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager"
+        xmlns:panels="using:CAP.Avalonia.Views.Panels"
         x:Class="CAP.Avalonia.Views.SettingsWindow"
         x:DataType="settings:SettingsWindowViewModel"
         Title="Settings"
@@ -201,7 +203,44 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
+
+                            <!-- Managed environments with Nazca (from the environment manager) -->
+                            <ItemsControl ItemsSource="{Binding ManagedCandidates}"
+                                          Margin="0,6,0,0"
+                                          x:Name="ManagedCandidatesList"
+                                          IsVisible="{Binding ManagedCandidates.Count}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Button Content="{Binding DisplayText}"
+                                                Command="{Binding #ManagedCandidatesList.DataContext.SelectManagedEnvironmentCommand}"
+                                                CommandParameter="{Binding}"
+                                                HorizontalAlignment="Stretch"
+                                                HorizontalContentAlignment="Left"
+                                                Margin="0,2,0,0" Padding="6,4"
+                                                Background="#2d3d2d" FontSize="11"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!-- Fallback: no Nazca anywhere -->
+                            <Border IsVisible="{Binding ShowNazcaInstallOffer}"
+                                    Background="#3d3320" CornerRadius="4" Padding="10" Margin="0,10,0,0">
+                                <StackPanel Spacing="6">
+                                    <TextBlock Text="No Nazca environment found."
+                                               Foreground="#e8c872" FontWeight="SemiBold" FontSize="12"/>
+                                    <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap"
+                                               Text="Lunima can create a managed Python environment and install Nazca into it automatically."/>
+                                    <Button Content="Create + install Nazca now"
+                                            Click="OnCreateNazcaEnvironmentClick"
+                                            Background="#3d5d3d" HorizontalAlignment="Left"/>
+                                </StackPanel>
+                            </Border>
                         </StackPanel>
+                    </DataTemplate>
+
+                    <!-- Python Environments (managed venvs with Nazca) -->
+                    <DataTemplate DataType="{x:Type vmPyEnv:PythonEnvironmentManagerViewModel}">
+                        <panels:PythonEnvironmentManagerPanel/>
                     </DataTemplate>
 
                     <!-- AI Assistant -->

--- a/CAP.Avalonia/Views/SettingsWindow.axaml.cs
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml.cs
@@ -14,4 +14,18 @@ public partial class SettingsWindow : Window
     {
         InitializeComponent();
     }
+
+    /// <summary>
+    /// "Create + install Nazca now" on the GDS-Export page: starts the default
+    /// install (via the GdsExportViewModel delegate) and navigates to the
+    /// Python-Environments page so the progress is visible there.
+    /// </summary>
+    private void OnCreateNazcaEnvironmentClick(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if ((sender as Button)?.DataContext is ViewModels.Export.GdsExportViewModel gdsExport)
+            gdsExport.InstallNazcaCommand.Execute(null);
+
+        if (DataContext is SettingsWindowViewModel vm)
+            vm.SelectPage(typeof(PythonEnvironmentsSettingsPage));
+    }
 }

--- a/Connect-A-Pic-Core/Export/GdsExportService.cs
+++ b/Connect-A-Pic-Core/Export/GdsExportService.cs
@@ -320,7 +320,10 @@ public class GdsExportService
         var args         = new[] { scriptPath };
         var workingDir   = Path.GetDirectoryName(scriptPath);
 
-        if (!_launchFactory.TryBuild(pythonCmd, args, workingDir, null, out var psi, out var launchError))
+        // PYTHONSAFEPATH: a leftover re.py/numpy.py NEXT TO the exported script must not
+        // shadow the modules the Nazca run imports (see PythonModuleShadowing).
+        if (!_launchFactory.TryBuild(pythonCmd, args, workingDir,
+                PythonModuleShadowing.SafePathEnvironment, out var psi, out var launchError))
             return (-1, string.Empty, launchError ?? "Failed to build process start info");
 
         psi.RedirectStandardOutput = true;

--- a/Connect-A-Pic-Core/Export/NazcaComponentPreviewService.cs
+++ b/Connect-A-Pic-Core/Export/NazcaComponentPreviewService.cs
@@ -193,7 +193,10 @@ public class NazcaComponentPreviewService
         try
         {
             var workingDir = Path.GetDirectoryName(_scriptPath);
-            if (!_launchFactory.TryBuild(_pythonExecutable, arguments, workingDir, null, out var psi, out var launchError))
+            // PYTHONSAFEPATH: stray sibling files next to the script must not shadow
+            // stdlib/Nazca modules (see PythonModuleShadowing).
+            if (!_launchFactory.TryBuild(_pythonExecutable, arguments, workingDir,
+                    PythonModuleShadowing.SafePathEnvironment, out var psi, out var launchError))
                 return NazcaPreviewResult.Fail($"Could not start Python '{_pythonExecutable}': {launchError}");
 
             psi.RedirectStandardOutput = true;

--- a/Connect-A-Pic-Core/Export/PythonModuleShadowing.cs
+++ b/Connect-A-Pic-Core/Export/PythonModuleShadowing.cs
@@ -39,4 +39,14 @@ public static class PythonModuleShadowing
     /// <param name="fileStem">File name without extension.</param>
     public static bool ShadowsPythonModule(string fileStem) =>
         ShadowedNames.Contains(fileStem);
+
+    /// <summary>
+    /// Environment for running generated Python scripts: <c>PYTHONSAFEPATH=1</c> keeps the
+    /// script's directory off <c>sys.path</c> (Python 3.11+; older versions ignore it), so
+    /// stray sibling files like a leftover <c>re.py</c> next to the exported script cannot
+    /// shadow stdlib/Nazca modules. Generated scripts never import sibling files, so this
+    /// is always safe for Lunima's own runs.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string> SafePathEnvironment =
+        new Dictionary<string, string> { ["PYTHONSAFEPATH"] = "1" };
 }

--- a/Connect-A-Pic-Core/Export/PythonModuleShadowing.cs
+++ b/Connect-A-Pic-Core/Export/PythonModuleShadowing.cs
@@ -1,0 +1,42 @@
+namespace CAP_Core.Export;
+
+/// <summary>
+/// Guard for exported Python script names. Python puts the script's own directory
+/// first on <c>sys.path</c>, so a script named like a module it (transitively)
+/// imports — e.g. <c>re.py</c> — shadows that module and fails with a confusing
+/// circular-import error regardless of the selected interpreter.
+/// </summary>
+public static class PythonModuleShadowing
+{
+    private static readonly HashSet<string> ShadowedNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Python standard library (the parts realistically imported during a Nazca run)
+        "abc", "argparse", "array", "ast", "asyncio", "base64", "bisect", "builtins",
+        "calendar", "cmath", "code", "codecs", "collections", "concurrent", "contextlib",
+        "copy", "csv", "ctypes", "dataclasses", "datetime", "decimal", "difflib", "dis",
+        "email", "enum", "errno", "faulthandler", "fnmatch", "fractions", "functools",
+        "gc", "getopt", "getpass", "gettext", "glob", "gzip", "hashlib", "heapq", "hmac",
+        "html", "http", "importlib", "inspect", "io", "ipaddress", "itertools", "json",
+        "keyword", "linecache", "locale", "logging", "lzma", "marshal", "math",
+        "mimetypes", "multiprocessing", "numbers", "opcode", "operator", "os", "pathlib",
+        "pickle", "platform", "pprint", "profile", "queue", "random", "re", "reprlib",
+        "runpy", "sched", "secrets", "select", "selectors", "shlex", "shutil", "signal",
+        "site", "socket", "sqlite3", "ssl", "stat", "statistics", "string", "struct",
+        "subprocess", "sys", "sysconfig", "tarfile", "tempfile", "textwrap", "threading",
+        "time", "token", "tokenize", "traceback", "types", "typing", "unicodedata",
+        "unittest", "urllib", "uuid", "venv", "warnings", "weakref", "webbrowser",
+        "xml", "zipfile", "zlib", "zoneinfo",
+        // Nazca and its dependency chain
+        "nazca", "numpy", "pandas", "scipy", "matplotlib", "pyclipper", "PIL", "pytz",
+        "dateutil", "six", "packaging", "pyparsing", "cycler", "kiwisolver", "fontTools",
+        "setuptools", "pip",
+    };
+
+    /// <summary>
+    /// True when a script saved as <paramref name="fileStem"/><c>.py</c> would shadow a
+    /// Python module that the Nazca run needs (case-insensitive — Windows file systems are).
+    /// </summary>
+    /// <param name="fileStem">File name without extension.</param>
+    public static bool ShadowsPythonModule(string fileStem) =>
+        ShadowedNames.Contains(fileStem);
+}

--- a/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+++ b/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
@@ -1,3 +1,4 @@
+using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Export;
 using CAP_Core.Export;
 using Shouldly;
@@ -103,5 +104,83 @@ public class GdsExportEnvironmentSelectionTests
         vm.InstallNazcaCommand.Execute(null);
 
         requested.ShouldBeTrue();
+    }
+
+    private sealed class FakeMessageBoxService : IMessageBoxService
+    {
+        public int ChoiceToReturn { get; set; } = -1;
+        public string? LastMessage { get; private set; }
+        public IReadOnlyList<string>? LastButtons { get; private set; }
+
+        public Task<SavePromptResult> ShowSavePromptAsync(string message, string title) =>
+            Task.FromResult(SavePromptResult.Cancel);
+
+        public Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels)
+        {
+            LastMessage = message;
+            LastButtons = buttonLabels;
+            return Task.FromResult(ChoiceToReturn);
+        }
+    }
+
+    [Fact]
+    public async Task PreflightGds_GdsGenerationDisabled_ProceedsWithoutDialog()
+    {
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = false;
+        var messageBox = new FakeMessageBoxService();
+
+        var decision = await vm.PreflightGdsAsync(messageBox);
+
+        decision.ShouldBe(GdsPreflightDecision.Proceed);
+        messageBox.LastMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task PreflightGds_EnvironmentReady_ProceedsWithoutDialog()
+    {
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = true;
+        vm.PythonAvailable = true;
+        vm.NazcaAvailable = true;
+        var messageBox = new FakeMessageBoxService();
+
+        var decision = await vm.PreflightGdsAsync(messageBox);
+
+        decision.ShouldBe(GdsPreflightDecision.Proceed);
+        messageBox.LastMessage.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(0, GdsPreflightDecision.InstallRequested)]
+    [InlineData(1, GdsPreflightDecision.OpenSettingsRequested)]
+    [InlineData(2, GdsPreflightDecision.SkipGds)]
+    [InlineData(-1, GdsPreflightDecision.SkipGds)]   // Dialog geschlossen
+    public async Task PreflightGds_NazcaMissing_MapsDialogChoice(int choice, GdsPreflightDecision expected)
+    {
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = true;
+        vm.PythonAvailable = true;
+        vm.NazcaAvailable = false;
+        var messageBox = new FakeMessageBoxService { ChoiceToReturn = choice };
+
+        var decision = await vm.PreflightGdsAsync(messageBox);
+
+        decision.ShouldBe(expected);
+        messageBox.LastButtons!.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task PreflightGds_NoMessageBoxService_ProceedsLikeBefore()
+    {
+        // Headless/legacy callers without a dialog service keep the old behavior:
+        // attempt the GDS generation and surface the failure in the result.
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = true;
+        vm.NazcaAvailable = false;
+
+        var decision = await vm.PreflightGdsAsync(null);
+
+        decision.ShouldBe(GdsPreflightDecision.Proceed);
     }
 }

--- a/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+++ b/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
@@ -188,6 +188,82 @@ public class GdsExportEnvironmentSelectionTests
         vm.ShowCreateEnvironmentButton.ShouldBeFalse();
     }
 
+    [Fact]
+    public void Initialize_NullPath_ClearsConfiguredInterpreter()
+    {
+        // Deleting the active managed environment pushes null through the registry
+        // callback — the stale (deleted) interpreter path must not survive that.
+        var service = new GdsExportService();
+        var vm = new GdsExportViewModel(service);
+        vm.Initialize("/envs/deleted/bin/python");
+
+        vm.Initialize(null);
+
+        vm.CustomPythonPath.ShouldBeEmpty();
+        vm.PythonPathSource.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task TrySelectFallback_NoInterpreterConfigured_PicksFirstCandidate()
+    {
+        var vm = CreateViewModel();
+        string? activated = null;
+        vm.ActivateManagedEnvironment = name => activated = name;
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("backup-env", "/envs/backup/bin/python", "Managed · backup-env"),
+        };
+        vm.RefreshManagedCandidates();
+
+        await vm.TrySelectFallbackInterpreterAsync();
+
+        activated.ShouldBe("backup-env");   // erster Kandidat wird automatisch übernommen
+    }
+
+    [Fact]
+    public async Task TrySelectFallback_ConfiguredInterpreterStillExists_DoesNothing()
+    {
+        var existing = Path.GetTempFileName();
+        try
+        {
+            var vm = CreateViewModel();
+            string? activated = null;
+            vm.ActivateManagedEnvironment = name => activated = name;
+            vm.CustomPythonPath = existing;
+            vm.ManagedEnvironmentsProvider = () => new[]
+            {
+                new ManagedEnvCandidate("other", "/envs/other/bin/python", "Managed · other"),
+            };
+            vm.RefreshManagedCandidates();
+
+            await vm.TrySelectFallbackInterpreterAsync();
+
+            activated.ShouldBeNull();       // funktionierende Auswahl bleibt unangetastet
+        }
+        finally
+        {
+            File.Delete(existing);
+        }
+    }
+
+    [Fact]
+    public async Task TrySelectFallback_ConfiguredInterpreterDeleted_PicksCandidate()
+    {
+        var vm = CreateViewModel();
+        string? activated = null;
+        vm.ActivateManagedEnvironment = name => activated = name;
+        vm.CustomPythonPath = Path.Combine(Path.GetTempPath(), "deleted-env", "python.exe");
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("backup-env", "/envs/backup/bin/python", "Managed · backup-env"),
+        };
+        vm.RefreshManagedCandidates();
+
+        await vm.TrySelectFallbackInterpreterAsync();
+
+        activated.ShouldBe("backup-env");
+    }
+
     private sealed class FakeMessageBoxService : IMessageBoxService
     {
         public int ChoiceToReturn { get; set; } = -1;

--- a/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+++ b/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
@@ -188,6 +188,72 @@ public class GdsExportEnvironmentSelectionTests
         vm.ShowCreateEnvironmentButton.ShouldBeFalse();
     }
 
+    /// <summary>Test double with hand-controlled discovery completion, to interleave runs.</summary>
+    private sealed class ControllableDiscoveryViewModel : GdsExportViewModel
+    {
+        public Queue<TaskCompletionSource<List<PythonDiscoveryService.PythonInstallation>>> PendingDiscoveries { get; } = new();
+
+        public ControllableDiscoveryViewModel() : base(new GdsExportService()) { }
+
+        protected override Task<List<PythonDiscoveryService.PythonInstallation>> DiscoverPythonsAsync()
+        {
+            var tcs = new TaskCompletionSource<List<PythonDiscoveryService.PythonInstallation>>();
+            PendingDiscoveries.Enqueue(tcs);
+            return tcs.Task;
+        }
+    }
+
+    private static List<PythonDiscoveryService.PythonInstallation> OneSystemPython() => new()
+    {
+        new PythonDiscoveryService.PythonInstallation
+        {
+            Path = "/usr/bin/python3",
+            Source = "System",
+            PythonVersion = "3.12.1",
+            NazcaVersion = "0.6.1",
+        },
+    };
+
+    [Fact]
+    public async Task SearchForPython_OverlappingRuns_DoNotDuplicateResults()
+    {
+        // Navigating GDS Export → elsewhere → GDS Export re-triggers the search while the
+        // first run is still in flight; both used to append their results (2 → 4 → 8 …).
+        var vm = new ControllableDiscoveryViewModel();
+        vm.CustomPythonPath = "/some/python";   // skip the auto-select side path
+
+        var first = vm.SearchForPythonAsync();
+        var second = vm.SearchForPythonAsync();
+
+        vm.PendingDiscoveries.Dequeue().SetResult(OneSystemPython());   // first finishes late
+        vm.PendingDiscoveries.Dequeue().SetResult(OneSystemPython());
+        await first;
+        await second;
+
+        vm.AvailablePythons.Count.ShouldBe(1);   // nur der neueste Lauf zählt
+        vm.IsSearching.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SearchForPython_SupersededRun_DoesNotOverwriteNewerResults()
+    {
+        var vm = new ControllableDiscoveryViewModel();
+        vm.CustomPythonPath = "/some/python";
+
+        var first = vm.SearchForPythonAsync();
+        var second = vm.SearchForPythonAsync();
+
+        // Der NEUERE Lauf kommt zuerst zurück, der alte danach — das alte Ergebnis
+        // darf das neue nicht mehr überschreiben oder ergänzen.
+        vm.PendingDiscoveries.ToArray()[1].SetResult(OneSystemPython());
+        await second;
+        vm.PendingDiscoveries.Dequeue().SetResult(new List<PythonDiscoveryService.PythonInstallation>());
+        await first;
+
+        vm.AvailablePythons.Count.ShouldBe(1);
+        vm.IsSearching.ShouldBeFalse();
+    }
+
     [Fact]
     public void Initialize_NullPath_ClearsConfiguredInterpreter()
     {

--- a/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+++ b/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
@@ -106,6 +106,88 @@ public class GdsExportEnvironmentSelectionTests
         requested.ShouldBeTrue();
     }
 
+    [Fact]
+    public void RebuildInterpreterOptions_MergesManagedAndDiscovered_WithActiveMarking()
+    {
+        var vm = CreateViewModel();
+        vm.CustomPythonPath = "/envs/nazca/bin/python";
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca"),
+        };
+        vm.AvailablePythons.Add(new PythonDiscoveryService.PythonInstallation
+        {
+            Path = "/usr/bin/python3",
+            Source = "System",
+            PythonVersion = "3.12.1",
+            NazcaVersion = "0.6.1",
+        });
+
+        vm.RefreshManagedCandidates();
+
+        vm.InterpreterOptions.Count.ShouldBe(2);
+        vm.InterpreterOptions[0].Path.ShouldBe("/envs/nazca/bin/python");
+        vm.InterpreterOptions[0].IsActive.ShouldBeTrue();      // matches CustomPythonPath
+        vm.InterpreterOptions[0].ManagedName.ShouldBe("nazca");
+        vm.InterpreterOptions[1].Path.ShouldBe("/usr/bin/python3");
+        vm.InterpreterOptions[1].IsActive.ShouldBeFalse();
+        vm.InterpreterOptions[1].ManagedName.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SelectInterpreter_ManagedOption_ActivatesViaRegistryDelegate()
+    {
+        var vm = CreateViewModel();
+        string? activated = null;
+        vm.ActivateManagedEnvironment = name => activated = name;
+        var option = new InterpreterOption("Managed · nazca", "/envs/nazca/bin/python", false, "nazca");
+
+        await vm.SelectInterpreterCommand.ExecuteAsync(option);
+
+        activated.ShouldBe("nazca");
+    }
+
+    [Fact]
+    public async Task SelectInterpreter_SystemOption_SetsPathAndPersists()
+    {
+        var vm = CreateViewModel();
+        string? persisted = null;
+        vm.OnPythonPathChanged = p => persisted = p;
+        var option = new InterpreterOption("System · 3.12", "/usr/bin/python3", false, null);
+
+        await vm.SelectInterpreterCommand.ExecuteAsync(option);
+
+        vm.CustomPythonPath.ShouldBe("/usr/bin/python3");
+        persisted.ShouldBe("/usr/bin/python3");
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_NoManagedEnvs_ShowsCreateEnvironmentButton()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = true;   // auch mit System-Nazca soll der Create-Button sichtbar bleiben
+        vm.ManagedEnvironmentsProvider = () => Array.Empty<ManagedEnvCandidate>();
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowCreateEnvironmentButton.ShouldBeTrue();
+        vm.ShowNazcaInstallOffer.ShouldBeFalse();   // Warnbanner nur ohne jegliches Nazca
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_ManagedEnvExists_HidesCreateEnvironmentButton()
+    {
+        var vm = CreateViewModel();
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca"),
+        };
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowCreateEnvironmentButton.ShouldBeFalse();
+    }
+
     private sealed class FakeMessageBoxService : IMessageBoxService
     {
         public int ChoiceToReturn { get; set; } = -1;

--- a/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+++ b/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
@@ -1,0 +1,107 @@
+using CAP.Avalonia.ViewModels.Export;
+using CAP_Core.Export;
+using Shouldly;
+
+namespace UnitTests.Export;
+
+/// <summary>
+/// Tests for the managed-environment candidate list and the "install Nazca"
+/// offer on <see cref="GdsExportViewModel"/> (settings page integration).
+/// </summary>
+public class GdsExportEnvironmentSelectionTests
+{
+    private static GdsExportViewModel CreateViewModel() =>
+        new(new GdsExportService());
+
+    [Fact]
+    public void RefreshManagedCandidates_WithProvider_ListsAllCandidates()
+    {
+        var vm = CreateViewModel();
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca"),
+            new ManagedEnvCandidate("py312", "/envs/py312/bin/python", "Managed · py312"),
+        };
+
+        vm.RefreshManagedCandidates();
+
+        vm.ManagedCandidates.Count.ShouldBe(2);
+        vm.ManagedCandidates[0].Name.ShouldBe("nazca");
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_NoNazcaAnywhere_ShowsInstallOffer()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = false;
+        vm.ManagedEnvironmentsProvider = () => Array.Empty<ManagedEnvCandidate>();
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowNazcaInstallOffer.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_NazcaInActiveInterpreter_HidesInstallOffer()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = true;
+        vm.ManagedEnvironmentsProvider = () => Array.Empty<ManagedEnvCandidate>();
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowNazcaInstallOffer.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_ManagedEnvExists_HidesInstallOfferEvenWithoutActiveNazca()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = false;
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca"),
+        };
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowNazcaInstallOffer.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_WithoutProvider_IsEmptyAndOffersInstallWhenNazcaMissing()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = false;
+
+        vm.RefreshManagedCandidates();
+
+        vm.ManagedCandidates.ShouldBeEmpty();
+        vm.ShowNazcaInstallOffer.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SelectManagedEnvironment_InvokesActivationDelegate()
+    {
+        var vm = CreateViewModel();
+        string? activated = null;
+        vm.ActivateManagedEnvironment = name => activated = name;
+        var candidate = new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca");
+
+        await vm.SelectManagedEnvironmentCommand.ExecuteAsync(candidate);
+
+        activated.ShouldBe("nazca");
+    }
+
+    [Fact]
+    public void InstallNazca_InvokesRequestDelegate()
+    {
+        var vm = CreateViewModel();
+        var requested = false;
+        vm.RequestNazcaInstall = () => requested = true;
+
+        vm.InstallNazcaCommand.Execute(null);
+
+        requested.ShouldBeTrue();
+    }
+}

--- a/UnitTests/Export/GdsExportGuardTests.cs
+++ b/UnitTests/Export/GdsExportGuardTests.cs
@@ -1,0 +1,77 @@
+using CAP.Avalonia.Services;
+using Shouldly;
+using UnitTests.Helpers;
+using UnitTests;
+
+namespace UnitTests.Export;
+
+/// <summary>
+/// Export-guard tests: triggering the Nazca export with GDS generation enabled but
+/// no Nazca available must prompt instead of silently failing the GDS step.
+/// </summary>
+public class GdsExportGuardTests
+{
+    private sealed class RecordingMessageBox : IMessageBoxService
+    {
+        public int ChoiceToReturn { get; set; } = 2; // "Skip GDS"
+        public int Calls { get; private set; }
+
+        public Task<SavePromptResult> ShowSavePromptAsync(string message, string title) =>
+            Task.FromResult(SavePromptResult.Cancel);
+
+        public Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels)
+        {
+            Calls++;
+            return Task.FromResult(ChoiceToReturn);
+        }
+    }
+
+    private sealed class FixedPathFileDialog : IFileDialogService
+    {
+        private readonly string _path;
+        public FixedPathFileDialog(string path) => _path = path;
+
+        public Task<string?> ShowSaveFileDialogAsync(string title, string defaultExtension, string filters) =>
+            Task.FromResult<string?>(_path);
+
+        public Task<string?> ShowOpenFileDialogAsync(string title, string filters) =>
+            Task.FromResult<string?>(null);
+    }
+
+    [Fact]
+    public async Task ExportNazca_GdsEnabledButNazcaMissing_PromptsAndSkipsGds()
+    {
+        var scriptPath = Path.Combine(Path.GetTempPath(), $"lunima-export-{Guid.NewGuid():N}.py");
+        try
+        {
+            var main = MainViewModelTestHelper.CreateMainViewModel();
+            var fileOps = main.FileOperations;
+            var messageBox = new RecordingMessageBox { ChoiceToReturn = 2 };
+            fileOps.MessageBoxService = messageBox;
+            fileOps.FileDialogService = new FixedPathFileDialog(scriptPath);
+            string? lastStatus = null;
+            fileOps.UpdateStatus = s => lastStatus = s;
+
+            // Deterministic "no Nazca": point the interpreter at a nonexistent path so the
+            // guard's environment re-check cannot find a system Python with Nazca.
+            var bogusPython = Path.Combine(Path.GetTempPath(), "no-python-here", "python");
+            await fileOps.GdsExport.SetPythonPathAsync(bogusPython);
+            fileOps.GdsExport.GenerateGdsEnabled = true;
+
+            // Eine Komponente, damit der Export nicht am leeren Canvas abbricht:
+            var component = TestComponentFactory.CreateStraightWaveGuide();
+            main.Canvas.AddComponent(component, "TestTemplate");
+
+            await fileOps.ExportNazcaCommand.ExecuteAsync(null);
+
+            messageBox.Calls.ShouldBe(1);                    // Guard hat gefragt
+            File.Exists(scriptPath).ShouldBeTrue();          // Skript wurde trotzdem exportiert
+            lastStatus.ShouldNotBeNull();
+            lastStatus!.ShouldContain("GDS skipped");
+        }
+        finally
+        {
+            if (File.Exists(scriptPath)) File.Delete(scriptPath);
+        }
+    }
+}

--- a/UnitTests/Export/GdsExportGuardTests.cs
+++ b/UnitTests/Export/GdsExportGuardTests.cs
@@ -39,6 +39,31 @@ public class GdsExportGuardTests
     }
 
     [Fact]
+    public async Task ExportNazca_FileNameShadowsPythonModule_RefusesExport()
+    {
+        // Real-world failure: a script saved as "re.py" shadows Python's stdlib re module,
+        // so numpy/nazca imports die with a circular-import error on ANY interpreter.
+        var scriptPath = Path.Combine(Path.GetTempPath(), "re.py");
+        var main = MainViewModelTestHelper.CreateMainViewModel();
+        var fileOps = main.FileOperations;
+        var messageBox = new RecordingMessageBox();
+        fileOps.MessageBoxService = messageBox;
+        fileOps.FileDialogService = new FixedPathFileDialog(scriptPath);
+        string? lastStatus = null;
+        fileOps.UpdateStatus = s => lastStatus = s;
+
+        var component = TestComponentFactory.CreateStraightWaveGuide();
+        main.Canvas.AddComponent(component, "TestTemplate");
+
+        await fileOps.ExportNazcaCommand.ExecuteAsync(null);
+
+        File.Exists(scriptPath).ShouldBeFalse();     // nichts geschrieben
+        messageBox.Calls.ShouldBe(1);                // Nutzer wurde informiert
+        lastStatus.ShouldNotBeNull();
+        lastStatus!.ShouldContain("shadows");
+    }
+
+    [Fact]
     public async Task ExportNazca_GdsEnabledButNazcaMissing_PromptsAndSkipsGds()
     {
         var scriptPath = Path.Combine(Path.GetTempPath(), $"lunima-export-{Guid.NewGuid():N}.py");

--- a/UnitTests/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModelTests.cs
+++ b/UnitTests/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModelTests.cs
@@ -108,6 +108,38 @@ public class PythonEnvironmentManagerViewModelTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task StartDefaultNazcaInstall_EnvAlreadyExists_DoesNotCreateDuplicateAndExplains()
+    {
+        var registry = CreateRegistry();
+        registry.AddOrUpdate(new PythonEnvironment
+        {
+            Name = PythonEnvironmentManagerViewModel.DefaultEnvironmentName,
+            VenvPath = Path.Combine(UvBootstrapper.EnvironmentsBaseDir,
+                PythonEnvironmentManagerViewModel.DefaultEnvironmentName),
+        });
+        var vm = CreateViewModel(registry);
+
+        await vm.StartDefaultNazcaInstallAsync();
+
+        registry.GetAll().Count.ShouldBe(1);                 // kein Duplikat
+        vm.IsBusy.ShouldBeFalse();                           // kein Install gestartet
+        vm.ProgressText.ShouldContain(
+            PythonEnvironmentManagerViewModel.DefaultEnvironmentName);
+    }
+
+    [Fact]
+    public async Task StartDefaultNazcaInstall_WhileBusy_IsIgnored()
+    {
+        var registry = CreateRegistry();
+        var vm = CreateViewModel(registry);
+        vm.IsBusy = true;
+
+        await vm.StartDefaultNazcaInstallAsync();
+
+        registry.GetAll().ShouldBeEmpty();                   // nichts registriert
+    }
+
     private static PythonEnvironment MakeEnv(string name) => new()
     {
         Name = name,

--- a/UnitTests/Export/PythonModuleShadowingTests.cs
+++ b/UnitTests/Export/PythonModuleShadowingTests.cs
@@ -1,0 +1,37 @@
+using CAP_Core.Export;
+using Shouldly;
+
+namespace UnitTests.Export;
+
+/// <summary>
+/// Tests for the export-filename guard: a Nazca script saved as e.g. <c>re.py</c>
+/// shadows Python's stdlib <c>re</c> module (the script directory is first on
+/// <c>sys.path</c>), which breaks numpy/nazca imports with a cryptic circular-import
+/// error no matter which interpreter is selected.
+/// </summary>
+public class PythonModuleShadowingTests
+{
+    [Theory]
+    [InlineData("re")]
+    [InlineData("RE")]          // Windows file systems are case-insensitive
+    [InlineData("os")]
+    [InlineData("json")]
+    [InlineData("inspect")]
+    [InlineData("numpy")]       // Nazca dependency — shadowing it breaks the import chain too
+    [InlineData("pandas")]
+    [InlineData("nazca")]
+    public void ShadowsPythonModule_KnownModuleNames_ReturnsTrue(string stem)
+    {
+        PythonModuleShadowing.ShadowsPythonModule(stem).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("chip1")]
+    [InlineData("my_design")]
+    [InlineData("mzi-export")]
+    [InlineData("")]
+    public void ShadowsPythonModule_HarmlessNames_ReturnsFalse(string stem)
+    {
+        PythonModuleShadowing.ShadowsPythonModule(stem).ShouldBeFalse();
+    }
+}

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -16,8 +16,6 @@ using CAP.Avalonia.ViewModels.Properties.Editors;
 using CAP.Avalonia.ViewModels.Update;
 using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.ViewModels.Export;
-using CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager;
-using CAP_Core.Export.PythonEnvironmentManager;
 using CAP.Avalonia.ViewModels.PdkOffset;
 using CAP_Core.Components.Creation;
 using CAP_Core.Export;
@@ -149,12 +147,7 @@ public static class MainViewModelTestHelper
             {
                 new GenericComponentEditorProvider()
             }),
-            new TimeDomainViewModel(),
-            new PythonEnvironmentManagerViewModel(
-                new PythonEnvironmentRegistry(Path.Combine(Path.GetTempPath(), $"lunima-test-registry-{Guid.NewGuid():N}.json")),
-                new UvBootstrapper(),
-                new NazcaPackageInstaller(),
-                new EnvironmentHealthChecker(new PythonDiscoveryService())));
+            new TimeDomainViewModel());
     }
 
     /// <summary>

--- a/UnitTests/Settings/SettingsRegistryTests.cs
+++ b/UnitTests/Settings/SettingsRegistryTests.cs
@@ -188,6 +188,16 @@ public class SettingsRegistryTests
     }
 
     [Fact]
+    public void PythonEnvironmentsSettingsPage_StableContract()
+    {
+        ISettingsPage page = new PythonEnvironmentsSettingsPage(null!);
+
+        page.Title.ShouldBe("Python Environments");
+        page.Icon.ShouldBe("📦");
+        page.Category.ShouldBe("Export");
+    }
+
+    [Fact]
     public void AiAssistantSettingsPage_StableContract()
     {
         ISettingsPage page = new AiAssistantSettingsPage(null!);

--- a/UnitTests/UI/UiScreenshotTests.cs
+++ b/UnitTests/UI/UiScreenshotTests.cs
@@ -53,6 +53,17 @@ public class UiScreenshotTests
         TryCapture(() => new RoutingDiagnosticsPanel(), vm, 600, 700, outputDir, "RoutingDiagnosticsPanel.png", captured, skipped);
         TryCapture(() => new SelectedComponentPropertiesPanel(), vm, 450, 600, outputDir, "SelectedComponentPropertiesPanel.png", captured, skipped);
 
+        // Settings content: the environment manager moved from the Properties sidebar to a
+        // Settings page — captured standalone with its own ViewModel (not part of MainViewModel).
+        var envVm = new CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager.PythonEnvironmentManagerViewModel(
+            new CAP_Core.Export.PythonEnvironmentManager.PythonEnvironmentRegistry(
+                Path.Combine(Path.GetTempPath(), $"lunima-ui-shot-registry-{Guid.NewGuid():N}.json")),
+            new CAP_Core.Export.PythonEnvironmentManager.UvBootstrapper(),
+            new CAP_Core.Export.PythonEnvironmentManager.NazcaPackageInstaller(),
+            new CAP_Core.Export.PythonEnvironmentManager.EnvironmentHealthChecker(
+                new CAP_Core.Export.PythonDiscoveryService()));
+        TryCapture(() => new PythonEnvironmentManagerPanel(), envVm, 500, 700, outputDir, "PythonEnvironmentManagerPanel.png", captured, skipped);
+
         foreach (var (name, reason) in skipped)
             Console.WriteLine($"[SKIPPED] {name}: {reason}");
 

--- a/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
+++ b/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
@@ -9,9 +9,7 @@ using CAP.Avalonia.ViewModels.AI;
 using CAP.Avalonia.ViewModels.Properties;
 using CAP.Avalonia.ViewModels.Properties.Editors;
 using CAP.Avalonia.ViewModels.Export;
-using CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager;
 using CAP_Core.Export;
-using CAP_Core.Export.PythonEnvironmentManager;
 using Moq;
 using CAP.Avalonia.Services;
 using CAP_DataAccess.Components.ComponentDraftMapper;
@@ -80,12 +78,7 @@ public class PanelWidthPersistenceTests : IDisposable
             {
                 new GenericComponentEditorProvider()
             }),
-            new TimeDomainViewModel(),
-            new PythonEnvironmentManagerViewModel(
-                new PythonEnvironmentRegistry(Path.Combine(Path.GetTempPath(), $"lunima-test-registry-{Guid.NewGuid():N}.json")),
-                new UvBootstrapper(),
-                new NazcaPackageInstaller(),
-                new EnvironmentHealthChecker(new PythonDiscoveryService())));
+            new TimeDomainViewModel());
 
     [Fact]
     public void LeftPanelWidth_DefaultsTo220()

--- a/UnitTests/ViewModels/SettingsWindowViewModelTests.cs
+++ b/UnitTests/ViewModels/SettingsWindowViewModelTests.cs
@@ -1,0 +1,44 @@
+using CAP.Avalonia.ViewModels.Settings;
+using Shouldly;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>Tests for settings-page navigation by page type.</summary>
+public class SettingsWindowViewModelTests
+{
+    private sealed class PageA : ISettingsPage
+    {
+        public string Title => "A";
+        public string Icon => "a";
+        public string? Category => null;
+        public object ViewModel => this;
+    }
+
+    private sealed class PageB : ISettingsPage
+    {
+        public string Title => "B";
+        public string Icon => "b";
+        public string? Category => null;
+        public object ViewModel => this;
+    }
+
+    [Fact]
+    public void SelectPage_KnownType_SwitchesSelectedPage()
+    {
+        var vm = new SettingsWindowViewModel(new ISettingsPage[] { new PageA(), new PageB() });
+
+        vm.SelectPage(typeof(PageB));
+
+        vm.SelectedPage.ShouldBeOfType<PageB>();
+    }
+
+    [Fact]
+    public void SelectPage_UnknownType_KeepsCurrentSelection()
+    {
+        var vm = new SettingsWindowViewModel(new ISettingsPage[] { new PageA() });
+
+        vm.SelectPage(typeof(PageB));
+
+        vm.SelectedPage.ShouldBeOfType<PageA>();
+    }
+}

--- a/docs/superpowers/plans/2026-07-02-nazca-env-settings-integration.md
+++ b/docs/superpowers/plans/2026-07-02-nazca-env-settings-integration.md
@@ -1,0 +1,1155 @@
+# Nazca-Environment-Integration in Settings & Export-Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Python-environment management out of the Properties sidebar into a dedicated Settings page, surface managed Nazca environments as selectable candidates on the GDS-Export settings page (with a "Create + install Nazca" fallback), and guard the Nazca/GDS export with an install prompt when no Nazca is available.
+
+**Architecture:** All new logic lives in the existing ViewModels (`GdsExportViewModel`, `PythonEnvironmentManagerViewModel`, `SettingsWindowViewModel`); cross-slice access goes through DI-injected delegates, never direct imports from the GDS-export slice into the env-manager slice. UI reuses the existing `PythonEnvironmentManagerPanel` UserControl inside a Settings `DataTemplate`.
+
+**Tech Stack:** C# / Avalonia / CommunityToolkit.Mvvm, xUnit + Shouldly, `python3 tools/smart_test.py` bzw. `py %USERPROFILE%\.cap-tools\smart_test.py` als Testrunner.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-nazca-env-settings-integration-design.md`
+
+## Global Constraints
+
+- Branch: `feat/nazca-env-settings-integration` (von `main` nach Merge von #598).
+- Tests IMMER via `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" <Pattern>` (nie `dotnet test` direkt).
+- Kein `new ProcessStartInfo` / `Process.Start("` in Produktionscode (Architektur-Test).
+- Max 250 Zeilen pro NEUER Datei; XML-Doku auf allen public Members.
+- Der reine Nazca-Skript-Export muss ohne Python/Nazca funktionieren wie bisher.
+- Commit-Präfixe: `(+)` neue Funktionalität, `(=)` Bugfix, `(~)` Refactoring, `(c)` Doku/Chore.
+
+---
+
+### Task 1: `IMessageBoxService.ShowChoicePromptAsync` (Drei-Knopf-Dialog)
+
+**Files:**
+- Modify: `CAP.Avalonia/Services/IMessageBoxService.cs`
+- Modify: `CAP.Avalonia/Services/MessageBoxService.cs`
+
+**Interfaces:**
+- Produces: `Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels)` — Rückgabe: Index des geklickten Buttons, `-1` wenn das Fenster geschlossen wurde. Von Task 3 (Preflight) und Task 8 (Export-Guard) konsumiert.
+
+Kein Unit-Test (öffnet ein echtes Avalonia-Fenster); Konsumenten testen gegen einen Fake. Manuelle Verifikation in Task 9.
+
+- [ ] **Step 1: Interface erweitern**
+
+In `IMessageBoxService.cs` am Ende des Interfaces ergänzen:
+
+```csharp
+    /// <summary>
+    /// Shows a dialog with one button per entry in <paramref name="buttonLabels"/>.
+    /// </summary>
+    /// <param name="message">Message to display.</param>
+    /// <param name="title">Dialog title.</param>
+    /// <param name="buttonLabels">Button captions, left to right.</param>
+    /// <returns>Index of the clicked button, or -1 if the dialog was closed.</returns>
+    Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels);
+```
+
+- [ ] **Step 2: Implementierung in `MessageBoxService`**
+
+Spiegelt `ShowSavePromptAsync` (gleiches Fenster-Layout, gleiche Farben):
+
+```csharp
+    /// <inheritdoc/>
+    public async Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels)
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop
+            || desktop.MainWindow == null)
+            return -1;
+
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 480,
+            SizeToContent = SizeToContent.Height,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Background = new SolidColorBrush(Color.Parse("#2d2d2d"))
+        };
+
+        var stackPanel = new StackPanel { Margin = new Thickness(20) };
+        stackPanel.Children.Add(new TextBlock
+        {
+            Text = message,
+            Margin = new Thickness(0, 10, 0, 20),
+            Foreground = Brushes.White,
+            TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+            FontSize = 14
+        });
+
+        var buttonPanel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Spacing = 10
+        };
+
+        var result = -1;
+        for (var i = 0; i < buttonLabels.Count; i++)
+        {
+            var index = i;
+            var button = new Button
+            {
+                Content = buttonLabels[i],
+                Height = 32,
+                Padding = new Thickness(12, 0),
+                Background = new SolidColorBrush(Color.Parse(i == 0 ? "#0d6efd" : "#3d3d3d")),
+                Foreground = Brushes.White
+            };
+            button.Click += (_, _) => { result = index; dialog.Close(); };
+            buttonPanel.Children.Add(button);
+        }
+
+        stackPanel.Children.Add(buttonPanel);
+        dialog.Content = stackPanel;
+        await dialog.ShowDialog(desktop.MainWindow);
+        return result;
+    }
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build ConnectAPICPro.sln -v q --nologo`
+Expected: 0 Fehler.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CAP.Avalonia/Services/IMessageBoxService.cs CAP.Avalonia/Services/MessageBoxService.cs
+git commit -m "(+) MessageBoxService: generic multi-choice prompt (ShowChoicePromptAsync)"
+```
+
+---
+
+### Task 2: Managed-Env-Kandidaten + Install-Angebot im `GdsExportViewModel`
+
+**Files:**
+- Create: `CAP.Avalonia/ViewModels/Export/ManagedEnvCandidate.cs`
+- Modify: `CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs`
+- Test: `UnitTests/Export/GdsExportEnvironmentSelectionTests.cs` (neu)
+
+**Interfaces:**
+- Produces (von Task 5 DI-verdrahtet, von Task 6 UI-gebunden):
+  - `record ManagedEnvCandidate(string Name, string PythonExecutable, string DisplayText);`
+  - `Func<IReadOnlyList<ManagedEnvCandidate>>? ManagedEnvironmentsProvider { get; set; }`
+  - `Action<string>? ActivateManagedEnvironment { get; set; }`
+  - `Action? RequestNazcaInstall { get; set; }`
+  - `ObservableCollection<ManagedEnvCandidate> ManagedCandidates { get; }`
+  - `bool ShowNazcaInstallOffer { get; }` (ObservableProperty)
+  - `void RefreshManagedCandidates()`
+  - `[RelayCommand] Task SelectManagedEnvironment(ManagedEnvCandidate candidate)` → generiert `SelectManagedEnvironmentCommand`
+  - `[RelayCommand] void InstallNazca()` → generiert `InstallNazcaCommand`
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+Neue Datei `UnitTests/Export/GdsExportEnvironmentSelectionTests.cs`:
+
+```csharp
+using CAP.Avalonia.ViewModels.Export;
+using CAP_Core.Export;
+using Shouldly;
+
+namespace UnitTests.Export;
+
+/// <summary>
+/// Tests for the managed-environment candidate list and the "install Nazca"
+/// offer on <see cref="GdsExportViewModel"/> (settings page integration).
+/// </summary>
+public class GdsExportEnvironmentSelectionTests
+{
+    private static GdsExportViewModel CreateViewModel() =>
+        new(new GdsExportService());
+
+    [Fact]
+    public void RefreshManagedCandidates_WithProvider_ListsAllCandidates()
+    {
+        var vm = CreateViewModel();
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca"),
+            new ManagedEnvCandidate("py312", "/envs/py312/bin/python", "Managed · py312"),
+        };
+
+        vm.RefreshManagedCandidates();
+
+        vm.ManagedCandidates.Count.ShouldBe(2);
+        vm.ManagedCandidates[0].Name.ShouldBe("nazca");
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_NoNazcaAnywhere_ShowsInstallOffer()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = false;
+        vm.ManagedEnvironmentsProvider = () => Array.Empty<ManagedEnvCandidate>();
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowNazcaInstallOffer.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_NazcaInActiveInterpreter_HidesInstallOffer()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = true;
+        vm.ManagedEnvironmentsProvider = () => Array.Empty<ManagedEnvCandidate>();
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowNazcaInstallOffer.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_ManagedEnvExists_HidesInstallOfferEvenWithoutActiveNazca()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = false;
+        vm.ManagedEnvironmentsProvider = () => new[]
+        {
+            new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca"),
+        };
+
+        vm.RefreshManagedCandidates();
+
+        vm.ShowNazcaInstallOffer.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RefreshManagedCandidates_WithoutProvider_IsEmptyAndOffersInstallWhenNazcaMissing()
+    {
+        var vm = CreateViewModel();
+        vm.NazcaAvailable = false;
+
+        vm.RefreshManagedCandidates();
+
+        vm.ManagedCandidates.ShouldBeEmpty();
+        vm.ShowNazcaInstallOffer.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SelectManagedEnvironment_InvokesActivationDelegate()
+    {
+        var vm = CreateViewModel();
+        string? activated = null;
+        vm.ActivateManagedEnvironment = name => activated = name;
+        var candidate = new ManagedEnvCandidate("nazca", "/envs/nazca/bin/python", "Managed · nazca");
+
+        await vm.SelectManagedEnvironmentCommand.ExecuteAsync(candidate);
+
+        activated.ShouldBe("nazca");
+    }
+
+    [Fact]
+    public void InstallNazca_InvokesRequestDelegate()
+    {
+        var vm = CreateViewModel();
+        var requested = false;
+        vm.RequestNazcaInstall = () => requested = true;
+
+        vm.InstallNazcaCommand.Execute(null);
+
+        requested.ShouldBeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: RED verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" GdsExportEnvironmentSelection`
+Expected: Compile-Fehler (`ManagedEnvCandidate`, `RefreshManagedCandidates` etc. existieren nicht) — das ist das RED-Signal bei neuer API.
+
+- [ ] **Step 3: `ManagedEnvCandidate` anlegen**
+
+`CAP.Avalonia/ViewModels/Export/ManagedEnvCandidate.cs`:
+
+```csharp
+namespace CAP.Avalonia.ViewModels.Export;
+
+/// <summary>
+/// A managed Python environment offered as an interpreter candidate on the
+/// GDS-Export settings page. Deliberately a plain DTO: the GDS-export slice
+/// never imports the environment-manager slice — the DI layer maps registry
+/// entries into this type (packages beyond Nazca, e.g. gdsfactory, extend
+/// <paramref name="DisplayText"/> later without UI changes).
+/// </summary>
+/// <param name="Name">Registry name of the environment (activation key).</param>
+/// <param name="PythonExecutable">Full path to the environment's interpreter.</param>
+/// <param name="DisplayText">Human-readable list entry, e.g. "Managed · nazca · Python 3.11 · Nazca 0.6.1".</param>
+public sealed record ManagedEnvCandidate(string Name, string PythonExecutable, string DisplayText);
+```
+
+- [ ] **Step 4: `GdsExportViewModel` erweitern**
+
+Zu den Feldern/Properties ergänzen:
+
+```csharp
+    [ObservableProperty]
+    private ObservableCollection<ManagedEnvCandidate> _managedCandidates = new();
+
+    [ObservableProperty]
+    private bool _showNazcaInstallOffer;
+
+    /// <summary>
+    /// Supplies the managed environments that carry Nazca (wired by the DI layer;
+    /// the GDS-export slice never references the environment-manager slice directly).
+    /// </summary>
+    public Func<IReadOnlyList<ManagedEnvCandidate>>? ManagedEnvironmentsProvider { get; set; }
+
+    /// <summary>Activates a managed environment by name (wired by the DI layer).</summary>
+    public Action<string>? ActivateManagedEnvironment { get; set; }
+
+    /// <summary>Starts the default Nazca environment installation (wired by the DI layer).</summary>
+    public Action? RequestNazcaInstall { get; set; }
+```
+
+Methoden ergänzen:
+
+```csharp
+    /// <summary>
+    /// Rebuilds <see cref="ManagedCandidates"/> from <see cref="ManagedEnvironmentsProvider"/>
+    /// and recomputes whether the "install Nazca" offer should be shown (no Nazca in the
+    /// active interpreter AND no managed environment to switch to).
+    /// </summary>
+    public void RefreshManagedCandidates()
+    {
+        ManagedCandidates.Clear();
+        foreach (var candidate in ManagedEnvironmentsProvider?.Invoke() ?? Array.Empty<ManagedEnvCandidate>())
+            ManagedCandidates.Add(candidate);
+
+        ShowNazcaInstallOffer = !NazcaAvailable && ManagedCandidates.Count == 0;
+    }
+
+    /// <summary>
+    /// Activates a managed environment: the registry callback (DI layer) persists the
+    /// interpreter and pushes it into this ViewModel, then the status is re-checked.
+    /// </summary>
+    [RelayCommand]
+    public async Task SelectManagedEnvironment(ManagedEnvCandidate candidate)
+    {
+        ActivateManagedEnvironment?.Invoke(candidate.Name);
+        await CheckEnvironmentAsync();
+    }
+
+    /// <summary>Requests creation + installation of the default Nazca environment.</summary>
+    [RelayCommand]
+    public void InstallNazca() => RequestNazcaInstall?.Invoke();
+```
+
+Am Ende von `CheckEnvironmentAsync` (im `try` nach `OnPropertyChanged(nameof(IsEnvironmentReady));` **und** im `catch` nach dem dortigen `OnPropertyChanged`) jeweils ergänzen:
+
+```csharp
+            RefreshManagedCandidates();
+```
+
+- [ ] **Step 5: GREEN verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" GdsExportEnvironmentSelection`
+Expected: 7 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CAP.Avalonia/ViewModels/Export/ManagedEnvCandidate.cs CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+git commit -m "(+) GDS settings: managed Nazca environments as selectable interpreter candidates"
+```
+
+---
+
+### Task 3: GDS-Preflight-Entscheidung (`PreflightGdsAsync`)
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs`
+- Test: `UnitTests/Export/GdsExportEnvironmentSelectionTests.cs` (erweitern)
+
+**Interfaces:**
+- Produces (von Task 8 konsumiert):
+  - `enum GdsPreflightDecision { Proceed, SkipGds, InstallRequested, OpenSettingsRequested }` (eigene Datei `CAP.Avalonia/ViewModels/Export/GdsPreflightDecision.cs`)
+  - `Task<GdsPreflightDecision> PreflightGdsAsync(IMessageBoxService? messageBox)` — reine Entscheidung auf Basis des AKTUELLEN Zustands (`GenerateGdsEnabled`, `IsEnvironmentReady`); ruft selbst KEINEN Environment-Check auf (das macht der Aufrufer vorher), damit Tests deterministisch bleiben.
+- Consumes: `IMessageBoxService.ShowChoicePromptAsync` aus Task 1.
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `GdsExportEnvironmentSelectionTests.cs` ergänzen (plus `using CAP.Avalonia.Services;`):
+
+```csharp
+    private sealed class FakeMessageBoxService : IMessageBoxService
+    {
+        public int ChoiceToReturn { get; set; } = -1;
+        public string? LastMessage { get; private set; }
+        public IReadOnlyList<string>? LastButtons { get; private set; }
+
+        public Task<SavePromptResult> ShowSavePromptAsync(string message, string title) =>
+            Task.FromResult(SavePromptResult.Cancel);
+
+        public Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels)
+        {
+            LastMessage = message;
+            LastButtons = buttonLabels;
+            return Task.FromResult(ChoiceToReturn);
+        }
+    }
+
+    [Fact]
+    public async Task PreflightGds_GdsGenerationDisabled_ProceedsWithoutDialog()
+    {
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = false;
+        var messageBox = new FakeMessageBoxService();
+
+        var decision = await vm.PreflightGdsAsync(messageBox);
+
+        decision.ShouldBe(GdsPreflightDecision.Proceed);
+        messageBox.LastMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task PreflightGds_EnvironmentReady_ProceedsWithoutDialog()
+    {
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = true;
+        vm.PythonAvailable = true;
+        vm.NazcaAvailable = true;
+        var messageBox = new FakeMessageBoxService();
+
+        var decision = await vm.PreflightGdsAsync(messageBox);
+
+        decision.ShouldBe(GdsPreflightDecision.Proceed);
+        messageBox.LastMessage.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(0, GdsPreflightDecision.InstallRequested)]
+    [InlineData(1, GdsPreflightDecision.OpenSettingsRequested)]
+    [InlineData(2, GdsPreflightDecision.SkipGds)]
+    [InlineData(-1, GdsPreflightDecision.SkipGds)]   // Dialog geschlossen
+    public async Task PreflightGds_NazcaMissing_MapsDialogChoice(int choice, GdsPreflightDecision expected)
+    {
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = true;
+        vm.PythonAvailable = true;
+        vm.NazcaAvailable = false;
+        var messageBox = new FakeMessageBoxService { ChoiceToReturn = choice };
+
+        var decision = await vm.PreflightGdsAsync(messageBox);
+
+        decision.ShouldBe(expected);
+        messageBox.LastButtons!.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task PreflightGds_NoMessageBoxService_ProceedsLikeBefore()
+    {
+        // Headless/legacy callers without a dialog service keep the old behavior:
+        // attempt the GDS generation and surface the failure in the result.
+        var vm = CreateViewModel();
+        vm.GenerateGdsEnabled = true;
+        vm.NazcaAvailable = false;
+
+        var decision = await vm.PreflightGdsAsync(null);
+
+        decision.ShouldBe(GdsPreflightDecision.Proceed);
+    }
+```
+
+- [ ] **Step 2: RED verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" GdsExportEnvironmentSelection`
+Expected: Compile-Fehler (`GdsPreflightDecision`/`PreflightGdsAsync` fehlen).
+
+- [ ] **Step 3: Implementieren**
+
+`CAP.Avalonia/ViewModels/Export/GdsPreflightDecision.cs`:
+
+```csharp
+namespace CAP.Avalonia.ViewModels.Export;
+
+/// <summary>Outcome of the pre-flight check before generating a GDS file.</summary>
+public enum GdsPreflightDecision
+{
+    /// <summary>Environment is ready (or GDS generation is disabled/headless) — continue.</summary>
+    Proceed,
+
+    /// <summary>User chose to skip the GDS step; the Nazca script export stands alone.</summary>
+    SkipGds,
+
+    /// <summary>User asked to install Nazca now (open settings + start default install).</summary>
+    InstallRequested,
+
+    /// <summary>User asked to open the settings without installing.</summary>
+    OpenSettingsRequested,
+}
+```
+
+In `GdsExportViewModel` (using `CAP.Avalonia.Services;` ergänzen):
+
+```csharp
+    /// <summary>
+    /// Decides how to proceed with GDS generation based on the current environment
+    /// state. Callers refresh the state (<see cref="CheckEnvironmentAsync"/>) first;
+    /// this method only maps state + user choice to a decision.
+    /// </summary>
+    /// <param name="messageBox">Dialog service; null (headless) proceeds like before.</param>
+    public async Task<GdsPreflightDecision> PreflightGdsAsync(IMessageBoxService? messageBox)
+    {
+        if (!GenerateGdsEnabled || IsEnvironmentReady || messageBox == null)
+            return GdsPreflightDecision.Proceed;
+
+        var choice = await messageBox.ShowChoicePromptAsync(
+            "Nazca is required to generate a GDS file, but no Python environment with Nazca is available. "
+            + "The Nazca Python script itself has been exported.",
+            "Nazca required",
+            new[] { "Install Nazca now", "Open Settings", "Skip GDS" });
+
+        return choice switch
+        {
+            0 => GdsPreflightDecision.InstallRequested,
+            1 => GdsPreflightDecision.OpenSettingsRequested,
+            _ => GdsPreflightDecision.SkipGds,
+        };
+    }
+```
+
+- [ ] **Step 4: GREEN verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" GdsExportEnvironmentSelection`
+Expected: alle Tests passed (7 aus Task 2 + 7 neue).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CAP.Avalonia/ViewModels/Export/GdsPreflightDecision.cs CAP.Avalonia/ViewModels/Export/GdsExportViewModel.cs UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+git commit -m "(+) GDS export: pre-flight decision when Nazca is missing (install/settings/skip)"
+```
+
+---
+
+### Task 4: `StartDefaultNazcaInstallAsync` im `PythonEnvironmentManagerViewModel`
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs`
+- Test: `UnitTests/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModelTests.cs` (erweitern)
+
+**Interfaces:**
+- Produces (von Task 5 DI-verdrahtet): `Task StartDefaultNazcaInstallAsync()` und `public const string DefaultEnvironmentName = "nazca";`
+- Consumes: bestehendes `CreateAndInstallCommand`, `PythonEnvironmentRegistry.Exists(string)`, `UvBootstrapper.DefaultPythonVersion`.
+
+- [ ] **Step 1: Failing Tests schreiben**
+
+In `PythonEnvironmentManagerViewModelTests.cs` ergänzen:
+
+```csharp
+    [Fact]
+    public async Task StartDefaultNazcaInstall_EnvAlreadyExists_DoesNotCreateDuplicateAndExplains()
+    {
+        var registry = CreateRegistry();
+        registry.AddOrUpdate(new PythonEnvironment
+        {
+            Name = PythonEnvironmentManagerViewModel.DefaultEnvironmentName,
+            VenvPath = Path.Combine(UvBootstrapper.EnvironmentsBaseDir,
+                PythonEnvironmentManagerViewModel.DefaultEnvironmentName),
+        });
+        var vm = CreateViewModel(registry);
+
+        await vm.StartDefaultNazcaInstallAsync();
+
+        registry.GetAll().Count.ShouldBe(1);                 // kein Duplikat
+        vm.IsBusy.ShouldBeFalse();                           // kein Install gestartet
+        vm.ProgressText.ShouldContain(
+            PythonEnvironmentManagerViewModel.DefaultEnvironmentName);
+    }
+
+    [Fact]
+    public async Task StartDefaultNazcaInstall_WhileBusy_IsIgnored()
+    {
+        var registry = CreateRegistry();
+        var vm = CreateViewModel(registry);
+        vm.IsBusy = true;
+
+        await vm.StartDefaultNazcaInstallAsync();
+
+        registry.GetAll().ShouldBeEmpty();                   // nichts registriert
+    }
+```
+
+- [ ] **Step 2: RED verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" PythonEnvironmentManagerViewModel`
+Expected: Compile-Fehler (`DefaultEnvironmentName`, `StartDefaultNazcaInstallAsync` fehlen).
+
+- [ ] **Step 3: Implementieren**
+
+Im ViewModel ergänzen:
+
+```csharp
+    /// <summary>Name of the environment created by the one-click "install Nazca" offers.</summary>
+    public const string DefaultEnvironmentName = "nazca";
+
+    /// <summary>
+    /// One-click entry point used by the GDS-export fallback and the export guard:
+    /// creates the default Nazca environment with default settings. No-ops (with an
+    /// explanatory status) when an environment of that name already exists, and does
+    /// nothing while another operation runs.
+    /// </summary>
+    public async Task StartDefaultNazcaInstallAsync()
+    {
+        if (IsBusy) return;
+
+        if (_registry.Exists(DefaultEnvironmentName))
+        {
+            ProgressText = $"Environment '{DefaultEnvironmentName}' already exists — "
+                + "select it below or use Repair if it is broken.";
+            return;
+        }
+
+        NewEnvironmentName = DefaultEnvironmentName;
+        PythonVersion = UvBootstrapper.DefaultPythonVersion;
+        await CreateAndInstallCommand.ExecuteAsync(null);
+    }
+```
+
+- [ ] **Step 4: GREEN verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" PythonEnvironmentManagerViewModel`
+Expected: alle passed (bestehende + 2 neue).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs UnitTests/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModelTests.cs
+git commit -m "(+) Env manager: one-click default Nazca install entry point"
+```
+
+---
+
+### Task 5: DI-Verdrahtung der Delegates
+
+**Files:**
+- Modify: `CAP.Avalonia/DI/ExportFeatureExtensions.cs`
+
+**Interfaces:**
+- Consumes: Task 2 (`ManagedEnvironmentsProvider`, `ActivateManagedEnvironment`, `RequestNazcaInstall`, `ManagedEnvCandidate`), Task 4 (`StartDefaultNazcaInstallAsync`), `PythonEnvironmentRegistry` (`GetAll()`, `SetActive(string)`, `PythonEnvironment.IsHealthy/PythonExecutable/PythonVersion/NazcaVersion`).
+- DI-Glue darf beide Slices importieren (wie `PythonEnvFeatureExtensions` bereits tut); Auflösung IMMER lazy im Delegate (`sp.GetRequiredService<...>` erst beim Aufruf), damit keine Zirkularität bei der Container-Konstruktion entsteht.
+
+Kein eigener Unit-Test (Glue); die Delegate-Logik ist in Task 2/4 getestet, die Verdrahtung wird in Task 9 im laufenden Programm verifiziert.
+
+- [ ] **Step 1: Verdrahtung in der `GdsExportViewModel`-Factory ergänzen**
+
+In `ExportFeatureExtensions.AddExportFeature`, innerhalb der bestehenden Factory nach `vm.OnPythonPathChanged = ...` (usings ergänzen: `using CAP_Core.Export.PythonEnvironmentManager;` und `using CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager;`):
+
+```csharp
+            // Managed-environment integration (lazy resolution — the registry and the
+            // env-manager ViewModel are resolved when the delegate fires, not at build time).
+            vm.ManagedEnvironmentsProvider = () =>
+                sp.GetRequiredService<PythonEnvironmentRegistry>().GetAll()
+                    .Where(e => e.IsHealthy)
+                    .Select(e => new ManagedEnvCandidate(
+                        e.Name,
+                        e.PythonExecutable,
+                        $"Managed · {e.Name} · Python {e.PythonVersion ?? "?"} · Nazca {e.NazcaVersion ?? "?"}"))
+                    .ToList();
+            vm.ActivateManagedEnvironment = name =>
+                sp.GetRequiredService<PythonEnvironmentRegistry>().SetActive(name);
+            vm.RequestNazcaInstall = () =>
+                _ = sp.GetRequiredService<PythonEnvironmentManagerViewModel>()
+                    .StartDefaultNazcaInstallAsync();
+```
+
+- [ ] **Step 2: Build + bestehende Tests**
+
+Run: `dotnet build ConnectAPICPro.sln -v q --nologo` und
+`$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" GdsExport`
+Expected: Build 0 Fehler, Tests grün.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CAP.Avalonia/DI/ExportFeatureExtensions.cs
+git commit -m "(+) DI: wire managed-env candidates + Nazca-install request into GdsExportViewModel"
+```
+
+---
+
+### Task 6: Settings-Seite „Python Environments" + Navigation + GDS-Seiten-UI
+
+**Files:**
+- Create: `CAP.Avalonia/ViewModels/Settings/PythonEnvironmentsSettingsPage.cs`
+- Modify: `CAP.Avalonia/DI/SettingsFeatureExtensions.cs`
+- Modify: `CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs`
+- Modify: `CAP.Avalonia/Views/SettingsWindow.axaml`
+- Modify: `CAP.Avalonia/Views/SettingsWindow.axaml.cs`
+- Test: `UnitTests/ViewModels/SettingsWindowViewModelTests.cs` (falls nicht vorhanden: neu)
+
+**Interfaces:**
+- Produces: `PythonEnvironmentsSettingsPage : ISettingsPage` (Title „Python Environments", Icon „📦", Category „Export", ViewModel = `PythonEnvironmentManagerViewModel`); `SettingsWindowViewModel.SelectPage(Type pageType)`.
+- Consumes: `ISettingsPage`, `PythonEnvironmentManagerViewModel`, `GdsExportViewModel.InstallNazcaCommand` + `ManagedCandidates` + `ShowNazcaInstallOffer` + `SelectManagedEnvironmentCommand` (Task 2).
+
+- [ ] **Step 1: Failing Test für `SelectPage`**
+
+`UnitTests/ViewModels/SettingsWindowViewModelTests.cs` (neu, falls fehlend):
+
+```csharp
+using CAP.Avalonia.ViewModels.Settings;
+using Shouldly;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>Tests for settings-page navigation by page type.</summary>
+public class SettingsWindowViewModelTests
+{
+    private sealed class PageA : ISettingsPage
+    {
+        public string Title => "A";
+        public string Icon => "a";
+        public string? Category => null;
+        public object ViewModel => this;
+    }
+
+    private sealed class PageB : ISettingsPage
+    {
+        public string Title => "B";
+        public string Icon => "b";
+        public string? Category => null;
+        public object ViewModel => this;
+    }
+
+    [Fact]
+    public void SelectPage_KnownType_SwitchesSelectedPage()
+    {
+        var vm = new SettingsWindowViewModel(new ISettingsPage[] { new PageA(), new PageB() });
+
+        vm.SelectPage(typeof(PageB));
+
+        vm.SelectedPage.ShouldBeOfType<PageB>();
+    }
+
+    [Fact]
+    public void SelectPage_UnknownType_KeepsCurrentSelection()
+    {
+        var vm = new SettingsWindowViewModel(new ISettingsPage[] { new PageA() });
+
+        vm.SelectPage(typeof(PageB));
+
+        vm.SelectedPage.ShouldBeOfType<PageA>();
+    }
+}
+```
+
+- [ ] **Step 2: RED verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" SettingsWindowViewModel`
+Expected: Compile-Fehler (`SelectPage` fehlt).
+
+- [ ] **Step 3: `SelectPage` implementieren**
+
+In `SettingsWindowViewModel`:
+
+```csharp
+    /// <summary>
+    /// Selects the page whose runtime type matches <paramref name="pageType"/>;
+    /// keeps the current selection when no such page is registered.
+    /// </summary>
+    public void SelectPage(Type pageType)
+    {
+        var page = Pages.FirstOrDefault(p => p.GetType() == pageType);
+        if (page != null)
+            SelectedPage = page;
+    }
+```
+
+- [ ] **Step 4: GREEN verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" SettingsWindowViewModel`
+Expected: 2 passed.
+
+- [ ] **Step 5: Settings-Seite anlegen + registrieren**
+
+`CAP.Avalonia/ViewModels/Settings/PythonEnvironmentsSettingsPage.cs`:
+
+```csharp
+using CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager;
+
+namespace CAP.Avalonia.ViewModels.Settings;
+
+/// <summary>
+/// Settings page hosting the managed Python environment manager (create, install
+/// Nazca, health-check, repair, remove, set active). Lives in Settings — not the
+/// Properties sidebar — because environments are application-wide configuration.
+/// </summary>
+public class PythonEnvironmentsSettingsPage : ISettingsPage
+{
+    /// <inheritdoc/>
+    public string Title => "Python Environments";
+
+    /// <inheritdoc/>
+    public string Icon => "📦";
+
+    /// <inheritdoc/>
+    public string? Category => "Export";
+
+    /// <inheritdoc/>
+    public object ViewModel { get; }
+
+    /// <summary>Initializes a new instance of <see cref="PythonEnvironmentsSettingsPage"/>.</summary>
+    public PythonEnvironmentsSettingsPage(PythonEnvironmentManagerViewModel viewModel)
+    {
+        ViewModel = viewModel;
+    }
+}
+```
+
+In `SettingsFeatureExtensions` nach der `GdsExportSettingsPage`-Zeile:
+
+```csharp
+        services.AddTransient<ISettingsPage, PythonEnvironmentsSettingsPage>();
+```
+
+- [ ] **Step 6: DataTemplate + GDS-Seiten-UI in `SettingsWindow.axaml`**
+
+Namespace-Deklarationen am Window-Element ergänzen (falls nicht vorhanden):
+
+```xml
+xmlns:panels="using:CAP.Avalonia.Views.Panels"
+xmlns:vmPyEnv="using:CAP.Avalonia.ViewModels.Export.PythonEnvironmentManager"
+```
+
+Neues DataTemplate neben den bestehenden (das UserControl erbt den DataContext):
+
+```xml
+                    <!-- Python Environments (managed venvs with Nazca) -->
+                    <DataTemplate DataType="{x:Type vmPyEnv:PythonEnvironmentManagerViewModel}">
+                        <panels:PythonEnvironmentManagerPanel/>
+                    </DataTemplate>
+```
+
+Im GDS-Export-DataTemplate nach dem bestehenden `AvailablePythons`-ItemsControl ergänzen:
+
+```xml
+                            <!-- Managed environments with Nazca (from the environment manager) -->
+                            <ItemsControl ItemsSource="{Binding ManagedCandidates}"
+                                          Margin="0,6,0,0"
+                                          x:Name="ManagedCandidatesList"
+                                          IsVisible="{Binding ManagedCandidates.Count}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Button Content="{Binding DisplayText}"
+                                                Command="{Binding #ManagedCandidatesList.DataContext.SelectManagedEnvironmentCommand}"
+                                                CommandParameter="{Binding}"
+                                                HorizontalAlignment="Stretch"
+                                                HorizontalContentAlignment="Left"
+                                                Margin="0,2,0,0" Padding="6,4"
+                                                Background="#2d3d2d" FontSize="11"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <!-- Fallback: no Nazca anywhere -->
+                            <Border IsVisible="{Binding ShowNazcaInstallOffer}"
+                                    Background="#3d3320" CornerRadius="4" Padding="10" Margin="0,10,0,0">
+                                <StackPanel Spacing="6">
+                                    <TextBlock Text="No Nazca environment found."
+                                               Foreground="#e8c872" FontWeight="SemiBold" FontSize="12"/>
+                                    <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap"
+                                               Text="Lunima can create a managed Python environment and install Nazca into it automatically."/>
+                                    <Button Content="Create + install Nazca now"
+                                            Click="OnCreateNazcaEnvironmentClick"
+                                            Background="#3d5d3d" HorizontalAlignment="Left"/>
+                                </StackPanel>
+                            </Border>
+```
+
+- [ ] **Step 7: Click-Handler in `SettingsWindow.axaml.cs`**
+
+```csharp
+    /// <summary>
+    /// "Create + install Nazca now" on the GDS-Export page: starts the default
+    /// install (via the GdsExportViewModel delegate) and navigates to the
+    /// Python-Environments page so the progress is visible there.
+    /// </summary>
+    private void OnCreateNazcaEnvironmentClick(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if ((sender as global::Avalonia.Controls.Button)?.DataContext
+            is ViewModels.Export.GdsExportViewModel gdsExport)
+            gdsExport.InstallNazcaCommand.Execute(null);
+
+        if (DataContext is ViewModels.Settings.SettingsWindowViewModel vm)
+            vm.SelectPage(typeof(ViewModels.Settings.PythonEnvironmentsSettingsPage));
+    }
+```
+
+- [ ] **Step 8: Build + Tests**
+
+Run: `dotnet build ConnectAPICPro.sln -v q --nologo` und
+`$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" Settings`
+Expected: Build 0 Fehler, Tests grün.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add CAP.Avalonia/ViewModels/Settings/PythonEnvironmentsSettingsPage.cs CAP.Avalonia/DI/SettingsFeatureExtensions.cs CAP.Avalonia/ViewModels/Settings/SettingsWindowViewModel.cs CAP.Avalonia/Views/SettingsWindow.axaml CAP.Avalonia/Views/SettingsWindow.axaml.cs UnitTests/ViewModels/SettingsWindowViewModelTests.cs
+git commit -m "(+) Settings: dedicated Python Environments page + managed candidates & Nazca-install offer on GDS page"
+```
+
+---
+
+### Task 7: Env-Manager-Panel aus der Properties-Sidebar entfernen
+
+**Files:**
+- Modify: `CAP.Avalonia/Views/MainWindow.axaml` (Bereich um Zeile 736)
+- Modify: `CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs` (Property Zeile ~120, Ctor-Param Zeile ~159)
+- Modify: `UnitTests/Helpers/MainViewModelTestHelper.cs` (Zeile ~154: die vier Env-Manager-Argumente entfernen)
+- Modify: `UnitTests/ViewModels/PanelWidthPersistenceTests.cs` (Zeile ~85: dito)
+
+**Interfaces:**
+- `RightPanelViewModel` verliert `PythonEnvironmentManagerViewModel PythonEnvManager { get; }` und den zugehörigen Konstruktor-Parameter. Der DI-Container registriert das ViewModel weiterhin (Settings-Seite konsumiert es).
+
+- [ ] **Step 1: XAML-Element entfernen**
+
+In `MainWindow.axaml` die zwei Zeilen löschen:
+
+```xml
+                    <!-- Python Environment Manager Panel -->
+                    <panels:PythonEnvironmentManagerPanel/>
+```
+
+- [ ] **Step 2: `RightPanelViewModel` bereinigen**
+
+Property `public PythonEnvironmentManagerViewModel PythonEnvManager { get; }`, den Konstruktor-Parameter `PythonEnvironmentManagerViewModel pythonEnvManager` und die Zuweisung entfernen; ggf. jetzt ungenutzte `using`-Zeile mitnehmen.
+
+- [ ] **Step 3: Testhelfer anpassen**
+
+In `MainViewModelTestHelper.cs` und `PanelWidthPersistenceTests.cs` die vier Argumente
+(`new PythonEnvironmentRegistry(...)`, `new UvBootstrapper()`, `new NazcaPackageInstaller()`, `new EnvironmentHealthChecker(new PythonDiscoveryService())`) aus der `RightPanelViewModel`-Konstruktion entfernen (sie fütterten nur den entfallenen Parameter).
+
+- [ ] **Step 4: Build + volle Suite**
+
+Run: `dotnet build ConnectAPICPro.sln -v q --nologo` und
+`$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py"`
+Expected: Build 0 Fehler, Suite grün (das Panel hängt jetzt nur noch an der Settings-Seite).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CAP.Avalonia/Views/MainWindow.axaml CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs UnitTests/Helpers/MainViewModelTestHelper.cs UnitTests/ViewModels/PanelWidthPersistenceTests.cs
+git commit -m "(-) Properties sidebar: remove Python Environment Manager panel (now a Settings page)"
+```
+
+---
+
+### Task 8: Export-Guard in `FileOperationsViewModel.ExportNazca`
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs` (Methode `ExportNazca`, Zeile ~1252; neue Property bei den anderen Service-Properties, Zeile ~113)
+- Modify: `CAP.Avalonia/ViewModels/MainViewModel.cs` (Verdrahtung, dort wo `FileOperations`-Delegates gesetzt werden)
+- Test: `UnitTests/Export/GdsExportGuardTests.cs` (neu)
+
+**Interfaces:**
+- Produces: `FileOperationsViewModel.ShowSettingsWindow` (`Func<Type?, Task>?`), von `MainViewModel` an `ShowSettingsWindowAsync` weitergereicht.
+- Consumes: `GdsExport.PreflightGdsAsync(IMessageBoxService?)` + `GdsPreflightDecision` (Task 3), `GdsExport.InstallNazcaCommand` (Task 2), `MessageBoxService`-Property (existiert, Zeile ~113), `PythonEnvironmentsSettingsPage` (Task 6).
+
+- [ ] **Step 1: Failing Test schreiben**
+
+`UnitTests/Export/GdsExportGuardTests.cs` — nutzt den bestehenden `MainViewModelTestHelper` (liefert einen voll verdrahteten `MainViewModel`; Muster siehe `UnitTests/ViewModels/PanelWidthPersistenceTests.cs`) und `TestComponentFactory` für eine platzierbare Komponente:
+
+```csharp
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Export;
+using Shouldly;
+using UnitTests.Helpers;
+
+namespace UnitTests.Export;
+
+/// <summary>
+/// Export-guard tests: triggering the Nazca export with GDS generation enabled but
+/// no Nazca available must prompt instead of silently failing the GDS step.
+/// </summary>
+public class GdsExportGuardTests
+{
+    private sealed class RecordingMessageBox : IMessageBoxService
+    {
+        public int ChoiceToReturn { get; set; } = 2; // "Skip GDS"
+        public int Calls { get; private set; }
+
+        public Task<SavePromptResult> ShowSavePromptAsync(string message, string title) =>
+            Task.FromResult(SavePromptResult.Cancel);
+
+        public Task<int> ShowChoicePromptAsync(string message, string title, IReadOnlyList<string> buttonLabels)
+        {
+            Calls++;
+            return Task.FromResult(ChoiceToReturn);
+        }
+    }
+
+    private sealed class FixedPathFileDialog : IFileDialogService
+    {
+        private readonly string _path;
+        public FixedPathFileDialog(string path) => _path = path;
+        public Task<string?> ShowSaveFileDialogAsync(string title, string ext, string filter) =>
+            Task.FromResult<string?>(_path);
+        public Task<string?> ShowOpenFileDialogAsync(string title, string filter) =>
+            Task.FromResult<string?>(null);
+    }
+
+    [Fact]
+    public async Task ExportNazca_GdsEnabledButNazcaMissing_PromptsAndSkipsGds()
+    {
+        var scriptPath = Path.Combine(Path.GetTempPath(), $"lunima-export-{Guid.NewGuid():N}.py");
+        try
+        {
+            var main = MainViewModelTestHelper.Create();
+            var fileOps = main.FileOperations;
+            var messageBox = new RecordingMessageBox { ChoiceToReturn = 2 };
+            fileOps.MessageBoxService = messageBox;
+            fileOps.FileDialogService = new FixedPathFileDialog(scriptPath);
+            string? lastStatus = null;
+            fileOps.UpdateStatus = s => lastStatus = s;
+
+            // Umgebung als "kein Nazca" markieren, GDS-Generierung aktiv:
+            fileOps.GdsExport.GenerateGdsEnabled = true;
+            fileOps.GdsExport.PythonAvailable = true;
+            fileOps.GdsExport.NazcaAvailable = false;
+
+            // Eine Komponente, damit der Export nicht am leeren Canvas abbricht:
+            MainViewModelTestHelper.PlaceAnyComponent(main);
+
+            await fileOps.ExportNazcaCommand.ExecuteAsync(null);
+
+            messageBox.Calls.ShouldBe(1);                    // Guard hat gefragt
+            File.Exists(scriptPath).ShouldBeTrue();          // Skript wurde trotzdem exportiert
+            lastStatus.ShouldNotBeNull();
+            lastStatus!.ShouldContain("GDS skipped");
+        }
+        finally
+        {
+            if (File.Exists(scriptPath)) File.Delete(scriptPath);
+        }
+    }
+}
+```
+
+Hinweis für den Implementierer: Die exakten Helfernamen (`MainViewModelTestHelper.Create()`, `PlaceAnyComponent`, `IFileDialogService`-Signaturen, `UpdateStatus`-Delegat) VOR dem Schreiben an `UnitTests/Helpers/MainViewModelTestHelper.cs`, `UnitTests/ViewModels/PanelWidthPersistenceTests.cs` und `CAP.Avalonia/Services/FileDialogService.cs` abgleichen und den Test entsprechend anpassen — die Struktur oben ist verbindlich (Fake-Dialog zählt Aufrufe, Skript entsteht, Status enthält „GDS skipped"), die Helper-Aufrufe folgen dem Bestand. Existiert kein Platzierungs-Helfer, eine Komponente über `TestComponentFactory` + `_canvas`-Zugriff des Helpers platzieren.
+
+- [ ] **Step 2: RED verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" GdsExportGuard`
+Expected: FAIL — `messageBox.Calls` ist 0 und der Status meldet „GDS generation failed" statt „GDS skipped" (der Guard existiert noch nicht).
+
+- [ ] **Step 3: Guard implementieren**
+
+In `FileOperationsViewModel` bei den Service-Properties (~Zeile 113) ergänzen:
+
+```csharp
+    /// <summary>
+    /// Opens the Settings window, optionally pre-selecting a page by type.
+    /// Wired by <see cref="MainViewModel"/>; null in headless contexts.
+    /// </summary>
+    public Func<Type?, Task>? ShowSettingsWindow { get; set; }
+```
+
+In `ExportNazca()` den Block zwischen Skript-Schreiben und GDS-Generierung ersetzen:
+
+```csharp
+                // Export Python script
+                var nazcaCode = _nazcaExporter.Export(_canvas, overrides: StoredNazcaOverrides);
+                await File.WriteAllTextAsync(filePath, nazcaCode);
+
+                // GDS pre-flight: refresh a stale "not ready" verdict once, then ask the
+                // user how to proceed when Nazca is genuinely unavailable.
+                if (GdsExport.GenerateGdsEnabled && !GdsExport.IsEnvironmentReady)
+                    await GdsExport.CheckEnvironmentAsync();
+
+                var decision = await GdsExport.PreflightGdsAsync(MessageBoxService);
+                if (decision == GdsPreflightDecision.InstallRequested)
+                {
+                    GdsExport.InstallNazcaCommand.Execute(null);
+                    if (ShowSettingsWindow != null)
+                        await ShowSettingsWindow(typeof(Settings.PythonEnvironmentsSettingsPage));
+                    UpdateStatus?.Invoke($"Exported {Path.GetFileName(filePath)} — GDS skipped (installing Nazca)");
+                    return;
+                }
+                if (decision == GdsPreflightDecision.OpenSettingsRequested)
+                {
+                    if (ShowSettingsWindow != null)
+                        await ShowSettingsWindow(typeof(Settings.PythonEnvironmentsSettingsPage));
+                    UpdateStatus?.Invoke($"Exported {Path.GetFileName(filePath)} — GDS skipped (Nazca not available)");
+                    return;
+                }
+                if (decision == GdsPreflightDecision.SkipGds)
+                {
+                    UpdateStatus?.Invoke($"Exported {Path.GetFileName(filePath)} — GDS skipped (Nazca not available)");
+                    return;
+                }
+
+                // Attempt GDS generation if enabled
+                var result = await GdsExport.ExportScriptToGdsAsync(filePath);
+```
+
+(Usings ergänzen: `using CAP.Avalonia.ViewModels.Export;` und `using CAP.Avalonia.ViewModels.Settings;` — der `Settings.`-Qualifier im Code oben entsprechend anpassen.)
+
+**Achtung Determinismus im Test:** `CheckEnvironmentAsync` würde den manipulierten Zustand überschreiben. Der Aufruf ist bewusst mit `!IsEnvironmentReady` geguardet — im Test ist `PythonAvailable=true, NazcaAvailable=false` → nicht ready → Check läuft und findet auf Maschinen MIT systemweitem Nazca doch eine Umgebung. Damit der Test überall deterministisch ist, VOR dem Check zusätzlich `GdsExport.CustomPythonPath` im Test auf einen nicht existierenden Pfad setzen (`Path.Combine(Path.GetTempPath(), "no-python-here", "python")` via `SetPythonPathAsync` NICHT verwenden — direkt `fileOps.GdsExport.CustomPythonPath = ...;` reicht nicht, weil der Service den Pfad hält). Deshalb im Test stattdessen: `await fileOps.GdsExport.SetPythonPathAsync(bogusPath);` VOR dem Setzen von `NazcaAvailable=false`. Dann findet der Re-Check keinen Interpreter und die Not-ready-Diagnose bleibt stabil.
+
+- [ ] **Step 4: `MainViewModel` verdrahten**
+
+An der Stelle, an der `FileOperations`-Delegates gesetzt werden (Konstruktor, in der Nähe von `UpdateStatus`-Wiring):
+
+```csharp
+        FileOperations.ShowSettingsWindow = async pageType =>
+        {
+            if (ShowSettingsWindowAsync != null)
+                await ShowSettingsWindowAsync(pageType);
+        };
+```
+
+- [ ] **Step 5: GREEN verifizieren**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" GdsExportGuard`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs CAP.Avalonia/ViewModels/MainViewModel.cs UnitTests/Export/GdsExportGuardTests.cs
+git commit -m "(+) Export guard: prompt to install Nazca when GDS generation has no environment"
+```
+
+---
+
+### Task 9: Gesamtverifikation
+
+**Files:** keine neuen.
+
+- [ ] **Step 1: Volle Suite**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py"`
+Expected: 0 failed.
+
+- [ ] **Step 2: Build ohne neue Warnungen**
+
+Run: `dotnet build ConnectAPICPro.sln -v q --nologo`
+Expected: 0 Fehler; keine NEUEN Warnungen gegenüber main.
+
+- [ ] **Step 3: UI-Verifikation (Screenshot-Harness)**
+
+Lunima besitzt einen UI-Screenshot-Harness (siehe PR #572). App starten, verifizieren:
+1. Properties-Sidebar enthält KEIN „Python Environment"-Panel mehr.
+2. Settings → „Python Environments" zeigt das Manager-Panel.
+3. Settings → „GDS Export" → „Check Environment" listet verwaltete Envs (falls vorhanden) bzw. zeigt das Banner „No Nazca environment found." (zum Provozieren: Python-Pfad auf Unsinn setzen).
+4. Banner-Button wechselt auf die Env-Seite.
+Screenshots der vier Zustände zur PR-Beschreibung legen.
+
+- [ ] **Step 4: PR erstellen**
+
+```bash
+git push -u origin feat/nazca-env-settings-integration
+gh pr create --title "(+) Settings: Python-Environments-Seite, Nazca-Kandidaten im GDS-Export + Install-Guard beim Export" --body "<Zusammenfassung gemäß Spec + Screenshots>"
+```
+
+---
+
+## Self-Review (erledigt)
+
+- **Spec-Abdeckung:** Sidebar-Entfernung (T7), eigene Settings-Seite (T6), Kandidatenliste + Aktivierung (T2/T5/T6), Fallback-Banner (T2/T6), Export-Guard (T1/T3/T8), Erweiterbarkeit gdsfactory (DTO-DisplayText, T2). ✓
+- **Platzhalter:** Task 8 Step 1 verweist bewusst auf Bestands-Helfer mit verbindlicher Teststruktur; alle übrigen Steps tragen vollständigen Code. ✓
+- **Typkonsistenz:** `ManagedEnvCandidate(Name, PythonExecutable, DisplayText)`, `GdsPreflightDecision`, `ShowChoicePromptAsync(message, title, IReadOnlyList<string>)`, `SelectPage(Type)`, `StartDefaultNazcaInstallAsync()`, `DefaultEnvironmentName` überall gleich benannt. ✓

--- a/docs/superpowers/specs/2026-07-02-nazca-env-settings-integration-design.md
+++ b/docs/superpowers/specs/2026-07-02-nazca-env-settings-integration-design.md
@@ -1,0 +1,133 @@
+# Nazca-Environment-Integration in Settings & Export-Flow
+
+**Datum:** 2026-07-02
+**Status:** Vom Nutzer freigegeben (Chat-Review)
+**Baut auf:** PR #598 (Managed Python Environment Manager, Issue #568)
+
+## Problem
+
+Der Python-Environment-Manager aus #598 hängt als Panel in der Properties-Sidebar,
+wo er nicht hingehört. Gleichzeitig kennt die Settings-Seite „GDS Export" die
+verwalteten Environments nicht: „Check Environment" prüft nur den konfigurierten
+Interpreter, und wer gar kein Nazca hat, bekommt keinerlei Angebot, es installieren
+zu lassen — weder in den Settings noch beim Auslösen des GDS-Exports.
+
+## Ziele
+
+1. Environment-Verwaltung raus aus der Properties-Sidebar, rein in ein eigenes
+   Settings-Blatt.
+2. Die GDS-Export-Settings zeigen nach „Check Environment" **alle** Nazca-fähigen
+   Interpreter (verwaltete Environments + per Discovery gefundene System-Pythons)
+   als klickbare Auswahl.
+3. Fallback in den GDS-Export-Settings: kein Nazca gefunden → Angebot
+   „Create + install Nazca now?".
+4. Guard im Export-Flow: GDS-Export ohne verfügbares Nazca → Dialog mit
+   „Install now / Open Settings / Cancel".
+
+## Nicht-Ziele
+
+- gdsfactory-Environments (kommt mit dem Layout-Backend aus #581; die
+  Kandidatenliste wird aber paket-erweiterbar gebaut).
+- Änderungen am reinen Nazca-**Skript**-Export: der funktioniert weiterhin ohne
+  Python/Nazca.
+- Eine zweite Fortschritts-UI: Installationen laufen immer sichtbar auf der
+  „Python Environments"-Settings-Seite.
+
+## Design
+
+### 1. Entfernen aus der Properties-Sidebar
+
+`PythonEnvironmentManagerPanel` wird aus `MainWindow.axaml` entfernt;
+`RightPanelViewModel` verliert die `PythonEnvManager`-Property samt
+Konstruktor-Parameter. Betroffene Tests (`MainViewModelTestHelper`,
+`PanelWidthPersistenceTests`) werden angepasst.
+
+### 2. Neue Settings-Seite „Python Environments"
+
+- Neue Klasse `PythonEnvironmentsSettingsPage : ISettingsPage`
+  (Titel „Python Environments", Kategorie „Export", ViewModel =
+  `PythonEnvironmentManagerViewModel` aus DI).
+- Registrierung in `SettingsFeatureExtensions` (eine `AddTransient`-Zeile).
+- Das bestehende Panel-Markup zieht als `DataTemplate` für
+  `PythonEnvironmentManagerViewModel` in `SettingsWindow.axaml` um; der
+  `UserControl` `PythonEnvironmentManagerPanel` wird im Template wiederverwendet
+  (kein Markup-Duplikat), nur sein Einstiegspunkt in der Sidebar entfällt.
+
+### 3. Vereinheitlichte Interpreter-Auswahl in „GDS Export"
+
+- `GdsExportViewModel.CheckEnvironmentAsync` füllt zusätzlich zur Statusanzeige
+  eine Kandidatenliste aus zwei Quellen:
+  - **Verwaltete Environments** mit Nazca (Registry-Einträge mit
+    `Status == Healthy`), dargestellt mit Badge
+    „Managed · Python {ver} · Nazca {ver}".
+  - **System-Pythons** aus der bestehenden Discovery
+    (`SearchForPythonAsync`/`AvailablePythons`-Mechanik).
+- Auswahl eines Kandidaten:
+  - Verwaltetes Env → `PythonEnvironmentRegistry.SetActive(name)` — wirkt durch
+    die #598-Verkabelung sofort auf Preferences **und** laufende Export-Pipeline.
+  - System-Python → bestehendes `SelectPython`-Verhalten.
+- **Slice-Regel:** `GdsExportViewModel` importiert die Registry nicht direkt.
+  Die DI-Schicht (`PythonEnvFeatureExtensions`) injiziert zwei Delegates in das
+  bereits dort verdrahtete `GdsExportViewModel`:
+  `Func<IReadOnlyList<ManagedEnvCandidate>>` (Kandidaten lesen) und
+  `Action<string>` (Env aktivieren). `ManagedEnvCandidate` ist ein kleines
+  DTO im GdsExport-Umfeld (Name, PythonExecutable, Anzeige-Text).
+
+### 4. Fallback-Banner „Create + install Nazca now?"
+
+- Sichtbarkeitslogik im `GdsExportViewModel`: Der letzte Check ergab
+  „Nazca fehlt im aktiven Interpreter" **und** es gibt kein gesundes verwaltetes
+  Env → `ShowNazcaInstallOffer == true`.
+- Banner auf der GDS-Export-Seite mit Button „Create + install Nazca now".
+- Klick: wechselt im Settings-Fenster auf die Seite „Python Environments"
+  (SelectedPage im `SettingsWindowViewModel`) und startet dort
+  `CreateAndInstall` mit Defaults (Name `nazca`, Python `3.11`), sofern kein
+  gleichnamiges Env existiert. Fortschritt/Fehler erscheinen in der dortigen UI.
+- Umsetzung über einen vom DI-Layer injizierten Delegate
+  (`Action RequestNazcaInstall`), damit auch hier kein Direktimport nötig ist.
+  Das Settings-Fenster verdrahtet den Seitenwechsel.
+
+### 5. Export-Guard
+
+- Einstiegspunkt: der GDS-Generierungspfad des Nazca-Exports (nur wenn
+  `GenerateGdsEnabled` aktiv ist und die GDS-Generierung einen Interpreter
+  braucht).
+- Vor dem Start: Wenn kein Nazca-fähiger Interpreter bekannt ist (letzter
+  bekannter Status bzw. schneller Registry-Blick), Dialog über den bestehenden
+  `IMessageBoxService` (um eine Drei-Knopf-Variante erweitert):
+  „Nazca is required to generate the GDS file." →
+  **Install now** (Settings öffnen auf Env-Seite + Auto-Install starten via
+  `ShowSettingsWindowAsync(typeof(PythonEnvironmentsSettingsPage))`),
+  **Open Settings** (nur öffnen), **Cancel** (Export abbrechen; das Nazca-Skript
+  selbst wurde ggf. schon geschrieben — das bleibt so).
+
+### 6. Erweiterbarkeit gdsfactory
+
+`ManagedEnvCandidate` trägt eine Paket-Beschreibung (v1: konstant „Nazca");
+wenn #581 gdsfactory-Envs bringt, wird daraus eine Liste ohne UI-Umbau.
+
+## Fehlerbehandlung
+
+- Aktivierung eines Kandidaten, dessen Interpreter inzwischen gelöscht ist →
+  bestehende Health-Check-Pfade melden Broken; die Auswahl zeigt den Fehler im
+  Status, kein Crash.
+- „Install now" bei bereits existierendem Env namens `nazca` → kein Duplikat;
+  die Env-Seite wird geöffnet und der Nutzer sieht das bestehende Env samt
+  Status (Repair steht dort zur Verfügung).
+- Dialog-Abbruch → Export endet wie bisher beim Skript (kein halbes GDS).
+
+## Tests
+
+- `GdsExportViewModel`: Kandidaten-Aggregation (managed + discovered),
+  Aktivierungs-Delegates, `ShowNazcaInstallOffer`-Logik (alle Kombinationen).
+- Export-Guard: Dialog-Service gemockt; „Cancel" bricht GDS-Generierung ab,
+  „Install now"/„Open Settings" rufen den Settings-Delegate auf.
+- Settings-Seite: Registrierung vorhanden, Seitenwechsel-Delegate wird
+  aufgerufen, Auto-Install startet nur bei nicht-existierendem Env.
+- Anpassung: `RightPanelViewModel`-/Panel-Tests ohne EnvManager.
+
+## Reihenfolge
+
+1. #598 mergen (erledigt, `f4fdf389`).
+2. Dieses Feature als eigener PR von `main`
+   (Branch `feat/nazca-env-settings-integration`).


### PR DESCRIPTION
Follow-up to #598 (managed Python environments, issue #568). Integrates the environment manager into the places users actually configure and trigger GDS export — and removes it from the Properties sidebar, where it didn't belong. Includes a UX-feedback iteration.

## What changed

**1. Properties sidebar cleaned up**
The Python Environment Manager panel is gone from the right Properties sidebar (`MainWindow.axaml`, `RightPanelViewModel`). Its bindings were rewritten to bind the environment-manager ViewModel directly (they previously went through `MainViewModel.RightPanel.*`, which left every button dead on the new settings page).

**2. New Settings page "Python Environments"** (category *Export*)
Hosts the manager panel (create / install Nazca / health-check / repair / remove / set active). One `ISettingsPage` class + one DI line; the `PythonEnvironmentManagerPanel` UserControl is reused as a `DataTemplate`.

**3. GDS Export settings: one unified, self-refreshing interpreter list**
- **One list** shows managed environments *and* discovered system Pythons; every entry carries its **full interpreter path** as a label, and the **active one is marked** (✓). Clicking an entry switches and persists the selection — managed entries activate via the registry (updates preferences **and** the running export pipeline immediately).
- The path box is **read-only**; the old magnifier + "Check Environment" button are replaced by a single **🔄 refresh**, and the list also refreshes **automatically when navigating to the page** (new `ISettingsPage.OnSelected()` hook).
- **First start:** the first discovered Nazca-Python is selected automatically and remembered.
- The GDS-export slice never imports the env-manager slice: DI injects provider/activation delegates (`ManagedEnvCandidate`/`InterpreterOption` DTOs), so gdsfactory environments (#581) can join later without UI changes.

**4. "Create + install Nazca now"**
Visible whenever **no managed environment exists** (the "No Nazca environment found" warning headline additionally shows when Nazca is missing everywhere). The button switches to the Python-Environments page and starts the default install (`nazca`, Python 3.11) there, where the progress is visible.

**5. Export guard**
Triggering the Nazca export with GDS generation enabled but no Nazca available asks instead of failing silently: **Install Nazca now / Open Settings / Skip GDS** (new generic `IMessageBoxService.ShowChoicePromptAsync`). The Nazca **script** export continues to work without Python, exactly as before.

## Tests
- 17 new unit tests: candidate aggregation, unified-list building with active marking, selection delegates, install-offer/create-button visibility, preflight decision mapping, one-click install guards, settings navigation, page contract, and an integration test driving `ExportNazcaCommand` end-to-end with a recording dialog fake.
- UI screenshot harness captures the environment-manager settings panel; verified visually (buttons enabled, selection-dependent actions correctly hidden without selection).
- Full suite green locally: **2666 passed, 0 failed, 5 skipped**; build clean.

## Docs
Spec: `docs/superpowers/specs/2026-07-02-nazca-env-settings-integration-design.md`
Plan: `docs/superpowers/plans/2026-07-02-nazca-env-settings-integration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)