### PR TITLE
Fix AppDataFolders.ResolveLinux tests failing on Windows dev machines

### DIFF
--- a/Connect-A-Pic-Core/Helpers/AppDataFolders.cs
+++ b/Connect-A-Pic-Core/Helpers/AppDataFolders.cs
@@ -42,9 +42,12 @@ public static class AppDataFolders
         if (string.IsNullOrEmpty(osProvidedPath) || string.IsNullOrEmpty(homeDirectory))
             return osProvidedPath;
 
-        var snapRoot = Path.Combine(homeDirectory, "snap") + Path.DirectorySeparatorChar;
-        return osProvidedPath.StartsWith(snapRoot, StringComparison.Ordinal)
-            ? Path.Combine(homeDirectory, ".local", "share")
+        // This function only ever sees Linux paths, so the separator is a
+        // literal '/' — Path.Combine would inject '\' when the test suite
+        // runs on a Windows dev machine and break the comparison.
+        var home = homeDirectory.TrimEnd('/');
+        return osProvidedPath.StartsWith(home + "/snap/", StringComparison.Ordinal)
+            ? home + "/.local/share"
             : osProvidedPath;
     }
 }


### PR DESCRIPTION
`AppDataFolders.ResolveLinux` (from #640) built its snap-root prefix with `Path.Combine`, so on a Windows dev machine the comparison string contained `\` and the Linux-style test inputs never matched — `AppDataFoldersTests` failed locally on Windows (noted as a known failure in #652's test run). The function only ever receives Linux paths (it is guarded by `OperatingSystem.IsLinux()` at the call site), so the separator is now a literal `/`. Behaviour on Linux is unchanged; the tests are now deterministic on all three OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)