### PR TITLE
(+) Single-process: enforce active process for component groups (#653)

### DIFF
--- a/CAP.Avalonia/Selection/ComponentClipboard.cs
+++ b/CAP.Avalonia/Selection/ComponentClipboard.cs
@@ -34,21 +34,20 @@ public class ComponentClipboard
     public Func<Component, string?>? PdkSourceResolver { get; set; }
 
     /// <summary>
-    /// PDK sources of every copied LEAF component, in copy order (issue #570). Groups are
-    /// expanded to their children — a group VM itself carries no PDK source, and treating
-    /// it as one entry made foreign-PDK components paste into a locked design unchecked.
-    /// Lets callers (e.g. <c>CanvasInteractionViewModel.PasteSelected</c>) check the
-    /// active-process policy against clipboard contents before executing the paste command.
+    /// PDK sources of every copied LEAF component, in copy order (issues #570/#653).
+    /// Groups are expanded to their recursive non-group children — a group carries no PDK
+    /// source of its own, and treating it as one entry let foreign-process components
+    /// smuggle past the paste guard. Lets callers (e.g.
+    /// <c>CanvasInteractionViewModel.PasteSelected</c>) check the active-process policy
+    /// against clipboard contents before executing the paste command.
     /// </summary>
     public IReadOnlyList<string?> PeekPdkSources() =>
         _entries.SelectMany(e => e.OriginalComponent is ComponentGroup group
-                ? Flatten(group).Select(child => PdkSourceResolver?.Invoke(child))
+                ? group.GetAllComponentsRecursive()
+                    .Where(child => child is not ComponentGroup)
+                    .Select(child => PdkSourceResolver?.Invoke(child))
                 : new[] { e.PdkSource ?? PdkSourceResolver?.Invoke(e.OriginalComponent) })
             .ToList();
-
-    private static IEnumerable<Component> Flatten(ComponentGroup group) =>
-        group.ChildComponents.SelectMany(c =>
-            c is ComponentGroup nested ? Flatten(nested) : new[] { c });
 
     /// <summary>
     /// Copies the given components and their internal connections.

--- a/CAP.Avalonia/Services/AiGridService.cs
+++ b/CAP.Avalonia/Services/AiGridService.cs
@@ -29,6 +29,13 @@ public class AiGridService : IAiGridService
     /// <summary>Names of loaded process-agnostic tool PDKs (see CanvasInteractionViewModel).</summary>
     public Func<IReadOnlyCollection<string>>? GetProcessAgnosticPdkNames { get; set; }
 
+    /// <summary>
+    /// Resolves a placed core component's PDK source from the loaded library
+    /// (see <c>ComponentPdkSourceResolver</c>). Needed so copying a GROUP via the AI
+    /// path checks the group's children instead of the group's null source (#653).
+    /// </summary>
+    public Func<Component, string?>? ResolveComponentPdkSource { get; set; }
+
     private (bool IsAllowed, string? BlockReason) CheckProcess(string? pdkSource) =>
         SingleProcessPolicy.CheckPlacement(
             GetActiveProcess?.Invoke(), pdkSource,
@@ -317,13 +324,18 @@ public class AiGridService : IAiGridService
         if (sourceVm == null)
             return Task.FromResult($"Component '{sourceId}' not found.");
 
-        // Single-process enforcement (issue #570) — mirrors the paste gate.
-        var (copyAllowed, copyBlockReason) = CheckProcess(sourceVm.TemplatePdkSource);
-        if (!copyAllowed)
-            return Task.FromResult(copyBlockReason ?? $"Cannot copy '{sourceId}' — it belongs to another process.");
-
-        var tempClipboard = new ComponentClipboard();
+        var tempClipboard = new ComponentClipboard { PdkSourceResolver = ResolveComponentPdkSource };
         tempClipboard.Copy(new[] { sourceVm }, _canvas.Connections);
+
+        // Single-process enforcement (issues #570/#653) — mirrors the paste gate;
+        // PeekPdkSources expands groups to their resolved children.
+        var copyBlockReason = tempClipboard.PeekPdkSources()
+            .Select(pdk => CheckProcess(pdk))
+            .Where(check => !check.IsAllowed)
+            .Select(check => check.BlockReason)
+            .FirstOrDefault();
+        if (copyBlockReason != null)
+            return Task.FromResult(copyBlockReason);
 
         var result = tempClipboard.Paste(_canvas, x, y);
         if (result == null || result.Components.Count == 0)

--- a/CAP.Avalonia/ViewModels/Library/ComponentPdkSourceResolver.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentPdkSourceResolver.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.ViewModels.Library;
+
+/// <summary>
+/// Resolves the PDK source of a placed core <see cref="Component"/> by matching its
+/// <c>NazcaFunctionName</c> against the loaded component library. Core components carry no
+/// PDK source of their own — only <see cref="ComponentTemplate"/>s do — so this lookup is the
+/// single shared way to recover it (used for saving designs and for single-process
+/// enforcement over group children, issues #570 / #653).
+/// </summary>
+public static class ComponentPdkSourceResolver
+{
+    /// <summary>
+    /// Returns the <see cref="ComponentTemplate.PdkSource"/> of the library template whose
+    /// Nazca function name matches <paramref name="component"/>, or null when no match exists
+    /// (e.g. user groups or components whose PDK is not loaded).
+    /// </summary>
+    public static string? Resolve(Component component, IEnumerable<ComponentTemplate> library)
+    {
+        var nazcaFunc = component.NazcaFunctionName;
+        if (string.IsNullOrEmpty(nazcaFunc))
+            return null;
+
+        var match = library.FirstOrDefault(t =>
+        {
+            var templateFunc = t.NazcaFunctionName
+                ?? $"nazca_{t.Name.ToLower().Replace(" ", "_")}";
+            return templateFunc == nazcaFunc;
+        });
+        return match?.PdkSource;
+    }
+}

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -230,23 +230,25 @@ public partial class MainViewModel : ObservableObject
         ViewportControl.UpdateStatus = UpdateStatusText;
         LeftPanel.UpdateStatus = UpdateStatusText;
 
-        // Single-process enforcement (issue #570): every placement surface — manual
+        // Single-process enforcement (issues #570/#653): every placement surface — manual
         // placement/paste, saved group templates, and the AI assistant — consults the
         // same active process, the same process-agnostic tool PDKs, and the same
-        // library-based PDK-source resolver.
+        // library-based PDK-source resolver (groups/pasted copies carry no source of
+        // their own, so children are resolved against the loaded library).
         Func<ActiveProcessSelection?> getActiveProcess = () => FileOperations.ActiveProcess;
         Func<IReadOnlyCollection<string>> getAgnosticPdkNames = () => LeftPanel.GetProcessAgnosticPdkNames();
-        Func<CAP_Core.Components.Core.Component, string?> resolvePdkSource =
-            comp => FileOperations.ResolveTemplatePdkSource(comp);
+        Func<CAP_Core.Components.Core.Component, string?> resolvePdkSource = component =>
+            ViewModels.Library.ComponentPdkSourceResolver.Resolve(component, LeftPanel.AllTemplates);
 
         CanvasInteraction.GetActiveProcess = getActiveProcess;
         CanvasInteraction.GetProcessAgnosticPdkNames = getAgnosticPdkNames;
-        CanvasInteraction.ResolvePdkSource = resolvePdkSource;
+        CanvasInteraction.ResolveComponentPdkSource = resolvePdkSource;
         _canvas.Clipboard.PdkSourceResolver = resolvePdkSource;
         if (aiGridService is Services.AiGridService aiGrid)
         {
             aiGrid.GetActiveProcess = getActiveProcess;
             aiGrid.GetProcessAgnosticPdkNames = getAgnosticPdkNames;
+            aiGrid.ResolveComponentPdkSource = resolvePdkSource;
         }
 
         // Let the export guard open the Settings window (e.g. on the Python-Environments

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -106,17 +106,12 @@ public partial class CanvasInteractionViewModel : ObservableObject
     public Func<IReadOnlyCollection<string>>? GetProcessAgnosticPdkNames { get; set; }
 
     /// <summary>
-    /// Resolves a component's PDK source from the loaded library (issue #570). Saved
-    /// group templates record no PDK source, so their children are resolved through
-    /// this before placement. Wired by <c>MainViewModel</c> to
-    /// <c>FileOperationsViewModel.ResolveTemplatePdkSource</c>.
+    /// Callback resolving the PDK source of a placed core component (groups carry none of
+    /// their own, so their children are resolved individually — issue #653). Wired by
+    /// <c>MainViewModel</c> to <c>ComponentPdkSourceResolver.Resolve</c> over the loaded
+    /// component library. When unwired, group children resolve to null (treated as built-in).
     /// </summary>
-    public Func<Component, string?>? ResolvePdkSource { get; set; }
-
-    /// <summary>Flattens a group's children, recursing into nested groups.</summary>
-    private static IEnumerable<Component> FlattenGroupChildren(ComponentGroup group) =>
-        group.ChildComponents.SelectMany(c =>
-            c is ComponentGroup nested ? FlattenGroupChildren(nested) : new[] { c });
+    public Func<Component, string?>? ResolveComponentPdkSource { get; set; }
 
     public CanvasInteractionViewModel(
         DesignCanvasViewModel canvas,
@@ -367,20 +362,16 @@ public partial class CanvasInteractionViewModel : ObservableObject
             return;
         }
 
-        // Single-process enforcement (issue #570): saved group templates record no PDK
-        // source themselves, so resolve every child component against the library and
-        // apply the same gate as single-component placement.
-        var active = GetActiveProcess?.Invoke();
-        var agnostic = GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>();
-        var blockReasonForGroup = FlattenGroupChildren(SelectedGroupTemplate.TemplateGroup)
-            .Select(child => SingleProcessPolicy.CheckPlacement(
-                active, ResolvePdkSource?.Invoke(child), agnostic))
-            .Where(check => !check.IsAllowed)
-            .Select(check => check.BlockReason)
-            .FirstOrDefault();
-        if (blockReasonForGroup != null)
+        // Single-process enforcement over the group's children (issue #653): a group has no
+        // PdkSource of its own, so a foreign-process child must not slip in via grouping.
+        var (isAllowed, blockReason) = GroupProcessPolicy.CheckGroupPlacement(
+            GetActiveProcess?.Invoke(),
+            ChildPdkSources(SelectedGroupTemplate.TemplateGroup),
+            GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>(),
+            SelectedGroupTemplate.Name);
+        if (!isAllowed)
         {
-            UpdateStatus?.Invoke(blockReasonForGroup);
+            UpdateStatus?.Invoke(blockReason ?? "Process mismatch — cannot place group.");
             return;
         }
 
@@ -396,6 +387,15 @@ public partial class CanvasInteractionViewModel : ObservableObject
         _commandManager.ExecuteCommand(cmd);
         UpdateStatus?.Invoke($"Placed group '{SelectedGroupTemplate.Name}' at ({x:F0}, {y:F0})µm");
     }
+
+    /// <summary>
+    /// Resolved PDK source of every recursive non-group child of <paramref name="group"/>,
+    /// used to check the single-process policy over a group's contents (issue #653).
+    /// </summary>
+    private IEnumerable<string?> ChildPdkSources(ComponentGroup group) =>
+        group.GetAllComponentsRecursive()
+            .Where(child => child is not ComponentGroup)
+            .Select(child => ResolveComponentPdkSource?.Invoke(child));
 
     /// <summary>
     /// Selects the component or connection at the given canvas position, keeping the
@@ -696,6 +696,9 @@ public partial class CanvasInteractionViewModel : ObservableObject
 
         var active = GetActiveProcess?.Invoke();
         var agnosticPdkNames = GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>();
+        // PeekPdkSources expands groups to their resolved children (the clipboard's
+        // PdkSourceResolver is wired by MainViewModel), so a copied group cannot
+        // smuggle foreign-process components past the paste guard (issue #653).
         var blockedCount = _canvas.Clipboard.PeekPdkSources()
             .Count(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, agnosticPdkNames).IsAllowed);
         if (blockedCount > 0)

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -479,28 +479,8 @@ public partial class FileOperationsViewModel : ObservableObject
     /// Finds the PDK source for a component by matching its NazcaFunctionName against the library.
     /// Returns null if no match is found.
     /// </summary>
-    /// <summary>
-    /// Resolves a component's PDK source from the loaded library (by Nazca function
-    /// name). Shared with the clipboard and group-template placement paths so process
-    /// enforcement (issue #570) sees a real source even when the ViewModel-level
-    /// <c>TemplatePdkSource</c> was lost (pasted copies, group children, undo).
-    /// </summary>
-    public string? ResolveTemplatePdkSource(Component component) => FindTemplatePdkSource(component);
-
-    private string? FindTemplatePdkSource(Component component)
-    {
-        var nazcaFunc = component.NazcaFunctionName;
-        if (string.IsNullOrEmpty(nazcaFunc))
-            return null;
-
-        var match = _componentLibrary.FirstOrDefault(t =>
-        {
-            var templateFunc = t.NazcaFunctionName
-                ?? $"nazca_{t.Name.ToLower().Replace(" ", "_")}";
-            return templateFunc == nazcaFunc;
-        });
-        return match?.PdkSource;
-    }
+    private string? FindTemplatePdkSource(Component component) =>
+        ComponentPdkSourceResolver.Resolve(component, _componentLibrary);
 
     /// <summary>
     /// Recursively serializes a ComponentGroup and all its nested child groups.

--- a/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CAP_Core.Components.Process;
+
+/// <summary>
+/// Extends <see cref="SingleProcessPolicy"/> to component groups (issue #653). A group carries
+/// no <c>PdkSource</c> of its own, so its process membership is derived from its child
+/// components' PDK sources: the group is placeable only when every child passes the
+/// per-component placement check (member / built-in / process-agnostic).
+/// </summary>
+public static class GroupProcessPolicy
+{
+    /// <summary>
+    /// Decides whether a group whose (recursive, non-group) children come from
+    /// <paramref name="childPdkSources"/> may be placed on a design locked to
+    /// <paramref name="active"/>. Each child is evaluated with
+    /// <see cref="SingleProcessPolicy.CheckPlacement"/>; a single foreign-process child
+    /// blocks the whole group. Playground / unset selections always pass.
+    /// </summary>
+    /// <param name="active">The design's active process selection, or null when unset.</param>
+    /// <param name="childPdkSources">PDK source of every child component (null = built-in/unknown).</param>
+    /// <param name="processAgnosticPdkNames">Names of PDKs flagged process-agnostic (tool libraries).</param>
+    /// <param name="groupName">Display name of the group, used in the block message.</param>
+    public static (bool IsAllowed, string? BlockReason) CheckGroupPlacement(
+        ActiveProcessSelection? active,
+        IEnumerable<string?> childPdkSources,
+        IReadOnlyCollection<string>? processAgnosticPdkNames = null,
+        string? groupName = null)
+    {
+        var blockedPdkNames = childPdkSources
+            .Where(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, processAgnosticPdkNames).IsAllowed)
+            .Select(pdk => pdk!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (blockedPdkNames.Count == 0)
+            return (true, null);
+
+        var groupLabel = string.IsNullOrWhiteSpace(groupName) ? "This group" : $"Group '{groupName}'";
+        return (false,
+            $"{groupLabel} contains component(s) from '{string.Join("', '", blockedPdkNames)}', but the " +
+            $"chip is locked to the process '{active!.DisplayName}'. A monolithic design uses one process — " +
+            "start a new design (or use Playground) to mix processes.");
+    }
+}

--- a/UnitTests/Components/Process/GroupProcessPolicyTests.cs
+++ b/UnitTests/Components/Process/GroupProcessPolicyTests.cs
@@ -1,0 +1,92 @@
+using CAP_Core.Components.Process;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.Process;
+
+/// <summary>
+/// Group-level single-process enforcement (issue #653): a group's process membership is
+/// derived from its children's PDK sources, so one foreign-process child blocks the group.
+/// </summary>
+public class GroupProcessPolicyTests
+{
+    private static ActiveProcessSelection Soi(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "SOI 220",
+            new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"),
+            memberPdkNames));
+
+    [Fact]
+    public void AllChildrenFromMemberPdk_IsAllowed()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "Demo", "Demo" });
+
+        isAllowed.ShouldBeTrue();
+        reason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void MixOfBuiltInAgnosticAndMemberChildren_IsAllowed()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"),
+            new[] { null, "Built-in", "Analysis Tools", "Demo" },
+            new[] { "Analysis Tools" });
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SingleForeignChild_BlocksWholeGroup_AndNamesOffenderAndProcess()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "Demo", "HHI-InP" }, groupName: "MyMixer");
+
+        isAllowed.ShouldBeFalse();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("MyMixer");
+        reason.ShouldContain("HHI-InP");
+        reason.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void MultipleForeignPdks_AreListedOnce_Each()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "HHI-InP", "hhi-inp", "IMEC" });
+
+        isAllowed.ShouldBeFalse();
+        reason!.ShouldContain("HHI-InP");
+        reason.ShouldContain("IMEC");
+        // Case-insensitive duplicate collapsed to one mention.
+        reason.Split("HHI-InP").Length.ShouldBe(2);
+    }
+
+    [Fact]
+    public void NoActiveProcess_AllowsForeignChildren()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            null, new[] { "HHI-InP" });
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Playground_AllowsForeignChildren()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            ActiveProcessSelection.Playground(), new[] { "HHI-InP", "Demo" });
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void EmptyGroup_IsAllowed()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), Array.Empty<string?>());
+
+        isAllowed.ShouldBeTrue();
+    }
+}

--- a/UnitTests/ViewModels/Panels/CanvasInteractionProcessEnforcementTests.cs
+++ b/UnitTests/ViewModels/Panels/CanvasInteractionProcessEnforcementTests.cs
@@ -199,7 +199,7 @@ public class CanvasInteractionProcessEnforcementTests
         interaction.GetProcessAgnosticPdkNames = () => Array.Empty<string>();
         // Group templates record no PDK source — every child resolves through the library,
         // here to a PDK that is not a member of the active process.
-        interaction.ResolvePdkSource = _ => "HHI-InP";
+        interaction.ResolveComponentPdkSource = _ => "HHI-InP";
 
         var group = TestComponentFactory.CreateComponentGroup("ForeignGroup", addChildren: true);
         interaction.SelectedGroupTemplate = new GroupTemplate

--- a/UnitTests/ViewModels/Panels/GroupProcessEnforcementTests.cs
+++ b/UnitTests/ViewModels/Panels/GroupProcessEnforcementTests.cs
@@ -1,0 +1,215 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_Core.LightCalculation;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels.Panels;
+
+/// <summary>
+/// Closes the grouping bypass of single-process enforcement (issue #653): groups carry no
+/// PdkSource, so their children must be checked individually when a group template is placed
+/// (<see cref="CanvasInteractionViewModel.PlaceGroupTemplateAt"/> via <c>CanvasClicked</c>)
+/// and when a copied group is pasted (<see cref="CanvasInteractionViewModel.PasteSelected"/>).
+/// </summary>
+public class GroupProcessEnforcementTests : IDisposable
+{
+    private readonly string _testLibraryPath;
+    private readonly GroupLibraryManager _libraryManager;
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly CanvasInteractionViewModel _interaction;
+    private readonly CommandManager _commandManager;
+
+    public GroupProcessEnforcementTests()
+    {
+        _testLibraryPath = Path.Combine(Path.GetTempPath(), $"GroupProcessEnforcementTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testLibraryPath);
+
+        _libraryManager = new GroupLibraryManager(_testLibraryPath);
+        _canvas = new DesignCanvasViewModel();
+        _commandManager = new CommandManager();
+        _interaction = new CanvasInteractionViewModel(
+            _canvas, _commandManager, new ComponentLibraryViewModel(_libraryManager));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testLibraryPath))
+            Directory.Delete(_testLibraryPath, true);
+    }
+
+    private static ActiveProcessSelection Soi(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "SOI 220",
+            new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"),
+            memberPdkNames));
+
+    /// <summary>Maps a child's NazcaFunctionName to a PDK source, mimicking the library lookup.</summary>
+    private static string? ResolveByNazcaFunction(Component component) => component.NazcaFunctionName switch
+    {
+        "member_func" => "Demo",
+        "foreign_func" => "HHI-InP",
+        _ => null
+    };
+
+    private void LockToSoiWithResolver()
+    {
+        _interaction.GetActiveProcess = () => Soi("Demo");
+        _interaction.GetProcessAgnosticPdkNames = () => Array.Empty<string>();
+        _interaction.ResolveComponentPdkSource = ResolveByNazcaFunction;
+        // The paste guard reads sources via the clipboard, which resolves group
+        // children through its own resolver (wired by MainViewModel in production).
+        _canvas.Clipboard.PdkSourceResolver = ResolveByNazcaFunction;
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_WithForeignProcessChild_BlocksPlacementAndReportsStatus()
+    {
+        LockToSoiWithResolver();
+        SelectGroupTemplate("InP Mixer", "member_func", "foreign_func");
+
+        string? status = null;
+        _interaction.UpdateStatus = s => status = s;
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(0, "a group with a foreign-process child must not be placed");
+        _commandManager.CanUndo.ShouldBeFalse("a blocked placement must not touch the undo stack");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("HHI-InP");
+        status.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_AllChildrenFromMemberPdk_IsPlaced()
+    {
+        LockToSoiWithResolver();
+        SelectGroupTemplate("SOI Pair", "member_func", "member_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1, "a group whose children are all member-PDK must place normally");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_NoResolverWired_IsPlaced()
+    {
+        // Without a resolver, child sources resolve to null (built-in) — legacy behavior.
+        _interaction.GetActiveProcess = () => Soi("Demo");
+        _interaction.GetProcessAgnosticPdkNames = () => Array.Empty<string>();
+        SelectGroupTemplate("Unknown Group", "foreign_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_NoActiveProcess_AllowsForeignChildren()
+    {
+        _interaction.ResolveComponentPdkSource = ResolveByNazcaFunction;
+        SelectGroupTemplate("Playground Group", "foreign_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1, "with no active process, any group is placeable");
+    }
+
+    [Fact]
+    public void PasteSelected_CopiedGroupWithForeignChild_BlocksWholePaste()
+    {
+        // Place the mixed group directly (bypassing the placement guard under test), copy it.
+        var group = BuildGroup("Mixed", "member_func", "foreign_func");
+        var vm = _canvas.AddComponent(group);
+        _canvas.Selection.SelectSingle(vm);
+        _interaction.CopySelectedCommand.Execute(null);
+
+        LockToSoiWithResolver();
+        string? status = null;
+        _interaction.UpdateStatus = s => status = s;
+
+        int countBefore = _canvas.Components.Count;
+        _interaction.PasteSelected();
+
+        _canvas.Components.Count.ShouldBe(countBefore, "pasting a group with a foreign-process child must be blocked");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void PasteSelected_CopiedGroupWithMemberChildrenOnly_Pastes()
+    {
+        var group = BuildGroup("Members", "member_func", "member_func");
+        var vm = _canvas.AddComponent(group);
+        _canvas.Selection.SelectSingle(vm);
+        _interaction.CopySelectedCommand.Execute(null);
+
+        LockToSoiWithResolver();
+
+        int countBefore = _canvas.Components.Count;
+        _interaction.PasteSelected();
+
+        _canvas.Components.Count.ShouldBe(countBefore + 1, "a member-only group must paste normally");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_ForeignChildInNestedGroup_IsAlsoBlocked()
+    {
+        LockToSoiWithResolver();
+
+        var outer = BuildGroup("Outer", "member_func");
+        var nested = BuildGroup("Nested", "foreign_func");
+        outer.AddChild(nested);
+        SelectBuiltGroup(outer, "Outer Template");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(0, "foreign children hidden inside nested groups must be found");
+    }
+
+    private void SelectGroupTemplate(string name, params string[] childNazcaFunctions)
+    {
+        var group = BuildGroup(name, childNazcaFunctions);
+        SelectBuiltGroup(group, name);
+    }
+
+    private void SelectBuiltGroup(ComponentGroup group, string templateName)
+    {
+        var template = _libraryManager.SaveTemplate(group, templateName);
+        template.TemplateGroup = group;
+        _interaction.SelectedGroupTemplate = template;
+    }
+
+    private static ComponentGroup BuildGroup(string name, params string[] childNazcaFunctions)
+    {
+        var group = new ComponentGroup(name) { PhysicalX = 0, PhysicalY = 0 };
+
+        for (int i = 0; i < childNazcaFunctions.Length; i++)
+        {
+            var child = new Component(
+                new Dictionary<int, SMatrix>(),
+                new List<Slider>(),
+                childNazcaFunctions[i],
+                "",
+                new Part[1, 1] { { new Part() } },
+                -1,
+                $"comp_{i}_{Guid.NewGuid():N}",
+                DiscreteRotation.R0,
+                new List<PhysicalPin>())
+            {
+                PhysicalX = i * 100,
+                PhysicalY = 0,
+                WidthMicrometers = 50,
+                HeightMicrometers = 30
+            };
+            group.AddChild(child);
+        }
+
+        return group;
+    }
+}


### PR DESCRIPTION
Closes #653. Supersedes #654, which GitHub auto-closed when its base branch (`feat/single-process-570`, PR #652) was merged and deleted.

Rebased onto main after the #652 merge and reconciled with the review fixes that landed there:

- **`GroupProcessPolicy` (core)** — derives a group's process membership from its recursive non-group children; one foreign child blocks the whole group with a message naming every blocked PDK and the group.
- **`ComponentPdkSourceResolver` (shared)** — single library-based lookup for a placed core component's PDK source; `FileOperationsViewModel.FindTemplatePdkSource` now delegates to it.
- **`PlaceGroupTemplateAt`** uses `GroupProcessPolicy.CheckGroupPlacement` (replacing the inline per-child check from the #652 review fixes — better message, core-level policy).
- **Clipboard**: kept the #652-review property-based `PdkSourceResolver` (covers null-source fallback for non-group entries too) and adopted `GetAllComponentsRecursive` for group expansion; the paste guard reads `PeekPdkSources()` which now expands groups.
- **AI assistant**: `CopyComponentAsync` now checks via the clipboard's expanded sources, so copying a GROUP with foreign children is blocked too (`ResolveComponentPdkSource` wired in MainViewModel alongside the other enforcement delegates).

Tests: `GroupProcessPolicyTests`, `GroupProcessEnforcementTests` (placement + paste, block + pass cases), plus the existing enforcement suites. Full suite green locally: 2850 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)