### PR TITLE
(+) gdsfactory instance-override: Nazca | gdsfactory toggle in Component Settings (#637)

### DIFF
--- a/CAP-DataAccess/Persistence/PIR/NazcaCodeOverride.cs
+++ b/CAP-DataAccess/Persistence/PIR/NazcaCodeOverride.cs
@@ -1,5 +1,15 @@
 namespace CAP_DataAccess.Persistence.PIR;
 
+/// <summary>Layout backend a raw-code override is written for (issue #637).</summary>
+public enum OverrideBackend
+{
+    /// <summary>Nazca cell code (default; every override saved before #637 is Nazca).</summary>
+    Nazca = 0,
+
+    /// <summary>gdsfactory component code (declares a <c>component</c> variable).</summary>
+    GdsFactory = 1,
+}
+
 /// <summary>
 /// Per-instance Nazca function parameter override for a single canvas component.
 /// All override fields are optional; a null value means "use the PDK template value".
@@ -56,6 +66,13 @@ public class NazcaCodeOverride
     /// (see <see cref="OverridePins"/> and <see cref="HasNoSimulationModel"/>).
     /// </summary>
     public string? RawCode { get; set; }
+
+    /// <summary>
+    /// Layout backend the <see cref="RawCode"/> is written for. Defaults to
+    /// <see cref="OverrideBackend.Nazca"/> so overrides saved before #637 keep working.
+    /// The matching export/preview backend is selected from this.
+    /// </summary>
+    public OverrideBackend Backend { get; set; } = OverrideBackend.Nazca;
 
     /// <summary>
     /// Component width (µm) recomputed from the rendered raw-code geometry's bounding box.
@@ -154,6 +171,7 @@ public class NazcaCodeOverride
         TemplateFunctionParameters = TemplateFunctionParameters,
         TemplateModuleName = TemplateModuleName,
         RawCode = RawCode,
+        Backend = Backend,
         OverrideWidthMicrometers = OverrideWidthMicrometers,
         OverrideHeightMicrometers = OverrideHeightMicrometers,
         OverridePins = OverridePins?.Select(p => p.Clone()).ToList(),

--- a/CAP.Avalonia/DI/PdkOffsetFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/PdkOffsetFeatureExtensions.cs
@@ -42,6 +42,16 @@ internal static class PdkOffsetFeatureExtensions
             return new NazcaComponentPreviewService(
                 python, script, launchFactory: sp.GetRequiredService<ProcessLaunchFactory>());
         });
+        // gdsfactory override preview (#637): same plumbing, gf renderer + the active
+        // (gdsfactory-capable) interpreter. Resolved lazily each time it is used.
+        services.AddSingleton(sp =>
+        {
+            var prefs = sp.GetRequiredService<UserPreferencesService>();
+            var python = prefs.GetCustomPythonPath() ?? PythonResolution.ResolvePythonExecutable();
+            var script = PythonResolution.FindScript("render_gdsfactory_preview.py");
+            return new GdsFactoryComponentPreviewService(
+                python, script, launchFactory: sp.GetRequiredService<ProcessLaunchFactory>());
+        });
         services.AddSingleton(sp => new PdkOffsetEditorViewModel(
             sp.GetRequiredService<PdkLoader>(),
             sp.GetRequiredService<PdkJsonSaver>(),

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
@@ -3,6 +3,7 @@ using System.Text;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components.Core;
 using CAP_Core.Export;
+using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.Services.GdsFactoryExport;
 
@@ -18,17 +19,22 @@ public class GdsFactoryExporter
     /// <summary>Exports the design to a gdsfactory Python script.</summary>
     /// <param name="canvas">The design canvas to export.</param>
     /// <param name="options">Component representation mode (stubs vs. ubcpdk cells).</param>
-    public string Export(DesignCanvasViewModel canvas, GdsFactoryExportOptions options)
+    /// <param name="overrides">Per-instance overrides; gdsfactory-backend ones are emitted as
+    /// component factories. Null skips override handling.</param>
+    public string Export(
+        DesignCanvasViewModel canvas, GdsFactoryExportOptions options,
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides = null)
     {
         var sb = new StringBuilder();
         AppendHeader(sb, options);
-        AppendStubs(sb, canvas, options);
+        AppendOverrideFactories(sb, canvas, overrides);
+        AppendStubs(sb, canvas, options, overrides);
         var refIndex = 0;
         sb.AppendLine("c = gf.Component('ConnectAPIC_Design')");
         sb.AppendLine();
         sb.AppendLine("# Components");
         foreach (var comp in EnumerateExportableComponents(canvas))
-            AppendPlacement(sb, comp, options, ref refIndex);
+            AppendPlacement(sb, comp, options, overrides, ref refIndex);
         sb.AppendLine();
         AppendConnections(sb, canvas);
         AppendFooter(sb);
@@ -45,6 +51,62 @@ public class GdsFactoryExporter
             .Where(name => !string.IsNullOrEmpty(name) && UbcPdkCellMap.MapToUbcPdkCell(name) == null)
             .Distinct(StringComparer.Ordinal)
             .ToList()!;
+
+    /// <summary>
+    /// Identifiers of instances whose override is written for Nazca — the gdsfactory export
+    /// cannot run that code, so those instances use their ubcpdk/stub geometry instead of the
+    /// custom override. Surfaced as a pre-export warning so the divergence is visible.
+    /// </summary>
+    public static IReadOnlyList<string> CollectBackendMismatches(
+        DesignCanvasViewModel canvas, IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+    {
+        if (overrides == null) return Array.Empty<string>();
+        return EnumerateExportableComponents(canvas)
+            .Where(c => overrides.TryGetValue(c.Identifier, out var o)
+                        && !string.IsNullOrWhiteSpace(o.RawCode)
+                        && o.Backend == OverrideBackend.Nazca)
+            .Select(c => c.Identifier)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>Returns the gdsfactory-backend override RawCode for a component, or null.</summary>
+    private static string? GdsFactoryOverrideCode(
+        Component comp, IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+    {
+        if (overrides != null
+            && overrides.TryGetValue(comp.Identifier, out var o)
+            && !string.IsNullOrWhiteSpace(o.RawCode)
+            && o.Backend == OverrideBackend.GdsFactory)
+            return o.RawCode;
+        return null;
+    }
+
+    private static string OverrideFactoryName(Component comp) =>
+        "override_" + System.Text.RegularExpressions.Regex.Replace(comp.Identifier, @"[^a-zA-Z0-9_]", "_");
+
+    /// <summary>Emits one factory per gdsfactory-backend override: the user's code wrapped in a
+    /// function that returns the `component` it defines.</summary>
+    private static void AppendOverrideFactories(
+        StringBuilder sb, DesignCanvasViewModel canvas,
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
+    {
+        var generated = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var comp in EnumerateExportableComponents(canvas))
+        {
+            var code = GdsFactoryOverrideCode(comp, overrides);
+            if (code == null) continue;
+            var name = OverrideFactoryName(comp);
+            if (!generated.Add(name)) continue;
+
+            sb.AppendLine($"def {name}() -> gf.Component:");
+            sb.AppendLine("    import gdsfactory as gf");
+            foreach (var line in code.Replace("\r\n", "\n").Split('\n'))
+                sb.AppendLine("    " + line);
+            sb.AppendLine("    return component");
+            sb.AppendLine();
+        }
+    }
 
     private static IEnumerable<Component> EnumerateExportableComponents(DesignCanvasViewModel canvas)
     {
@@ -85,12 +147,15 @@ public class GdsFactoryExporter
         sb.AppendLine();
     }
 
-    private static void AppendStubs(StringBuilder sb, DesignCanvasViewModel canvas, GdsFactoryExportOptions options)
+    private static void AppendStubs(
+        StringBuilder sb, DesignCanvasViewModel canvas, GdsFactoryExportOptions options,
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
     {
         var generated = new HashSet<string>(StringComparer.Ordinal);
         foreach (var comp in EnumerateExportableComponents(canvas))
         {
-            if (UsesUbcPdkCell(comp, options))
+            // A gdsfactory override provides the geometry itself; a ubcpdk cell replaces the stub.
+            if (GdsFactoryOverrideCode(comp, overrides) != null || UsesUbcPdkCell(comp, options))
                 continue;
             GdsFactoryStubWriter.AppendStub(sb, comp, generated);
         }
@@ -105,7 +170,8 @@ public class GdsFactoryExporter
     /// origin to the mapper placement — equivalent to Nazca's <c>put('org', x, y, rot)</c>.
     /// </summary>
     private static void AppendPlacement(
-        StringBuilder sb, Component comp, GdsFactoryExportOptions options, ref int refIndex)
+        StringBuilder sb, Component comp, GdsFactoryExportOptions options,
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides, ref int refIndex)
     {
         var ci = CultureInfo.InvariantCulture;
         var placement = NazcaCoordinateMapper.GetCellPlacement(comp, rawOverrideAnchor: null);
@@ -114,9 +180,13 @@ public class GdsFactoryExporter
         var rot = placement.RotationDegrees.ToString("F0", ci);
         var varName = $"ref_{refIndex}";
 
-        var factory = UsesUbcPdkCell(comp, options)
-            ? $"gf.get_component('{UbcPdkCellMap.MapToUbcPdkCell(comp.NazcaFunctionName)}')"
-            : $"{GdsFactoryStubWriter.StubFunctionName(comp)}({StubArguments(comp)})";
+        string factory;
+        if (GdsFactoryOverrideCode(comp, overrides) != null)
+            factory = $"{OverrideFactoryName(comp)}()";
+        else if (UsesUbcPdkCell(comp, options))
+            factory = $"gf.get_component('{UbcPdkCellMap.MapToUbcPdkCell(comp.NazcaFunctionName)}')";
+        else
+            factory = $"{GdsFactoryStubWriter.StubFunctionName(comp)}({StubArguments(comp)})";
 
         sb.AppendLine($"{varName} = c.add_ref({factory})  # {comp.Identifier}");
         sb.AppendLine($"{varName}.rotate({rot})");

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -58,7 +58,10 @@ public class SimpleNazcaExporter
 
     /// <summary>
     /// Reduces the full override map to a dictionary of identifier -> RawCode,
-    /// keeping only entries whose RawCode is non-null and non-empty.
+    /// keeping only entries whose RawCode is non-null and non-empty AND whose backend is
+    /// Nazca. A gdsfactory-backend override must NOT be emitted into the Nazca script (its
+    /// gdsfactory Python would crash the Nazca run) — such an instance falls back to its
+    /// PDK cell here; the gdsfactory export honours it instead.
     /// </summary>
     private static Dictionary<string, string> BuildRawOverrides(
         IReadOnlyDictionary<string, NazcaCodeOverride>? overrides)
@@ -69,8 +72,9 @@ public class SimpleNazcaExporter
 
         foreach (var kv in overrides)
         {
-            if (!string.IsNullOrWhiteSpace(kv.Value?.RawCode))
-                result[kv.Key] = kv.Value!.RawCode!;
+            if (!string.IsNullOrWhiteSpace(kv.Value?.RawCode)
+                && kv.Value!.Backend == OverrideBackend.Nazca)
+                result[kv.Key] = kv.Value.RawCode!;
         }
         return result;
     }

--- a/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/ComponentSettingsDialogViewModel.cs
@@ -211,7 +211,8 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
         Func<double, double, IReadOnlyList<string>>? nazcaOverlapCheck = null,
         Action? nazcaDimensionsChanged = null,
         Action<IReadOnlyList<PhysicalPin>>? nazcaPinsChanged = null,
-        Func<string>? smatrixKeyResolver = null)
+        Func<string>? smatrixKeyResolver = null,
+        NazcaComponentPreviewService? gdsFactoryPreviewService = null)
     {
         _smatrixKey = smatrixKey;
         _smatrixKeyResolver = smatrixKeyResolver;
@@ -265,7 +266,8 @@ public partial class ComponentSettingsDialogViewModel : ObservableObject
                 nazcaOverlapCheck,
                 nazcaDimensionsChanged,
                 OnNazcaGeometryChanged,
-                nazcaPinsChanged);
+                nazcaPinsChanged,
+                gdsFactoryPreviewService);
         }
         else
         {

--- a/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.Backend.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.Backend.cs
@@ -40,11 +40,51 @@ public partial class InstanceNazcaCodeEditorViewModel
         ? "Write gdsfactory code and assign your component to a variable named `component`."
         : "Write self-contained Nazca code that defines a component() cell.";
 
+    /// <summary>Section title above the editor, per backend.</summary>
+    public string CodeSectionTitle => IsGdsFactoryBackend
+        ? "gdsfactory Code (geometry only)"
+        : "Nazca Code (geometry only)";
+
+    /// <summary>Docs-button caption, per backend.</summary>
+    public string DocsButtonLabel => IsGdsFactoryBackend ? "gdsfactory docs ↗" : "Nazca docs ↗";
+
+    /// <summary>Docs URL opened by the docs button, per backend.</summary>
+    public string DocsUrl => IsGdsFactoryBackend
+        ? "https://gdsfactory.github.io/gdsfactory/"
+        : "https://nazca-design.org/manual/";
+
+    /// <summary>Quick-help title in the "?" flyout, per backend.</summary>
+    public string QuickHelpTitle => IsGdsFactoryBackend
+        ? "gdsfactory — assign a Component to `component`"
+        : "Nazca elements — showcase circuit (Insert, or select & Ctrl+C)";
+
+    /// <summary>Example snippet shown in the "?" flyout and inserted by "Insert into editor".</summary>
+    public string StarterExample => IsGdsFactoryBackend ? GdsFactoryExample : Services.NazcaCodeExamples.Complex;
+
+    /// <summary>Cheat-sheet line of common elements, per backend.</summary>
+    public string QuickHelpElements => IsGdsFactoryBackend
+        ? "gf.components: straight(length, width) · bend_euler(radius, angle) · mmi1x2() · mmi2x2() · "
+          + "coupler(gap, length) · ring_single(radius) · taper(length, width1, width2) · grating_coupler_elliptical()"
+        : "strt(length, width) · bend(radius, angle, width) · taper(length, width1, width2) · euler(width, radius, angle) · "
+          + "sinebend(width, distance, offset) · cobra(xya=(x,y,a), width1, width2) · ring(radius, width) · Pin(name).put(x, y, angle)";
+
+    /// <summary>Runnable gdsfactory starter (verified against gdsfactory 9.x).</summary>
+    private const string GdsFactoryExample =
+        "import gdsfactory as gf\n\n" +
+        "# Assign your component to `component`. Ports become the instance pins.\n" +
+        "component = gf.components.mmi1x2()\n";
+
     partial void OnSelectedBackendChanged(OverrideBackend value)
     {
         OnPropertyChanged(nameof(IsGdsFactoryBackend));
         OnPropertyChanged(nameof(UseGdsFactoryBackend));
         OnPropertyChanged(nameof(BackendHelp));
+        OnPropertyChanged(nameof(CodeSectionTitle));
+        OnPropertyChanged(nameof(DocsButtonLabel));
+        OnPropertyChanged(nameof(DocsUrl));
+        OnPropertyChanged(nameof(QuickHelpTitle));
+        OnPropertyChanged(nameof(StarterExample));
+        OnPropertyChanged(nameof(QuickHelpElements));
         // Re-seed only when the user hasn't authored code yet (still on a starter), so a
         // toggle never discards real work.
         if (IsOnAStarter())

--- a/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.Backend.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.Backend.cs
@@ -40,11 +40,6 @@ public partial class InstanceNazcaCodeEditorViewModel
         ? "Write gdsfactory code and assign your component to a variable named `component`."
         : "Write self-contained Nazca code that defines a component() cell.";
 
-    /// <summary>Section title above the editor, per backend.</summary>
-    public string CodeSectionTitle => IsGdsFactoryBackend
-        ? "gdsfactory Code (geometry only)"
-        : "Nazca Code (geometry only)";
-
     /// <summary>Docs-button caption, per backend.</summary>
     public string DocsButtonLabel => IsGdsFactoryBackend ? "gdsfactory docs ↗" : "Nazca docs ↗";
 
@@ -79,7 +74,6 @@ public partial class InstanceNazcaCodeEditorViewModel
         OnPropertyChanged(nameof(IsGdsFactoryBackend));
         OnPropertyChanged(nameof(UseGdsFactoryBackend));
         OnPropertyChanged(nameof(BackendHelp));
-        OnPropertyChanged(nameof(CodeSectionTitle));
         OnPropertyChanged(nameof(DocsButtonLabel));
         OnPropertyChanged(nameof(DocsUrl));
         OnPropertyChanged(nameof(QuickHelpTitle));

--- a/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.Backend.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.Backend.cs
@@ -1,0 +1,88 @@
+using CAP_DataAccess.Persistence.PIR;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CAP.Avalonia.ViewModels.ComponentSettings.InstanceOverride;
+
+/// <summary>
+/// Backend-selection members of the instance override editor (issue #637): the
+/// Nazca | gdsfactory toggle, its help text, and the starter re-seeding. Kept in a
+/// separate partial file so the main editor stays within the file-size limit.
+/// </summary>
+public partial class InstanceNazcaCodeEditorViewModel
+{
+    /// <summary>Self-contained starter shown when the gdsfactory backend is selected.</summary>
+    private const string GdsFactoryOverrideStub =
+        "# Override this component's geometry with your own gdsfactory code.\n" +
+        "# Assign your component to a variable named `component`.\n" +
+        "# Example:\n" +
+        "# import gdsfactory as gf\n" +
+        "# component = gf.components.mmi1x2()\n";
+
+    /// <summary>
+    /// The layout backend this override targets. Switching re-seeds the editor with the
+    /// matching starter code and routes Run Preview / Apply to that backend.
+    /// </summary>
+    [ObservableProperty]
+    private OverrideBackend _selectedBackend = OverrideBackend.Nazca;
+
+    /// <summary>True when the gdsfactory backend is selected (drives help text/visibility).</summary>
+    public bool IsGdsFactoryBackend => SelectedBackend == OverrideBackend.GdsFactory;
+
+    /// <summary>Two-way bindable toggle for the backend radio buttons.</summary>
+    public bool UseGdsFactoryBackend
+    {
+        get => SelectedBackend == OverrideBackend.GdsFactory;
+        set => SelectedBackend = value ? OverrideBackend.GdsFactory : OverrideBackend.Nazca;
+    }
+
+    /// <summary>Backend-specific one-line help shown above the editor.</summary>
+    public string BackendHelp => IsGdsFactoryBackend
+        ? "Write gdsfactory code and assign your component to a variable named `component`."
+        : "Write self-contained Nazca code that defines a component() cell.";
+
+    partial void OnSelectedBackendChanged(OverrideBackend value)
+    {
+        OnPropertyChanged(nameof(IsGdsFactoryBackend));
+        OnPropertyChanged(nameof(UseGdsFactoryBackend));
+        OnPropertyChanged(nameof(BackendHelp));
+        // Re-seed only when the user hasn't authored code yet (still on a starter), so a
+        // toggle never discards real work.
+        if (IsOnAStarter())
+        {
+            Code = value == OverrideBackend.GdsFactory ? GdsFactoryOverrideStub : OverrideStub;
+            _originalSourceCode = value == OverrideBackend.GdsFactory ? null : _originalSourceCode;
+        }
+        IsValid = false;
+        ApplyOverrideCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool IsOnAStarter()
+    {
+        var c = (Code ?? string.Empty).Trim();
+        return c.Length == 0 || c == OverrideStub.Trim() || c == GdsFactoryOverrideStub.Trim()
+            || (_originalSourceCode != null && c == _originalSourceCode.Trim());
+    }
+
+    /// <summary>
+    /// Renders the current code through the backend-appropriate preview service. Returns
+    /// null (with <see cref="PreviewError"/> set) when the required service is missing:
+    /// gdsfactory always runs raw-code; Nazca runs raw-code for edited code or module mode
+    /// for the unedited original.
+    /// </summary>
+    private async System.Threading.Tasks.Task<CAP_Core.Export.NazcaPreviewResult?> RenderForBackendAsync()
+    {
+        if (IsGdsFactoryBackend)
+        {
+            if (_gdsFactoryPreviewService == null)
+            {
+                PreviewError = "gdsfactory preview service unavailable.";
+                return null;
+            }
+            return await _gdsFactoryPreviewService.RenderRawCodeAsync(Code);
+        }
+
+        return IsCustomCode
+            ? await _previewService!.RenderRawCodeAsync(Code)
+            : await _previewService!.RenderAsync(_moduleName, _nazcaFunction, _nazcaParameters);
+    }
+}

--- a/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.cs
@@ -30,6 +30,7 @@ public partial class InstanceNazcaCodeEditorViewModel : ObservableObject
     private readonly Component? _liveComponent;
     private readonly string _componentKey;
     private readonly NazcaComponentPreviewService? _previewService;
+    private readonly NazcaComponentPreviewService? _gdsFactoryPreviewService;
     private readonly Func<double, double, IReadOnlyList<string>>? _overlapCheck;
     private readonly Action? _onDimensionsChanged;
     private readonly Action? _onChanged;
@@ -182,7 +183,8 @@ public partial class InstanceNazcaCodeEditorViewModel : ObservableObject
         Func<double, double, IReadOnlyList<string>>? overlapCheck = null,
         Action? onDimensionsChanged = null,
         Action? onChanged = null,
-        Action<IReadOnlyList<PhysicalPin>>? onPinsChanged = null)
+        Action<IReadOnlyList<PhysicalPin>>? onPinsChanged = null,
+        NazcaComponentPreviewService? gdsFactoryPreviewService = null)
     {
         _componentKey = componentKey;
         _storedOverrides = storedOverrides;
@@ -192,6 +194,7 @@ public partial class InstanceNazcaCodeEditorViewModel : ObservableObject
         _nazcaParameters = nazcaParameters;
         _templateCode = templateCode ?? string.Empty;
         _previewService = previewService;
+        _gdsFactoryPreviewService = gdsFactoryPreviewService;
         _overlapCheck = overlapCheck;
         _onDimensionsChanged = onDimensionsChanged;
         _onChanged = onChanged;
@@ -302,12 +305,12 @@ public partial class InstanceNazcaCodeEditorViewModel : ObservableObject
         StatusText = "Running preview…";
         try
         {
-            // Unedited original → render the real component via module mode (handles demo
-            // PDK and SiEPIC PCells, whose source is not standalone-runnable). Edited code
-            // → run the user's own self-contained snippet via raw-code mode.
-            var result = IsCustomCode
-                ? await _previewService.RenderRawCodeAsync(Code)
-                : await _previewService.RenderAsync(_moduleName, _nazcaFunction, _nazcaParameters);
+            var result = await RenderForBackendAsync();
+            if (result == null)
+            {
+                IsValid = false;
+                return;
+            }
             if (result.Success)
             {
                 _lastSuccessfulPreview = result;
@@ -385,6 +388,7 @@ public partial class InstanceNazcaCodeEditorViewModel : ObservableObject
         // Derive override pins from the preview pin stubs.
         var overridePins = OverridePinMapper.BuildOverridePins(_lastSuccessfulPreview);
         overrideData.RawCode = Code;
+        overrideData.Backend = SelectedBackend;
         overrideData.SetOverrideGeometry(
             width, height, _lastSuccessfulPreview.XMin, _lastSuccessfulPreview.YMax);
         overrideData.OverridePins = overridePins;
@@ -480,6 +484,7 @@ public partial class InstanceNazcaCodeEditorViewModel : ObservableObject
         {
             // A stored override is always editable code the user authored/saved.
             Code = stored.RawCode;
+            SelectedBackend = stored.Backend;
             HasOverride = true;
             HasEditableSource = true;
             HasNoSimulationModel = stored.HasNoSimulationModel;

--- a/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModel.cs
@@ -429,7 +429,7 @@ public partial class InstanceNazcaCodeEditorViewModel : ObservableObject
 
     /// <summary>Replaces the editor content with the showcase example (from the help flyout).</summary>
     [RelayCommand]
-    private void InsertStarter() => Code = Services.NazcaCodeExamples.Complex;
+    private void InsertStarter() => Code = StarterExample;
 
     /// <summary>
     /// Clears the raw-code override for this instance and restores the editor to the

--- a/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
@@ -27,6 +27,11 @@ public partial class GdsFactoryExportViewModel : ObservableObject
     [ObservableProperty]
     private ObservableCollection<string> _unmappedComponents = new();
 
+    /// <summary>Instances whose override is written for Nazca — not honoured in the gdsfactory
+    /// export (they use ubcpdk/stub geometry instead). Surfaced as a pre-export warning.</summary>
+    [ObservableProperty]
+    private ObservableCollection<string> _backendMismatches = new();
+
     [ObservableProperty]
     private string _statusText = string.Empty;
 
@@ -35,6 +40,10 @@ public partial class GdsFactoryExportViewModel : ObservableObject
 
     /// <summary>File dialog service; wired by the UI layer like the other exporters.</summary>
     public IFileDialogService? FileDialogService { get; set; }
+
+    /// <summary>Supplies the per-instance overrides (wired by the UI layer to the design's
+    /// stored overrides); gdsfactory-backend ones are emitted as factories.</summary>
+    public Func<IReadOnlyDictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>>? OverridesProvider { get; set; }
 
     /// <summary>
     /// Ensures gdsfactory is installed into a managed environment (creating one if needed)
@@ -61,14 +70,19 @@ public partial class GdsFactoryExportViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Recomputes the list of components that would fall back to stub geometry in
-    /// ubcpdk mode. Called when the export dialog opens.
+    /// Recomputes the pre-export info: components that fall back to stub geometry (no ubcpdk
+    /// cell) and instances whose override targets Nazca (not honoured here). Called when the
+    /// export dialog opens.
     /// </summary>
     public void RefreshUnmappedComponents()
     {
         UnmappedComponents.Clear();
         foreach (var name in GdsFactoryExporter.CollectUnmappedComponents(_canvas))
             UnmappedComponents.Add(name);
+
+        BackendMismatches.Clear();
+        foreach (var id in GdsFactoryExporter.CollectBackendMismatches(_canvas, OverridesProvider?.Invoke()))
+            BackendMismatches.Add(id);
     }
 
     /// <summary>Runs the export: file dialog → shadowing guard → script → optional GDS.</summary>
@@ -109,8 +123,11 @@ public partial class GdsFactoryExportViewModel : ObservableObject
         try
         {
             // Always ubcpdk-where-available with stub fallback — no geometry question.
+            // gdsfactory-backend overrides are emitted as factories; Nazca-backend ones fall
+            // back to ubcpdk/stub (surfaced as a mismatch warning).
             await File.WriteAllTextAsync(filePath,
-                _exporter.Export(_canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells)));
+                _exporter.Export(_canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells),
+                    OverridesProvider?.Invoke()));
 
             StatusText = "Running gdsfactory to generate the GDS...";
             var result = await _exportService.ExportToGdsAsync(filePath, generateGds: true);

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -195,6 +195,8 @@ public partial class MainViewModel : ObservableObject
         VerilogAExportFormat = new VerilogAExportFormat(verilogAExport);
         GdsFactoryExportFormat = new GdsFactoryExportFormat();
         GdsFactoryExport = gdsFactoryExport;
+        // gdsfactory export honours gdsfactory-backend overrides from the design's store.
+        GdsFactoryExport.OverridesProvider = () => FileOperations.StoredNazcaOverrides;
         ExportMenu = new ExportMenuViewModel(new IExportFormat[]
         {
             new NazcaExportFormat(FileOperations.ExportNazcaCommand),

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -1297,6 +1297,18 @@ public partial class FileOperationsViewModel : ObservableObject
                 var nazcaCode = _nazcaExporter.Export(_canvas, overrides: StoredNazcaOverrides);
                 await File.WriteAllTextAsync(filePath, nazcaCode);
 
+                // Warn if any instance has a gdsfactory-backend override: the Nazca export
+                // can't run gdsfactory code, so those instances use their PDK cell here.
+                var gfOverrides = StoredNazcaOverrides
+                    .Where(kv => !string.IsNullOrWhiteSpace(kv.Value.RawCode)
+                                 && kv.Value.Backend == CAP_DataAccess.Persistence.PIR.OverrideBackend.GdsFactory)
+                    .Select(kv => kv.Key).ToList();
+                if (gfOverrides.Count > 0)
+                    _errorConsole?.LogWarning(
+                        $"Nazca export: {gfOverrides.Count} instance(s) have a gdsfactory override "
+                        + $"not applied here (PDK geometry used instead): {string.Join(", ", gfOverrides)}. "
+                        + "Use the gdsfactory export to honour them.");
+
                 // GDS pre-flight: refresh a stale "not ready" verdict once, then ask the
                 // user how to proceed when Nazca is genuinely unavailable.
                 if (GdsExport.GenerateGdsEnabled && !GdsExport.IsEnvironmentReady)

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -78,12 +78,9 @@
                                TextWrapping="Wrap" VerticalAlignment="Center"/>
                 </StackPanel>
 
-                <!-- Section header (title/docs/cheat-sheet all backend-aware) -->
+                <!-- Section actions/badges (title omitted — it's the window title already;
+                     docs + cheat-sheet are backend-aware, #556/#637) -->
                 <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBlock Text="{Binding CodeSectionTitle}"
-                               FontWeight="SemiBold"
-                               FontSize="12"
-                               Foreground="#8888cc"/>
                     <TextBlock Text="🔧 Override active"
                                FontSize="10"
                                Foreground="#FFA500"
@@ -159,21 +156,22 @@
                      place isn't supported — it's a decorated closure with non-standalone
                      references — so it's shown for understanding only; use the override
                      editor below to replace the geometry with your own self-contained code. -->
-                <Expander Header="Original source (read-only reference)"
-                          IsExpanded="False"
-                          Margin="0,2,0,0"
-                          MinHeight="0"
-                          FontSize="11"
-                          Padding="6,1"
-                          IsVisible="{Binding HasEditableSource}">
-                    <ScrollViewer MaxHeight="160" VerticalScrollBarVisibility="Auto">
-                        <SelectableTextBlock Text="{Binding OriginalSource}"
-                                             FontFamily="Consolas, Courier New, monospace"
-                                             FontSize="10"
-                                             Foreground="#9aa0b0"
-                                             TextWrapping="NoWrap"/>
-                    </ScrollViewer>
-                </Expander>
+                <!-- Original source (read-only reference), always visible but kept thin;
+                     scroll for the rest. -->
+                <TextBlock Text="Original source (read-only reference)"
+                           Foreground="#777799" FontSize="10" Margin="0,2,0,0"
+                           IsVisible="{Binding HasEditableSource}"/>
+                <ScrollViewer MaxHeight="56" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Auto"
+                              Background="#101018"
+                              IsVisible="{Binding HasEditableSource}">
+                    <SelectableTextBlock Text="{Binding OriginalSource}"
+                                         FontFamily="Consolas, Courier New, monospace"
+                                         FontSize="10"
+                                         Foreground="#9aa0b0"
+                                         Margin="4"
+                                         TextWrapping="NoWrap"/>
+                </ScrollViewer>
 
                 <!-- Override editor (left) + live preview (right) -->
                 <Grid ColumnDefinitions="*,160" Height="340">
@@ -254,27 +252,21 @@
             </StackPanel>
         </Border>
 
-        <!-- Load button -->
-        <Button DockPanel.Dock="Bottom"
-                Content="Load S-matrix from file…"
-                Command="{Binding LoadFromFileCommand}"
-                HorizontalAlignment="Left"
-                Margin="0,4,0,0"
-                Padding="12,2"
-                Background="#3d5d3d"
-                ToolTip.Tip="Import numerical S-parameters (Lumerical .dat) or Touchstone (.s2p/.s4p) data for this component."
-                IsEnabled="{Binding IsImporting, Converter={x:Static BoolConverters.Not}}"/>
-
-        <!-- Recalculate via FDTD: like Load, but the S-matrix is computed from the
-             component geometry with the open-source Meep solver instead of imported. -->
-        <Button DockPanel.Dock="Bottom"
-                Content="Recalculate S-matrix (FDTD)…"
-                Command="{Binding RecalculateSMatrixCommand}"
-                HorizontalAlignment="Left"
-                Margin="0,3,0,0"
-                Padding="12,2"
-                Background="#3d4d6d"
-                IsVisible="{Binding CanRecalculate}"/>
+        <!-- Load + Recalculate side by side. Recalculate (FDTD) computes the S-matrix from
+             the component geometry with the open-source Meep solver instead of importing. -->
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="8" Margin="0,4,0,0">
+            <Button Content="Load S-matrix from file…"
+                    Command="{Binding LoadFromFileCommand}"
+                    Padding="12,2"
+                    Background="#3d5d3d"
+                    ToolTip.Tip="Import numerical S-parameters (Lumerical .dat) or Touchstone (.s2p/.s4p) data for this component."
+                    IsEnabled="{Binding IsImporting, Converter={x:Static BoolConverters.Not}}"/>
+            <Button Content="Recalculate S-matrix (FDTD)…"
+                    Command="{Binding RecalculateSMatrixCommand}"
+                    Padding="12,2"
+                    Background="#3d4d6d"
+                    IsVisible="{Binding CanRecalculate}"/>
+        </StackPanel>
 
         <!-- Solver / simulation status -->
         <Border DockPanel.Dock="Bottom"

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -63,9 +63,24 @@
                 DataContext="{Binding NazcaCodeEditor}"
                 x:DataType="io:InstanceNazcaCodeEditorViewModel">
             <StackPanel Spacing="6">
-                <!-- Section header -->
+                <!-- Backend toggle (#637): Nazca | gdsfactory. Above the header so the whole
+                     section (title, docs, cheat-sheet) reflects the selected backend. -->
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <TextBlock Text="Backend:" Foreground="#9aa0b0" FontSize="11"
+                               VerticalAlignment="Center"/>
+                    <RadioButton Content="Nazca" GroupName="overrideBackend" FontSize="11"
+                                 Foreground="#ddddee"
+                                 IsChecked="{Binding !UseGdsFactoryBackend}"/>
+                    <RadioButton Content="gdsfactory" GroupName="overrideBackend" FontSize="11"
+                                 Foreground="#ddddee"
+                                 IsChecked="{Binding UseGdsFactoryBackend, Mode=TwoWay}"/>
+                    <TextBlock Text="{Binding BackendHelp}" Foreground="#777799" FontSize="10"
+                               TextWrapping="Wrap" VerticalAlignment="Center"/>
+                </StackPanel>
+
+                <!-- Section header (title/docs/cheat-sheet all backend-aware) -->
                 <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBlock Text="Nazca Code (geometry only)"
+                    <TextBlock Text="{Binding CodeSectionTitle}"
                                FontWeight="SemiBold"
                                FontSize="12"
                                Foreground="#8888cc"/>
@@ -79,8 +94,8 @@
                                Foreground="#FF8888"
                                VerticalAlignment="Center"
                                IsVisible="{Binding HasOverlap}"/>
-                    <!-- Nazca docs + cheat-sheet (issue #556) -->
-                    <Button Content="Nazca docs ↗"
+                    <!-- Docs + cheat-sheet — backend-aware (issue #556/#637) -->
+                    <Button Content="{Binding DocsButtonLabel}"
                             Click="OnOpenNazcaDocs"
                             Padding="6,1"
                             Background="Transparent"
@@ -88,7 +103,7 @@
                             BorderThickness="0"
                             FontSize="10"
                             VerticalAlignment="Center"
-                            ToolTip.Tip="Open the Nazca Design manual in your browser"/>
+                            ToolTip.Tip="Open the selected backend's manual in your browser"/>
                     <Button Content="?"
                             Padding="8,1"
                             Background="#33335a"
@@ -98,20 +113,20 @@
                             FontSize="11"
                             FontWeight="Bold"
                             VerticalAlignment="Center"
-                            ToolTip.Tip="Quick help — most-used Nazca commands">
+                            ToolTip.Tip="Quick help — most-used commands for the selected backend">
                         <Button.Flyout>
                             <Flyout>
                                 <StackPanel Spacing="4" MaxWidth="460">
-                                    <TextBlock Text="Nazca elements — showcase circuit (Insert, or select &amp; Ctrl+C)"
+                                    <TextBlock Text="{Binding QuickHelpTitle}"
                                                FontWeight="SemiBold" FontSize="11" Foreground="#aaaacc"
                                                TextWrapping="Wrap"/>
-                                    <!-- Verified-runnable showcase (NazcaCodeExamples.Complex). Selectable for copy. -->
+                                    <!-- Backend-appropriate runnable example. Selectable for copy. -->
                                     <Border Background="#101018" BorderBrush="#333355" BorderThickness="1"
                                             CornerRadius="3" Padding="6">
                                         <ScrollViewer MaxHeight="260" VerticalScrollBarVisibility="Auto">
                                             <SelectableTextBlock FontFamily="Consolas, Courier New, monospace"
                                                                  FontSize="10" Foreground="#dddddd"
-                                                                 Text="{x:Static services:NazcaCodeExamples.Complex}"/>
+                                                                 Text="{Binding StarterExample}"/>
                                         </ScrollViewer>
                                     </Border>
                                     <Button Content="Insert into editor"
@@ -119,33 +134,16 @@
                                             Padding="8,3" FontSize="10"
                                             Background="#2a4a2a" Foreground="#cceecc" BorderThickness="0"
                                             HorizontalAlignment="Left"
-                                            ToolTip.Tip="Replace the editor content with this showcase circuit"/>
-                                    <TextBlock Text="Common elements (chain with .put(), or .put(x, y, angle)):"
+                                            ToolTip.Tip="Replace the editor content with this example"/>
+                                    <TextBlock Text="Common elements:"
                                                FontSize="10" Foreground="#aaaacc" Margin="0,2,0,0" TextWrapping="Wrap"/>
                                     <SelectableTextBlock FontFamily="Consolas, Courier New, monospace"
                                                          FontSize="9" Foreground="#9aa0b0" TextWrapping="Wrap"
-                                                         Text="strt(length, width) · bend(radius, angle, width) · taper(length, width1, width2) · ptaper(...) · euler(width, radius, angle) · sinebend(width, distance, offset) · cobra(xya=(x,y,a), width1, width2) · ring(radius, width) · text(text, height, layer) · Pin(name).put(x, y, angle)"/>
-                                    <TextBlock Text="Tip: ring()/text() return polygon lists — add them with nd.Polygon(...)/loops, not .put(). Full reference: nazca-design.org/manual."
-                                               FontSize="9" Foreground="#777799" TextWrapping="Wrap"/>
+                                                         Text="{Binding QuickHelpElements}"/>
                                 </StackPanel>
                             </Flyout>
                         </Button.Flyout>
                     </Button>
-                </StackPanel>
-
-                <!-- Backend toggle (#637): Nazca | gdsfactory. Switches the help text and
-                     which backend runs Preview/Apply; the code editor below is shared. -->
-                <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,2,0,0">
-                    <TextBlock Text="Backend:" Foreground="#9aa0b0" FontSize="11"
-                               VerticalAlignment="Center"/>
-                    <RadioButton Content="Nazca" GroupName="overrideBackend" FontSize="11"
-                                 Foreground="#ddddee"
-                                 IsChecked="{Binding !UseGdsFactoryBackend}"/>
-                    <RadioButton Content="gdsfactory" GroupName="overrideBackend" FontSize="11"
-                                 Foreground="#ddddee"
-                                 IsChecked="{Binding UseGdsFactoryBackend, Mode=TwoWay}"/>
-                    <TextBlock Text="{Binding BackendHelp}" Foreground="#777799" FontSize="10"
-                               TextWrapping="Wrap" VerticalAlignment="Center"/>
                 </StackPanel>
 
                 <!-- No-editable-source note: shown for fixed-cell GDS / KLayout PCells
@@ -164,6 +162,9 @@
                 <Expander Header="Original source (read-only reference)"
                           IsExpanded="False"
                           Margin="0,2,0,0"
+                          MinHeight="0"
+                          FontSize="11"
+                          Padding="6,1"
                           IsVisible="{Binding HasEditableSource}">
                     <ScrollViewer MaxHeight="160" VerticalScrollBarVisibility="Auto">
                         <SelectableTextBlock Text="{Binding OriginalSource}"
@@ -173,9 +174,6 @@
                                              TextWrapping="NoWrap"/>
                     </ScrollViewer>
                 </Expander>
-
-                <TextBlock Text="Override — your own self-contained Nazca code. Run shows the real component until you define a component()."
-                           Foreground="#8888aa" FontSize="10" Margin="0,4,0,2" TextWrapping="Wrap"/>
 
                 <!-- Override editor (left) + live preview (right) -->
                 <Grid ColumnDefinitions="*,160" Height="340">
@@ -261,9 +259,10 @@
                 Content="Load S-matrix from file…"
                 Command="{Binding LoadFromFileCommand}"
                 HorizontalAlignment="Left"
-                Margin="0,10,0,0"
-                Padding="12,6"
+                Margin="0,4,0,0"
+                Padding="12,2"
                 Background="#3d5d3d"
+                ToolTip.Tip="Import numerical S-parameters (Lumerical .dat) or Touchstone (.s2p/.s4p) data for this component."
                 IsEnabled="{Binding IsImporting, Converter={x:Static BoolConverters.Not}}"/>
 
         <!-- Recalculate via FDTD: like Load, but the S-matrix is computed from the
@@ -272,8 +271,8 @@
                 Content="Recalculate S-matrix (FDTD)…"
                 Command="{Binding RecalculateSMatrixCommand}"
                 HorizontalAlignment="Left"
-                Margin="0,6,0,0"
-                Padding="12,6"
+                Margin="0,3,0,0"
+                Padding="12,2"
                 Background="#3d4d6d"
                 IsVisible="{Binding CanRecalculate}"/>
 
@@ -296,7 +295,7 @@
 
         <!-- Empty state -->
         <TextBlock DockPanel.Dock="Top"
-                   Text="No S-matrices stored for this component.&#10;Use 'Load S-matrix from file…' to import Lumerical or Touchstone data."
+                   Text="No custom S-matrix for this component yet — it uses its PDK S-matrix. Load or recalculate one below to override it."
                    Foreground="Gray"
                    FontSize="11"
                    Margin="0,0,0,10"

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -133,6 +133,21 @@
                     </Button>
                 </StackPanel>
 
+                <!-- Backend toggle (#637): Nazca | gdsfactory. Switches the help text and
+                     which backend runs Preview/Apply; the code editor below is shared. -->
+                <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,2,0,0">
+                    <TextBlock Text="Backend:" Foreground="#9aa0b0" FontSize="11"
+                               VerticalAlignment="Center"/>
+                    <RadioButton Content="Nazca" GroupName="overrideBackend" FontSize="11"
+                                 Foreground="#ddddee"
+                                 IsChecked="{Binding !UseGdsFactoryBackend}"/>
+                    <RadioButton Content="gdsfactory" GroupName="overrideBackend" FontSize="11"
+                                 Foreground="#ddddee"
+                                 IsChecked="{Binding UseGdsFactoryBackend, Mode=TwoWay}"/>
+                    <TextBlock Text="{Binding BackendHelp}" Foreground="#777799" FontSize="10"
+                               TextWrapping="Wrap" VerticalAlignment="Center"/>
+                </StackPanel>
+
                 <!-- No-editable-source note: shown for fixed-cell GDS / KLayout PCells
                      whose Python source can't be introspected. The geometry preview
                      still renders; the user may paste their own Nazca code to override. -->

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml
@@ -23,13 +23,7 @@
                   HorizontalScrollBarVisibility="Disabled">
     <DockPanel Margin="16">
 
-        <!-- Title -->
-        <TextBlock DockPanel.Dock="Top"
-                   Text="{Binding Title}"
-                   FontWeight="SemiBold"
-                   FontSize="15"
-                   Foreground="LightBlue"
-                   Margin="0,0,0,12"/>
+        <!-- No in-content title: the window title bar already shows {Binding Title}. -->
 
         <!-- Status bar -->
         <Border DockPanel.Dock="Bottom"
@@ -156,15 +150,22 @@
                      place isn't supported — it's a decorated closure with non-standalone
                      references — so it's shown for understanding only; use the override
                      editor below to replace the geometry with your own self-contained code. -->
-                <!-- Original source (read-only reference), always visible but kept thin;
-                     scroll for the rest. -->
-                <TextBlock Text="Original source (read-only reference)"
-                           Foreground="#777799" FontSize="10" Margin="0,2,0,0"
-                           IsVisible="{Binding HasEditableSource}"/>
-                <ScrollViewer MaxHeight="56" VerticalScrollBarVisibility="Auto"
-                              HorizontalScrollBarVisibility="Auto"
-                              Background="#101018"
-                              IsVisible="{Binding HasEditableSource}">
+                <!-- Original source (read-only reference): a thin toggle expands a scrollable
+                     code box. A ToggleButton (not an Expander) so the control height is minimal. -->
+                <ToggleButton x:Name="OrigSrcToggle"
+                              Content="▸ Original source (read-only reference)"
+                              FontSize="10"
+                              Foreground="#777799"
+                              Background="Transparent"
+                              BorderThickness="0"
+                              Padding="2,0"
+                              MinHeight="0"
+                              Margin="0,2,0,0"
+                              HorizontalAlignment="Left"
+                              IsVisible="{Binding HasEditableSource}"/>
+                <ScrollViewer MaxHeight="160" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Auto" Background="#101018"
+                              IsVisible="{Binding #OrigSrcToggle.IsChecked}">
                     <SelectableTextBlock Text="{Binding OriginalSource}"
                                          FontFamily="Consolas, Courier New, monospace"
                                          FontSize="10"

--- a/CAP.Avalonia/Views/ComponentSettingsDialog.axaml.cs
+++ b/CAP.Avalonia/Views/ComponentSettingsDialog.axaml.cs
@@ -52,13 +52,15 @@ public partial class ComponentSettingsDialog : Window
         });
     }
 
-    /// <summary>Opens the Nazca Design manual in the user's default browser (issue #556).</summary>
+    /// <summary>Opens the backend-appropriate manual (Nazca or gdsfactory) in the browser.</summary>
     private void OnOpenNazcaDocs(object? sender, RoutedEventArgs e)
     {
         var launcher = TopLevel.GetTopLevel(this)?.Launcher;
         if (launcher == null)
             return;
-        _ = launcher.LaunchUriAsync(new Uri("https://nazca-design.org/manual/"));
+        var url = (DataContext as ComponentSettingsDialogViewModel)?.NazcaCodeEditor?.DocsUrl
+                  ?? "https://nazca-design.org/manual/";
+        _ = launcher.LaunchUriAsync(new Uri(url));
     }
 
     /// <summary>Copies the current preview error to the clipboard so it can be pasted into a report.</summary>

--- a/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml
+++ b/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml
@@ -43,6 +43,23 @@
                     </StackPanel>
                 </Border>
 
+                <!-- Backend mismatch: instances with a Nazca override won't get their custom
+                     geometry in a gdsfactory export. -->
+                <Border Background="#3a2020" CornerRadius="4" Padding="8"
+                        IsVisible="{Binding BackendMismatches.Count}">
+                    <StackPanel Spacing="4">
+                        <TextBlock Text="⚠ Nazca override not applied here (uses ubcpdk/stub instead):"
+                                   Foreground="#e8a0a0" FontSize="11" FontWeight="SemiBold" TextWrapping="Wrap"/>
+                        <ItemsControl ItemsSource="{Binding BackendMismatches}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}" Foreground="Gray" FontSize="10"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+
                 <TextBlock Text="{Binding StatusText}"
                            Foreground="LightSkyBlue" FontSize="11" TextWrapping="Wrap"
                            IsVisible="{Binding StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -660,6 +660,8 @@ public partial class MainWindow : Window
         // Per-instance raw Nazca code editor (issue #556) — only in per-instance mode.
         var nazcaPreviewService = App.Services.GetService(typeof(CAP_Core.Export.NazcaComponentPreviewService))
             as CAP_Core.Export.NazcaComponentPreviewService;
+        var gdsFactoryPreviewService = App.Services.GetService(typeof(CAP_Core.Export.GdsFactoryComponentPreviewService))
+            as CAP_Core.Export.GdsFactoryComponentPreviewService;
         string? nazcaTemplateCode = null;
         Func<double, double, IReadOnlyList<string>>? nazcaOverlapCheck = null;
         Action? nazcaDimensionsChanged = null;
@@ -720,7 +722,8 @@ public partial class MainWindow : Window
             nazcaOverlapCheck: nazcaOverlapCheck,
             nazcaDimensionsChanged: nazcaDimensionsChanged,
             nazcaPinsChanged: nazcaPinsChanged,
-            smatrixKeyResolver: smatrixKeyResolver);
+            smatrixKeyResolver: smatrixKeyResolver,
+            gdsFactoryPreviewService: gdsFactoryPreviewService);
 
         var dialog = new ComponentSettingsDialog { DataContext = dialogVm };
         dialog.Show(this);

--- a/CAP.Desktop/CAP.Desktop.csproj
+++ b/CAP.Desktop/CAP.Desktop.csproj
@@ -36,6 +36,12 @@
              Link="scripts\render_component_preview.py"
              CopyToOutputDirectory="PreserveNewest"
              CopyToPublishDirectory="PreserveNewest" />
+    <!-- gdsfactory preview renderer (issue #637): same --code-file CLI + JSON
+         contract as render_component_preview.py, so the preview parser is shared. -->
+    <Content Include="..\scripts\render_gdsfactory_preview.py"
+             Link="scripts\render_gdsfactory_preview.py"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- FDTD S-matrix solver bridge (issue #569). DockerFdtdSMatrixService /

--- a/CAP.Desktop/CAP.Desktop.csproj
+++ b/CAP.Desktop/CAP.Desktop.csproj
@@ -36,7 +36,7 @@
              Link="scripts\render_component_preview.py"
              CopyToOutputDirectory="PreserveNewest"
              CopyToPublishDirectory="PreserveNewest" />
-    <!-- gdsfactory preview renderer (issue #637): same --code-file CLI + JSON
+    <!-- gdsfactory preview renderer (issue #637): same code-file CLI + JSON
          contract as render_component_preview.py, so the preview parser is shared. -->
     <Content Include="..\scripts\render_gdsfactory_preview.py"
              Link="scripts\render_gdsfactory_preview.py"

--- a/Connect-A-Pic-Core/Export/GdsFactoryComponentPreviewService.cs
+++ b/Connect-A-Pic-Core/Export/GdsFactoryComponentPreviewService.cs
@@ -1,0 +1,25 @@
+namespace CAP_Core.Export;
+
+/// <summary>
+/// Geometry-preview service for gdsfactory override code (issue #637). Behaves exactly
+/// like <see cref="NazcaComponentPreviewService"/> — same subprocess plumbing, timeout,
+/// caching and JSON parsing — but points at <c>render_gdsfactory_preview.py</c>, which
+/// speaks the same <c>--code-file</c> CLI and emits the same result contract. A distinct
+/// type so DI can register and resolve it alongside the Nazca preview service.
+/// Only raw-code mode (<see cref="NazcaComponentPreviewService.RenderRawCodeAsync"/>) is
+/// used for gdsfactory; there is no PDK "module mode".
+/// </summary>
+public sealed class GdsFactoryComponentPreviewService : NazcaComponentPreviewService
+{
+    /// <summary>Initializes the gdsfactory preview service.</summary>
+    /// <param name="pythonExecutable">Interpreter that has gdsfactory installed.</param>
+    /// <param name="scriptPath">Path to <c>render_gdsfactory_preview.py</c>.</param>
+    /// <param name="timeout">Optional subprocess timeout.</param>
+    /// <param name="launchFactory">Shared cross-platform launch factory.</param>
+    public GdsFactoryComponentPreviewService(
+        string pythonExecutable, string scriptPath, TimeSpan? timeout = null,
+        ProcessLaunchFactory? launchFactory = null)
+        : base(pythonExecutable, scriptPath, timeout, launchFactory)
+    {
+    }
+}

--- a/UnitTests/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModelTests.cs
+++ b/UnitTests/ComponentSettings/InstanceOverride/InstanceNazcaCodeEditorViewModelTests.cs
@@ -42,7 +42,8 @@ public class InstanceNazcaCodeEditorViewModelTests
         Dictionary<string, NazcaCodeOverride>? store = null,
         Component? live = null,
         Func<double, double, IReadOnlyList<string>>? overlapCheck = null,
-        Action? onChanged = null)
+        Action? onChanged = null,
+        NazcaComponentPreviewService? gdsFactoryService = null)
     {
         return new InstanceNazcaCodeEditorViewModel(
             componentKey: "comp-1",
@@ -55,7 +56,51 @@ public class InstanceNazcaCodeEditorViewModelTests
             previewService: service,
             overlapCheck: overlapCheck,
             onDimensionsChanged: null,
-            onChanged: onChanged);
+            onChanged: onChanged,
+            gdsFactoryPreviewService: gdsFactoryService);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Backend toggle (#637): gdsfactory routes to the gdsfactory preview service.
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GdsFactoryBackend_RunPreview_UsesGdsFactoryServiceNotNazca()
+    {
+        var nazca = MockService();
+        nazca.Setup(s => s.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NazcaPreviewResult.Fail("nazca should not be called"));
+        var gf = MockService();
+        gf.Setup(s => s.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(w: 25, h: 3));
+        var vm = BuildVm(nazca.Object, gdsFactoryService: gf.Object);
+
+        vm.UseGdsFactoryBackend = true;
+        vm.Code = "component = gf.components.straight(length=25)";
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+
+        vm.IsValid.ShouldBeTrue();
+        gf.Verify(s => s.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        nazca.Verify(s => s.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        vm.BackendHelp.ShouldContain("gdsfactory");
+    }
+
+    [Fact]
+    public async Task GdsFactoryBackend_Apply_TagsOverrideBackend()
+    {
+        var gf = MockService();
+        gf.Setup(s => s.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(w: 25, h: 3));
+        var store = new Dictionary<string, NazcaCodeOverride>();
+        var vm = BuildVm(MockService().Object, store: store, gdsFactoryService: gf.Object);
+
+        vm.UseGdsFactoryBackend = true;
+        vm.Code = "component = gf.components.straight(length=25)";
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        vm.ApplyOverrideCommand.Execute(null);
+
+        store["comp-1"].Backend.ShouldBe(OverrideBackend.GdsFactory);
+        store["comp-1"].RawCode.ShouldContain("gf.components.straight");
     }
 
     [Fact]

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryExporterTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryExporterTests.cs
@@ -44,6 +44,69 @@ public class GdsFactoryExporterTests
             canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells));
 
     [Fact]
+    public void NazcaExport_SkipsGdsFactoryBackendOverride()
+    {
+        // Safety: a gdsfactory-backend override must NOT be emitted into the Nazca script
+        // (its gdsfactory Python would crash the Nazca run); the PDK cell is used instead.
+        var canvas = CreateCanvasWithComponent("ebeam_y_1550", "C1");
+        var store = new Dictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>
+        {
+            ["C1"] = new()
+            {
+                RawCode = "component = gf.components.mmi1x2()",
+                Backend = CAP_DataAccess.Persistence.PIR.OverrideBackend.GdsFactory,
+            },
+        };
+
+        var nazca = new CAP.Avalonia.Services.SimpleNazcaExporter().Export(canvas, overrides: store);
+
+        nazca.ShouldNotContain("gf.components.mmi1x2");   // gdsfactory code not in the Nazca script
+    }
+
+    [Fact]
+    public void Export_GdsFactoryBackendOverride_EmittedAsFactory()
+    {
+        var canvas = CreateCanvasWithComponent("ebeam_y_1550", "C1");
+        var overrides = new Dictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>
+        {
+            ["C1"] = new()
+            {
+                RawCode = "component = gf.components.straight(length=12)",
+                Backend = CAP_DataAccess.Persistence.PIR.OverrideBackend.GdsFactory,
+            },
+        };
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells), overrides);
+
+        script.ShouldContain("def override_C1(");
+        script.ShouldContain("component = gf.components.straight(length=12)");
+        script.ShouldContain("c.add_ref(override_C1())");
+        script.ShouldNotContain("gf.get_component('ebeam_y_1550')");  // override replaces the ubcpdk cell
+    }
+
+    [Fact]
+    public void Export_NazcaBackendOverride_IsNotHonoured_AndReportedAsMismatch()
+    {
+        var canvas = CreateCanvasWithComponent("ebeam_y_1550", "C1");
+        var overrides = new Dictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>
+        {
+            ["C1"] = new()
+            {
+                RawCode = "import nazca as nd\ndef component(): ...",
+                Backend = CAP_DataAccess.Persistence.PIR.OverrideBackend.Nazca,
+            },
+        };
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells), overrides);
+
+        script.ShouldNotContain("override_C1");                      // Nazca code not emitted
+        script.ShouldContain("gf.get_component('ebeam_y_1550')");    // uses the ubcpdk cell instead
+        GdsFactoryExporter.CollectBackendMismatches(canvas, overrides).ShouldBe(new[] { "C1" });
+    }
+
+    [Fact]
     public void Export_Standalone_HasGdsFactoryHeaderWithoutPdkActivation()
     {
         var script = ExportStandalone(CreateCanvasWithComponent("ebeam_y_1550"));

--- a/docs/superpowers/specs/2026-07-03-gdsfactory-instance-override-design.md
+++ b/docs/superpowers/specs/2026-07-03-gdsfactory-instance-override-design.md
@@ -1,0 +1,47 @@
+# Per-instance structure override for gdsfactory (Issue #637)
+
+**Datum:** 2026-07-03 · Baut auf #581 (gdsfactory-Export, gemergt).
+**Ground Truth:** gdsfactory 9.34.2 + ubcpdk 3.3.4.
+
+## Ziel
+Der per-Instanz-Code-Override in den Component Settings (heute Nazca-only, #556/#559)
+soll auch **gdsfactory**-Code unterstützen. UX (vom Nutzer): ein **Segment-Toggle
+„Nazca | gdsfactory"** oben im Editor; er schaltet Hilfetext/Beispiel/Docs und das
+Backend für Preview + Apply um. Darunter unverändert: Code-Editor, Run Preview,
+Apply, Size/Pin-Recompute.
+
+## Verifizierter Kern (dieser PR)
+`scripts/render_gdsfactory_preview.py`: führt Nutzer-gdsfactory-Code aus und emittiert
+**denselben JSON-Kontrakt** wie `render_component_preview.py`
+(`{success, bbox, polygons:[{layer,vertices}], pins:[{name,x,y,angle}]}`) — verifiziert
+gegen gf 9.34.2 (`gf.components.mmi1x2`, echte `ubcpdk`-Zelle, Fehlerfall). Damit ist
+die **Preview-Plumbing wiederverwendbar** (gleiche `--code-file`-CLI wie der
+Nazca-Raw-Code-Modus): der Editor bekommt einen zweiten Preview-Service, der auf dieses
+Skript zeigt, und routet nach Backend.
+
+- Component-Deklaration im Nutzercode: Variable `component` (oder `c`, oder die einzige
+  `gf.Component` im Scope). `gf.gpdk.PDK.activate()` läuft vorab, damit Layer-Tupel ohne
+  eigenes PDK auflösen; aktiviert der Nutzercode ein PDK (z. B. ubcpdk), gewinnt das.
+
+## Verbleibende Schritte (Folge-PRs, klar geschnitten)
+1. **Datenmodell**: `NazcaCodeOverride.Backend` (enum `Nazca|GdsFactory`, Default `Nazca`
+   für Rückwärtskompatibilität) + Clone/Persistenz.
+2. **Preview-Service-Wiring**: DI erzeugt einen Preview-Service auf das gf-Skript;
+   Editor-VM erhält beide Services und wählt nach `SelectedBackend`.
+3. **Editor-VM + XAML**: `SelectedBackend`-Toggle, Hilfetext/Beispiel je Backend,
+   Preview/Apply route zum gewählten Backend. (Der VM ist bereits 495 Zeilen — die
+   backend-neutralen Teile beim Erweitern faktorisieren.)
+4. **Export-Anbindung**: `GdsFactoryExporter` respektiert gf-Backend-Overrides (emittiert
+   den Nutzer-Code als Component-Factory statt Stub); `SimpleNazcaExporter` ignoriert
+   gf-Overrides. Nazca-Overrides bleiben unverändert der Default.
+
+## Nicht-Ziele
+- Kein Zwang, denselben Code für beide Backends zu schreiben (Backend ist pro Override
+  getaggt).
+- Kein Auto-Konvertieren bestehender Nazca-Overrides.
+
+## Tests / Verifikation
+- Renderer-E2E gegen den gf-Env (skippt ohne Installation).
+- VM-Tests: Backend-Toggle schaltet Hilfetext + Preview-Route; Apply mit gf-Backend
+  übernimmt Größe/Pins aus dem gf-Render.
+- Export-Test: gf-Backend-Override erscheint als Factory im gf-Skript.

--- a/scripts/render_gdsfactory_preview.py
+++ b/scripts/render_gdsfactory_preview.py
@@ -1,0 +1,127 @@
+"""Render a gdsfactory component to a geometry-preview JSON (issue #637).
+
+Parallel to render_component_preview.py (Nazca), this executes user-supplied
+gdsfactory code and emits the SAME JSON contract the C# preview parser expects:
+
+    { "success": true,
+      "bbox": {"xmin": -5.0, "ymin": -10.0, "xmax": 75.0, "ymax": 45.0},
+      "polygons": [{"layer": 1, "vertices": [[x, y], ...]}],
+      "pins": [{"name": "o1", "x": 0.0, "y": 27.5, "angle": 180.0}] }
+
+or, on any failure:
+
+    { "success": false, "error": "message" }
+
+Usage: python render_gdsfactory_preview.py --code-file <file>
+       python render_gdsfactory_preview.py <file>          (positional shorthand)
+The user code must produce a gdsfactory Component: either assign it to a
+variable named ``component`` (preferred) or ``c``, or leave a single
+gf.Component in module scope. A ``gf.gpdk.PDK.activate()`` is done first so
+plain layer tuples resolve without an explicit PDK.
+"""
+import json
+import sys
+
+
+def _emit(result):
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+def _find_component(namespace):
+    """Locates the gf.Component the user's code produced."""
+    import gdsfactory as gf
+    for key in ("component", "c"):
+        obj = namespace.get(key)
+        if isinstance(obj, gf.Component):
+            return obj
+    candidates = [v for v in namespace.values() if isinstance(v, gf.Component)]
+    if len(candidates) == 1:
+        return candidates[0]
+    raise ValueError(
+        "No gdsfactory Component found. Assign your component to a variable "
+        "named 'component' (e.g. `component = gf.components.straight()`).")
+
+
+def _layer_index(layer):
+    """Reduces a gdstk/gdsfactory layer key to the layer number for the preview."""
+    if isinstance(layer, tuple):
+        return int(layer[0])
+    try:
+        return int(layer)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _extract(component):
+    import gdsfactory as gf  # noqa: F401  (ensures gdsfactory is importable)
+
+    bb = component.dbbox()
+    polygons = []
+    # get_polygons_points(by='tuple') -> {(layer,dtype): [ndarray(N,2), ...]} in µm.
+    by_layer = component.get_polygons_points(by="tuple")
+    for layer, polys in by_layer.items():
+        lidx = _layer_index(layer)
+        for poly in polys:
+            verts = [[float(x), float(y)] for x, y in poly]
+            if verts:
+                polygons.append({"layer": lidx, "vertices": verts})
+
+    pins = []
+    for p in component.ports:
+        cx, cy = p.dcenter
+        pins.append({
+            "name": str(p.name),
+            "x": float(cx),
+            "y": float(cy),
+            "angle": float(p.orientation),
+        })
+
+    return {
+        "success": True,
+        "bbox": {
+            "xmin": float(bb.left),
+            "ymin": float(bb.bottom),
+            "xmax": float(bb.right),
+            "ymax": float(bb.top),
+        },
+        "polygons": polygons,
+        "pins": pins,
+    }
+
+
+def _code_file_arg():
+    """Accepts '--code-file <path>' (matching the Nazca raw-code CLI) or a bare path."""
+    args = sys.argv[1:]
+    if "--code-file" in args:
+        i = args.index("--code-file")
+        if i + 1 < len(args):
+            return args[i + 1]
+        return None
+    return args[0] if args else None
+
+
+def main():
+    path = _code_file_arg()
+    if not path:
+        _emit({"success": False, "error": "usage: render_gdsfactory_preview.py --code-file <file>"})
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            code = f.read()
+
+        import gdsfactory as gf
+        try:
+            gf.gpdk.PDK.activate()
+        except Exception:
+            pass  # a PDK the user's code activates itself takes precedence
+
+        namespace = {"gf": gf}
+        exec(compile(code, "<override>", "exec"), namespace)
+        component = _find_component(namespace)
+        _emit(_extract(component))
+    except Exception as exc:  # noqa: BLE001 — any failure becomes a structured error
+        _emit({"success": False, "error": str(exc)})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #637.

Per-instance structure overrides in Component Settings now support **gdsfactory** alongside Nazca, via the segmented toggle you described.

## What you can test
- Open Component Settings on a placed instance → the override editor has a **Backend: Nazca | gdsfactory** toggle.
- Switch to **gdsfactory** → the help text changes and the editor seeds a gdsfactory starter (`component = gf.components.mmi1x2()`); switching backends never discards code you've already written.
- Write gdsfactory code, **Run Preview** → rendered by the gdsfactory backend (real gf geometry: bbox + ports), **Apply** → updates the instance's size/pins and tags the override as gdsfactory.
- Reopening restores the saved backend.

## How it works
- Verified renderer `render_gdsfactory_preview.py` (same `--code-file` CLI + JSON contract as the Nazca renderer) → reused via `GdsFactoryComponentPreviewService`.
- `NazcaCodeOverride.Backend` (Nazca|GdsFactory, default Nazca so existing overrides keep working).
- Preview service resolved from DI (active interpreter + gf renderer), threaded MainWindow → dialog → editor VM.
- Backend members split into a partial file to keep the editor within the file-size limit.

## Tests
- gdsfactory preview renderer E2E (gf 9.34.2; `mmi1x2`, real ubcpdk cell, error path).
- VM routing: gdsfactory backend uses the gf service (not Nazca), Apply tags the backend; full suite **2728 passed, 0 failed**.

## Follow-up (noted in the commit)
The gdsfactory **export** honoring a gdsfactory-backend override (emitting the raw code as the component's factory) — Apply already updates the live geometry/pins from the gf render; the export-honors-override symmetry is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)