### PR TITLE
(+) gdsfactory-native component previews (canvas, library, offset editor) (#570)

### DIFF
--- a/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewKey.cs
+++ b/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewKey.cs
@@ -11,20 +11,29 @@ namespace CAP.Avalonia.Controls.Canvas.ComponentPreview;
 public readonly record struct GdsPreviewKey(string? Module, string? Function, string? Parameters)
 {
     /// <summary>Bump to invalidate every cached entry (format or render-semantics change).</summary>
-    public const int FormatVersion = 1;
+    public const int FormatVersion = 2;
 
     /// <summary>ASCII unit separator — never appears in module/function/parameter strings.</summary>
     private const char FieldSeparator = (char)31;
 
-    /// <summary>True when there is a function to render (built-in components have none).</summary>
-    public bool IsRenderable => !string.IsNullOrWhiteSpace(Function);
+    /// <summary>
+    /// Module-qualified gdsfactory factory name for gdsfactory-native components
+    /// (e.g. "cspdk.sin300.mmi1x2"); null for Nazca components. When set, the geometry is
+    /// rendered via the gdsfactory preview service instead of Nazca (#570).
+    /// </summary>
+    public string? GdsFactoryFunction { get; init; }
+
+    /// <summary>True when there is something to render — a Nazca function or a gdsfactory
+    /// factory (built-in / external-port components have neither).</summary>
+    public bool IsRenderable =>
+        !string.IsNullOrWhiteSpace(Function) || !string.IsNullOrWhiteSpace(GdsFactoryFunction);
 
     /// <summary>Stable filesystem-safe hash, prefixed with the format version.</summary>
     public string Hash()
     {
         // Separate the fields so distinct tuples can't collide via boundary shifts,
         // e.g. ("ab","c") vs ("a","bc").
-        var material = $"{Module}{FieldSeparator}{Function}{FieldSeparator}{Parameters}";
+        var material = $"{Module}{FieldSeparator}{Function}{FieldSeparator}{Parameters}{FieldSeparator}{GdsFactoryFunction}";
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(material));
         var hex = Convert.ToHexString(bytes, 0, 12).ToLowerInvariant(); // 24 hex chars
         return $"v{FormatVersion}-{hex}";

--- a/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewRenderService.cs
+++ b/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewRenderService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Avalonia.Threading;
+using CAP.Avalonia.Services.GdsFactoryExport;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Export;
 
@@ -35,6 +36,12 @@ public sealed class GdsPreviewRenderService
     internal const int MinBitmapPixels = 16;
 
     private readonly NazcaComponentPreviewService _previewService;
+
+    /// <summary>Renders gdsfactory-native components (cspdk etc.); null falls back to no preview.
+    /// Typed as the base so it can be mocked in tests; DI injects the
+    /// <see cref="GdsFactoryComponentPreviewService"/> instance.</summary>
+    private readonly NazcaComponentPreviewService? _gdsFactoryPreviewService;
+
     private readonly GdsPreviewCache _cache = new();
 
     /// <summary>Persistent on-disk cache for resolution-independent geometry.</summary>
@@ -74,19 +81,25 @@ public sealed class GdsPreviewRenderService
     /// Initializes the service with the shared Nazca preview back-end and a
     /// default disk cache.
     /// </summary>
-    public GdsPreviewRenderService(NazcaComponentPreviewService previewService)
-        : this(previewService, new GdsPreviewDiskCache())
+    public GdsPreviewRenderService(
+        NazcaComponentPreviewService previewService,
+        NazcaComponentPreviewService? gdsFactoryPreviewService = null)
+        : this(previewService, new GdsPreviewDiskCache(), gdsFactoryPreviewService)
     {
     }
 
     /// <summary>
-    /// Initializes the service with the shared Nazca preview back-end and an
-    /// explicit disk cache (used by tests to redirect cache files).
+    /// Initializes the service with the shared Nazca preview back-end, an explicit disk cache
+    /// (used by tests to redirect cache files), and an optional gdsfactory preview back-end
+    /// for gdsfactory-native components (#570).
     /// </summary>
-    public GdsPreviewRenderService(NazcaComponentPreviewService previewService, GdsPreviewDiskCache diskCache)
+    public GdsPreviewRenderService(
+        NazcaComponentPreviewService previewService, GdsPreviewDiskCache diskCache,
+        NazcaComponentPreviewService? gdsFactoryPreviewService = null)
     {
         _previewService = previewService ?? throw new ArgumentNullException(nameof(previewService));
         _diskCache = diskCache ?? throw new ArgumentNullException(nameof(diskCache));
+        _gdsFactoryPreviewService = gdsFactoryPreviewService;
     }
 
     /// <summary>
@@ -128,10 +141,16 @@ public sealed class GdsPreviewRenderService
             return $"rawcode|{ComputeRawCodeHash(rawCode)}|{comp.Width:F2}|{comp.Height:F2}";
 
         var fn = comp.Component.NazcaFunctionName;
-        if (string.IsNullOrWhiteSpace(fn))
-            return null;
+        if (!string.IsNullOrWhiteSpace(fn))
+            return $"{fn}|{comp.Width:F2}|{comp.Height:F2}";
 
-        return $"{fn}|{comp.Width:F2}|{comp.Height:F2}";
+        // gdsfactory-native component (e.g. CornerStone SiN): no Nazca function, render via the
+        // gdsfactory factory instead so it gets a real geometry preview rather than a rectangle (#570).
+        var gdsFn = comp.Component.GdsFactoryFunction;
+        if (!string.IsNullOrWhiteSpace(gdsFn))
+            return $"gdsfactory|{gdsFn}|{comp.Width:F2}|{comp.Height:F2}";
+
+        return null;
     }
 
     private static string ComputeRawCodeHash(string code)
@@ -139,6 +158,18 @@ public sealed class GdsPreviewRenderService
         var bytes = System.Security.Cryptography.SHA256.HashData(
             System.Text.Encoding.UTF8.GetBytes(code));
         return Convert.ToHexString(bytes);
+    }
+
+    /// <summary>
+    /// Renders a gdsfactory-native component's geometry via the gdsfactory preview back-end,
+    /// or a failure result when no service is wired / the function is not module-qualified (#570).
+    /// </summary>
+    private async Task<NazcaPreviewResult> RenderGdsFactoryAsync(string? gdsFactoryFunction)
+    {
+        var code = GdsFactoryPreviewCode.For(gdsFactoryFunction);
+        if (code == null || _gdsFactoryPreviewService == null)
+            return NazcaPreviewResult.Fail("No gdsfactory preview available for this component.");
+        return await _gdsFactoryPreviewService.RenderRawCodeAsync(code);
     }
 
     private async Task FetchAndCacheAsync(string cacheKey, ComponentViewModel comp, string? rawCode)
@@ -149,6 +180,11 @@ public sealed class GdsPreviewRenderService
             if (rawCode != null)
             {
                 result = await _previewService.RenderRawCodeAsync(rawCode);
+            }
+            else if (string.IsNullOrWhiteSpace(comp.Component.NazcaFunctionName)
+                     && !string.IsNullOrWhiteSpace(comp.Component.GdsFactoryFunction))
+            {
+                result = await RenderGdsFactoryAsync(comp.Component.GdsFactoryFunction);
             }
             else
             {
@@ -220,7 +256,12 @@ public sealed class GdsPreviewRenderService
             }
             await _renderGate.WaitAsync();
             NazcaPreviewResult result;
-            try { result = await _previewService.RenderAsync(key.Module, key.Function!, key.Parameters); }
+            try
+            {
+                result = string.IsNullOrWhiteSpace(key.Function)
+                    ? await RenderGdsFactoryAsync(key.GdsFactoryFunction)
+                    : await _previewService.RenderAsync(key.Module, key.Function!, key.Parameters);
+            }
             finally { _renderGate.Release(); }
 
             if (result.Success && result.Polygons.Count > 0)

--- a/CAP.Avalonia/Controls/ComponentPreview.cs
+++ b/CAP.Avalonia/Controls/ComponentPreview.cs
@@ -30,6 +30,9 @@ public class ComponentPreview : Control
     public static readonly StyledProperty<string?> NazcaFunctionNameProperty =
         AvaloniaProperty.Register<ComponentPreview, string?>(nameof(NazcaFunctionName));
 
+    public static readonly StyledProperty<string?> GdsFactoryFunctionProperty =
+        AvaloniaProperty.Register<ComponentPreview, string?>(nameof(GdsFactoryFunction));
+
     /// <summary>Attached service, set once on an ancestor so all thumbnails inherit it.</summary>
     public static readonly AttachedProperty<GdsPreviewRenderService?> RenderServiceProperty =
         AvaloniaProperty.RegisterAttached<ComponentPreview, Control, GdsPreviewRenderService?>("RenderService", inherits: true);
@@ -68,6 +71,14 @@ public class ComponentPreview : Control
         set => SetValue(NazcaFunctionNameProperty, value);
     }
 
+    /// <summary>Module-qualified gdsfactory factory name for gdsfactory-native components
+    /// (e.g. "cspdk.sin300.mmi1x2"); drives the gdsfactory geometry preview (#570).</summary>
+    public string? GdsFactoryFunction
+    {
+        get => GetValue(GdsFactoryFunctionProperty);
+        set => SetValue(GdsFactoryFunctionProperty, value);
+    }
+
     private GdsPreviewRenderService? _service;
 
     static ComponentPreview()
@@ -77,7 +88,8 @@ public class ComponentPreview : Control
             HeightMicrometersProperty,
             PinDefinitionsProperty,
             NazcaModuleNameProperty,
-            NazcaFunctionNameProperty);
+            NazcaFunctionNameProperty,
+            GdsFactoryFunctionProperty);
     }
 
     /// <inheritdoc/>
@@ -118,7 +130,8 @@ public class ComponentPreview : Control
         double offsetX = pad + (availW - drawW) / 2;
         double offsetY = pad + (availH - drawH) / 2;
 
-        var geometry = _service?.TryGetGeometry(new GdsPreviewKey(NazcaModuleName, NazcaFunctionName, null));
+        var geometry = _service?.TryGetGeometry(
+            new GdsPreviewKey(NazcaModuleName, NazcaFunctionName, null) { GdsFactoryFunction = GdsFactoryFunction });
         if (geometry != null && geometry.Polygons.Count > 0)
             GdsPolygonRenderer.DrawPolygonsAsGeometry(context, geometry, offsetX, offsetY, drawW, drawH);
         else

--- a/CAP.Avalonia/DI/CanvasAndPanelExtensions.cs
+++ b/CAP.Avalonia/DI/CanvasAndPanelExtensions.cs
@@ -28,9 +28,12 @@ internal static class CanvasAndPanelExtensions
         services.AddSingleton<ViewportControlViewModel>();
 
         // GDS preview render service — shared by the canvas overlay and the
-        // component-library thumbnails (depends on the Nazca preview backend).
+        // component-library thumbnails. Uses the Nazca backend for Nazca components and the
+        // gdsfactory backend for gdsfactory-native components (CornerStone SiN etc., #570).
         services.AddSingleton(sp =>
-            new GdsPreviewRenderService(sp.GetRequiredService<NazcaComponentPreviewService>()));
+            new GdsPreviewRenderService(
+                sp.GetRequiredService<NazcaComponentPreviewService>(),
+                sp.GetRequiredService<GdsFactoryComponentPreviewService>()));
 
         // Left panel sub-ViewModels
         services.AddTransient<HierarchyPanelViewModel>();

--- a/CAP.Avalonia/DI/PdkOffsetFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/PdkOffsetFeatureExtensions.cs
@@ -56,7 +56,8 @@ internal static class PdkOffsetFeatureExtensions
             sp.GetRequiredService<PdkLoader>(),
             sp.GetRequiredService<PdkJsonSaver>(),
             sp.GetRequiredService<PdkManagerViewModel>(),
-            sp.GetRequiredService<NazcaComponentPreviewService>()));
+            sp.GetRequiredService<NazcaComponentPreviewService>(),
+            sp.GetRequiredService<GdsFactoryComponentPreviewService>()));
 
         return services;
     }

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryPreviewCode.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryPreviewCode.cs
@@ -1,0 +1,33 @@
+namespace CAP.Avalonia.Services.GdsFactoryExport;
+
+/// <summary>
+/// Builds the raw gdsfactory Python that <c>render_gdsfactory_preview.py</c> consumes for a
+/// gdsfactory-native PDK component. The script looks for a module-scope <c>component</c>
+/// variable, so we import + activate the component's PDK module and resolve the cell from the
+/// active PDK registry — the same path the exporter uses (<see cref="GdsFactoryExporter"/>).
+/// A gdsfactory-native component carries a module-qualified <c>GdsFactoryFunction</c>
+/// (e.g. "cspdk.sin300.mmi1x2") instead of a Nazca function, so the Nazca preview path
+/// produces nothing; this gives those components a real geometry preview (#570).
+/// </summary>
+public static class GdsFactoryPreviewCode
+{
+    /// <summary>
+    /// Returns the preview code for a module-qualified gdsfactory function, or null when the
+    /// name is empty or bare (dotless) — a bare name has no importable PDK module to activate,
+    /// so no preview can be rendered.
+    /// </summary>
+    public static string? For(string? gdsFactoryFunction)
+    {
+        if (string.IsNullOrEmpty(gdsFactoryFunction) || !gdsFactoryFunction!.Contains('.'))
+            return null;
+
+        var lastDot = gdsFactoryFunction.LastIndexOf('.');
+        var module = gdsFactoryFunction.Substring(0, lastDot);
+        var cell = gdsFactoryFunction.Substring(lastDot + 1);
+
+        return $"import gdsfactory as gf\n"
+             + $"import {module}\n"
+             + $"{module}.PDK.activate()\n"
+             + $"component = gf.get_component('{cell}')\n";
+    }
+}

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.Overlay.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.Overlay.cs
@@ -1,3 +1,4 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
 using CAP_Core.Export;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 
@@ -102,12 +103,7 @@ public partial class PdkOffsetEditorViewModel
 
         try
         {
-            var (module, function) = ResolveModuleAndFunction(draft.NazcaFunction);
-            var result = await _previewService!.RenderAsync(
-                module,
-                function,
-                draft.NazcaParameters,
-                token);
+            var result = await RenderDraftAsync(draft, token);
 
             if (token.IsCancellationRequested) return;
             // SelectedComponent has moved on while we were waiting — drop result.
@@ -162,12 +158,39 @@ public partial class PdkOffsetEditorViewModel
     }
 
     /// <summary>
+    /// Renders the selected component: gdsfactory-native components (no Nazca function, a
+    /// gdsfactory factory) go through the gdsfactory preview back-end; everything else uses the
+    /// Nazca path. Without this branch a gdsfactory component resolves to <c>demo.()</c> and the
+    /// Nazca script fails (#570).
+    /// </summary>
+    private Task<NazcaPreviewResult> RenderDraftAsync(PdkComponentDraft draft, System.Threading.CancellationToken token)
+    {
+        if (string.IsNullOrWhiteSpace(draft.NazcaFunction)
+            && !string.IsNullOrWhiteSpace(draft.GdsFactoryFunction))
+        {
+            var code = GdsFactoryPreviewCode.For(draft.GdsFactoryFunction);
+            if (code != null && _gdsFactoryPreviewService != null)
+                return _gdsFactoryPreviewService.RenderRawCodeAsync(code, token);
+            return Task.FromResult(
+                NazcaPreviewResult.Fail("No gdsfactory preview available for this component."));
+        }
+
+        var (module, function) = ResolveModuleAndFunction(draft.NazcaFunction);
+        return _previewService!.RenderAsync(module, function, draft.NazcaParameters, token);
+    }
+
+    /// <summary>
     /// Renders the same Python the preview helper would execute, as a string
     /// the user can read and copy. Different shape per render path:
-    /// SiEPIC → klayout GDS load; demofab → Nazca cell call.
+    /// gdsfactory → PDK factory call; SiEPIC → klayout GDS load; demofab → Nazca cell call.
     /// </summary>
-    private static string BuildPreviewSource(PdkComponentDraft draft)
+    internal static string BuildPreviewSource(PdkComponentDraft draft)
     {
+        if (string.IsNullOrWhiteSpace(draft.NazcaFunction)
+            && !string.IsNullOrWhiteSpace(draft.GdsFactoryFunction))
+            return GdsFactoryPreviewCode.For(draft.GdsFactoryFunction)
+                   ?? "# No gdsfactory preview available for this component.";
+
         var (module, function) = ResolveModuleAndFunction(draft.NazcaFunction);
         var paramsBlock = string.IsNullOrWhiteSpace(draft.NazcaParameters)
             ? "" : draft.NazcaParameters;

--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.cs
@@ -28,6 +28,12 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
     private readonly PdkJsonSaver _pdkSaver;
     private readonly PdkManagerViewModel _pdkManager;
     private readonly NazcaComponentPreviewService? _previewService;
+
+    /// <summary>gdsfactory preview back-end for gdsfactory-native components (#570); null → no preview.
+    /// Typed as the base so it can be mocked in tests; DI injects the
+    /// <see cref="GdsFactoryComponentPreviewService"/> instance.</summary>
+    private readonly NazcaComponentPreviewService? _gdsFactoryPreviewService;
+
     private PdkDraft? _loadedPdk;
     private string? _loadedFilePath;
     private double _nazcaCanvasRefX;
@@ -208,12 +214,14 @@ public partial class PdkOffsetEditorViewModel : ObservableObject
         PdkLoader pdkLoader,
         PdkJsonSaver pdkSaver,
         PdkManagerViewModel pdkManager,
-        NazcaComponentPreviewService? previewService = null)
+        NazcaComponentPreviewService? previewService = null,
+        NazcaComponentPreviewService? gdsFactoryPreviewService = null)
     {
         _pdkLoader = pdkLoader;
         _pdkSaver = pdkSaver;
         _pdkManager = pdkManager;
         _previewService = previewService;
+        _gdsFactoryPreviewService = gdsFactoryPreviewService;
     }
 
     /// <summary>Opens a file dialog and loads the selected PDK JSON file.</summary>

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -570,6 +570,7 @@
                                             PinDefinitions="{Binding PinDefinitions}"
                                             NazcaModuleName="{Binding NazcaModuleName}"
                                             NazcaFunctionName="{Binding NazcaFunctionName}"
+                                            GdsFactoryFunction="{Binding GdsFactoryFunction}"
                                             Margin="0,0,6,0"/>
                                         <StackPanel VerticalAlignment="Center">
                                             <StackPanel Orientation="Horizontal">

--- a/UnitTests/Canvas/ComponentPreview/GdsPreviewKeyTests.cs
+++ b/UnitTests/Canvas/ComponentPreview/GdsPreviewKeyTests.cs
@@ -37,4 +37,20 @@ public class GdsPreviewKeyTests
         new GdsPreviewKey("m", "   ", "p").IsRenderable.ShouldBeFalse();
         new GdsPreviewKey("m", "f", "p").IsRenderable.ShouldBeTrue();
     }
+
+    [Fact]
+    public void IsRenderable_TrueWhenGdsFactoryFunctionSet_EvenWithoutNazcaFunction()
+    {
+        // gdsfactory-native components have no Nazca function but must still render (#570).
+        var key = new GdsPreviewKey(null, null, null) { GdsFactoryFunction = "cspdk.sin300.mmi1x2" };
+        key.IsRenderable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Hash_DiffersByGdsFactoryFunction()
+    {
+        var a = new GdsPreviewKey(null, null, null) { GdsFactoryFunction = "cspdk.sin300.mmi1x2" };
+        var b = new GdsPreviewKey(null, null, null) { GdsFactoryFunction = "cspdk.sin300.mmi2x2" };
+        a.Hash().ShouldNotBe(b.Hash());
+    }
 }

--- a/UnitTests/Canvas/ComponentPreview/GdsPreviewRenderServiceTests.cs
+++ b/UnitTests/Canvas/ComponentPreview/GdsPreviewRenderServiceTests.cs
@@ -59,6 +59,48 @@ public sealed class GdsPreviewRenderServiceTests
         key1.ShouldNotBe(key2);
     }
 
+    [Fact]
+    public void BuildCacheKey_GdsFactoryNativeComponent_ReturnsGdsfactoryKey()
+    {
+        // A gdsfactory-native component (no Nazca function, a gdsfactory factory) must still get
+        // a cache key so it renders a real preview instead of falling back to a rectangle (#570).
+        var comp = TestComponentFactory.CreateComponentViewModel(nazcaFunctionName: "");
+        comp.Component.GdsFactoryFunction = "cspdk.sin300.mmi1x2";
+
+        var key = GdsPreviewRenderService.BuildCacheKey(comp);
+
+        key.ShouldNotBeNull();
+        key!.ShouldStartWith("gdsfactory|cspdk.sin300.mmi1x2|");
+    }
+
+    [Fact]
+    public async Task GetGeometry_GdsFactoryKey_RendersViaGdsFactoryServiceNotNazca()
+    {
+        // A gdsfactory-native render identity must be resolved by the gdsfactory preview
+        // back-end (RenderRawCodeAsync with generated get_component code), never Nazca (#570).
+        var nazca = new Mock<NazcaComponentPreviewService>("python", "nazca.py", (TimeSpan?)null, (ProcessLaunchFactory?)null);
+        // The gdsfactory back-end is typed as the base service (mockable, sealed derived type isn't).
+        var gf = new Mock<NazcaComponentPreviewService>("python", "gf.py", (TimeSpan?)null, (ProcessLaunchFactory?)null);
+        gf.Setup(s => s.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Ok());
+
+        var diskDir = Path.Combine(Path.GetTempPath(), "lunima-gf-" + Guid.NewGuid().ToString("N"));
+        var svc = new GdsPreviewRenderService(nazca.Object, new GdsPreviewDiskCache(diskDir), gf.Object);
+        var key = new GdsPreviewKey(null, null, null) { GdsFactoryFunction = "cspdk.sin300.mmi1x2" };
+
+        key.IsRenderable.ShouldBeTrue();
+        svc.TryGetGeometry(key).ShouldBeNull();       // miss → async render kicked off
+        await svc.WaitForPendingAsync();
+        svc.TryGetGeometry(key).ShouldNotBeNull();    // rendered via gdsfactory service
+
+        gf.Verify(s => s.RenderRawCodeAsync(
+            It.Is<string>(c => c.Contains("gf.get_component('mmi1x2')")), It.IsAny<CancellationToken>()), Times.Once);
+        nazca.Verify(s => s.RenderAsync(
+            It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        try { Directory.Delete(diskDir, true); } catch { }
+    }
+
     // ── TryGetPreview — fallback behaviour ─────────────────────────────────
 
     [Fact]

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryPreviewCodeTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryPreviewCodeTests.cs
@@ -1,0 +1,33 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
+using Shouldly;
+
+namespace UnitTests.Export.GdsFactoryExport;
+
+/// <summary>
+/// Tests for the gdsfactory preview-code builder: it turns a component's
+/// <c>GdsFactoryFunction</c> (e.g. "cspdk.sin300.mmi1x2") into the raw code that
+/// <c>render_gdsfactory_preview.py</c> expects — import + activate the PDK, then
+/// assign <c>component</c> from the PDK registry (#570 preview fix).
+/// </summary>
+public class GdsFactoryPreviewCodeTests
+{
+    [Fact]
+    public void For_ModuleQualifiedFunction_ImportsActivatesAndResolvesTheCell()
+    {
+        var code = GdsFactoryPreviewCode.For("cspdk.sin300.mmi1x2");
+
+        code.ShouldNotBeNull();
+        code!.ShouldContain("import cspdk.sin300");
+        code.ShouldContain("cspdk.sin300.PDK.activate()");
+        code.ShouldContain("component = gf.get_component('mmi1x2')");   // render script looks for `component`
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("straight")]   // bare name: no importable module → cannot render
+    public void For_EmptyOrBareName_ReturnsNull(string? function)
+    {
+        GdsFactoryPreviewCode.For(function).ShouldBeNull();
+    }
+}

--- a/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
@@ -13,6 +13,25 @@ namespace UnitTests.PdkOffset;
 /// </summary>
 public class PdkOffsetEditorViewModelTests
 {
+    [Fact]
+    public void BuildPreviewSource_GdsFactoryNativeDraft_EmitsFactoryCode_NotDemoCall()
+    {
+        // Before the fix, a gdsfactory-native draft (empty NazcaFunction) resolved to demo.(),
+        // whose Nazca render crashed the offset editor. It must now emit real gdsfactory code (#570).
+        var draft = new PdkComponentDraft
+        {
+            Name = "SiN MMI",
+            NazcaFunction = "",
+            GdsFactoryFunction = "cspdk.sin300.mmi1x2",
+        };
+
+        var source = PdkOffsetEditorViewModel.BuildPreviewSource(draft);
+
+        source.ShouldContain("import cspdk.sin300");
+        source.ShouldContain("component = gf.get_component('mmi1x2')");
+        source.ShouldNotContain("demo.()");   // the broken empty-function Nazca call
+    }
+
     private static PdkDraft BuildTestPdk(string pdkName = "Test PDK") => new()
     {
         Name = pdkName,


### PR DESCRIPTION
## Problem
CornerStone SiN (gdsfactory-native) components showed **no preview** — a grey rectangle in the canvas and component library, and the **PDK Offset Editor errored** ("Preview unavailable"). The entire preview pipeline was keyed on `Component.NazcaFunctionName`, which is empty for gdsfactory-native components, so every route fell back to the placeholder or built a nonsense `demo.()` Nazca call (the #661-review-flagged offset-editor bug).

## Fix
The gdsfactory render back-end already existed (`GdsFactoryComponentPreviewService` + `render_gdsfactory_preview.py`, #637) but was wired **only** into the instance-override editor. This routes the three preview surfaces to it for gdsfactory-native components:

- **`GdsFactoryPreviewCode.For(gdsFactoryFunction)`** (new): builds the raw code the render script expects — import + activate the PDK module, `component = gf.get_component('<cell>')` — mirroring the exporter's factory resolution.
- **`GdsPreviewRenderService`**: takes the gdsfactory back-end; components/keys with a `GdsFactoryFunction` (and no Nazca function) route through it. `BuildCacheKey` + `GdsPreviewKey` gained a gdsfactory identity → canvas overlay **and** library thumbnails.
- **`PdkOffsetEditorViewModel`**: renders gdsfactory drafts via the gdsfactory back-end instead of `demo.()`; the readable preview source shows the real factory code.
- **DI**: the gdsfactory preview service is injected into both the canvas/library render service and the offset editor (typed as the base service so it stays test-mockable, matching the #637 pattern).

## Verification
- Generated preview code renders real geometry through `render_gdsfactory_preview.py` against cspdk (`mmi1x2`: 1 polygon, 3 pins, real bbox).
- Degrades gracefully to the rectangle when no gdsfactory-capable interpreter is present.
- New tests: `GdsFactoryPreviewCodeTests`, gdsfactory routing in `GdsPreviewRenderServiceTests`, `GdsPreviewKeyTests` (renderable + hash), `PdkOffsetEditorViewModelTests` (factory code, not `demo.()`).
- Full suite green (2896).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
