### PR TITLE
Properties panel: pin migration of hardcoded Laser/Slider sections to IComponentEditorProvider (#554)

### DIFF
--- a/UnitTests/ViewModels/Properties/ComponentEditorFactoryTests.cs
+++ b/UnitTests/ViewModels/Properties/ComponentEditorFactoryTests.cs
@@ -121,6 +121,34 @@ namespace UnitTests.ViewModels.Properties
             wrongOrder.CreateEditor(vm).ShouldBeOfType<GenericComponentEditorViewModel>();
         }
 
+        [Theory]
+        [InlineData("Grating Coupler")]
+        [InlineData("Phase Shifter")]
+        public void CreateEditor_SpecificComponents_MatchExactlyOneSpecificProvider(string templateName)
+        {
+            // Regression guard for issue #554: the old MainWindow.axaml carried
+            // hard-coded "Laser Configuration" / "Component Parameter" sections
+            // that duplicated the provider editors. With the migration done,
+            // exactly ONE specific (non-generic) provider must claim the
+            // component, so exactly one editor section is rendered.
+            var template = FindTemplate(templateName);
+            if (template == null) return; // CI guard
+
+            var vm = BuildVm(template);
+            var specificProviders = new IComponentEditorProvider[]
+            {
+                new OnaAnalyzerEditorProvider(),
+                new LightSourceEditorProvider(),
+                new SliderEditorProvider(),
+            };
+
+            var matches = specificProviders
+                .Select(p => p.TryCreateEditor(vm))
+                .Count(editor => editor != null);
+
+            matches.ShouldBe(1);
+        }
+
         [Fact]
         public void OnaAnalyzerEditor_OpenSweep_CallsWiredDelegate()
         {

--- a/UnitTests/ViewModels/Properties/PropertiesPanelDeduplicationTests.cs
+++ b/UnitTests/ViewModels/Properties/PropertiesPanelDeduplicationTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels.Properties
+{
+    /// <summary>
+    /// Regression guards for issue #554: the hard-coded "Laser Configuration"
+    /// and "Component Parameter" (slider) sections were removed from
+    /// MainWindow.axaml in favour of the <c>IComponentEditorProvider</c>
+    /// editors hosted by <c>SelectedComponentPropertiesPanel</c>. These tests
+    /// pin that single-source-of-truth state so the duplicate sections cannot
+    /// silently return.
+    /// </summary>
+    public class PropertiesPanelDeduplicationTests
+    {
+        private static string MainWindowAxaml =>
+            File.ReadAllText(Path.Combine(FindRepoRoot(), "CAP.Avalonia", "Views", "MainWindow.axaml"));
+
+        private static string PropertiesPanelAxaml =>
+            File.ReadAllText(Path.Combine(FindRepoRoot(), "CAP.Avalonia", "Views", "Panels",
+                "SelectedComponentPropertiesPanel.axaml"));
+
+        [Fact]
+        public void MainWindow_HasNoHardcodedLaserConfigurationSection()
+        {
+            var content = MainWindowAxaml;
+
+            content.ShouldNotContain("Laser Configuration");
+            // The laser editor's bindings must only live in the provider template.
+            content.ShouldNotContain("IsLightSource");
+            content.ShouldNotContain("LaserConfig");
+        }
+
+        [Fact]
+        public void MainWindow_HasNoHardcodedComponentParameterSliderSection()
+        {
+            var content = MainWindowAxaml;
+
+            content.ShouldNotContain("Component Parameter");
+            // SliderValue/SliderLabel belong to SliderEditorViewModel's template.
+            // (SliderMin/SliderMax are still legitimately used by Parameter Sweep.)
+            content.ShouldNotContain("SelectedComponent.SliderValue");
+            content.ShouldNotContain("SelectedComponent.SliderLabel");
+        }
+
+        [Fact]
+        public void MainWindow_HostsSelectedComponentPropertiesPanel()
+        {
+            MainWindowAxaml.ShouldContain("SelectedComponentPropertiesPanel");
+        }
+
+        [Fact]
+        public void PropertiesPanel_LightSourceTemplate_KeepsFeatureParity()
+        {
+            var content = PropertiesPanelAxaml;
+
+            // Parity with the removed hard-coded section: curated wavelength
+            // dropdown + input-power slider.
+            content.ShouldContain("WavelengthOptions");
+            content.ShouldContain("LaserConfig.WavelengthNm");
+            content.ShouldContain("LaserConfig.InputPower");
+        }
+
+        [Fact]
+        public void PropertiesPanel_SliderTemplate_KeepsFeatureParity()
+        {
+            var content = PropertiesPanelAxaml;
+
+            content.ShouldContain("SliderLabel");
+            // Two-way value binding so slider edits reach the S-matrix.
+            content.ShouldContain("{Binding Value, Mode=TwoWay}");
+        }
+
+        private static string FindRepoRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, "CAP.Avalonia", "App.axaml.cs")))
+                dir = dir.Parent;
+
+            return dir?.FullName ?? throw new InvalidOperationException("Could not locate repository root");
+        }
+    }
+}


### PR DESCRIPTION
Closes #554

## Summary
- Investigation showed the core migration was **already completed in PR #550** (commit 3ae0c90b): the hardcoded "Laser Configuration" and "Component Parameter (Slider)" sections are gone from `MainWindow.axaml`, and `SelectedComponentPropertiesPanel` hosts the provider editors with full feature parity (curated `WavelengthOptions` ComboBox, input-power slider, slider + NumericUpDown).
- This PR completes the remaining checklist items by pinning that state with regression tests:
  - `PropertiesPanelDeduplicationTests`: `MainWindow.axaml` must not re-grow the hardcoded laser/slider sections; the provider templates must keep feature parity (wavelength dropdown, input power, two-way slider binding).
  - `ComponentEditorFactoryTests`: for light-source (Grating Coupler) and slider (Phase Shifter) components, **exactly one** specific provider claims the component — guaranteeing a single editor section is rendered.

## Test plan
- [x] Build green (0 errors, 0 warnings)
- [x] `smart_test.py Properties` — 37/37 passed (incl. 8 new tests)
- [x] Full suite: 2675 passed; 3 failures are pre-existing environment issues in the agent worktree (`.git` is a file, not a directory, breaking those tests' repo-root lookup; plus a Nazca preview integration test requiring a Python env) — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)