### PR TITLE
[VERIFY-ONLY] gdsfactory export (#624) + demo-pdk mojibake fix (#634) combined for testing

### DIFF
--- a/CAP-DataAccess/PDKs/demo-pdk.json
+++ b/CAP-DataAccess/PDKs/demo-pdk.json
@@ -444,7 +444,7 @@
       }
     },
     {
-      "name": "Straight Waveguide 100\u00C2\u00B5m",
+      "name": "Straight Waveguide 100\u00B5m",
       "category": "Waveguides",
       "nazcaFunction": "demo.shallow.strt",
       "nazcaParameters": "length=100",
@@ -479,7 +479,7 @@
       }
     },
     {
-      "name": "90\u00C2\u00B0 Bend",
+      "name": "90\u00B0 Bend",
       "category": "Waveguides",
       "nazcaFunction": "demo.shallow.bend",
       "nazcaParameters": "angle=90",

--- a/CAP.Avalonia/DI/ExportFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/ExportFeatureExtensions.cs
@@ -50,6 +50,8 @@ internal static class ExportFeatureExtensions
         services.AddSingleton<PhotonTorchExporter>();
         services.AddSingleton<PhotonTorchExportViewModel>();
 
+        services.AddSingleton<GdsFactoryExportViewModel>();
+
         services.AddSingleton<VerilogAExporter>();
         services.AddSingleton<VerilogAFileWriter>();
         services.AddSingleton<VerilogAExportViewModel>();

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExportOptions.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExportOptions.cs
@@ -1,0 +1,21 @@
+namespace CAP.Avalonia.Services.GdsFactoryExport;
+
+/// <summary>How the gdsfactory export represents PDK components.</summary>
+public enum GdsFactoryComponentMode
+{
+    /// <summary>
+    /// Self-contained stub geometry from Lunima's dimensions and pins — mirrors the
+    /// Nazca export; runs with a plain gdsfactory install, no PDK package needed.
+    /// </summary>
+    StandaloneStubs,
+
+    /// <summary>
+    /// Real ubcpdk (SiEPIC EBeam) cells where a mapping exists; components without a
+    /// ubcpdk equivalent fall back to stub geometry.
+    /// </summary>
+    UbcPdkCells,
+}
+
+/// <summary>Options for a gdsfactory export run.</summary>
+/// <param name="Mode">Component representation mode.</param>
+public sealed record GdsFactoryExportOptions(GdsFactoryComponentMode Mode);

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
@@ -1,0 +1,182 @@
+using System.Globalization;
+using System.Text;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+
+namespace CAP.Avalonia.Services.GdsFactoryExport;
+
+/// <summary>
+/// Second layout emitter next to the Nazca exporter (issue #581, option 1): generates a
+/// self-contained gdsfactory Python script from the design. Placement, pins, and routed
+/// segments follow the same coordinate contract as the Nazca export (both targets are
+/// Y-up), delegated to <see cref="NazcaCoordinateMapper"/>. The script writes its GDS
+/// next to itself (same convention as Nazca), so the existing script-runner finds it.
+/// </summary>
+public class GdsFactoryExporter
+{
+    /// <summary>Exports the design to a gdsfactory Python script.</summary>
+    /// <param name="canvas">The design canvas to export.</param>
+    /// <param name="options">Component representation mode (stubs vs. ubcpdk cells).</param>
+    public string Export(DesignCanvasViewModel canvas, GdsFactoryExportOptions options)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, options);
+        AppendStubs(sb, canvas, options);
+        var refIndex = 0;
+        sb.AppendLine("c = gf.Component('ConnectAPIC_Design')");
+        sb.AppendLine();
+        sb.AppendLine("# Components");
+        foreach (var comp in EnumerateExportableComponents(canvas))
+            AppendPlacement(sb, comp, options, ref refIndex);
+        sb.AppendLine();
+        AppendConnections(sb, canvas);
+        AppendFooter(sb);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Lists the distinct nazcaFunction names in the design that have no ubcpdk
+    /// equivalent — shown in the export dialog as the stub-fallback list.
+    /// </summary>
+    public static IReadOnlyList<string> CollectUnmappedComponents(DesignCanvasViewModel canvas) =>
+        EnumerateExportableComponents(canvas)
+            .Select(comp => comp.NazcaFunctionName)
+            .Where(name => !string.IsNullOrEmpty(name) && UbcPdkCellMap.MapToUbcPdkCell(name) == null)
+            .Distinct(StringComparer.Ordinal)
+            .ToList()!;
+
+    private static IEnumerable<Component> EnumerateExportableComponents(DesignCanvasViewModel canvas)
+    {
+        foreach (var compVm in canvas.Components)
+        {
+            var comp = compVm.Component;
+            if (comp.IsAnalysisTool) continue;
+            if (comp is ComponentGroup group)
+            {
+                foreach (var child in group.GetAllComponentsRecursive())
+                    if (!child.IsAnalysisTool)
+                        yield return child;
+            }
+            else
+            {
+                yield return comp;
+            }
+        }
+    }
+
+    private static void AppendHeader(StringBuilder sb, GdsFactoryExportOptions options)
+    {
+        sb.AppendLine("import os");
+        sb.AppendLine("import gdsfactory as gf");
+        if (options.Mode == GdsFactoryComponentMode.UbcPdkCells)
+        {
+            sb.AppendLine("from ubcpdk import PDK");
+            sb.AppendLine("PDK.activate()");
+        }
+        else
+        {
+            // gdsfactory 9.x refuses layer lookups without an active PDK — the generic
+            // PDK is enough for the self-contained stub geometry.
+            sb.AppendLine("gf.gpdk.PDK.activate()");
+        }
+        sb.AppendLine();
+        sb.AppendLine("WG_WIDTH = 0.45  # waveguide width in um");
+        sb.AppendLine();
+    }
+
+    private static void AppendStubs(StringBuilder sb, DesignCanvasViewModel canvas, GdsFactoryExportOptions options)
+    {
+        var generated = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var comp in EnumerateExportableComponents(canvas))
+        {
+            if (UsesUbcPdkCell(comp, options))
+                continue;
+            GdsFactoryStubWriter.AppendStub(sb, comp, generated);
+        }
+    }
+
+    private static bool UsesUbcPdkCell(Component comp, GdsFactoryExportOptions options) =>
+        options.Mode == GdsFactoryComponentMode.UbcPdkCells
+        && UbcPdkCellMap.MapToUbcPdkCell(comp.NazcaFunctionName) != null;
+
+    /// <summary>
+    /// Places one component: <c>rotate</c> about the cell origin, then <c>move</c> the
+    /// origin to the mapper placement — equivalent to Nazca's <c>put('org', x, y, rot)</c>.
+    /// </summary>
+    private static void AppendPlacement(
+        StringBuilder sb, Component comp, GdsFactoryExportOptions options, ref int refIndex)
+    {
+        var ci = CultureInfo.InvariantCulture;
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, rawOverrideAnchor: null);
+        var x = placement.X.ToString("F2", ci);
+        var y = placement.Y.ToString("F2", ci);
+        var rot = placement.RotationDegrees.ToString("F0", ci);
+        var varName = $"ref_{refIndex}";
+
+        var factory = UsesUbcPdkCell(comp, options)
+            ? $"gf.get_component('{UbcPdkCellMap.MapToUbcPdkCell(comp.NazcaFunctionName)}')"
+            : $"{GdsFactoryStubWriter.StubFunctionName(comp)}({StubArguments(comp)})";
+
+        sb.AppendLine($"{varName} = c.add_ref({factory})  # {comp.Identifier}");
+        sb.AppendLine($"{varName}.rotate({rot})");
+        sb.AppendLine($"{varName}.move(({x}, {y}))");
+
+        refIndex++;
+    }
+
+    /// <summary>Forwards stored parameters for parametric straights (length=…).</summary>
+    private static string StubArguments(Component comp) =>
+        NazcaCoordinateMapper.IsParametricStraight(comp.NazcaFunctionName, comp.NazcaFunctionParameters)
+        && !string.IsNullOrEmpty(comp.NazcaFunctionParameters)
+            ? comp.NazcaFunctionParameters
+            : string.Empty;
+
+    private static void AppendConnections(StringBuilder sb, DesignCanvasViewModel canvas)
+    {
+        sb.AppendLine("# Waveguide connections");
+        foreach (var connVm in canvas.Connections)
+        {
+            var conn = connVm.Connection;
+            if (conn.StartPin?.ParentComponent?.IsAnalysisTool == true) continue;
+            if (conn.EndPin?.ParentComponent?.IsAnalysisTool == true) continue;
+
+            var segments = conn.GetPathSegments();
+            if (segments.Count > 0)
+                GdsFactorySegmentWriter.AppendSegments(sb, segments, conn.StartPin, conn.EndPin);
+            else if (conn.StartPin != null && conn.EndPin != null)
+                GdsFactorySegmentWriter.AppendPinToPinFallback(sb, conn.StartPin, conn.EndPin);
+        }
+
+        foreach (var compVm in canvas.Components)
+        {
+            if (compVm.Component is ComponentGroup group)
+                AppendGroupFrozenPaths(sb, group);
+        }
+        sb.AppendLine();
+    }
+
+    private static void AppendGroupFrozenPaths(StringBuilder sb, ComponentGroup group)
+    {
+        foreach (var frozenPath in group.InternalPaths)
+        {
+            if (frozenPath?.Path?.Segments?.Count > 0)
+                GdsFactorySegmentWriter.AppendSegments(
+                    sb, frozenPath.Path.Segments, frozenPath.StartPin, frozenPath.EndPin);
+        }
+
+        foreach (var child in group.ChildComponents)
+        {
+            if (child is ComponentGroup nested)
+                AppendGroupFrozenPaths(sb, nested);
+        }
+    }
+
+    private static void AppendFooter(StringBuilder sb)
+    {
+        sb.AppendLine("# Export GDS with filename matching this script");
+        sb.AppendLine("gds_path = os.path.splitext(os.path.abspath(__file__))[0] + '.gds'");
+        sb.AppendLine("c.write_gds(gds_path)");
+        sb.AppendLine("print(f'GDS exported to: {gds_path}')");
+    }
+}

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactorySegmentWriter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactorySegmentWriter.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+using System.Text;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using CAP_Core.Routing;
+
+namespace CAP.Avalonia.Services.GdsFactoryExport;
+
+/// <summary>
+/// Emits routed waveguide segments as absolutely placed gdsfactory references.
+/// The coordinate contract is identical to the Nazca segment export (both targets
+/// are Y-up): geometry converts via <see cref="NazcaCoordinateMapper.ToNazca"/> and
+/// angles are negated. Emitted lines reference the module-level design component
+/// variable <c>c</c> defined by <see cref="GdsFactoryExporter"/>.
+/// </summary>
+public static class GdsFactorySegmentWriter
+{
+    /// <summary>
+    /// Appends all segments of one routed connection. A single straight segment with
+    /// known pins is emitted pin-to-pin (exact endpoints) like the Nazca export.
+    /// </summary>
+    /// <param name="sb">Target script builder.</param>
+    /// <param name="segments">Routed path segments in editor (app) coordinates.</param>
+    /// <param name="startPin">Start pin, used for single-straight pin-to-pin geometry.</param>
+    /// <param name="endPin">End pin, used for single-straight pin-to-pin geometry.</param>
+    public static void AppendSegments(
+        StringBuilder sb, IReadOnlyList<PathSegment> segments,
+        PhysicalPin? startPin = null, PhysicalPin? endPin = null)
+    {
+        if (segments.Count == 1 && segments[0] is StraightSegment && startPin != null && endPin != null)
+        {
+            var (sx, sy) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
+            var (ex, ey) = NazcaCoordinateMapper.GetPinNazcaPosition(endPin);
+            AppendStraight(sb, sx, sy, ex, ey);
+            return;
+        }
+
+        foreach (var segment in segments)
+        {
+            var (nsx, nsy) = NazcaCoordinateMapper.ToNazca(segment.StartPoint.X, segment.StartPoint.Y);
+            switch (segment)
+            {
+                case StraightSegment:
+                    var (nex, ney) = NazcaCoordinateMapper.ToNazca(segment.EndPoint.X, segment.EndPoint.Y);
+                    AppendStraight(sb, nsx, nsy, nex, ney);
+                    break;
+                case BendSegment bend:
+                    AppendBend(sb, bend, nsx, nsy);
+                    break;
+                default:
+                    sb.AppendLine($"# Unknown segment type: {segment.GetType().Name}");
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Appends the pin-to-pin fallback for connections without routed segments —
+    /// a direct straight between both pin positions (no auto-routing in v1).
+    /// </summary>
+    public static void AppendPinToPinFallback(StringBuilder sb, PhysicalPin startPin, PhysicalPin endPin)
+    {
+        var (sx, sy) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
+        var (ex, ey) = NazcaCoordinateMapper.GetPinNazcaPosition(endPin);
+        sb.AppendLine("# routeless connection: direct pin-to-pin straight");
+        AppendStraight(sb, sx, sy, ex, ey);
+    }
+
+    private static void AppendStraight(StringBuilder sb, double sx, double sy, double ex, double ey)
+    {
+        var ci = CultureInfo.InvariantCulture;
+        double dx = ex - sx;
+        double dy = ey - sy;
+        double length = Math.Sqrt(dx * dx + dy * dy);
+        double angleDeg = Math.Atan2(dy, dx) * 180.0 / Math.PI;
+
+        sb.AppendLine($"_seg = c.add_ref(gf.components.straight(length={length.ToString("F2", ci)}, width=WG_WIDTH))");
+        AppendPlacement(sb, angleDeg, sx, sy, ci);
+    }
+
+    private static void AppendBend(StringBuilder sb, BendSegment bend, double sx, double sy)
+    {
+        var ci = CultureInfo.InvariantCulture;
+        var radius = bend.RadiusMicrometers.ToString("F2", ci);
+        var sweep = NazcaCoordinateMapper.NormalizeZero(-bend.SweepAngleDegrees).ToString("F2", ci);
+
+        sb.AppendLine($"_seg = c.add_ref(gf.components.bend_circular(radius={radius}, angle={sweep}, "
+                      + "width=WG_WIDTH, allow_min_radius_violation=True))");
+        AppendPlacement(sb, -bend.StartAngleDegrees, sx, sy, ci);
+    }
+
+    private static void AppendPlacement(StringBuilder sb, double angleDeg, double x, double y, CultureInfo ci)
+    {
+        var a = NazcaCoordinateMapper.NormalizeZero(angleDeg).ToString("F2", ci);
+        var px = NazcaCoordinateMapper.NormalizeZero(x).ToString("F2", ci);
+        var py = NazcaCoordinateMapper.NormalizeZero(y).ToString("F2", ci);
+        sb.AppendLine($"_seg.rotate({a})");
+        sb.AppendLine($"_seg.move(({px}, {py}))");
+    }
+}

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryStubWriter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryStubWriter.cs
@@ -1,0 +1,109 @@
+using System.Globalization;
+using System.Text;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+
+namespace CAP.Avalonia.Services.GdsFactoryExport;
+
+/// <summary>
+/// Emits self-contained gdsfactory component factories ("stubs") from Lunima's stored
+/// dimensions and pins — the same geometry contract as the Nazca stub export, so both
+/// backends produce coinciding layouts: polygon <c>[-ox, oy-H] .. [W-ox, oy]</c> around
+/// the cell origin, ports at <c>(OffsetX-ox, oy-OffsetY)</c> with orientation
+/// <c>-AngleDegrees</c>.
+/// </summary>
+public static class GdsFactoryStubWriter
+{
+    /// <summary>Returns the sanitized Python factory name for a component.</summary>
+    public static string StubFunctionName(Component comp)
+    {
+        var key = string.IsNullOrEmpty(comp.NazcaFunctionName)
+            ? comp.Identifier
+            : comp.NazcaFunctionName;
+        return "stub_" + System.Text.RegularExpressions.Regex.Replace(key, @"[^a-zA-Z0-9_]", "_");
+    }
+
+    /// <summary>
+    /// Appends the stub factory for <paramref name="comp"/> unless one with the same
+    /// name was already generated. Parametric straights get a length-parameterised
+    /// factory (real waveguide geometry); everything else a rectangle with ports.
+    /// </summary>
+    public static void AppendStub(StringBuilder sb, Component comp, HashSet<string> generated)
+    {
+        var name = StubFunctionName(comp);
+        if (!generated.Add(name))
+            return;
+
+        var ci = CultureInfo.InvariantCulture;
+        if (NazcaCoordinateMapper.IsParametricStraight(comp.NazcaFunctionName, comp.NazcaFunctionParameters))
+            AppendParametricStraightStub(sb, name, comp, ci);
+        else
+            AppendStandardStub(sb, name, comp, ci);
+    }
+
+    /// <summary>
+    /// Length-parameterised straight-waveguide factory, mirroring the Nazca parametric
+    /// stub: the waveguide centre line sits at the mapper's stub anchor relative to the
+    /// first pin, ports at x=0 and x=length.
+    /// </summary>
+    private static void AppendParametricStraightStub(
+        StringBuilder sb, string name, Component comp, CultureInfo ci)
+    {
+        var (_, anchorY) = NazcaCoordinateMapper.GetStubAnchor(comp);
+        var firstPin = comp.PhysicalPins.FirstOrDefault();
+        var firstPinY = firstPin != null
+            ? NazcaCoordinateMapper.GetUnrotatedPinOffset(comp, firstPin).OffsetY
+            : 0;
+        var strtY = NazcaCoordinateMapper.NormalizeZero(anchorY - firstPinY).ToString("F2", ci);
+
+        sb.AppendLine($"def {name}(length=100, width=WG_WIDTH) -> gf.Component:");
+        sb.AppendLine($"    \"\"\"Parametric straight stub for {comp.NazcaFunctionName}.\"\"\"");
+        sb.AppendLine("    comp = gf.Component()");
+        sb.AppendLine("    seg = comp.add_ref(gf.components.straight(length=length, width=width))");
+        sb.AppendLine($"    seg.move((0, {strtY}))");
+
+        foreach (var pin in comp.PhysicalPins)
+        {
+            var (uox, uoy) = NazcaCoordinateMapper.GetUnrotatedPinOffset(comp, pin);
+            var py = NazcaCoordinateMapper.NormalizeZero(anchorY - uoy).ToString("F2", ci);
+            var pa = NazcaCoordinateMapper.NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
+            var px = uox == 0 ? "0" : "length";
+            sb.AppendLine($"    comp.add_port(name='{pin.Name}', center=({px}, {py}), "
+                          + $"orientation={pa}, width=width, layer=(1, 0))");
+        }
+
+        sb.AppendLine("    return comp");
+        sb.AppendLine();
+    }
+
+    /// <summary>Rectangle-with-ports factory for a non-parametric component.</summary>
+    private static void AppendStandardStub(StringBuilder sb, string name, Component comp, CultureInfo ci)
+    {
+        var w = comp.WidthMicrometers;
+        var h = comp.HeightMicrometers;
+        double ox = comp.NazcaOriginOffsetX;
+        double oy = comp.NazcaOriginOffsetY;
+
+        var x0 = NazcaCoordinateMapper.NormalizeZero(-ox).ToString("F2", ci);
+        var y0 = NazcaCoordinateMapper.NormalizeZero(oy - h).ToString("F2", ci);
+        var x1 = NazcaCoordinateMapper.NormalizeZero(w - ox).ToString("F2", ci);
+        var y1 = NazcaCoordinateMapper.NormalizeZero(oy).ToString("F2", ci);
+
+        sb.AppendLine($"def {name}() -> gf.Component:");
+        sb.AppendLine($"    \"\"\"Stub for {comp.NazcaFunctionName} ({w}x{h} um).\"\"\"");
+        sb.AppendLine("    comp = gf.Component()");
+        sb.AppendLine($"    comp.add_polygon([({x0}, {y0}), ({x1}, {y0}), ({x1}, {y1}), ({x0}, {y1})], layer=(1, 0))");
+
+        foreach (var pin in comp.PhysicalPins)
+        {
+            var px = NazcaCoordinateMapper.NormalizeZero(pin.OffsetXMicrometers - ox).ToString("F2", ci);
+            var py = NazcaCoordinateMapper.NormalizeZero(oy - pin.OffsetYMicrometers).ToString("F2", ci);
+            var pa = NazcaCoordinateMapper.NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
+            sb.AppendLine($"    comp.add_port(name='{pin.Name}', center=({px}, {py}), "
+                          + $"orientation={pa}, width=WG_WIDTH, layer=(1, 0))");
+        }
+
+        sb.AppendLine("    return comp");
+        sb.AppendLine();
+    }
+}

--- a/CAP.Avalonia/Services/GdsFactoryExport/UbcPdkCellMap.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/UbcPdkCellMap.cs
@@ -1,0 +1,72 @@
+namespace CAP.Avalonia.Services.GdsFactoryExport;
+
+/// <summary>
+/// Maps Lunima's SiEPIC <c>nazcaFunction</c> names to ubcpdk cell names (the SiEPIC
+/// EBeam PDK for gdsfactory). Verified against a real install (gdsfactory 9.34.2 +
+/// ubcpdk 3.3.4): 35 names exist verbatim in ubcpdk's <c>PDK.cells</c> registry,
+/// three differ only in spelling, four have no equivalent (callers fall back to
+/// stub geometry). See docs/superpowers/specs/2026-07-02-gdsfactory-export-design.md.
+/// </summary>
+public static class UbcPdkCellMap
+{
+    private static readonly HashSet<string> VerbatimCells = new(StringComparer.Ordinal)
+    {
+        "ANT_MMI_1x2_te1550_3dB_BB",
+        "GC_SiN_TE_1310_8degOxide_BB",
+        "GC_SiN_TE_1550_8degOxide_BB",
+        "GC_TE_1310_8degOxide_BB",
+        "GC_TE_1550_8degOxide_BB",
+        "GC_TM_1310_8degOxide_BB",
+        "GC_TM_1550_8degOxide_BB",
+        "crossing_horizontal",
+        "crossing_manhattan",
+        "ebeam_BondPad",
+        "ebeam_DC_te895",
+        "ebeam_MMI_2x2_5050_te1310",
+        "ebeam_Polarizer_TM_1550_UQAM",
+        "ebeam_YBranch_895",
+        "ebeam_YBranch_te1310",
+        "ebeam_adiabatic_te1550",
+        "ebeam_adiabatic_tm1550",
+        "ebeam_bdc_te1550",
+        "ebeam_crossing4",
+        "ebeam_gc_te1310",
+        "ebeam_gc_te1550",
+        "ebeam_gc_te895",
+        "ebeam_splitter_swg_assist_te1310",
+        "ebeam_splitter_swg_assist_te1550",
+        "ebeam_terminator_SiN_1550",
+        "ebeam_terminator_SiN_te895",
+        "ebeam_terminator_te1310",
+        "ebeam_terminator_te1550",
+        "ebeam_terminator_tm1550",
+        "ebeam_y_1550",
+        "ebeam_y_adiabatic",
+        "ebeam_y_adiabatic_500pin",
+        "taper_SiN_750_3000",
+        "taper_si_simm_1310",
+        "taper_si_simm_1550",
+    };
+
+    private static readonly Dictionary<string, string> Renames = new(StringComparer.Ordinal)
+    {
+        ["ebeam_DC_2-1_te895"] = "ebeam_DC_2m1_te895",
+        ["ebeam_routing_taper_te1550_w=500nm_to_w=3000nm_L=20um"]
+            = "ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um",
+        ["ebeam_routing_taper_te1550_w=500nm_to_w=3000nm_L=40um"]
+            = "ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um",
+    };
+
+    /// <summary>
+    /// Returns the ubcpdk cell name for <paramref name="nazcaFunction"/>, or null when
+    /// no equivalent exists (the caller falls back to stub geometry).
+    /// </summary>
+    public static string? MapToUbcPdkCell(string? nazcaFunction)
+    {
+        if (string.IsNullOrEmpty(nazcaFunction))
+            return null;
+        if (VerbatimCells.Contains(nazcaFunction))
+            return nazcaFunction;
+        return Renames.TryGetValue(nazcaFunction, out var renamed) ? renamed : null;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Export/Formats/GdsFactoryExportFormat.cs
+++ b/CAP.Avalonia/ViewModels/Export/Formats/GdsFactoryExportFormat.cs
@@ -1,0 +1,49 @@
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Export.Formats;
+
+/// <summary>
+/// Export format for gdsfactory layout scripts (#581): opens an options dialog for
+/// the component mode (standalone stubs vs. ubcpdk cells) and GDS generation.
+/// </summary>
+public class GdsFactoryExportFormat : IExportFormat
+{
+    private readonly AsyncRelayCommand _exportCommand;
+
+    /// <inheritdoc/>
+    public string Name => "gdsfactory";
+
+    /// <inheritdoc/>
+    public string Icon => "🏭";
+
+    /// <inheritdoc/>
+    public string Description => "Export a gdsfactory Python script (+ GDS) — standalone or with ubcpdk (SiEPIC) cells";
+
+    /// <inheritdoc/>
+    public string Background => "#3d5d4d";
+
+    /// <inheritdoc/>
+    public IAsyncRelayCommand ExportCommand => _exportCommand;
+
+    /// <summary>
+    /// Callback that opens the gdsfactory export options dialog. Wired by the UI layer
+    /// (<c>Views.Dialogs.ExportDialogWiring.Wire</c>); invoking the command before that
+    /// throws <see cref="InvalidOperationException"/>.
+    /// </summary>
+    public Func<Task>? ShowOptionsDialogAsync { get; set; }
+
+    /// <summary>Initializes the gdsfactory export format adapter.</summary>
+    public GdsFactoryExportFormat()
+    {
+        _exportCommand = new AsyncRelayCommand(RunExportFlowAsync);
+    }
+
+    private async Task RunExportFlowAsync()
+    {
+        if (ShowOptionsDialogAsync == null)
+            throw new InvalidOperationException(
+                $"{nameof(GdsFactoryExportFormat)}.{nameof(ShowOptionsDialogAsync)} has not been wired. " +
+                "The UI layer (Views.Dialogs.ExportDialogWiring.Wire) must set this callback before the export command can run.");
+        await ShowOptionsDialogAsync();
+    }
+}

--- a/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
@@ -135,11 +135,26 @@ public partial class GdsFactoryExportViewModel : ObservableObject
         if (result.Success)
             return $"Exported {scriptName}.";
 
-        var hint = result.ErrorMessage?.Contains("gdsfactory", StringComparison.OrdinalIgnoreCase) == true
-            ? " Install gdsfactory into the active environment "
-              + "(Settings → Python Environments → Install gdsfactory)."
-            : string.Empty;
+        // Full traceback goes to the (copyable) Error Console only — the dialog shows a
+        // short, actionable line so it doesn't duplicate an uncopyable wall of text.
         _errorConsole?.LogError($"gdsfactory GDS generation failed: {result.ErrorMessage}");
-        return $"Exported {scriptName}, but the GDS run failed: {result.ErrorMessage}.{hint}";
+        return BuildFailureMessage(scriptName, result.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Builds the short, dialog-facing failure line. The full error is logged to the
+    /// Error Console separately; this never embeds the raw traceback so the dialog stays
+    /// concise and the copyable detail lives in one place.
+    /// </summary>
+    internal static string BuildFailureMessage(string scriptName, string? errorMessage)
+    {
+        var gdsFactoryMissing = errorMessage?.Contains("No module named 'gdsfactory'",
+            StringComparison.OrdinalIgnoreCase) == true;
+        if (gdsFactoryMissing)
+            return $"Exported {scriptName}, but gdsfactory is not installed in the active "
+                + "environment. Install it under Settings → Python Environments → Install gdsfactory, "
+                + "then export again.";
+
+        return $"Exported {scriptName}, but the GDS run failed — see the Error Console for details.";
     }
 }

--- a/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
@@ -1,0 +1,145 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.GdsFactoryExport;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core;
+using CAP_Core.Export;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Export;
+
+/// <summary>
+/// ViewModel for the gdsfactory export dialog (#581): mode selection (standalone stub
+/// geometry vs. real ubcpdk cells), optional GDS generation through the configured
+/// interpreter, and the list of components without a ubcpdk mapping.
+/// </summary>
+public partial class GdsFactoryExportViewModel : ObservableObject
+{
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly GdsExportService _exportService;
+    private readonly ErrorConsoleService? _errorConsole;
+    private readonly GdsFactoryExporter _exporter = new();
+
+    [ObservableProperty]
+    private bool _useUbcPdkCells;
+
+    [ObservableProperty]
+    private bool _generateGdsEnabled = true;
+
+    [ObservableProperty]
+    private ObservableCollection<string> _unmappedComponents = new();
+
+    [ObservableProperty]
+    private string _statusText = string.Empty;
+
+    [ObservableProperty]
+    private bool _isExporting;
+
+    /// <summary>File dialog service; wired by the UI layer like the other exporters.</summary>
+    public IFileDialogService? FileDialogService { get; set; }
+
+    /// <summary>Initializes a new instance of <see cref="GdsFactoryExportViewModel"/>.</summary>
+    /// <param name="canvas">The design canvas to export.</param>
+    /// <param name="exportService">Script runner used for the optional GDS generation.</param>
+    /// <param name="errorConsole">Optional error logging.</param>
+    public GdsFactoryExportViewModel(
+        DesignCanvasViewModel canvas,
+        GdsExportService exportService,
+        ErrorConsoleService? errorConsole = null)
+    {
+        _canvas = canvas;
+        _exportService = exportService;
+        _errorConsole = errorConsole;
+    }
+
+    /// <summary>
+    /// Recomputes the list of components that would fall back to stub geometry in
+    /// ubcpdk mode. Called when the export dialog opens.
+    /// </summary>
+    public void RefreshUnmappedComponents()
+    {
+        UnmappedComponents.Clear();
+        foreach (var name in GdsFactoryExporter.CollectUnmappedComponents(_canvas))
+            UnmappedComponents.Add(name);
+    }
+
+    /// <summary>Runs the export: file dialog → shadowing guard → script → optional GDS.</summary>
+    [RelayCommand]
+    public async Task Export()
+    {
+        if (FileDialogService == null)
+        {
+            StatusText = "Export not available (no file dialog service).";
+            return;
+        }
+
+        if (_canvas.Components.Count == 0)
+        {
+            StatusText = "Nothing to export — add some components first.";
+            return;
+        }
+
+        var filePath = await FileDialogService.ShowSaveFileDialogAsync(
+            "Export to gdsfactory Python", "py", "Python Files|*.py|All Files|*.*");
+        if (filePath == null)
+            return;
+
+        var stem = Path.GetFileNameWithoutExtension(filePath);
+        if (PythonModuleShadowing.ShadowsPythonModule(stem))
+        {
+            StatusText = $"'{Path.GetFileName(filePath)}' shadows the Python module "
+                + $"'{stem.ToLowerInvariant()}' — please choose a different file name (e.g. chip1.py).";
+            return;
+        }
+
+        await RunExportAsync(filePath);
+    }
+
+    private async Task RunExportAsync(string filePath)
+    {
+        IsExporting = true;
+        try
+        {
+            var options = new GdsFactoryExportOptions(UseUbcPdkCells
+                ? GdsFactoryComponentMode.UbcPdkCells
+                : GdsFactoryComponentMode.StandaloneStubs);
+            await File.WriteAllTextAsync(filePath, _exporter.Export(_canvas, options));
+
+            if (!GenerateGdsEnabled)
+            {
+                StatusText = $"Exported {Path.GetFileName(filePath)} (GDS generation skipped).";
+                return;
+            }
+
+            StatusText = "Running gdsfactory to generate the GDS...";
+            var result = await _exportService.ExportToGdsAsync(filePath, generateGds: true);
+            StatusText = DescribeResult(filePath, result);
+        }
+        catch (Exception ex)
+        {
+            _errorConsole?.LogError($"gdsfactory export failed: {ex.Message}", ex);
+            StatusText = $"Export failed: {ex.Message}";
+        }
+        finally
+        {
+            IsExporting = false;
+        }
+    }
+
+    private string DescribeResult(string filePath, GdsExportService.ExportResult result)
+    {
+        var scriptName = Path.GetFileName(filePath);
+        if (result.Success && result.GdsPath != null)
+            return $"Exported {scriptName} and {Path.GetFileName(result.GdsPath)}.";
+        if (result.Success)
+            return $"Exported {scriptName}.";
+
+        var hint = result.ErrorMessage?.Contains("gdsfactory", StringComparison.OrdinalIgnoreCase) == true
+            ? " Install gdsfactory into the active environment "
+              + "(Settings → Python Environments → Install gdsfactory)."
+            : string.Empty;
+        _errorConsole?.LogError($"gdsfactory GDS generation failed: {result.ErrorMessage}");
+        return $"Exported {scriptName}, but the GDS run failed: {result.ErrorMessage}.{hint}";
+    }
+}

--- a/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentItemViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentItemViewModel.cs
@@ -52,6 +52,8 @@ public partial class PythonEnvironmentItemViewModel : ObservableObject
                 parts.Add($"Nazca {Environment.NazcaVersion}");
             if (Environment.HasPyclipper)
                 parts.Add("pyclipper ✓");
+            if (Environment.GdsFactoryVersion != null)
+                parts.Add($"gdsfactory {Environment.GdsFactoryVersion}");
             if (!string.IsNullOrEmpty(Environment.LastError))
                 parts.Add($"Error: {Environment.LastError}");
             return parts.Count > 0 ? string.Join("  |  ", parts) : string.Empty;

--- a/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
@@ -140,6 +140,28 @@ public partial class PythonEnvironmentManagerViewModel : ObservableObject
         }, env, $"Environment '{name}' is ready.");
     }
 
+    /// <summary>
+    /// Installs gdsfactory + ubcpdk into the selected environment (for the gdsfactory
+    /// export, #581/#622). gdsfactory is optional per environment — the health status
+    /// stays governed by Nazca.
+    /// </summary>
+    [RelayCommand]
+    private async Task InstallGdsFactoryAsync()
+    {
+        var item = SelectedEnvironment;
+        if (item == null) return;
+        var env = item.Environment;
+
+        await RunLongOperationAsync(async ct =>
+        {
+            var progress = CreateProgress(env);
+            var uvPath = await _bootstrapper.EnsureUvAsync(progress, ct);
+            await _installer.InstallGdsFactoryAsync(uvPath, env.VenvPath, progress, ct);
+            await _healthChecker.CheckAsync(env, ct);
+            _registry.AddOrUpdate(env);
+        }, env, $"gdsfactory installed into '{env.Name}'.");
+    }
+
     /// <summary>Re-installs packages into the selected environment (repair).</summary>
     [RelayCommand]
     private async Task RepairAsync()

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -92,6 +92,12 @@ public partial class MainViewModel : ObservableObject
     /// <summary>PhotonTorch format — exposes <c>ShowOptionsDialogAsync</c> for code-behind wiring.</summary>
     public PhotonTorchExportFormat PhotonTorchExportFormat { get; private set; } = null!;
 
+    /// <summary>gdsfactory format — exposes <c>ShowOptionsDialogAsync</c> for code-behind wiring.</summary>
+    public GdsFactoryExportFormat GdsFactoryExportFormat { get; private set; } = null!;
+
+    /// <summary>gdsfactory export options/executor ViewModel (dialog DataContext).</summary>
+    public ViewModels.Export.GdsFactoryExportViewModel GdsFactoryExport { get; private set; } = null!;
+
     /// <summary>Verilog-A format — exposes <c>ShowOptionsDialogAsync</c> for code-behind wiring.</summary>
     public VerilogAExportFormat VerilogAExportFormat { get; private set; } = null!;
 
@@ -103,6 +109,7 @@ public partial class MainViewModel : ObservableObject
             FileOperations.FileDialogService = value;
             FileOperations.PhotonTorchExport.FileDialogService = value;
             FileOperations.VerilogAExport.FileDialogService = value;
+            GdsFactoryExport.FileDialogService = value;
             LeftPanel.FileDialogService = value;
         }
     }
@@ -156,6 +163,7 @@ public partial class MainViewModel : ObservableObject
         PdkOffsetEditorViewModel pdkOffsetEditor,
         ViewModels.Export.PhotonTorchExportViewModel photonTorchExport,
         ViewModels.Export.VerilogAExportViewModel verilogAExport,
+        ViewModels.Export.GdsFactoryExportViewModel gdsFactoryExport,
         ViewModels.Canvas.ChipSizeViewModel chipSize,
         Services.UserSMatrixOverrideStore userSMatrixOverrideStore,
         GdsPreviewRenderService gdsPreviewRenderService,
@@ -185,9 +193,12 @@ public partial class MainViewModel : ObservableObject
         // Build the unified Export menu (add new IExportFormat here for new formats)
         PhotonTorchExportFormat = new PhotonTorchExportFormat();
         VerilogAExportFormat = new VerilogAExportFormat(verilogAExport);
+        GdsFactoryExportFormat = new GdsFactoryExportFormat();
+        GdsFactoryExport = gdsFactoryExport;
         ExportMenu = new ExportMenuViewModel(new IExportFormat[]
         {
             new NazcaExportFormat(FileOperations.ExportNazcaCommand),
+            GdsFactoryExportFormat,
             new SaxExportFormat(FileOperations.ExportSaxCommand),
             PhotonTorchExportFormat,
             VerilogAExportFormat,

--- a/CAP.Avalonia/Views/Dialogs/ExportDialogWiring.cs
+++ b/CAP.Avalonia/Views/Dialogs/ExportDialogWiring.cs
@@ -27,6 +27,14 @@ public static class ExportDialogWiring
         vm.VerilogAExportFormat.ShowOptionsDialogAsync = () =>
             ShowSafelyAsync(vm, owner, errorConsole, "Verilog-A",
                 () => new VerilogAExportDialog { DataContext = vm.VerilogAExportFormat.OptionsViewModel });
+
+        vm.GdsFactoryExportFormat.ShowOptionsDialogAsync = () =>
+        {
+            // Recompute the stub-fallback list against the current canvas on every open.
+            vm.GdsFactoryExport.RefreshUnmappedComponents();
+            return ShowSafelyAsync(vm, owner, errorConsole, "gdsfactory",
+                () => new GdsFactoryExportDialog { DataContext = vm.GdsFactoryExport });
+        };
     }
 
     private static async Task ShowSafelyAsync(MainViewModel vm, Window owner, ErrorConsoleService? errorConsole, string formatName, Func<Window> dialogFactory)

--- a/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml
+++ b/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml
@@ -1,0 +1,75 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:CAP.Avalonia.ViewModels.Export"
+        x:Class="CAP.Avalonia.Views.Dialogs.GdsFactoryExportDialog"
+        x:DataType="vm:GdsFactoryExportViewModel"
+        Title="Export — gdsfactory"
+        Width="440" Height="420"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#1e1e1e"
+        Foreground="White">
+
+    <DockPanel Margin="16" LastChildFill="True">
+
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
+            <Button Content="Export…"
+                    Command="{Binding ExportCommand}"
+                    Width="90" Background="#3d5d4d"
+                    IsEnabled="{Binding IsExporting, Converter={x:Static BoolConverters.Not}}"/>
+            <Button Content="Close" x:Name="CloseButton" Width="70" Click="OnCloseClicked"/>
+        </StackPanel>
+
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="10">
+                <TextBlock Text="🏭 gdsfactory Export" FontSize="15" FontWeight="SemiBold"
+                           Foreground="LightGreen"/>
+                <TextBlock Text="Exports the design as a gdsfactory Python script; optionally runs it with the configured Python to produce the GDS."
+                           Foreground="Gray" FontSize="10" TextWrapping="Wrap"/>
+
+                <Separator Background="#3d3d3d"/>
+
+                <TextBlock Text="Component geometry:" Foreground="Gray" FontSize="11"/>
+                <RadioButton GroupName="mode"
+                             Content="Standalone — stub geometry from Lunima dimensions"
+                             IsChecked="{Binding !UseUbcPdkCells}"
+                             Foreground="White" FontSize="12"/>
+                <TextBlock Text="Runs with a plain gdsfactory install; layout matches the canvas 1:1 (like the Nazca export)."
+                           Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="24,0,0,0"/>
+                <RadioButton GroupName="mode"
+                             Content="ubcpdk (SiEPIC) — real PDK cells where available"
+                             IsChecked="{Binding UseUbcPdkCells}"
+                             Foreground="White" FontSize="12"/>
+                <TextBlock Text="Requires the ubcpdk package; components without a ubcpdk equivalent fall back to stub geometry."
+                           Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="24,0,0,0"/>
+
+                <!-- Components without a ubcpdk mapping (relevant in ubcpdk mode) -->
+                <Border Background="#2a2a20" CornerRadius="4" Padding="8"
+                        IsVisible="{Binding UnmappedComponents.Count}">
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="Without ubcpdk mapping (stub fallback):"
+                                   Foreground="#e8c872" FontSize="11" FontWeight="SemiBold"/>
+                        <ItemsControl ItemsSource="{Binding UnmappedComponents}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}" Foreground="Gray" FontSize="10"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+
+                <Separator Background="#3d3d3d"/>
+
+                <CheckBox Content="Generate GDS after export (requires Python + gdsfactory)"
+                          IsChecked="{Binding GenerateGdsEnabled}"
+                          Foreground="White" FontSize="12"/>
+
+                <TextBlock Text="{Binding StatusText}"
+                           Foreground="LightSkyBlue" FontSize="11" TextWrapping="Wrap"
+                           IsVisible="{Binding StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml.cs
+++ b/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace CAP.Avalonia.Views.Dialogs;
+
+/// <summary>Options dialog for the gdsfactory export (#581).</summary>
+public partial class GdsFactoryExportDialog : Window
+{
+    /// <summary>Initializes a new instance of <see cref="GdsFactoryExportDialog"/>.</summary>
+    public GdsFactoryExportDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void OnCloseClicked(object? sender, RoutedEventArgs e) => Close();
+}

--- a/CAP.Avalonia/Views/Panels/PythonEnvironmentManagerPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/PythonEnvironmentManagerPanel.axaml
@@ -58,6 +58,12 @@
                         Width="70" Background="#5d4d3d" FontSize="11"
                         IsEnabled="{Binding IsBusy,
                                             Converter={x:Static BoolConverters.Not}}"/>
+                <Button Content="Install gdsfactory"
+                        Command="{Binding InstallGdsFactoryCommand}"
+                        Background="#3d5d4d" FontSize="11"
+                        ToolTip.Tip="Install gdsfactory + ubcpdk into this environment (needed for the gdsfactory export)"
+                        IsEnabled="{Binding IsBusy,
+                                            Converter={x:Static BoolConverters.Not}}"/>
                 <Button Content="Remove"
                         Command="{Binding RemoveCommand}"
                         Width="70" Background="#5d3d3d" FontSize="11"

--- a/CAP.Avalonia/Views/SettingsWindow.axaml
+++ b/CAP.Avalonia/Views/SettingsWindow.axaml
@@ -142,10 +142,11 @@
                             <TextBlock Text="GDS Export" FontSize="18" FontWeight="SemiBold" Foreground="White" Margin="0,0,0,8"/>
                             <TextBlock Foreground="Gray" FontSize="11" TextWrapping="Wrap" Margin="0,0,0,4">
                                 Configures how the "Export" top-toolbar action generates a GDS file
-                                from the exported Nazca Python script.
+                                from the exported Nazca Python script. The gdsfactory export is a separate
+                                Export-menu entry; install gdsfactory below via "Install gdsfactory".
                             </TextBlock>
 
-                            <CheckBox Content="Generate GDS file after Nazca export (requires Python + Nazca)"
+                            <CheckBox Content="Generate GDS file after Nazca export (Nazca export requires Python + Nazca; gdsfactory export requires gdsfactory)"
                                       IsChecked="{Binding GenerateGdsEnabled}"
                                       Foreground="White" Margin="0,4,0,0"/>
 

--- a/Connect-A-Pic-Core/Export/PythonEnvironmentManager/EnvironmentHealthChecker.cs
+++ b/Connect-A-Pic-Core/Export/PythonEnvironmentManager/EnvironmentHealthChecker.cs
@@ -56,6 +56,7 @@ public class EnvironmentHealthChecker
         }
 
         env.HasPyclipper = await CheckPyclipperAsync(pythonExe, ct);
+        env.GdsFactoryVersion = await ProbeGdsFactoryVersionAsync(pythonExe, ct);
 
         env.Status = PythonEnvironmentStatus.Healthy;
         env.LastError = null;
@@ -68,6 +69,32 @@ public class EnvironmentHealthChecker
     {
         env.Status = PythonEnvironmentStatus.Broken;
         env.LastError = reason;
+    }
+
+    /// <summary>
+    /// Returns the installed gdsfactory version, or null when it is not importable.
+    /// gdsfactory is optional — its absence never marks the environment broken.
+    /// </summary>
+    private async Task<string?> ProbeGdsFactoryVersionAsync(string pythonPath, CancellationToken ct)
+    {
+        try
+        {
+            var (exitCode, output, _) = await UvBootstrapper.RunProcessAsync(
+                _launchFactory,
+                pythonPath,
+                new[] { "-c", "import gdsfactory; print(gdsfactory.__version__)" },
+                ct,
+                timeoutMs: 30_000);
+            return exitCode == 0 && !string.IsNullOrWhiteSpace(output) ? output.Trim() : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private async Task<bool> CheckPyclipperAsync(string pythonPath, CancellationToken ct)

--- a/Connect-A-Pic-Core/Export/PythonEnvironmentManager/NazcaPackageInstaller.cs
+++ b/Connect-A-Pic-Core/Export/PythonEnvironmentManager/NazcaPackageInstaller.cs
@@ -48,6 +48,26 @@ public class NazcaPackageInstaller
         }
     }
 
+    /// <summary>
+    /// Installs gdsfactory + ubcpdk (both on PyPI) into the given venv — the packages
+    /// needed to run the gdsfactory export (#581). Surfaces pip stderr on failure.
+    /// </summary>
+    /// <param name="uvPath">Absolute path to the uv binary.</param>
+    /// <param name="venvPath">Root directory of the target virtual environment.</param>
+    /// <param name="progress">Receives human-readable status updates.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task InstallGdsFactoryAsync(
+        string uvPath,
+        string venvPath,
+        IProgress<string>? progress,
+        CancellationToken ct = default)
+    {
+        progress?.Report("Installing gdsfactory + ubcpdk (this can take a few minutes)...");
+        await RunUvPipInstall(uvPath, venvPath, "gdsfactory", progress, ct);
+        await RunUvPipInstall(uvPath, venvPath, "ubcpdk", progress, ct);
+        progress?.Report("gdsfactory installed successfully.");
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────
 
     private static async Task<string> DownloadNazcaTarballAsync(

--- a/Connect-A-Pic-Core/Export/PythonEnvironmentManager/PythonEnvironment.cs
+++ b/Connect-A-Pic-Core/Export/PythonEnvironmentManager/PythonEnvironment.cs
@@ -23,6 +23,9 @@ public class PythonEnvironment
     /// <summary>Detected Nazca version, e.g. "0.6.1". Null if not installed.</summary>
     public string? NazcaVersion { get; set; }
 
+    /// <summary>Detected gdsfactory version, e.g. "9.34.2". Null if not installed.</summary>
+    public string? GdsFactoryVersion { get; set; }
+
     /// <summary>True when pyclipper is importable in this environment.</summary>
     public bool HasPyclipper { get; set; }
 

--- a/UnitTests/Export/ExportMenuViewModelTests.cs
+++ b/UnitTests/Export/ExportMenuViewModelTests.cs
@@ -204,14 +204,15 @@ public class ExportMenuViewModelTests
     }
 
     [Fact]
-    public void MainViewModel_ExportMenu_HasFourFormatsInExpectedOrder()
+    public void MainViewModel_ExportMenu_HasFiveFormatsInExpectedOrder()
     {
         var vm = MainViewModelTestHelper.CreateMainViewModel();
 
-        vm.ExportMenu.Formats.Count.ShouldBe(4);
+        vm.ExportMenu.Formats.Count.ShouldBe(5);
         vm.ExportMenu.Formats.Select(f => f.Name).ShouldBe(new[]
         {
             "Nazca Python + GDS",
+            "gdsfactory",
             "SAX (Simphony)",
             "PhotonTorch",
             "Verilog-A / SPICE",

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
@@ -86,6 +86,31 @@ public class GdsFactoryExportViewModelTests
     }
 
     [Fact]
+    public void BuildFailureMessage_MissingGdsFactory_GuidesToInstallWithoutTraceback()
+    {
+        var traceback = "Python script execution failed (exit code 1): Traceback ...\n"
+            + "ModuleNotFoundError: No module named 'gdsfactory'";
+
+        var msg = GdsFactoryExportViewModel.BuildFailureMessage("test.py", traceback);
+
+        msg.ShouldContain("gdsfactory is not installed");
+        msg.ShouldContain("Install gdsfactory");
+        msg.ShouldNotContain("Traceback");         // no raw error in the dialog line
+        msg.ShouldNotContain("ModuleNotFoundError");
+    }
+
+    [Fact]
+    public void BuildFailureMessage_OtherError_PointsToErrorConsoleWithoutTraceback()
+    {
+        var msg = GdsFactoryExportViewModel.BuildFailureMessage(
+            "test.py", "Traceback ...\nSomeOtherError: boom");
+
+        msg.ShouldContain("Error Console");
+        msg.ShouldNotContain("Traceback");
+        msg.ShouldNotContain("boom");
+    }
+
+    [Fact]
     public void RefreshUnmappedComponents_ListsOnlyUnmapped()
     {
         var vm = new GdsFactoryExportViewModel(CanvasWithComponent("ebeam_dc_te1550"), new GdsExportService());

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
@@ -1,0 +1,97 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP_Core.Export;
+using Shouldly;
+
+namespace UnitTests.Export.GdsFactoryExport;
+
+/// <summary>Tests for the gdsfactory export dialog ViewModel (#581).</summary>
+public class GdsFactoryExportViewModelTests
+{
+    private sealed class FixedPathFileDialog : IFileDialogService
+    {
+        private readonly string? _path;
+        public FixedPathFileDialog(string? path) => _path = path;
+
+        public Task<string?> ShowSaveFileDialogAsync(string title, string defaultExtension, string filters) =>
+            Task.FromResult(_path);
+
+        public Task<string?> ShowOpenFileDialogAsync(string title, string filters) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private static DesignCanvasViewModel CanvasWithComponent(string nazcaFunction)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var component = TestComponentFactory.CreateBasicComponent();
+        component.Identifier = "C1";
+        component.NazcaFunctionName = nazcaFunction;
+        canvas.AddComponent(component, nazcaFunction);
+        return canvas;
+    }
+
+    [Fact]
+    public async Task Export_EmptyCanvas_ExplainsAndWritesNothing()
+    {
+        var vm = new GdsFactoryExportViewModel(new DesignCanvasViewModel(), new GdsExportService())
+        {
+            FileDialogService = new FixedPathFileDialog("unused.py"),
+        };
+
+        await vm.ExportCommand.ExecuteAsync(null);
+
+        vm.StatusText.ShouldContain("Nothing to export");
+    }
+
+    [Fact]
+    public async Task Export_ShadowingFileName_IsRefused()
+    {
+        var scriptPath = Path.Combine(Path.GetTempPath(), "re.py");
+        var vm = new GdsFactoryExportViewModel(CanvasWithComponent("ebeam_y_1550"), new GdsExportService())
+        {
+            FileDialogService = new FixedPathFileDialog(scriptPath),
+        };
+
+        await vm.ExportCommand.ExecuteAsync(null);
+
+        File.Exists(scriptPath).ShouldBeFalse();
+        vm.StatusText.ShouldContain("shadows");
+    }
+
+    [Fact]
+    public async Task Export_WithoutGdsGeneration_WritesScriptInSelectedMode()
+    {
+        var scriptPath = Path.Combine(Path.GetTempPath(), $"gfvm-{Guid.NewGuid():N}.py");
+        try
+        {
+            var vm = new GdsFactoryExportViewModel(CanvasWithComponent("ebeam_y_1550"), new GdsExportService())
+            {
+                FileDialogService = new FixedPathFileDialog(scriptPath),
+                GenerateGdsEnabled = false,
+                UseUbcPdkCells = true,
+            };
+
+            await vm.ExportCommand.ExecuteAsync(null);
+
+            File.Exists(scriptPath).ShouldBeTrue();
+            var script = await File.ReadAllTextAsync(scriptPath);
+            script.ShouldContain("gf.get_component('ebeam_y_1550')");   // ubcpdk mode was honored
+            vm.StatusText.ShouldContain("GDS generation skipped");
+        }
+        finally
+        {
+            if (File.Exists(scriptPath)) File.Delete(scriptPath);
+        }
+    }
+
+    [Fact]
+    public void RefreshUnmappedComponents_ListsOnlyUnmapped()
+    {
+        var vm = new GdsFactoryExportViewModel(CanvasWithComponent("ebeam_dc_te1550"), new GdsExportService());
+
+        vm.RefreshUnmappedComponents();
+
+        vm.UnmappedComponents.ShouldBe(new[] { "ebeam_dc_te1550" });
+    }
+}

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryExporterTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryExporterTests.cs
@@ -1,0 +1,171 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Export;
+using CAP_Core.Routing;
+using Shouldly;
+
+namespace UnitTests.Export.GdsFactoryExport;
+
+/// <summary>
+/// Tests for the gdsfactory script generator (#581). The emitted script mirrors the
+/// Nazca exporter's coordinate contract (both targets are Y-up), so expected values
+/// are derived from <see cref="NazcaCoordinateMapper"/> in the tests themselves.
+/// </summary>
+public class GdsFactoryExporterTests
+{
+    private static DesignCanvasViewModel CreateCanvasWithComponent(
+        string nazcaFunction, string identifier = "C1")
+    {
+        var canvas = new DesignCanvasViewModel();
+        var component = TestComponentFactory.CreateBasicComponent();
+        component.Identifier = identifier;
+        component.NazcaFunctionName = nazcaFunction;
+        component.PhysicalX = 30;
+        component.PhysicalY = 20;
+        component.RotationDegrees = 0;
+        component.PhysicalPins.Add(new CAP_Core.Components.Core.PhysicalPin
+        {
+            Name = "opt1",
+            ParentComponent = component,
+            OffsetXMicrometers = 0,
+            OffsetYMicrometers = 5,
+            AngleDegrees = 180,
+        });
+        canvas.AddComponent(component, nazcaFunction);
+        return canvas;
+    }
+
+    private static string ExportStandalone(DesignCanvasViewModel canvas) =>
+        new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs));
+
+    private static string ExportUbcPdk(DesignCanvasViewModel canvas) =>
+        new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells));
+
+    [Fact]
+    public void Export_Standalone_HasGdsFactoryHeaderWithoutPdkActivation()
+    {
+        var script = ExportStandalone(CreateCanvasWithComponent("ebeam_y_1550"));
+
+        script.ShouldContain("import gdsfactory as gf");
+        script.ShouldNotContain("ubcpdk");
+        script.ShouldContain("gf.gpdk.PDK.activate()");   // generic PDK for stub geometry
+    }
+
+    [Fact]
+    public void Export_Standalone_EmitsStubWithPolygonAndPorts()
+    {
+        var canvas = CreateCanvasWithComponent("ebeam_y_1550");
+        var script = ExportStandalone(canvas);
+
+        script.ShouldContain("def stub_ebeam_y_1550(");
+        script.ShouldContain("add_polygon(");
+        script.ShouldContain("add_port(");
+        script.ShouldContain("c.add_ref(stub_ebeam_y_1550(");
+    }
+
+    [Fact]
+    public void Export_PlacementUsesCoordinateMapperContract()
+    {
+        var canvas = CreateCanvasWithComponent("ebeam_y_1550");
+        var comp = canvas.Components.Single().Component;
+        var placement = NazcaCoordinateMapper.GetCellPlacement(comp, rawOverrideAnchor: null);
+        var script = ExportStandalone(canvas);
+
+        script.ShouldContain($".rotate({placement.RotationDegrees.ToString("F0", System.Globalization.CultureInfo.InvariantCulture)}");
+        script.ShouldContain($".move(({placement.X.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)}, "
+                             + placement.Y.ToString("F2", System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Export_FooterWritesGdsNextToScript()
+    {
+        var script = ExportStandalone(CreateCanvasWithComponent("ebeam_y_1550"));
+
+        script.ShouldContain("os.path.splitext(");
+        script.ShouldContain(".gds'");
+        script.ShouldContain("write_gds(");
+        script.ShouldContain("GDS exported to:");
+    }
+
+    [Fact]
+    public void Export_AnalysisToolsAreSkipped()
+    {
+        var canvas = CreateCanvasWithComponent("ebeam_y_1550");
+        var tool = TestComponentFactory.CreateBasicComponent();
+        tool.Identifier = "PWR1";
+        tool.NazcaFunctionName = CAP_Core.Components.Core.Component.AnalysisToolNazcaSentinel;
+        canvas.AddComponent(tool, "PowerMeter");
+
+        var script = ExportStandalone(canvas);
+
+        script.ShouldNotContain("PWR1");
+    }
+
+    [Fact]
+    public void Export_UbcPdkMode_UsesRealCellForMappedComponents()
+    {
+        var script = ExportUbcPdk(CreateCanvasWithComponent("ebeam_y_1550"));
+
+        script.ShouldContain("from ubcpdk import PDK");
+        script.ShouldContain("PDK.activate()");
+        script.ShouldContain("gf.get_component('ebeam_y_1550')");
+        script.ShouldNotContain("def stub_ebeam_y_1550(");
+    }
+
+    [Fact]
+    public void Export_UbcPdkMode_FallsBackToStubForUnmappedComponents()
+    {
+        var script = ExportUbcPdk(CreateCanvasWithComponent("ebeam_dc_te1550"));
+
+        script.ShouldContain("def stub_ebeam_dc_te1550(");
+        script.ShouldNotContain("gf.get_component('ebeam_dc_te1550')");
+    }
+
+    [Fact]
+    public void CollectUnmappedComponents_ListsOnlyComponentsWithoutUbcPdkCell()
+    {
+        var canvas = CreateCanvasWithComponent("ebeam_y_1550", "A");
+        var unmappedComp = TestComponentFactory.CreateBasicComponent();
+        unmappedComp.Identifier = "B";
+        unmappedComp.NazcaFunctionName = "ebeam_dc_te1550";
+        canvas.AddComponent(unmappedComp, "DC");
+
+        var unmapped = GdsFactoryExporter.CollectUnmappedComponents(canvas);
+
+        unmapped.ShouldBe(new[] { "ebeam_dc_te1550" });
+    }
+
+    [Fact]
+    public void SegmentWriter_StraightSegment_EmitsAbsolutelyPlacedStraight()
+    {
+        // App (10,20) → (60,20) horizontal; gds space negates Y.
+        var segment = new StraightSegment(10, 20, 60, 20, 0);
+        var sb = new System.Text.StringBuilder();
+
+        GdsFactorySegmentWriter.AppendSegments(sb, new PathSegment[] { segment });
+        var script = sb.ToString();
+
+        script.ShouldContain("gf.components.straight(length=50.00");
+        script.ShouldContain(".move((10.00, -20.00))");
+    }
+
+    [Fact]
+    public void SegmentWriter_BendSegment_EmitsBendCircularWithNegatedAngles()
+    {
+        var bend = new BendSegment(centerX: 0, centerY: 0, radius: 25, startAngle: 90, sweepAngle: -90)
+        {
+            StartPoint = (10, 20),
+            EndPoint = (35, 45),
+        };
+        var sb = new System.Text.StringBuilder();
+
+        GdsFactorySegmentWriter.AppendSegments(sb, new PathSegment[] { bend });
+        var script = sb.ToString();
+
+        script.ShouldContain("gf.components.bend_circular(radius=25.00, angle=90.00");
+        script.ShouldContain(".rotate(-90.00)");
+        script.ShouldContain(".move((10.00, -20.00))");
+    }
+}

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryScriptExecutionTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryScriptExecutionTests.cs
@@ -1,0 +1,74 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Export;
+using Shouldly;
+
+namespace UnitTests.Export.GdsFactoryExport;
+
+/// <summary>
+/// End-to-end: runs the generated gdsfactory script with a real Python and asserts a
+/// GDS file is produced. Skips silently when no gdsfactory-capable interpreter is
+/// available (CI without the ground-truth env). Locally, create one via
+/// <c>%LOCALAPPDATA%\Lunima\tools\uv.exe venv %TEMP%\gf-groundtruth --python 3.12</c>
+/// + <c>uv pip install gdsfactory ubcpdk</c>.
+/// </summary>
+public class GdsFactoryScriptExecutionTests
+{
+    private static string? FindGdsFactoryPython()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(Path.GetTempPath(), "gf-groundtruth", "Scripts", "python.exe"),
+            Path.Combine(Path.GetTempPath(), "gf-groundtruth", "bin", "python"),
+        };
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    [Fact]
+    public async Task StandaloneScript_RunsAndProducesGds()
+    {
+        var python = FindGdsFactoryPython();
+        if (python == null) return;   // environment not available — covered locally
+
+        var canvas = new DesignCanvasViewModel();
+        var component = TestComponentFactory.CreateBasicComponent();
+        component.Identifier = "Y1";
+        component.NazcaFunctionName = "ebeam_y_1550";
+        component.PhysicalX = 10;
+        component.PhysicalY = 20;
+        component.PhysicalPins.Add(new CAP_Core.Components.Core.PhysicalPin
+        {
+            Name = "opt1",
+            ParentComponent = component,
+            OffsetXMicrometers = 0,
+            OffsetYMicrometers = 5,
+            AngleDegrees = 180,
+        });
+        canvas.AddComponent(component, "YBranch");
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs));
+
+        var dir = Path.Combine(Path.GetTempPath(), $"gf-e2e-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var scriptPath = Path.Combine(dir, "design.py");
+        var gdsPath = Path.Combine(dir, "design.gds");
+        try
+        {
+            await File.WriteAllTextAsync(scriptPath, script);
+
+            var factory = ProcessLaunchFactory.CreateDefault();
+            var (exitCode, _, stderr) = await CAP_Core.Export.PythonEnvironmentManager.UvBootstrapper
+                .RunProcessAsync(factory, python, new[] { scriptPath },
+                    CancellationToken.None, timeoutMs: 180_000);
+
+            exitCode.ShouldBe(0, $"script must run cleanly.\nstderr:\n{stderr}");
+            File.Exists(gdsPath).ShouldBeTrue();
+            new FileInfo(gdsPath).Length.ShouldBeGreaterThan(0);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryScriptExecutionTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryScriptExecutionTests.cs
@@ -24,14 +24,10 @@ public class GdsFactoryScriptExecutionTests
         return candidates.FirstOrDefault(File.Exists);
     }
 
-    [Fact]
-    public async Task StandaloneScript_RunsAndProducesGds()
+    private static DesignCanvasViewModel CreateSingleComponentCanvas(out CAP_Core.Components.Core.Component component)
     {
-        var python = FindGdsFactoryPython();
-        if (python == null) return;   // environment not available — covered locally
-
         var canvas = new DesignCanvasViewModel();
-        var component = TestComponentFactory.CreateBasicComponent();
+        component = TestComponentFactory.CreateBasicComponent();
         component.Identifier = "Y1";
         component.NazcaFunctionName = "ebeam_y_1550";
         component.PhysicalX = 10;
@@ -45,7 +41,22 @@ public class GdsFactoryScriptExecutionTests
             AngleDegrees = 180,
         });
         canvas.AddComponent(component, "YBranch");
+        return canvas;
+    }
 
+    private static async Task<(int exitCode, string output, string stderr)> RunPythonAsync(
+        string python, params string[] args) =>
+        await CAP_Core.Export.PythonEnvironmentManager.UvBootstrapper.RunProcessAsync(
+            ProcessLaunchFactory.CreateDefault(), python, args,
+            CancellationToken.None, timeoutMs: 300_000);
+
+    [Fact]
+    public async Task StandaloneScript_RunsAndGdsGeometryLandsOnThePlacementContract()
+    {
+        var python = FindGdsFactoryPython();
+        if (python == null) return;   // environment not available — covered locally
+
+        var canvas = CreateSingleComponentCanvas(out var component);
         var script = new GdsFactoryExporter().Export(
             canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs));
 
@@ -56,13 +67,66 @@ public class GdsFactoryScriptExecutionTests
         try
         {
             await File.WriteAllTextAsync(scriptPath, script);
-
-            var factory = ProcessLaunchFactory.CreateDefault();
-            var (exitCode, _, stderr) = await CAP_Core.Export.PythonEnvironmentManager.UvBootstrapper
-                .RunProcessAsync(factory, python, new[] { scriptPath },
-                    CancellationToken.None, timeoutMs: 180_000);
-
+            var (exitCode, _, stderr) = await RunPythonAsync(python, scriptPath);
             exitCode.ShouldBe(0, $"script must run cleanly.\nstderr:\n{stderr}");
+            File.Exists(gdsPath).ShouldBeTrue();
+
+            // Geometry check with the same engine that wrote the file: the stub rectangle's
+            // world bbox must match the NazcaCoordinateMapper placement contract.
+            var placement = NazcaCoordinateMapper.GetCellPlacement(component, rawOverrideAnchor: null);
+            var expected = (
+                X0: placement.X - component.NazcaOriginOffsetX,
+                Y0: placement.Y + component.NazcaOriginOffsetY - component.HeightMicrometers,
+                X1: placement.X - component.NazcaOriginOffsetX + component.WidthMicrometers,
+                Y1: placement.Y + component.NazcaOriginOffsetY);
+
+            // Select the design cell by name — gdsfactory also writes a top-level
+            // $$$CONTEXT_INFO$$$ metadata cell whose bbox ignores placements.
+            var (bboxExit, bboxOut, bboxErr) = await RunPythonAsync(python, "-c",
+                $"import gdstk; lib = gdstk.read_gds(r'{gdsPath}'); "
+                + "top = [c for c in lib.cells if c.name == 'ConnectAPIC_Design'][0]; "
+                + "b = top.bounding_box(); "
+                + "print(f'{b[0][0]:.2f};{b[0][1]:.2f};{b[1][0]:.2f};{b[1][1]:.2f}')");
+            bboxExit.ShouldBe(0, $"bbox probe must run.\nstderr:\n{bboxErr}");
+
+            var parts = bboxOut.Trim().Split(';');
+            double.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture).ShouldBe(expected.X0, 0.01);
+            double.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture).ShouldBe(expected.Y0, 0.01);
+            double.Parse(parts[2], System.Globalization.CultureInfo.InvariantCulture).ShouldBe(expected.X1, 0.01);
+            double.Parse(parts[3], System.Globalization.CultureInfo.InvariantCulture).ShouldBe(expected.Y1, 0.01);
+        }
+        finally
+        {
+            var debugDir = Environment.GetEnvironmentVariable("GF_E2E_DEBUG_DIR");
+            if (!string.IsNullOrEmpty(debugDir))
+            {
+                Directory.CreateDirectory(debugDir);
+                foreach (var f in Directory.GetFiles(dir))
+                    File.Copy(f, Path.Combine(debugDir, Path.GetFileName(f)), overwrite: true);
+            }
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UbcPdkScript_RunsWithRealSiepicCellAndProducesGds()
+    {
+        var python = FindGdsFactoryPython();
+        if (python == null) return;   // environment not available — covered locally
+
+        var canvas = CreateSingleComponentCanvas(out _);
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells));
+
+        var dir = Path.Combine(Path.GetTempPath(), $"gf-e2e-ubc-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var scriptPath = Path.Combine(dir, "design.py");
+        var gdsPath = Path.Combine(dir, "design.gds");
+        try
+        {
+            await File.WriteAllTextAsync(scriptPath, script);
+            var (exitCode, _, stderr) = await RunPythonAsync(python, scriptPath);
+            exitCode.ShouldBe(0, $"ubcpdk script must run cleanly.\nstderr:\n{stderr}");
             File.Exists(gdsPath).ShouldBeTrue();
             new FileInfo(gdsPath).Length.ShouldBeGreaterThan(0);
         }

--- a/UnitTests/Export/GdsFactoryExport/UbcPdkCellMapTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/UbcPdkCellMapTests.cs
@@ -1,0 +1,50 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
+using Shouldly;
+
+namespace UnitTests.Export.GdsFactoryExport;
+
+/// <summary>
+/// Tests for the nazcaFunction → ubcpdk cell-name mapping. The exact-hit list and
+/// the renames were verified against a real install (gdsfactory 9.34.2 + ubcpdk 3.3.4,
+/// see docs/superpowers/specs/2026-07-02-gdsfactory-export-design.md).
+/// </summary>
+public class UbcPdkCellMapTests
+{
+    [Theory]
+    [InlineData("ebeam_y_1550")]
+    [InlineData("ebeam_bdc_te1550")]
+    [InlineData("ebeam_crossing4")]
+    [InlineData("ebeam_gc_te1550")]
+    [InlineData("GC_TE_1550_8degOxide_BB")]
+    [InlineData("ebeam_MMI_2x2_5050_te1310")]
+    [InlineData("crossing_horizontal")]
+    [InlineData("taper_si_simm_1550")]
+    public void MapToUbcPdkCell_VerbatimUbcPdkNames_MapIdentically(string name)
+    {
+        UbcPdkCellMap.MapToUbcPdkCell(name).ShouldBe(name);
+    }
+
+    [Theory]
+    [InlineData("ebeam_DC_2-1_te895", "ebeam_DC_2m1_te895")]
+    [InlineData("ebeam_routing_taper_te1550_w=500nm_to_w=3000nm_L=20um",
+                "ebeam_routing_taper_te1550_w500nm_to_w3000nm_L20um")]
+    [InlineData("ebeam_routing_taper_te1550_w=500nm_to_w=3000nm_L=40um",
+                "ebeam_routing_taper_te1550_w500nm_to_w3000nm_L40um")]
+    public void MapToUbcPdkCell_KnownRenames_MapToUbcPdkSpelling(string nazca, string expected)
+    {
+        UbcPdkCellMap.MapToUbcPdkCell(nazca).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("ebeam_dc_te1550")]                 // kein ubcpdk-Pendant (nur bdc)
+    [InlineData("ebeam_dc_halfring_straight")]
+    [InlineData("ebeam_taper_te1550")]
+    [InlineData("contra_directional_coupler")]
+    [InlineData("demo_pdk.ring_resonator")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void MapToUbcPdkCell_UnknownNames_ReturnNull(string? name)
+    {
+        UbcPdkCellMap.MapToUbcPdkCell(name).ShouldBeNull();
+    }
+}

--- a/UnitTests/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModelTests.cs
+++ b/UnitTests/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModelTests.cs
@@ -140,6 +140,31 @@ public class PythonEnvironmentManagerViewModelTests : IDisposable
         registry.GetAll().ShouldBeEmpty();                   // nichts registriert
     }
 
+    [Fact]
+    public async Task InstallGdsFactory_NoSelection_IsIgnored()
+    {
+        var registry = CreateRegistry();
+        var vm = CreateViewModel(registry);
+
+        await vm.InstallGdsFactoryCommand.ExecuteAsync(null);
+
+        vm.IsBusy.ShouldBeFalse();
+        registry.GetAll().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GdsFactoryVersion_RoundTripsThroughRegistryPersistence()
+    {
+        var registry = CreateRegistry();
+        var env = MakeEnv("gf-env");
+        env.GdsFactoryVersion = "9.34.2";
+        registry.AddOrUpdate(env);
+
+        var reloaded = new PythonEnvironmentRegistry(_tempRegistryFile);
+
+        reloaded.GetAll().Single().GdsFactoryVersion.ShouldBe("9.34.2");
+    }
+
     private static PythonEnvironment MakeEnv(string name) => new()
     {
         Name = name,

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -63,6 +63,7 @@ public static class MainViewModelTestHelper
             Mock.Of<IUrlLauncher>());
         var photonTorchVm = new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas);
         var verilogAVm = new VerilogAExportViewModel(new VerilogAExporter(), new VerilogAFileWriter(), canvas);
+        var gdsFactoryVm = new GdsFactoryExportViewModel(canvas, new GdsExportService(), errorConsoleService);
 
         return new MainViewModel(
             canvas,
@@ -83,6 +84,7 @@ public static class MainViewModelTestHelper
             new PdkOffsetEditorViewModel(pdkLoader, new PdkJsonSaver(), new PdkManagerViewModel()),
             photonTorchVm,
             verilogAVm,
+            gdsFactoryVm,
             new CAP.Avalonia.ViewModels.Canvas.ChipSizeViewModel(preferencesService, canvas),
             // Test-isolated user S-matrix store: a unique temp path per call so
             // tests don't contaminate each other or the developer's real file.

--- a/docs/superpowers/plans/2026-07-02-gdsfactory-export.md
+++ b/docs/superpowers/plans/2026-07-02-gdsfactory-export.md
@@ -1,0 +1,69 @@
+# gdsfactory-Export (Issue #581) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans.
+> Spec: `docs/superpowers/specs/2026-07-02-gdsfactory-export-design.md` — alle
+> Code-Kontrakte (Script-Aufbau, Koordinaten, Mapping) stehen dort und gelten verbatim.
+
+**Goal:** gdsfactory als zweiter Layout-Emitter neben Nazca (Export .py + GDS),
+mit Modus-Auswahl-UI (Standalone-Stubs / ubcpdk-SiEPIC) und gdsfactory-Installation
+in verwaltete Environments.
+
+**Branch:** `feat/gdsfactory-export-581` · Tests via
+`$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" <Pattern>`.
+
+## Global Constraints
+
+- Kein `new ProcessStartInfo`/`Process.Start("` (Architektur-Test); Skript-Läufe
+  über den bestehenden `GdsExportService`-Pfad (inkl. `PYTHONSAFEPATH`).
+- Max 250 Zeilen pro neuer Datei; XML-Doku; `CultureInfo.InvariantCulture` für
+  alle emittierten Zahlen.
+- Ground-Truth-Umgebung für lokale E2E-Läufe: `%TEMP%\gf-groundtruth`
+  (gdsfactory 9.34.2 + ubcpdk 3.3.4; neu erzeugbar via
+  `%LOCALAPPDATA%\Lunima\tools\uv.exe venv … && uv pip install gdsfactory ubcpdk`).
+
+### Task 1: UbcPdkCellMap + Tests
+`CAP.Avalonia/Services/GdsFactoryExport/UbcPdkCellMap.cs`:
+`static string? MapToUbcPdkCell(string nazcaFunction)` — identisch, wenn der Name
+in der verifizierten 35er-Liste (Spec) liegt; Renames:
+`ebeam_DC_2-1_te895→ebeam_DC_2m1_te895`,
+`ebeam_routing_taper_te1550_w=500nm_to_w=3000nm_L=20um→…w500nm_to_w3000nm_L20um`
+(analog L=40um); sonst null. TDD: exakte Treffer, Renames, Fallback-null.
+
+### Task 2: Skript-Generator (Stub-Modus) + Tests
+`GdsFactoryExporter.Export(DesignCanvasViewModel canvas, GdsFactoryExportOptions options)`
+mit `record GdsFactoryExportOptions(GdsFactoryComponentMode Mode)` und
+`enum GdsFactoryComponentMode { StandaloneStubs, UbcPdkCells }`.
+Aufbau exakt nach Spec (Header/Stubs/Placements/Segmente/Footer);
+`GdsFactoryStubWriter` und `GdsFactorySegmentWriter` als Hilfsklassen.
+Wiederverwendet `NazcaCoordinateMapper` (GetCellPlacement, GetPinNazcaPosition,
+GetStubAnchor, GetUnrotatedPinOffset, ToNazca, NormalizeZero).
+TDD (String-Assertions am generierten Skript): Platzierungszeile
+`ref_N.rotate(...)`/`.move((x, y))`, Stub-Polygon-Koordinaten, Port-Zeilen,
+straight/bend-Segmente, Footer-write_gds, Gruppen-Flattening, Analysis-Tools
+übersprungen.
+
+### Task 3: ubcpdk-Modus + Fallback-Liste + Tests
+Im ubcpdk-Modus `gf.get_component('<name>')` für gemappte, Stub für ungemappte
+Komponenten; `GdsFactoryExporter.CollectUnmappedComponents(canvas)` liefert die
+Fallback-Liste für den Dialog. Tests: gemappt vs. Fallback, PDK.activate im Header
+nur in diesem Modus.
+
+### Task 4: UI — Export-Menü + Options-Dialog
+`GdsFactoryExportFormat : IExportFormat` (Muster `PhotonTorchExportFormat`),
+Dialog `GdsFactoryExportDialog.axaml` + `GdsFactoryExportOptionsViewModel`
+(Radio Modus, CheckBox GenerateGds, Fallback-Liste), Command
+`FileOperationsViewModel.ExportGdsFactory` (Dateidialog .py → Shadowing-Guard →
+Skript schreiben → optional `GdsExport.ExportScriptToGdsAsync`-Pfad).
+Registrierung im Export-Menü (`MainViewModel`-Formatliste) + DI.
+Tests: Options-VM-Logik, Command-Flow mit Fake-Dialogen (Muster GdsExportGuardTests).
+
+### Task 5: Env-Manager — gdsfactory installierbar
+`NazcaPackageInstaller.InstallGdsFactoryAsync` (uv pip install gdsfactory ubcpdk,
+LongOperationTimeoutMs), `PythonEnvironment.GdsFactoryVersion`,
+`EnvironmentHealthChecker` prüft `import gdsfactory` (Version), Env-Panel-Button
+„Install gdsfactory" (selected env, IsBusy/Cancel wie Repair). Tests: VM-Guards.
+
+### Task 6: E2E + Suite + PR
+Generiertes Skript beider Modi in `%TEMP%\gf-groundtruth` ausführen → `.gds`
+entsteht; Stichprobe `scripts/extract_gds_coords.py`. CI-sichere Tests skippen
+ohne gdsfactory. Volle Suite, Push, PR mit Verweis auf #581-Entscheidung.

--- a/docs/superpowers/specs/2026-07-02-gdsfactory-export-design.md
+++ b/docs/superpowers/specs/2026-07-02-gdsfactory-export-design.md
@@ -1,0 +1,113 @@
+# gdsfactory-Export neben Nazca (Issue #581, Option 1)
+
+**Datum:** 2026-07-02 · **Status:** Entscheidung auf #581 gepostet; autonome Umsetzung vom Nutzer beauftragt.
+**Ground Truth:** gdsfactory 9.34.2 + ubcpdk 3.3.4, verifiziert per uv-Testumgebung.
+
+## Entscheidung
+
+Option 1 aus #581: Die `.lun`-Datei bleibt die neutrale IR; gdsfactory wird ein
+**zweiter Emitter** neben dem Nazca-Exporter. Keine Nazca↔gdsfactory-Konvertierung.
+
+## Ziele (v1 = Export)
+
+1. **Export-Menü**: neuer Eintrag „gdsfactory (.py + GDS)" mit **Options-Dialog**:
+   - Modus **Standalone**: Stub-Geometrie aus Lunima-Dimensionen/Pins (spiegelt den
+     heutigen Nazca-Export; braucht nur `gdsfactory`).
+   - Modus **ubcpdk (SiEPIC)**: echte ubcpdk-Zellen, wo ein Mapping existiert
+     (38/42 Komponenten des SiEPIC-PDKs); Rest fällt auf Stubs zurück, der Dialog
+     zeigt die Liste der Fallbacks.
+   - Toggle „GDS nach Export generieren" (nutzt den bestehenden Script-Runner).
+2. **Koordinatentreue**: identische Konvention wie Nazca (beide Y-up) — der
+   bestehende `NazcaCoordinateMapper` liefert Platzierungen, Pin-Positionen und
+   Segment-Transformationen unverändert.
+3. **Waveguides**: geroutete Segmente werden 1:1 emittiert
+   (`gf.components.straight`, `gf.components.bend_circular`, absolut platziert wie
+   beim Nazca-Export — kein Re-Routing durch gdsfactory).
+4. **Env-Integration**: gdsfactory (+ubcpdk) ist per Klick in ein verwaltetes
+   Environment installierbar (Teil-Vorgriff auf #622); der generierte Lauf nutzt
+   den konfigurierten Interpreter inkl. `PYTHONSAFEPATH`.
+
+## Nicht-Ziele
+
+- gdsfactory-**Import** (Folge-Ausbau, im Issue skizziert).
+- Automatische Konvertierung bestehender Nazca-PDK-JSONs (separat, #620).
+- Kalibrier-Editor für ubcpdk-Offsets (die SiEPIC-Nazca- und ubcpdk-Zellen stammen
+  aus derselben EBeam-GDS-Bibliothek; die vorhandene Kalibrierung wird übernommen —
+  Abweichungen sind ein Folge-Issue, nicht v1-Blocker).
+
+## Architektur
+
+### Script-Aufbau (gespiegelt am SimpleNazcaExporter)
+
+```
+CAP.Avalonia/Services/GdsFactoryExport/
+  GdsFactoryExporter.cs        — Orchestrierung: Header, Stubs, Placements, Segmente, Footer
+  GdsFactoryStubWriter.cs      — Stub-Komponenten (Rechteck + Ports) aus Lunima-Dimensionen
+  GdsFactorySegmentWriter.cs   — straight/bend_circular aus PathSegments (absolut platziert)
+  UbcPdkCellMap.cs             — nazcaFunction → ubcpdk-Zellname (35 exakt + 3 Renames), sonst null
+```
+
+- **Header**: `import gdsfactory as gf`; im ubcpdk-Modus zusätzlich
+  `from ubcpdk import PDK; PDK.activate()`.
+- **Stubs**: pro eindeutiger Komponente eine Factory
+  `def stub_<name>() -> gf.Component` mit Rechteck-Polygon
+  `[-ox, oy-H]..[W-ox, oy]` (Layer (1,0)) und Ports an
+  `(OffsetX-ox, oy-OffsetY)` mit Orientierung `-AngleDegrees` — exakt die
+  Nazca-Stub-Kontrakte, damit beide Backends dieselbe Geometrie liefern.
+- **Platzierung**: `ref = c.add_ref(cell); ref.rotate(rot); ref.move((x, y))` mit
+  `(x, y, rot)` aus `NazcaCoordinateMapper.GetCellPlacement` — Rotation um den
+  Zellursprung, dann Translation: identisch zur `put('org', x, y, rot)`-Semantik.
+- **ubcpdk-Modus**: `gf.get_component('<zellname>')` statt Stub, wenn
+  `UbcPdkCellMap` einen Namen liefert; sonst Stub + Kommentar im Skript und
+  Eintrag in der Fallback-Liste des Dialogs.
+- **Segmente**: dieselbe Absolut-Platzierung wie der Nazca-Export
+  (`straight(length=L, width=0.45)` bzw. `bend_circular(radius=R, angle=±A,
+  allow_min_radius_violation=True)`, dann `rotate`/`move` auf den Startpunkt).
+  Bend-Orientierung: gdsfactory-Bögen starten bei 0° und krümmen um `angle`;
+  Start-Rotation = `-StartAngleDegrees` wie im Nazca-Pfad.
+- **Footer**: `c.write_gds(os.path.splitext(__file__)[0] + '.gds')` — dieselbe
+  Namenskonvention wie Nazca, damit `GdsExportService.ExportToGdsAsync` das GDS
+  unverändert findet und öffnet.
+- Raw-Nazca-Overrides (#559) haben im gf-Skript keine Entsprechung → betroffene
+  Instanzen exportieren als Stub (Kommentar im Skript, Hinweis im Dialog).
+- ComponentGroups werden wie im Nazca-Export geflattet (inkl. frozen paths).
+
+### UI
+
+- `GdsFactoryExportFormat : IExportFormat` im Export-Menü (Muster:
+  `PhotonTorchExportFormat` mit `ShowOptionsDialogAsync`).
+- Options-Dialog (`GdsFactoryExportDialog`): Radio Standalone/ubcpdk,
+  CheckBox „Generate GDS", Info-Liste „ohne ubcpdk-Mapping: …" (live aus dem
+  aktuellen Canvas berechnet), OK/Cancel.
+- `FileOperationsViewModel.ExportGdsFactory`: Dateidialog (.py) → Shadowing-Guard
+  (bestehend) → Skript schreiben → optional GDS-Lauf über den bestehenden
+  `GdsExportService`-Pfad (inkl. `PYTHONSAFEPATH`). Fehlt `gdsfactory` im
+  Interpreter, nennt die Fehlermeldung den Settings-Weg („Install gdsfactory…").
+
+### Env-Manager
+
+- `NazcaPackageInstaller` erhält `InstallGdsFactoryAsync(uvPath, venvPath, …)`
+  (uv pip install `gdsfactory ubcpdk` — beide auf PyPI, kein Tarball nötig).
+- `PythonEnvironmentManagerViewModel`: Button „Install gdsfactory" für das
+  ausgewählte Environment (async, cancelbar, Health-Text zeigt gdsfactory-Version;
+  `PythonEnvironment` bekommt `GdsFactoryVersion`-Feld, Health-Check prüft
+  `import gdsfactory` analog pyclipper).
+
+## Verifikation
+
+- Unit-Tests: Skript-Erzeugung (Platzierungszeilen, Stub-Geometrie, Segment-
+  Emission, ubcpdk-Mapping inkl. Renames und Fallbacks) als String-Assertions.
+- E2E lokal: generiertes Skript in der Ground-Truth-uv-Umgebung ausführen →
+  GDS entsteht; Koordinaten-Stichprobe via `scripts/extract_gds_coords.py`
+  gegen den Nazca-Export desselben Designs.
+- CI-sicher: Tests, die echtes gdsfactory brauchen, skippen ohne Installation.
+
+## Risiken / bewusste Kompromisse
+
+- ubcpdk-Zellgeometrie ≠ Lunima-Stub-Kalibrierung: SiEPIC-Nazca und ubcpdk teilen
+  die EBeam-GDS-Fixzellen, daher wird die vorhandene Origin-Kalibrierung
+  übernommen; Feinabweichungen einzelner Zellen sind Folgearbeit (Offset-Editor
+  für gf wie für Nazca).
+- gdsfactory-API bewegt sich schnell → generierter Code nutzt nur stabile
+  Primitive (Component, add_ref, rotate/move, add_port, write_gds, straight,
+  bend_circular), verifiziert gegen 9.34.2.


### PR DESCRIPTION
**Draft — verification aid, not a merge unit.** This branch merges both open PRs onto main so all findings from the last review round can be checked in a single build. The real merge units stay **#624** (gdsfactory export) and **#634** (demo-pdk name fix).

## What to verify here (in one run)

**From #634 (data):**
- Component library: **90° Bend** and **Straight Waveguide 100µm** now show correct glyphs (no `Â`).

**From #624 (gdsfactory export):**
- Export menu has a **gdsfactory** entry → options dialog with **Standalone / ubcpdk** modes, a GDS toggle, and a live "without ubcpdk mapping" fallback list.
- Export with gdsfactory **not installed** → the dialog shows a short, actionable line (full traceback only in the Error Console, copyable), pointing to Settings → Python Environments → Install gdsfactory.
- Settings → **Python Environments** → select an env → **Install gdsfactory** (installs gdsfactory + ubcpdk); details line then shows the gdsfactory version.
- After install, gdsfactory export (both modes) produces a `.gds`.

## Not in these PRs — filed as issues from the same review round
- #635 — Nazca export: 90° Bend placed ~190.7 µm too high (coordinate bug).
- #636 — DC Halfring-Straight upper pins orientation (PDK data; verify vs real cell).
- #637 — per-instance structure override for gdsfactory (Nazca|gdsfactory toggle).

Full suite green locally: 2723 passed, 0 failed, 5 skipped (the UI screenshot test is parallel-load flaky; passes isolated and on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)