### PR TITLE
(+) Single-process: enforce active process for component groups (#653)

### DIFF
--- a/CAP.Avalonia/Selection/ComponentClipboard.cs
+++ b/CAP.Avalonia/Selection/ComponentClipboard.cs
@@ -29,9 +29,29 @@ public class ComponentClipboard
     /// <summary>
     /// PDK sources of every copied component, in copy order (issue #570). Lets callers
     /// (e.g. <c>CanvasInteractionViewModel.PasteSelected</c>) check the active-process policy
-    /// against clipboard contents before executing the paste command.
+    /// against clipboard contents before executing the paste command. When
+    /// <paramref name="resolveGroupChildPdkSource"/> is provided, copied
+    /// <see cref="ComponentGroup"/>s additionally contribute the resolved PDK source of every
+    /// recursive non-group child, so a group cannot smuggle foreign-process components past
+    /// the paste guard (issue #653).
     /// </summary>
-    public IReadOnlyList<string?> PeekPdkSources() => _entries.Select(e => e.PdkSource).ToList();
+    public IReadOnlyList<string?> PeekPdkSources(
+        Func<Component, string?>? resolveGroupChildPdkSource = null)
+    {
+        var sources = new List<string?>();
+        foreach (var entry in _entries)
+        {
+            sources.Add(entry.PdkSource);
+
+            if (resolveGroupChildPdkSource != null && entry.OriginalComponent is ComponentGroup group)
+            {
+                sources.AddRange(group.GetAllComponentsRecursive()
+                    .Where(child => child is not ComponentGroup)
+                    .Select(resolveGroupChildPdkSource));
+            }
+        }
+        return sources;
+    }
 
     /// <summary>
     /// Copies the given components and their internal connections.

--- a/CAP.Avalonia/ViewModels/Library/ComponentPdkSourceResolver.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentPdkSourceResolver.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.ViewModels.Library;
+
+/// <summary>
+/// Resolves the PDK source of a placed core <see cref="Component"/> by matching its
+/// <c>NazcaFunctionName</c> against the loaded component library. Core components carry no
+/// PDK source of their own — only <see cref="ComponentTemplate"/>s do — so this lookup is the
+/// single shared way to recover it (used for saving designs and for single-process
+/// enforcement over group children, issues #570 / #653).
+/// </summary>
+public static class ComponentPdkSourceResolver
+{
+    /// <summary>
+    /// Returns the <see cref="ComponentTemplate.PdkSource"/> of the library template whose
+    /// Nazca function name matches <paramref name="component"/>, or null when no match exists
+    /// (e.g. user groups or components whose PDK is not loaded).
+    /// </summary>
+    public static string? Resolve(Component component, IEnumerable<ComponentTemplate> library)
+    {
+        var nazcaFunc = component.NazcaFunctionName;
+        if (string.IsNullOrEmpty(nazcaFunc))
+            return null;
+
+        var match = library.FirstOrDefault(t =>
+        {
+            var templateFunc = t.NazcaFunctionName
+                ?? $"nazca_{t.Name.ToLower().Replace(" ", "_")}";
+            return templateFunc == nazcaFunc;
+        });
+        return match?.PdkSource;
+    }
+}

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -233,6 +233,10 @@ public partial class MainViewModel : ObservableObject
         // active process and the process-agnostic tool PDKs (e.g. "Analysis Tools").
         CanvasInteraction.GetActiveProcess = () => FileOperations.ActiveProcess;
         CanvasInteraction.GetProcessAgnosticPdkNames = () => LeftPanel.GetProcessAgnosticPdkNames();
+        // Group children carry no PdkSource of their own — resolve via the loaded library so
+        // group placement/paste is checked against the active process too (issue #653).
+        CanvasInteraction.ResolveComponentPdkSource = component =>
+            ViewModels.Library.ComponentPdkSourceResolver.Resolve(component, LeftPanel.AllTemplates);
 
         // Let the export guard open the Settings window (e.g. on the Python-Environments
         // page when Nazca is missing); ShowSettingsWindowAsync is wired later by MainWindow.

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -105,6 +105,14 @@ public partial class CanvasInteractionViewModel : ObservableObject
     /// </summary>
     public Func<IReadOnlyCollection<string>>? GetProcessAgnosticPdkNames { get; set; }
 
+    /// <summary>
+    /// Callback resolving the PDK source of a placed core component (groups carry none of
+    /// their own, so their children are resolved individually — issue #653). Wired by
+    /// <c>MainViewModel</c> to <c>ComponentPdkSourceResolver.Resolve</c> over the loaded
+    /// component library. When unwired, group children resolve to null (treated as built-in).
+    /// </summary>
+    public Func<Component, string?>? ResolveComponentPdkSource { get; set; }
+
     public CanvasInteractionViewModel(
         DesignCanvasViewModel canvas,
         CommandManager commandManager,
@@ -354,6 +362,19 @@ public partial class CanvasInteractionViewModel : ObservableObject
             return;
         }
 
+        // Single-process enforcement over the group's children (issue #653): a group has no
+        // PdkSource of its own, so a foreign-process child must not slip in via grouping.
+        var (isAllowed, blockReason) = GroupProcessPolicy.CheckGroupPlacement(
+            GetActiveProcess?.Invoke(),
+            ChildPdkSources(SelectedGroupTemplate.TemplateGroup),
+            GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>(),
+            SelectedGroupTemplate.Name);
+        if (!isAllowed)
+        {
+            UpdateStatus?.Invoke(blockReason ?? "Process mismatch — cannot place group.");
+            return;
+        }
+
         var libraryManager = _libraryViewModel.GetLibraryManager();
         var cmd = PlaceGroupTemplateCommand.TryCreate(_canvas, libraryManager, SelectedGroupTemplate, x, y);
 
@@ -366,6 +387,15 @@ public partial class CanvasInteractionViewModel : ObservableObject
         _commandManager.ExecuteCommand(cmd);
         UpdateStatus?.Invoke($"Placed group '{SelectedGroupTemplate.Name}' at ({x:F0}, {y:F0})µm");
     }
+
+    /// <summary>
+    /// Resolved PDK source of every recursive non-group child of <paramref name="group"/>,
+    /// used to check the single-process policy over a group's contents (issue #653).
+    /// </summary>
+    private IEnumerable<string?> ChildPdkSources(ComponentGroup group) =>
+        group.GetAllComponentsRecursive()
+            .Where(child => child is not ComponentGroup)
+            .Select(child => ResolveComponentPdkSource?.Invoke(child));
 
     /// <summary>
     /// Selects the component or connection at the given canvas position, keeping the
@@ -666,7 +696,9 @@ public partial class CanvasInteractionViewModel : ObservableObject
 
         var active = GetActiveProcess?.Invoke();
         var agnosticPdkNames = GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>();
-        var blockedCount = _canvas.Clipboard.PeekPdkSources()
+        // Include resolved group-child PDK sources so a copied group cannot smuggle
+        // foreign-process components past the paste guard (issue #653).
+        var blockedCount = _canvas.Clipboard.PeekPdkSources(ResolveComponentPdkSource)
             .Count(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, agnosticPdkNames).IsAllowed);
         if (blockedCount > 0)
         {

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -472,20 +472,8 @@ public partial class FileOperationsViewModel : ObservableObject
     /// Finds the PDK source for a component by matching its NazcaFunctionName against the library.
     /// Returns null if no match is found.
     /// </summary>
-    private string? FindTemplatePdkSource(Component component)
-    {
-        var nazcaFunc = component.NazcaFunctionName;
-        if (string.IsNullOrEmpty(nazcaFunc))
-            return null;
-
-        var match = _componentLibrary.FirstOrDefault(t =>
-        {
-            var templateFunc = t.NazcaFunctionName
-                ?? $"nazca_{t.Name.ToLower().Replace(" ", "_")}";
-            return templateFunc == nazcaFunc;
-        });
-        return match?.PdkSource;
-    }
+    private string? FindTemplatePdkSource(Component component) =>
+        ComponentPdkSourceResolver.Resolve(component, _componentLibrary);
 
     /// <summary>
     /// Recursively serializes a ComponentGroup and all its nested child groups.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,14 @@ C# / Avalonia / MVVM photonic simulation tool. Stability, clarity, and architect
 
 ---
 
+## User Personas (UX North Star)
+
+**Before any UX/UI design, redesign, or feature-prioritization work, read [`docs/PERSONAS.md`](docs/PERSONAS.md).**
+
+It defines who Lunima is built for — Peter (Figma-precision GDS layout engineer), Priya (academic lab with own fab, GDSFactory + Tidy3D, measurement feedback), Mirko (full-stack system simulation, open formats, netlist export, photonic IR), and Ingrid (investor, demo path) — including per-persona design implications and the priority order when they conflict. Justify UX decisions against these personas in issues and PRs.
+
+---
+
 ## Implementation Guidelines: When to Include UI
 
 **User-Facing Features (with UI):** Keywords: "add button", "implement dialog", "user can", "add panel"
@@ -341,6 +349,7 @@ python scripts/compare_gds_coords.py /tmp/ref_coords.json /tmp/test_coords.json
 
 | Purpose | Path |
 |---------|------|
+| User personas (UX reference) | `docs/PERSONAS.md` |
 | DI container setup | `CAP.Avalonia/App.axaml.cs` |
 | Main ViewModel | `CAP.Avalonia/ViewModels/MainViewModel.cs` |
 | Main Window layout | `CAP.Avalonia/Views/MainWindow.axaml` |

--- a/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CAP_Core.Components.Process;
+
+/// <summary>
+/// Extends <see cref="SingleProcessPolicy"/> to component groups (issue #653). A group carries
+/// no <c>PdkSource</c> of its own, so its process membership is derived from its child
+/// components' PDK sources: the group is placeable only when every child passes the
+/// per-component placement check (member / built-in / process-agnostic).
+/// </summary>
+public static class GroupProcessPolicy
+{
+    /// <summary>
+    /// Decides whether a group whose (recursive, non-group) children come from
+    /// <paramref name="childPdkSources"/> may be placed on a design locked to
+    /// <paramref name="active"/>. Each child is evaluated with
+    /// <see cref="SingleProcessPolicy.CheckPlacement"/>; a single foreign-process child
+    /// blocks the whole group. Playground / unset selections always pass.
+    /// </summary>
+    /// <param name="active">The design's active process selection, or null when unset.</param>
+    /// <param name="childPdkSources">PDK source of every child component (null = built-in/unknown).</param>
+    /// <param name="processAgnosticPdkNames">Names of PDKs flagged process-agnostic (tool libraries).</param>
+    /// <param name="groupName">Display name of the group, used in the block message.</param>
+    public static (bool IsAllowed, string? BlockReason) CheckGroupPlacement(
+        ActiveProcessSelection? active,
+        IEnumerable<string?> childPdkSources,
+        IReadOnlyCollection<string>? processAgnosticPdkNames = null,
+        string? groupName = null)
+    {
+        var blockedPdkNames = childPdkSources
+            .Where(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, processAgnosticPdkNames).IsAllowed)
+            .Select(pdk => pdk!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (blockedPdkNames.Count == 0)
+            return (true, null);
+
+        var groupLabel = string.IsNullOrWhiteSpace(groupName) ? "This group" : $"Group '{groupName}'";
+        return (false,
+            $"{groupLabel} contains component(s) from '{string.Join("', '", blockedPdkNames)}', but the " +
+            $"chip is locked to the process '{active!.DisplayName}'. A monolithic design uses one process — " +
+            "start a new design (or use Playground) to mix processes.");
+    }
+}

--- a/UnitTests/Components/Process/GroupProcessPolicyTests.cs
+++ b/UnitTests/Components/Process/GroupProcessPolicyTests.cs
@@ -1,0 +1,92 @@
+using CAP_Core.Components.Process;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.Process;
+
+/// <summary>
+/// Group-level single-process enforcement (issue #653): a group's process membership is
+/// derived from its children's PDK sources, so one foreign-process child blocks the group.
+/// </summary>
+public class GroupProcessPolicyTests
+{
+    private static ActiveProcessSelection Soi(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "SOI 220",
+            new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"),
+            memberPdkNames));
+
+    [Fact]
+    public void AllChildrenFromMemberPdk_IsAllowed()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "Demo", "Demo" });
+
+        isAllowed.ShouldBeTrue();
+        reason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MixOfBuiltInAgnosticAndMemberChildren_IsAllowed()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"),
+            new[] { null, "Built-in", "Analysis Tools", "Demo" },
+            new[] { "Analysis Tools" });
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SingleForeignChild_BlocksWholeGroup_AndNamesOffenderAndProcess()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "Demo", "HHI-InP" }, groupName: "MyMixer");
+
+        isAllowed.ShouldBeFalse();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("MyMixer");
+        reason.ShouldContain("HHI-InP");
+        reason.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void MultipleForeignPdks_AreListedOnce_Each()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "HHI-InP", "hhi-inp", "IMEC" });
+
+        isAllowed.ShouldBeFalse();
+        reason!.ShouldContain("HHI-InP");
+        reason.ShouldContain("IMEC");
+        // Case-insensitive duplicate collapsed to one mention.
+        reason.Split("HHI-InP").Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void NoActiveProcess_AllowsForeignChildren()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            null, new[] { "HHI-InP" });
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Playground_AllowsForeignChildren()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            ActiveProcessSelection.Playground(), new[] { "HHI-InP", "Demo" });
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EmptyGroup_IsAllowed()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), Array.Empty<string?>());
+
+        isAllowed.ShouldBeTrue();
+    }
+}

--- a/UnitTests/ViewModels/Panels/GroupProcessEnforcementTests.cs
+++ b/UnitTests/ViewModels/Panels/GroupProcessEnforcementTests.cs
@@ -1,0 +1,212 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_Core.LightCalculation;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels.Panels;
+
+/// <summary>
+/// Closes the grouping bypass of single-process enforcement (issue #653): groups carry no
+/// PdkSource, so their children must be checked individually when a group template is placed
+/// (<see cref="CanvasInteractionViewModel.PlaceGroupTemplateAt"/> via <c>CanvasClicked</c>)
+/// and when a copied group is pasted (<see cref="CanvasInteractionViewModel.PasteSelected"/>).
+/// </summary>
+public class GroupProcessEnforcementTests : IDisposable
+{
+    private readonly string _testLibraryPath;
+    private readonly GroupLibraryManager _libraryManager;
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly CanvasInteractionViewModel _interaction;
+    private readonly CommandManager _commandManager;
+
+    public GroupProcessEnforcementTests()
+    {
+        _testLibraryPath = Path.Combine(Path.GetTempPath(), $"GroupProcessEnforcementTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testLibraryPath);
+
+        _libraryManager = new GroupLibraryManager(_testLibraryPath);
+        _canvas = new DesignCanvasViewModel();
+        _commandManager = new CommandManager();
+        _interaction = new CanvasInteractionViewModel(
+            _canvas, _commandManager, new ComponentLibraryViewModel(_libraryManager));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testLibraryPath))
+            Directory.Delete(_testLibraryPath, true);
+    }
+
+    private static ActiveProcessSelection Soi(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "SOI 220",
+            new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"),
+            memberPdkNames));
+
+    /// <summary>Maps a child's NazcaFunctionName to a PDK source, mimicking the library lookup.</summary>
+    private static string? ResolveByNazcaFunction(Component component) => component.NazcaFunctionName switch
+    {
+        "member_func" => "Demo",
+        "foreign_func" => "HHI-InP",
+        _ => null
+    };
+
+    private void LockToSoiWithResolver()
+    {
+        _interaction.GetActiveProcess = () => Soi("Demo");
+        _interaction.GetProcessAgnosticPdkNames = () => Array.Empty<string>();
+        _interaction.ResolveComponentPdkSource = ResolveByNazcaFunction;
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_WithForeignProcessChild_BlocksPlacementAndReportsStatus()
+    {
+        LockToSoiWithResolver();
+        SelectGroupTemplate("InP Mixer", "member_func", "foreign_func");
+
+        string? status = null;
+        _interaction.UpdateStatus = s => status = s;
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(0, "a group with a foreign-process child must not be placed");
+        _commandManager.CanUndo.ShouldBeFalse("a blocked placement must not touch the undo stack");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("HHI-InP");
+        status.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_AllChildrenFromMemberPdk_IsPlaced()
+    {
+        LockToSoiWithResolver();
+        SelectGroupTemplate("SOI Pair", "member_func", "member_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1, "a group whose children are all member-PDK must place normally");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_NoResolverWired_IsPlaced()
+    {
+        // Without a resolver, child sources resolve to null (built-in) — legacy behavior.
+        _interaction.GetActiveProcess = () => Soi("Demo");
+        _interaction.GetProcessAgnosticPdkNames = () => Array.Empty<string>();
+        SelectGroupTemplate("Unknown Group", "foreign_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_NoActiveProcess_AllowsForeignChildren()
+    {
+        _interaction.ResolveComponentPdkSource = ResolveByNazcaFunction;
+        SelectGroupTemplate("Playground Group", "foreign_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1, "with no active process, any group is placeable");
+    }
+
+    [Fact]
+    public void PasteSelected_CopiedGroupWithForeignChild_BlocksWholePaste()
+    {
+        // Place the mixed group directly (bypassing the placement guard under test), copy it.
+        var group = BuildGroup("Mixed", "member_func", "foreign_func");
+        var vm = _canvas.AddComponent(group);
+        _canvas.Selection.SelectSingle(vm);
+        _interaction.CopySelectedCommand.Execute(null);
+
+        LockToSoiWithResolver();
+        string? status = null;
+        _interaction.UpdateStatus = s => status = s;
+
+        int countBefore = _canvas.Components.Count;
+        _interaction.PasteSelected();
+
+        _canvas.Components.Count.ShouldBe(countBefore, "pasting a group with a foreign-process child must be blocked");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void PasteSelected_CopiedGroupWithMemberChildrenOnly_Pastes()
+    {
+        var group = BuildGroup("Members", "member_func", "member_func");
+        var vm = _canvas.AddComponent(group);
+        _canvas.Selection.SelectSingle(vm);
+        _interaction.CopySelectedCommand.Execute(null);
+
+        LockToSoiWithResolver();
+
+        int countBefore = _canvas.Components.Count;
+        _interaction.PasteSelected();
+
+        _canvas.Components.Count.ShouldBe(countBefore + 1, "a member-only group must paste normally");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_ForeignChildInNestedGroup_IsAlsoBlocked()
+    {
+        LockToSoiWithResolver();
+
+        var outer = BuildGroup("Outer", "member_func");
+        var nested = BuildGroup("Nested", "foreign_func");
+        outer.AddChild(nested);
+        SelectBuiltGroup(outer, "Outer Template");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(0, "foreign children hidden inside nested groups must be found");
+    }
+
+    private void SelectGroupTemplate(string name, params string[] childNazcaFunctions)
+    {
+        var group = BuildGroup(name, childNazcaFunctions);
+        SelectBuiltGroup(group, name);
+    }
+
+    private void SelectBuiltGroup(ComponentGroup group, string templateName)
+    {
+        var template = _libraryManager.SaveTemplate(group, templateName);
+        template.TemplateGroup = group;
+        _interaction.SelectedGroupTemplate = template;
+    }
+
+    private static ComponentGroup BuildGroup(string name, params string[] childNazcaFunctions)
+    {
+        var group = new ComponentGroup(name) { PhysicalX = 0, PhysicalY = 0 };
+
+        for (int i = 0; i < childNazcaFunctions.Length; i++)
+        {
+            var child = new Component(
+                new Dictionary<int, SMatrix>(),
+                new List<Slider>(),
+                childNazcaFunctions[i],
+                "",
+                new Part[1, 1] { { new Part() } },
+                -1,
+                $"comp_{i}_{Guid.NewGuid():N}",
+                DiscreteRotation.R0,
+                new List<PhysicalPin>())
+            {
+                PhysicalX = i * 100,
+                PhysicalY = 0,
+                WidthMicrometers = 50,
+                HeightMicrometers = 30
+            };
+            group.AddChild(child);
+        }
+
+        return group;
+    }
+}

--- a/docs/PERSONAS.md
+++ b/docs/PERSONAS.md
@@ -1,0 +1,113 @@
+# Lunima User Personas
+
+This file is the reference for **who Lunima is built for**. Agents redesigning UX, prioritizing features, writing copy, or making workflow trade-offs must read this first and justify design decisions against these personas.
+
+When personas conflict, the priority order for product decisions is: **Peter ≥ Mirko > Priya > Ingrid** — but no change may make the tool *incomprehensible* to Ingrid (the investor demo path must stay obvious).
+
+---
+
+## Persona 1: Peter — The Precision Layout Engineer
+
+**Role:** Photonic engineer at a photonic-CPU company.
+**Background:** Computer science + physics. Expert-level Nazca user. Loves cats, works long hours, very communicative — he will file detailed feedback and expects the tool to keep up with him.
+
+### What he wants
+
+- Edit GDS layouts **like Figma**: direct manipulation, immediate visual feedback, pixel-perfect (here: nanometer-perfect) control.
+- Set **curves and pin-to-pin connection types precisely** — bend radius, curve type (Euler / arc / Bezier), waveguide width transitions — not accept whatever an autorouter picks.
+- Fast, fluid canvas interactions: snapping, alignment guides, numeric input for exact values, keyboard shortcuts, undo that never lies.
+
+### What frustrates him
+
+- Modal dialogs interrupting flow; anything that requires more clicks than Figma would.
+- Autorouting that silently overrides his manual choices.
+- Imprecise or hidden geometry (rounded display values that don't match the exported GDS).
+
+### Design implications
+
+- Every connection/curve property must be **inspectable and editable** in a properties panel with exact numeric values.
+- Direct manipulation first, dialogs last. Prefer in-canvas handles and inline editors.
+- Manual edits are sacred: the system may *suggest*, never *overwrite*.
+- Expose Nazca-level concepts (he knows them by name) rather than dumbing them down.
+
+---
+
+## Persona 2: Priya — The Academic Lab Researcher *(working name)*
+
+**Role:** Researcher at a Princeton photonics lab with **its own fab**.
+**Background:** Uses **GDSFactory**. Doesn't care about official foundry tape-outs — the lab fabricates in-house, iterates fast, and measures everything themselves.
+
+### What she wants
+
+- **Import her lab's own PDK** into Lunima with minimal friction and "play around": place components, test circuits, iterate.
+- Run occasional FDTD — but typically via **Tidy3D** (cloud FDTD), because the lab has no big compute cluster.
+- After in-house tape-out: **measure real devices and feed measurement results back into Lunima**, so simulated and measured behavior can be compared and the component models improve over time.
+
+### What frustrates her
+
+- PDK import that assumes a commercial foundry workflow (DRC sign-off, official tape-out gates).
+- Simulation results that live in a silo — no way to attach measured S-parameters / spectra back to a component.
+- GDSFactory ↔ Lunima friction (naming, layer maps, port conventions).
+
+### Design implications
+
+- The custom-PDK import path is a **first-class flow**, not an expert backdoor. Sensible defaults, forgiving validation.
+- Support a **measurement-feedback loop**: attach measured data to a component/PDK entry and visualize measured vs. simulated.
+- Interop with GDSFactory conventions where cheap (port naming, layer maps).
+- Tidy3D integration matters to her mainly as a *consumer*: submit, wait, get S-matrix back.
+
+---
+
+## Persona 3: Mirko — The Full-Stack System Simulator
+
+**Role:** Physicist building toward his own photonic CPU.
+**Background:** Owns an Ansys Lumerical license but **prefers open-source tools**. Uses **Tidy3D** for FDTD-derived S-matrices. Deeply skeptical of black boxes — he has written **his own Python autorouting scripts** because he doesn't trust built-in autorouting.
+
+### What he wants
+
+- Simulate the chip **on all levels**: component FDTD → S-matrix → circuit → multi-chiplet system.
+- **Export netlists** in formats other tools can consume.
+- A **photonic intermediate representation (IR)**: one artifact that can hold S-matrices, netlists, FDTD results, and possibly PDK data — portable, inspectable, scriptable.
+- Better/deeper **Tidy3D integration** for generating S-matrices.
+- **End goal:** co-simulate a PIC together with a simulated electronic FPGA, across multiple chiplets — a full photonic-CPU system simulation with every intermediate step verifiable.
+
+### What frustrates him
+
+- Anything he can't verify, script, or replace. Autorouting he can't bypass or audit is a dealbreaker.
+- Closed or lossy file formats; results he can't export.
+- Being forced into proprietary tooling when an open-source path exists.
+
+### Design implications
+
+- Every pipeline stage must have an **escape hatch**: import/export at each level (geometry, S-matrix, netlist, results).
+- Autorouting must be **optional and overridable**, with a documented interface so his own Python routing can plug in.
+- File formats: open, documented, diff-able (JSON/text where feasible). The PDK JSON format (see `docs/PDK_JSON_FORMAT.md`) is a step in this direction.
+- Netlist export is a product feature, not a debug tool.
+
+---
+
+## Persona 4: Ingrid — The Investor *(working name, secondary persona)*
+
+**Role:** Potential investor evaluating Lunima.
+**Background:** Limited physics/photonics understanding. Will spend **minutes, not hours** in the tool — usually watching a demo.
+
+### What she wants
+
+- To grasp **quickly and visually** why this tool is useful and what problem it solves.
+- A demo path that "just works": open example → see a circuit → run a simulation → see a compelling, understandable result.
+
+### Design implications
+
+- Ship **polished example projects** that open and simulate without setup.
+- First-run experience and empty states must communicate value, not assume expertise.
+- Visualizations should be legible to a non-physicist at a glance (clear legends, plain-language labels alongside technical ones).
+- Never *block* expert workflows for her sake — she is a constraint on the happy path's clarity, not a driver of feature depth.
+
+---
+
+## How agents should use this file
+
+1. **Before UX redesigns:** state which persona(s) the change serves and check it against the "frustrates" lists of the others.
+2. **Feature trade-offs:** precision & scriptability (Peter, Mirko) beat convenience shortcuts; convenience (Priya) beats demo polish (Ingrid); demo polish still matters on the first-run path.
+3. **New integrations:** Tidy3D and open formats serve two personas (Priya, Mirko) — prefer them over single-persona integrations.
+4. **When a persona is missing context** (e.g., a niche workflow none of them covers), say so explicitly in the issue/PR instead of inventing a fifth persona.


### PR DESCRIPTION
Closes #653. **Based on `feat/single-process-570` (PR #652)** — the group guard builds directly on `SingleProcessPolicy`, so this PR targets that branch and should merge after it.

## Problem
`SingleProcessPolicy.CheckPlacement` keys on a component's `PdkSource`, but `ComponentGroup`s carry none — `IsBuiltIn(null) == true`, so a group was always placeable. Grouping foreign-PDK components (or dropping a saved group template authored in another process) bypassed the #570 enforcement entirely, and `PlaceGroupTemplateAt` had no guard at all.

## Fix
- **`GroupProcessPolicy` (core, `Connect-A-Pic-Core/Components/Process/`)** — derives a group's process membership from its recursive non-group children's PDK sources; each child is evaluated with the existing `SingleProcessPolicy.CheckPlacement` (member / built-in / process-agnostic pass), one foreign child blocks the whole group with a message naming the offending PDK(s) and the locked process.
- **`ComponentPdkSourceResolver` (shared)** — group children are core `Component`s with no `PdkSource`, so resolution goes through `NazcaFunctionName` → library-template matching. Extracted from `FileOperationsViewModel.FindTemplatePdkSource` (now delegates), reused by the guards; wired into `CanvasInteractionViewModel` by `MainViewModel` over `LeftPanel.AllTemplates`.
- **`PlaceGroupTemplateAt`** — now checked via `GroupProcessPolicy.CheckGroupPlacement` before creating the command (undo stack untouched on block).
- **Group paste** — `ComponentClipboard.PeekPdkSources` optionally takes the resolver and additionally yields every copied group's recursive child sources, so `PasteSelected`'s existing per-source check covers group contents.

**Not blocking group *creation*:** under a locked process, everything on the canvas is already member/agnostic, so a mixed group can only be *created* in Playground — where mixing is the point. The placement/paste guards are what protect the invariant when such a group later meets a locked design.

## Tests
- `UnitTests/Components/Process/GroupProcessPolicyTests.cs` — member/agnostic/built-in pass, foreign child blocks (message names offender + process), case-insensitive dedupe of offenders, Playground/unset/empty-group allowed.
- `UnitTests/ViewModels/Panels/GroupProcessEnforcementTests.cs` — group-template placement blocked (incl. foreign child in a *nested* group; undo stack untouched) vs. member-only placed; unwired resolver / no active process keep legacy behavior; group paste blocked vs. member-only pastes.

Full suite: 2820 passed; the only 5 failures are pre-existing environment ones (worktree `FindRepoRoot`, GDS/python env) unrelated to this change. Touched-area run (Clipboard/CanvasInteraction/Paste/GroupTemplate/Process/FileOperations): 235/235 green.

## Out of scope (from the issue's "minor UX polish" list)
Enable-All/Disable-All gating, New-Design dialog `IsCancel`, indicator tooltip content, Playground PDK-enable restore — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)