### PR TITLE
(=) Fabrication Process dialog reflects the active process selection (#660)

### DIFF
--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -416,6 +416,13 @@ public partial class LeftPanelViewModel : ObservableObject
             .Select(d => new PdkProcessEntry(d.Name, ProcessFingerprintFactory.From(d))).ToList();
 
     /// <summary>
+    /// All currently loaded PDK drafts. The Fabrication Process details dialog reads the
+    /// members' <c>process</c> blocks from here so it always reflects the live PDK state
+    /// (issue #660) instead of keeping its own copy.
+    /// </summary>
+    public IReadOnlyList<PdkDraft> GetLoadedPdkDrafts() => _loadedPdkDrafts;
+
+    /// <summary>
     /// Names of loaded PDKs flagged process-agnostic (e.g. "Analysis Tools" — virtual analyzers
     /// and other tool libraries). These stay usable regardless of the active fabrication process
     /// (issue #570).

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CAP.Avalonia.ViewModels;
+
+/// <summary>
+/// Wires the Fabrication Process details dialog to the design's active process
+/// (issue #660, follow-up to #652). The dialog derives its state fresh from
+/// <c>FileOperationsViewModel.ActiveProcess</c> and the loaded PDK drafts every
+/// time it opens — it never keeps its own copy of "the current process".
+/// </summary>
+public partial class ProcessManagementViewModel
+{
+    /// <summary>Fingerprint of the active process (core, thickness, cladding, wavelength).</summary>
+    [ObservableProperty]
+    private string _fingerprintSummary = string.Empty;
+
+    /// <summary>Comma-separated member PDKs of the active process.</summary>
+    [ObservableProperty]
+    private string _memberPdksText = string.Empty;
+
+    /// <summary>True when the design is in Playground (no single process; drives the banner).</summary>
+    [ObservableProperty]
+    private bool _isPlaygroundState;
+
+    /// <summary>
+    /// Derives the dialog state from the design's active process selection and the loaded
+    /// PDK drafts: a locked process shows its name, fingerprint, member PDKs and the merged
+    /// <c>process</c> blocks of those members; Playground and "no process" show explicit
+    /// explanations instead of an empty page.
+    /// </summary>
+    public void ShowActiveProcess(ActiveProcessSelection? active, IReadOnlyList<PdkDraft> loadedPdks)
+    {
+        ResetState();
+
+        if (active == null)
+        {
+            StatusText = "No process selected yet. Pick one at startup or via File \u2192 New Design; " +
+                         "this dialog then shows that process's layer stack, materials and design rules.";
+            return;
+        }
+
+        if (active.IsPlayground)
+        {
+            IsPlaygroundState = true;
+            ProcessName = active.DisplayName;
+            StatusText = "Playground \u2014 the design has no single fabrication process and is not " +
+                         "manufacturable. Pick a real process via File \u2192 New Design to see its details here.";
+            return;
+        }
+
+        ShowLockedProcess(active, loadedPdks);
+    }
+
+    private void ShowLockedProcess(ActiveProcessSelection active, IReadOnlyList<PdkDraft> loadedPdks)
+    {
+        ProcessName = active.DisplayName;
+        FingerprintSummary = FormatFingerprint(active.Fingerprint);
+        MemberPdksText = active.MemberPdkNames.Count > 0
+            ? string.Join(", ", active.MemberPdkNames)
+            : "(none loaded)";
+
+        var definitions = MemberProcessDefinitions(active, loadedPdks);
+        foreach (var definition in definitions)
+            Merge(definition);
+
+        // Merge() may adopt the PDK-declared process name; the dialog reflects the
+        // active selection, so its display name always wins.
+        ProcessName = active.DisplayName;
+        HasProcess = true;
+
+        StatusText = definitions.Count > 0
+            ? $"Active process for this design. Layer stack, cross-sections and materials merged from " +
+              $"{definitions.Count} member PDK(s)."
+            : "Active process for this design. Its member PDKs declare no detailed process block \u2014 " +
+              "showing the fingerprint only; data can be imported or entered below.";
+    }
+
+    private static IReadOnlyList<ProcessDefinition> MemberProcessDefinitions(
+        ActiveProcessSelection active, IReadOnlyList<PdkDraft> loadedPdks) =>
+        active.MemberPdkNames
+            .Select(name => loadedPdks.FirstOrDefault(
+                d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase))?.Process)
+            .Where(p => p != null)
+            .Select(p => p!)
+            .ToList();
+
+    private static string FormatFingerprint(ProcessFingerprint? fp)
+    {
+        if (fp == null)
+            return "No fingerprint declared by the member PDKs.";
+
+        var core = fp.CoreMaterial ?? "?";
+        var thickness = fp.CoreThicknessNm.HasValue
+            ? fp.CoreThicknessNm.Value.ToString("0.#", CultureInfo.InvariantCulture) + " nm"
+            : "? nm";
+        var cladding = fp.Cladding ?? "?";
+        return $"Core {core} \u00b7 {thickness} \u00b7 cladding {cladding} \u00b7 \u03bb {fp.DesignWavelengthNm} nm";
+    }
+
+    private void ResetState()
+    {
+        ProcessName = string.Empty;
+        FingerprintSummary = string.Empty;
+        MemberPdksText = string.Empty;
+        IsPlaygroundState = false;
+        HasProcess = false;
+        Layers.Clear();
+        Xsections.Clear();
+        Materials.Clear();
+    }
+}

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -84,10 +84,13 @@ public partial class MainWindow : Window
                     editorWindow.Show(this);
                 };
 
-                // Wire up Fabrication Process window (process model — #570)
+                // Wire up Fabrication Process window (process model — #570). The dialog derives
+                // its state from the design's active process + loaded PDKs at open time, so a
+                // reopened dialog always reflects the current selection (#660).
                 vm.ShowProcessManagerRequested = () =>
                 {
                     var processVm = new ProcessManagementViewModel(new FileDialogService(this));
+                    processVm.ShowActiveProcess(vm.FileOperations.ActiveProcess, vm.LeftPanel.GetLoadedPdkDrafts());
                     var processWindow = new ProcessManagementWindow
                     {
                         DataContext = processVm

--- a/CAP.Avalonia/Views/ProcessManagementWindow.axaml
+++ b/CAP.Avalonia/Views/ProcessManagementWindow.axaml
@@ -15,7 +15,23 @@
         <StackPanel DockPanel.Dock="Top" Spacing="6" Margin="0,0,0,10">
             <TextBlock Text="Fabrication Process" FontWeight="SemiBold" FontSize="16" Foreground="LightBlue"/>
             <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="#9999bb"
-                       Text="A chip is built in one fabrication process — one layer stack, one material system, one set of design rules. Import it from a foundry PDK (CSV tables) and adjust as needed."/>
+                       Text="A chip is built in one fabrication process — chosen for this design at startup / File → New Design. Here you inspect and edit what that process is: layer stack and materials (future FDTD input) and design rules (why a fab may reject certain components). Import details from a foundry PDK (uPDK YAML / CSV tables) and adjust as needed."/>
+
+            <!-- Playground: explicit state instead of an empty page (#660) -->
+            <Border IsVisible="{Binding IsPlaygroundState}" Background="#4d3d1e" CornerRadius="4" Padding="8,6" Margin="0,4,0,0">
+                <TextBlock TextWrapping="Wrap" FontSize="12" Foreground="#ffcc66"
+                           Text="⚠ Playground — this design mixes components freely and has no single fabrication process. It is not manufacturable. Choose a real process via File → New Design to see its details here."/>
+            </Border>
+
+            <!-- Active process identity (#660) -->
+            <StackPanel IsVisible="{Binding HasProcess}" Spacing="2" Margin="0,4,0,0">
+                <TextBlock Text="{Binding FingerprintSummary}" FontSize="12" Foreground="#aaccee"/>
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <TextBlock Text="Member PDKs:" FontSize="11" Foreground="#888"/>
+                    <TextBlock Text="{Binding MemberPdksText}" FontSize="11" Foreground="#ccc" TextWrapping="Wrap"/>
+                </StackPanel>
+            </StackPanel>
+
             <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,4,0,0">
                 <Button Content="Import from PDK…" Command="{Binding ImportFromPdkCommand}"
                         Padding="12,6" Background="#3d4d6d"

--- a/UnitTests/ViewModels/ProcessManagementActiveProcessTests.cs
+++ b/UnitTests/ViewModels/ProcessManagementActiveProcessTests.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+using System.Linq;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>
+/// Verifies the Fabrication Process details dialog derives its state from the design's
+/// active process selection (issue #660): locked process, Playground, no process, and
+/// a locked process whose member PDKs declare no process block.
+/// </summary>
+public class ProcessManagementActiveProcessTests
+{
+    private static ProcessManagementViewModel CreateVm() =>
+        new(Mock.Of<IFileDialogService>());
+
+    private static ProcessFingerprint SoiFingerprint() =>
+        new("Si", 220, "SiO2", 1550, "Generic SOI 220nm");
+
+    private static PdkDraft Draft(string name, ProcessDefinition? process) =>
+        new() { Name = name, Process = process };
+
+    [Fact]
+    public void ShowActiveProcess_LockedProcess_ShowsNameFingerprintMembersAndData()
+    {
+        var vm = CreateVm();
+        var active = new ActiveProcessSelection(
+            "Generic SOI 220nm", SoiFingerprint(), new List<string> { "PdkA", "PdkB" }, IsPlayground: false);
+        var pdks = new List<PdkDraft>
+        {
+            Draft("PdkA", new ProcessDefinition
+            {
+                Name = "SOI-220",
+                Layers = { new ProcessLayer { Name = "WAVEGUIDE", Layer = 12 } },
+                Materials = { new ProcessMaterial { Name = "Si", Role = "core" } },
+            }),
+            Draft("PdkB", new ProcessDefinition
+            {
+                Xsections = { new ProcessXsection { Name = "STRIP", WidthUm = 0.5 } },
+            }),
+        };
+
+        vm.ShowActiveProcess(active, pdks);
+
+        vm.ProcessName.ShouldBe("Generic SOI 220nm");
+        vm.HasProcess.ShouldBeTrue();
+        vm.IsPlaygroundState.ShouldBeFalse();
+        vm.FingerprintSummary.ShouldContain("Si");
+        vm.FingerprintSummary.ShouldContain("220 nm");
+        vm.FingerprintSummary.ShouldContain("SiO2");
+        vm.FingerprintSummary.ShouldContain("1550 nm");
+        vm.MemberPdksText.ShouldBe("PdkA, PdkB");
+        vm.Layers.Single().Name.ShouldBe("WAVEGUIDE");
+        vm.Xsections.Single().Name.ShouldBe("STRIP");
+        vm.Materials.Single().Name.ShouldBe("Si");
+        vm.StatusText.ShouldContain("2 member PDK(s)");
+    }
+
+    [Fact]
+    public void ShowActiveProcess_Playground_ShowsExplicitPlaygroundState()
+    {
+        var vm = CreateVm();
+
+        vm.ShowActiveProcess(ActiveProcessSelection.Playground(), new List<PdkDraft>());
+
+        vm.IsPlaygroundState.ShouldBeTrue();
+        vm.HasProcess.ShouldBeFalse();
+        vm.ProcessName.ShouldBe("Playground");
+        vm.StatusText.ShouldContain("not manufacturable");
+    }
+
+    [Fact]
+    public void ShowActiveProcess_NoSelection_ExplainsHowToPickOne()
+    {
+        var vm = CreateVm();
+
+        vm.ShowActiveProcess(null, new List<PdkDraft>());
+
+        vm.HasProcess.ShouldBeFalse();
+        vm.IsPlaygroundState.ShouldBeFalse();
+        vm.StatusText.ShouldContain("No process selected");
+    }
+
+    [Fact]
+    public void ShowActiveProcess_MembersWithoutProcessBlock_ShowsFingerprintOnly()
+    {
+        var vm = CreateVm();
+        var active = new ActiveProcessSelection(
+            "Generic SOI 220nm", SoiFingerprint(), new List<string> { "PdkA" }, IsPlayground: false);
+
+        vm.ShowActiveProcess(active, new List<PdkDraft> { Draft("PdkA", process: null) });
+
+        vm.HasProcess.ShouldBeTrue();
+        vm.FingerprintSummary.ShouldContain("220 nm");
+        vm.Layers.ShouldBeEmpty();
+        vm.StatusText.ShouldContain("no detailed process block");
+    }
+
+    [Fact]
+    public void ShowActiveProcess_MemberPdkNotLoaded_IsSkippedGracefully()
+    {
+        var vm = CreateVm();
+        var active = new ActiveProcessSelection(
+            "Generic SOI 220nm", SoiFingerprint(), new List<string> { "Missing", "PdkA" }, IsPlayground: false);
+        var pdks = new List<PdkDraft>
+        {
+            Draft("PdkA", new ProcessDefinition { Layers = { new ProcessLayer { Name = "WG" } } }),
+        };
+
+        vm.ShowActiveProcess(active, pdks);
+
+        vm.HasProcess.ShouldBeTrue();
+        vm.Layers.Single().Name.ShouldBe("WG");
+        vm.StatusText.ShouldContain("1 member PDK(s)");
+    }
+
+    [Fact]
+    public void ShowActiveProcess_CalledAgain_ReflectsNewSelectionWithoutLeftovers()
+    {
+        var vm = CreateVm();
+        var soi = new ActiveProcessSelection(
+            "Generic SOI 220nm", SoiFingerprint(), new List<string> { "PdkA" }, IsPlayground: false);
+        var pdks = new List<PdkDraft>
+        {
+            Draft("PdkA", new ProcessDefinition { Layers = { new ProcessLayer { Name = "WG" } } }),
+        };
+        vm.ShowActiveProcess(soi, pdks);
+
+        vm.ShowActiveProcess(ActiveProcessSelection.Playground(), pdks);
+
+        vm.IsPlaygroundState.ShouldBeTrue();
+        vm.HasProcess.ShouldBeFalse();
+        vm.Layers.ShouldBeEmpty();
+        vm.FingerprintSummary.ShouldBe(string.Empty);
+        vm.MemberPdksText.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void ShowActiveProcess_NullFingerprint_ExplainsMissingFingerprint()
+    {
+        var vm = CreateVm();
+        var active = new ActiveProcessSelection(
+            "Unspecified PDK", Fingerprint: null, new List<string> { "PdkA" }, IsPlayground: false);
+
+        vm.ShowActiveProcess(active, new List<PdkDraft> { Draft("PdkA", process: null) });
+
+        vm.HasProcess.ShouldBeTrue();
+        vm.FingerprintSummary.ShouldContain("No fingerprint");
+    }
+}


### PR DESCRIPTION
Closes #660. Follow-up to #652 (merged while this was in flight; branch is synced with main, diff is only this change).

## What
The "Fabrication Process…" details dialog now reflects the process the design is locked to, instead of opening empty/detached:

- **Locked process** → shows the active process's display name, fingerprint (core material · thickness · cladding · λ), member PDK list, and the merged `process` blocks (layer stack, cross-sections, materials) of those member PDKs.
- **Playground** → explicit banner: "no single process — design not manufacturable", with a hint how to pick one. No empty page.
- **No process yet** → status text explaining that the process is chosen at startup / File → New Design.
- **Roles stated in the UI**: header text now distinguishes the picker (choose *which* process) from this dialog (inspect/edit *what* the process is — future FDTD input / DRC data).

## How (no second source of truth)
`ProcessManagementViewModel.ShowActiveProcess(ActiveProcessSelection?, IReadOnlyList<PdkDraft>)` (new partial-class file, 117 lines) derives all state fresh from `FileOperationsViewModel.ActiveProcess` and `LeftPanelViewModel.GetLoadedPdkDrafts()` at dialog-open time (`MainWindow.axaml.cs` wiring). The dialog VM is created per open, so a change of active process (New Design, load) is reflected on reopen without restart. Edits remain dialog-local as before (definition editing/override semantics stay a design-phase decision per the issue's point 4 — no fingerprint-relevant write-back path was added, so catalog/selection cannot silently diverge).

## Tests
`UnitTests/ViewModels/ProcessManagementActiveProcessTests.cs` — 7 tests covering the acceptance criteria: locked (name + fingerprint + members + merged data), Playground, no selection, member PDKs without a process block (fingerprint-only), missing/unloaded member PDK, repeated calls (no leftover state), null fingerprint.

Full suite: 2833 passed; the only 5 failures are known local-environment ones (agent worktree has a `.git` file → `FileSizeLimitTests` can't find repo root; `PdkJsonSaverRoundTrip`; Python GDS integration) — unrelated to this change, CI-irrelevant.

Cross-platform: UI text/formatting only; numbers formatted with `CultureInfo.InvariantCulture`; no process launching or path handling touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)