### PR TITLE
(=) DC Halfring-Straight: upper ring ports face up (#636)

### DIFF
--- a/CAP-DataAccess/PDKs/siepic-ebeam-pdk.json
+++ b/CAP-DataAccess/PDKs/siepic-ebeam-pdk.json
@@ -4517,7 +4517,7 @@
           "name": "port 2",
           "offsetXMicrometers": 0.7599999999999998,
           "offsetYMicrometers": 0.009999999999999787,
-          "angleDegrees": 180
+          "angleDegrees": 90
         },
         {
           "name": "port 3",
@@ -4529,7 +4529,7 @@
           "name": "port 4",
           "offsetXMicrometers": 20.759999999999998,
           "offsetYMicrometers": 0.009999999999999787,
-          "angleDegrees": 0
+          "angleDegrees": 90
         }
       ],
       "sMatrix": {

--- a/UnitTests/Components/SiepicPdkTests.cs
+++ b/UnitTests/Components/SiepicPdkTests.cs
@@ -59,6 +59,28 @@ public class SiepicPdkTests
     }
 
     [Fact]
+    public void LoadSiepicPdk_DcHalfringStraight_UpperRingPortsFaceUp()
+    {
+        // #636: DC Halfring-Straight is a half-ring — the waveguide enters from the top,
+        // arcs down, and exits at the top again. Its two upper ports (the ring-arc ends,
+        // port 2 and port 4 at offsetY≈0) must face up (90°), not left/right; the lower
+        // straight-bus ports (port 1/3) stay horizontal. The arc connects port 2↔port 4,
+        // which is why the S-matrix shows strong transmission between them.
+        var path = GetSiepicPdkPath();
+        if (!File.Exists(path)) return;
+
+        var loader = new PdkLoader();
+        var pdk = loader.LoadFromFile(path);
+
+        var halfring = pdk.Components.First(c => c.NazcaFunction == "ebeam_dc_halfring_straight");
+        halfring.Pins.First(p => p.Name == "port 2").AngleDegrees.ShouldBe(90);
+        halfring.Pins.First(p => p.Name == "port 4").AngleDegrees.ShouldBe(90);
+        // Lower straight-bus ports remain horizontal.
+        halfring.Pins.First(p => p.Name == "port 1").AngleDegrees.ShouldBe(180);
+        halfring.Pins.First(p => p.Name == "port 3").AngleDegrees.ShouldBe(0);
+    }
+
+    [Fact]
     public void LoadSiepicPdk_HasMultiWavelengthData()
     {
         var path = GetSiepicPdkPath();


### PR DESCRIPTION
Closes #636.

The **DC Halfring-Straight** is a half-ring: the waveguide enters from the top, arcs down through the component, and exits at the top again. Its two **upper** ports (the ring-arc ends — `port 2` and `port 4` at offsetY≈0) were oriented horizontally (180°/0°) but must **face up (90°)**. The lower straight-bus ports (`port 1`/`port 3`) stay horizontal.

The arc connects `port 2 ↔ port 4`, which is exactly why the stored S-matrix shows strong transmission between them — so **no S-matrix change is needed**, only the two upper pin angles. (This resolves the apparent conflict I raised earlier: the 0.98 transmission comes *through the ring arc*, not a straight guide.)

- `port 2` angle 180 → 90, `port 4` angle 0 → 90.
- Regression test in `SiepicPdkTests` locking the four port orientations.

Geometry confirmed by the domain expert (#636).

🤖 Generated with [Claude Code](https://claude.com/claude-code)