### PR TITLE
(*) gdsfactory export just works: auto-generate+open GDS, auto-install gdsfactory, no prompts

### DIFF
--- a/CAP.Avalonia/DI/ExportFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/ExportFeatureExtensions.cs
@@ -50,7 +50,20 @@ internal static class ExportFeatureExtensions
         services.AddSingleton<PhotonTorchExporter>();
         services.AddSingleton<PhotonTorchExportViewModel>();
 
-        services.AddSingleton<GdsFactoryExportViewModel>();
+        services.AddSingleton<GdsFactoryExportViewModel>(sp =>
+        {
+            var vm = new GdsFactoryExportViewModel(
+                sp.GetRequiredService<CAP.Avalonia.ViewModels.Canvas.DesignCanvasViewModel>(),
+                sp.GetRequiredService<GdsExportService>(),
+                sp.GetService<IUrlLauncher>(),
+                sp.GetService<CAP_Core.ErrorConsoleService>());
+            // Auto-install gdsfactory on export (env-manager slice resolved lazily so the
+            // export slice never imports it directly).
+            vm.EnsureGdsFactoryAsync = (progress, ct) =>
+                sp.GetRequiredService<PythonEnvironmentManagerViewModel>()
+                    .EnsureGdsFactoryInstalledAsync(progress, ct);
+            return vm;
+        });
 
         services.AddSingleton<VerilogAExporter>();
         services.AddSingleton<VerilogAFileWriter>();

--- a/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
@@ -10,22 +10,19 @@ using CommunityToolkit.Mvvm.Input;
 namespace CAP.Avalonia.ViewModels.Export;
 
 /// <summary>
-/// ViewModel for the gdsfactory export dialog (#581): mode selection (standalone stub
-/// geometry vs. real ubcpdk cells), optional GDS generation through the configured
-/// interpreter, and the list of components without a ubcpdk mapping.
+/// ViewModel for the gdsfactory export dialog (#581/#643). The export "just works":
+/// it always uses real ubcpdk (SiEPIC) cells where a mapping exists and falls back to
+/// stub geometry otherwise (no geometry question), always generates the GDS and opens it,
+/// and — when gdsfactory is missing from the active interpreter — auto-installs it into a
+/// managed environment (creating one if needed) and retries.
 /// </summary>
 public partial class GdsFactoryExportViewModel : ObservableObject
 {
     private readonly DesignCanvasViewModel _canvas;
     private readonly GdsExportService _exportService;
+    private readonly IUrlLauncher _urlLauncher;
     private readonly ErrorConsoleService? _errorConsole;
     private readonly GdsFactoryExporter _exporter = new();
-
-    [ObservableProperty]
-    private bool _useUbcPdkCells;
-
-    [ObservableProperty]
-    private bool _generateGdsEnabled = true;
 
     [ObservableProperty]
     private ObservableCollection<string> _unmappedComponents = new();
@@ -39,17 +36,27 @@ public partial class GdsFactoryExportViewModel : ObservableObject
     /// <summary>File dialog service; wired by the UI layer like the other exporters.</summary>
     public IFileDialogService? FileDialogService { get; set; }
 
+    /// <summary>
+    /// Ensures gdsfactory is installed into a managed environment (creating one if needed)
+    /// and returns true when it is available afterwards. Wired by the DI layer to the
+    /// environment manager so the export slice does not import it directly.
+    /// </summary>
+    public Func<IProgress<string>, CancellationToken, Task<bool>>? EnsureGdsFactoryAsync { get; set; }
+
     /// <summary>Initializes a new instance of <see cref="GdsFactoryExportViewModel"/>.</summary>
     /// <param name="canvas">The design canvas to export.</param>
-    /// <param name="exportService">Script runner used for the optional GDS generation.</param>
+    /// <param name="exportService">Script runner used for GDS generation.</param>
+    /// <param name="urlLauncher">Launcher used to open the generated GDS.</param>
     /// <param name="errorConsole">Optional error logging.</param>
     public GdsFactoryExportViewModel(
         DesignCanvasViewModel canvas,
         GdsExportService exportService,
+        IUrlLauncher? urlLauncher = null,
         ErrorConsoleService? errorConsole = null)
     {
         _canvas = canvas;
         _exportService = exportService;
+        _urlLauncher = urlLauncher ?? PlatformShellLauncher.CreateDefault();
         _errorConsole = errorConsole;
     }
 
@@ -101,20 +108,29 @@ public partial class GdsFactoryExportViewModel : ObservableObject
         IsExporting = true;
         try
         {
-            var options = new GdsFactoryExportOptions(UseUbcPdkCells
-                ? GdsFactoryComponentMode.UbcPdkCells
-                : GdsFactoryComponentMode.StandaloneStubs);
-            await File.WriteAllTextAsync(filePath, _exporter.Export(_canvas, options));
-
-            if (!GenerateGdsEnabled)
-            {
-                StatusText = $"Exported {Path.GetFileName(filePath)} (GDS generation skipped).";
-                return;
-            }
+            // Always ubcpdk-where-available with stub fallback — no geometry question.
+            await File.WriteAllTextAsync(filePath,
+                _exporter.Export(_canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells)));
 
             StatusText = "Running gdsfactory to generate the GDS...";
             var result = await _exportService.ExportToGdsAsync(filePath, generateGds: true);
+
+            // gdsfactory missing → auto-install into a managed environment and retry once.
+            if (!result.Success && IsGdsFactoryMissing(result.ErrorMessage) && EnsureGdsFactoryAsync != null)
+            {
+                var progress = new Progress<string>(m => StatusText = m);
+                StatusText = "gdsfactory not found — installing it into a managed environment...";
+                var installed = await EnsureGdsFactoryAsync(progress, CancellationToken.None);
+                if (installed)
+                {
+                    StatusText = "Retrying GDS generation...";
+                    result = await _exportService.ExportToGdsAsync(filePath, generateGds: true);
+                }
+            }
+
             StatusText = DescribeResult(filePath, result);
+            if (result.Success && result.GdsPath != null)
+                TryOpenGds(result.GdsPath);
         }
         catch (Exception ex)
         {
@@ -127,11 +143,28 @@ public partial class GdsFactoryExportViewModel : ObservableObject
         }
     }
 
+    private static bool IsGdsFactoryMissing(string? errorMessage) =>
+        errorMessage?.Contains("No module named 'gdsfactory'", StringComparison.OrdinalIgnoreCase) == true;
+
+    /// <summary>Opens the generated GDS in the default viewer (KLayout etc.), best-effort.</summary>
+    private void TryOpenGds(string gdsPath)
+    {
+        try
+        {
+            if (File.Exists(gdsPath))
+                _urlLauncher.OpenFileOrDirectory(gdsPath);
+        }
+        catch (Exception ex)
+        {
+            _errorConsole?.LogWarning($"Could not open {Path.GetFileName(gdsPath)}: {ex.Message}");
+        }
+    }
+
     private string DescribeResult(string filePath, GdsExportService.ExportResult result)
     {
         var scriptName = Path.GetFileName(filePath);
         if (result.Success && result.GdsPath != null)
-            return $"Exported {scriptName} and {Path.GetFileName(result.GdsPath)}.";
+            return $"Exported {scriptName} and opened {Path.GetFileName(result.GdsPath)}.";
         if (result.Success)
             return $"Exported {scriptName}.";
 

--- a/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/PythonEnvironmentManager/PythonEnvironmentManagerViewModel.cs
@@ -210,6 +210,59 @@ public partial class PythonEnvironmentManagerViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Ensures a managed environment with gdsfactory exists and is active — used by the
+    /// gdsfactory export to auto-provision on first use. Installs gdsfactory (+ubcpdk) into
+    /// the active managed env, or creates the default environment (Nazca + gdsfactory) when
+    /// none exists, then activates it. Reports progress; returns true when gdsfactory is
+    /// available afterwards. No-ops to false while another operation runs.
+    /// </summary>
+    public async Task<bool> EnsureGdsFactoryInstalledAsync(
+        IProgress<string> progress, CancellationToken ct)
+    {
+        if (IsBusy) return false;
+
+        var active = _registry.GetActive();
+        var target = active ?? _registry.GetAll().FirstOrDefault();
+
+        IsBusy = true;
+        CanCancel = true;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        try
+        {
+            var token = _cts.Token;
+            var uvPath = await _bootstrapper.EnsureUvAsync(progress, token);
+
+            if (target == null)
+            {
+                var venvPath = Path.Combine(UvBootstrapper.EnvironmentsBaseDir, DefaultEnvironmentName);
+                target = new PythonEnvironment { Name = DefaultEnvironmentName, VenvPath = venvPath };
+                progress.Report($"Creating managed environment '{DefaultEnvironmentName}'...");
+                await _bootstrapper.CreateVenvAsync(uvPath, venvPath, UvBootstrapper.DefaultPythonVersion, progress, token);
+                await _installer.InstallAsync(uvPath, venvPath, progress, token);
+            }
+
+            await _installer.InstallGdsFactoryAsync(uvPath, target.VenvPath, progress, token);
+            await _healthChecker.CheckAsync(target, token);
+            _registry.AddOrUpdate(target);
+            _registry.SetActive(target.Name);
+            RefreshList();
+            return target.GdsFactoryVersion != null;
+        }
+        catch (Exception ex)
+        {
+            ProgressText = $"gdsfactory install failed: {ex.Message}";
+            return false;
+        }
+        finally
+        {
+            IsBusy = false;
+            CanCancel = false;
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+
     /// <summary>Sets the selected environment as the active Python for export/preview.</summary>
     [RelayCommand]
     private void SetActive()

--- a/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml
+++ b/CAP.Avalonia/Views/Dialogs/GdsFactoryExportDialog.axaml
@@ -4,16 +4,16 @@
         x:Class="CAP.Avalonia.Views.Dialogs.GdsFactoryExportDialog"
         x:DataType="vm:GdsFactoryExportViewModel"
         Title="Export — gdsfactory"
-        Width="440" Height="420"
+        Width="460" Height="480"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         Background="#1e1e1e"
         Foreground="White">
 
-    <DockPanel Margin="16" LastChildFill="True">
+    <DockPanel Margin="16,10" LastChildFill="True">
 
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
-                    HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
+                    HorizontalAlignment="Right" Spacing="8" Margin="0,8,0,0">
             <Button Content="Export…"
                     Command="{Binding ExportCommand}"
                     Width="90" Background="#3d5d4d"
@@ -22,33 +22,16 @@
         </StackPanel>
 
         <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
-            <StackPanel Spacing="10">
+            <StackPanel Spacing="8">
                 <TextBlock Text="🏭 gdsfactory Export" FontSize="15" FontWeight="SemiBold"
                            Foreground="LightGreen"/>
-                <TextBlock Text="Exports the design as a gdsfactory Python script; optionally runs it with the configured Python to produce the GDS."
-                           Foreground="Gray" FontSize="10" TextWrapping="Wrap"/>
+                <TextBlock TextWrapping="Wrap" Foreground="Gray" FontSize="11"
+                           Text="Exports the design to a gdsfactory Python script, runs it to produce the GDS, and opens the GDS. Real ubcpdk (SiEPIC) cells are used where available; other components use stub geometry. If gdsfactory isn't installed, it is set up in a managed environment automatically."/>
 
-                <Separator Background="#3d3d3d"/>
-
-                <TextBlock Text="Component geometry:" Foreground="Gray" FontSize="11"/>
-                <RadioButton GroupName="mode"
-                             Content="Standalone — stub geometry from Lunima dimensions"
-                             IsChecked="{Binding !UseUbcPdkCells}"
-                             Foreground="White" FontSize="12"/>
-                <TextBlock Text="Runs with a plain gdsfactory install; layout matches the canvas 1:1 (like the Nazca export)."
-                           Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="24,0,0,0"/>
-                <RadioButton GroupName="mode"
-                             Content="ubcpdk (SiEPIC) — real PDK cells where available"
-                             IsChecked="{Binding UseUbcPdkCells}"
-                             Foreground="White" FontSize="12"/>
-                <TextBlock Text="Requires the ubcpdk package; components without a ubcpdk equivalent fall back to stub geometry."
-                           Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="24,0,0,0"/>
-
-                <!-- Components without a ubcpdk mapping (relevant in ubcpdk mode) -->
                 <Border Background="#2a2a20" CornerRadius="4" Padding="8"
                         IsVisible="{Binding UnmappedComponents.Count}">
                     <StackPanel Spacing="4">
-                        <TextBlock Text="Without ubcpdk mapping (stub fallback):"
+                        <TextBlock Text="Stub geometry (no ubcpdk cell):"
                                    Foreground="#e8c872" FontSize="11" FontWeight="SemiBold"/>
                         <ItemsControl ItemsSource="{Binding UnmappedComponents}">
                             <ItemsControl.ItemTemplate>
@@ -59,12 +42,6 @@
                         </ItemsControl>
                     </StackPanel>
                 </Border>
-
-                <Separator Background="#3d3d3d"/>
-
-                <CheckBox Content="Generate GDS after export (requires Python + gdsfactory)"
-                          IsChecked="{Binding GenerateGdsEnabled}"
-                          Foreground="White" FontSize="12"/>
 
                 <TextBlock Text="{Binding StatusText}"
                            Foreground="LightSkyBlue" FontSize="11" TextWrapping="Wrap"

--- a/Connect-A-Pic-Core/Export/GdsExportService.cs
+++ b/Connect-A-Pic-Core/Export/GdsExportService.cs
@@ -152,7 +152,7 @@ public class GdsExportService
     /// <param name="scriptPath">Path to the Python script to execute.</param>
     /// <param name="generateGds">If true, attempts to generate GDS from the script.</param>
     /// <returns>Export result with status information.</returns>
-    public async Task<ExportResult> ExportToGdsAsync(string scriptPath, bool generateGds)
+    public virtual async Task<ExportResult> ExportToGdsAsync(string scriptPath, bool generateGds)
     {
         if (!File.Exists(scriptPath))
         {

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
@@ -60,24 +60,23 @@ public class GdsFactoryExportViewModelTests
     }
 
     [Fact]
-    public async Task Export_WithoutGdsGeneration_WritesScriptInSelectedMode()
+    public async Task Export_AlwaysWritesUbcPdkScript()
     {
+        // No geometry question anymore: the export always uses ubcpdk cells where available
+        // (stub fallback otherwise) and always attempts GDS generation.
         var scriptPath = Path.Combine(Path.GetTempPath(), $"gfvm-{Guid.NewGuid():N}.py");
         try
         {
             var vm = new GdsFactoryExportViewModel(CanvasWithComponent("ebeam_y_1550"), new GdsExportService())
             {
                 FileDialogService = new FixedPathFileDialog(scriptPath),
-                GenerateGdsEnabled = false,
-                UseUbcPdkCells = true,
             };
 
             await vm.ExportCommand.ExecuteAsync(null);
 
             File.Exists(scriptPath).ShouldBeTrue();
             var script = await File.ReadAllTextAsync(scriptPath);
-            script.ShouldContain("gf.get_component('ebeam_y_1550')");   // ubcpdk mode was honored
-            vm.StatusText.ShouldContain("GDS generation skipped");
+            script.ShouldContain("gf.get_component('ebeam_y_1550')");   // real ubcpdk cell used
         }
         finally
         {
@@ -108,6 +107,50 @@ public class GdsFactoryExportViewModelTests
         msg.ShouldContain("Error Console");
         msg.ShouldNotContain("Traceback");
         msg.ShouldNotContain("boom");
+    }
+
+    [Fact]
+    public async Task Export_GdsFactoryMissing_TriggersAutoInstallThenRetries()
+    {
+        // When the GDS run reports "No module named 'gdsfactory'", the export must invoke the
+        // auto-install delegate and retry — without asking the user.
+        var scriptPath = Path.Combine(Path.GetTempPath(), $"gfvm-{Guid.NewGuid():N}.py");
+        try
+        {
+            // A GdsExportService whose python has no gdsfactory yields the missing-module error;
+            // here we only assert the delegate is invoked, so a stub export service that always
+            // reports the missing-module error drives the path deterministically.
+            var vm = new GdsFactoryExportViewModel(
+                CanvasWithComponent("ebeam_y_1550"),
+                new StubMissingGdsFactoryExportService())
+            {
+                FileDialogService = new FixedPathFileDialog(scriptPath),
+            };
+            var installCalls = 0;
+            vm.EnsureGdsFactoryAsync = (_, _) => { installCalls++; return Task.FromResult(true); };
+
+            await vm.ExportCommand.ExecuteAsync(null);
+
+            installCalls.ShouldBe(1);   // auto-install was triggered, no user prompt
+        }
+        finally
+        {
+            if (File.Exists(scriptPath)) File.Delete(scriptPath);
+        }
+    }
+
+    /// <summary>Export service that always reports the missing-gdsfactory error, to drive the
+    /// auto-install path without a real Python.</summary>
+    private sealed class StubMissingGdsFactoryExportService : GdsExportService
+    {
+        public override Task<ExportResult> ExportToGdsAsync(string scriptPath, bool generateGds) =>
+            Task.FromResult(new ExportResult
+            {
+                ScriptPath = scriptPath,
+                Success = false,
+                ErrorMessage = "Python script execution failed (exit code 1): "
+                    + "ModuleNotFoundError: No module named 'gdsfactory'",
+            });
     }
 
     [Fact]

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -63,7 +63,7 @@ public static class MainViewModelTestHelper
             Mock.Of<IUrlLauncher>());
         var photonTorchVm = new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas);
         var verilogAVm = new VerilogAExportViewModel(new VerilogAExporter(), new VerilogAFileWriter(), canvas);
-        var gdsFactoryVm = new GdsFactoryExportViewModel(canvas, new GdsExportService(), errorConsoleService);
+        var gdsFactoryVm = new GdsFactoryExportViewModel(canvas, new GdsExportService(), errorConsole: errorConsoleService);
 
         return new MainViewModel(
             canvas,


### PR DESCRIPTION
Addresses the gdsfactory-export UX feedback (follow-up to #624).

## What changed
- **No more geometry question, no GDS checkbox.** The export always uses real ubcpdk (SiEPIC) cells where a mapping exists and falls back to stub geometry otherwise, and it always generates the GDS.
- **Opens the GDS** in the default viewer (KLayout etc.) after generating it.
- **Auto-installs gdsfactory** when it's missing from the active interpreter: `PythonEnvironmentManagerViewModel.EnsureGdsFactoryInstalledAsync` installs gdsfactory (+ubcpdk) into the active managed environment, or creates the default managed environment (Nazca + gdsfactory) if none exists, activates it, then the export retries the GDS generation once — without asking the user.
- **Dialog** stripped of the mode radios and the GDS checkbox; a bit taller with smaller vertical margins; shows only the stub-fallback list + progress/status.

## Tests
- `Export_AlwaysWritesUbcPdkScript`, `Export_GdsFactoryMissing_TriggersAutoInstallThenRetries` (fake install delegate; `ExportToGdsAsync` made virtual for the stub), plus the existing failure-message/unmapped tests updated.
- Full suite green locally: **2726 passed, 0 failed**.

## Not here (separate, larger UX — see follow-up issue)
Unifying the interpreter selection into the Python Environments tab (show discovered system Pythons alongside managed envs, each with Nazca **and** gdsfactory versions, selectable there) — the GDS-export page's lower "Python Environment" section would then move/point there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)