### PR TITLE
(=) demo-pdk: fix mojibake (Â) in '90° Bend' / '100µm' component names

### DIFF
--- a/CAP-DataAccess/PDKs/demo-pdk.json
+++ b/CAP-DataAccess/PDKs/demo-pdk.json
@@ -444,7 +444,7 @@
       }
     },
     {
-      "name": "Straight Waveguide 100\u00C2\u00B5m",
+      "name": "Straight Waveguide 100\u00B5m",
       "category": "Waveguides",
       "nazcaFunction": "demo.shallow.strt",
       "nazcaParameters": "length=100",
@@ -479,7 +479,7 @@
       }
     },
     {
-      "name": "90\u00C2\u00B0 Bend",
+      "name": "90\u00B0 Bend",
       "category": "Waveguides",
       "nazcaFunction": "demo.shallow.bend",
       "nazcaParameters": "angle=90",


### PR DESCRIPTION
Two component names in `demo-pdk.json` carried a stray U+00C2 (a UTF-8 `°`/`µ` byte that got read as Latin-1 and re-encoded), so the component library showed **90Â° Bend** and **Straight Waveguide 100Âµm**. Restored to `90° Bend` and `100µm`. Pure data fix; JSON validated.

Reported during gdsfactory export testing (#581).

🤖 Generated with [Claude Code](https://claude.com/claude-code)