### PR TITLE
(+) Photonic Registry: core RegistryClient with offline cache (#655)

### DIFF
--- a/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryCache.cs
+++ b/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryCache.cs
@@ -1,0 +1,59 @@
+using CAP_Core.Helpers;
+
+namespace CAP_Core.ComponentRegistry;
+
+/// <summary>
+/// File-based cache for raw registry JSON documents, keyed by their
+/// repo-relative path. Lives under the Lunima app-data directory so the
+/// registry stays browsable offline once it has been fetched.
+/// </summary>
+public sealed class RegistryCache
+{
+    private readonly string _rootDirectory;
+
+    /// <summary>
+    /// Initialises the cache.
+    /// </summary>
+    /// <param name="rootDirectory">Cache directory; null uses the default under the Lunima app-data folder.</param>
+    public RegistryCache(string? rootDirectory = null)
+    {
+        _rootDirectory = rootDirectory ?? Path.Combine(
+            AppDataFolders.LocalApplicationData, "Lunima", "registry-cache");
+    }
+
+    /// <summary>
+    /// Reads the cached document for <paramref name="relativePath"/>,
+    /// or null if it is not cached.
+    /// </summary>
+    public string? Read(string relativePath)
+    {
+        var file = ResolveSafe(relativePath);
+        if (file == null || !File.Exists(file))
+            return null;
+        return File.ReadAllText(file);
+    }
+
+    /// <summary>Stores <paramref name="content"/> as the cached document for <paramref name="relativePath"/>.</summary>
+    public void Write(string relativePath, string content)
+    {
+        var file = ResolveSafe(relativePath);
+        if (file == null)
+            return;
+        Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+        File.WriteAllText(file, content);
+    }
+
+    /// <summary>
+    /// Maps a repo-relative path to a file inside the cache root, rejecting
+    /// paths that would escape it (rooted paths or ".." segments).
+    /// </summary>
+    private string? ResolveSafe(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath) || Path.IsPathRooted(relativePath))
+            return null;
+        var segments = relativePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Any(s => s == ".."))
+            return null;
+        return Path.Combine(new[] { _rootDirectory }.Concat(segments).ToArray());
+    }
+}

--- a/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryClient.cs
+++ b/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryClient.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+
+namespace CAP_Core.ComponentRegistry;
+
+/// <summary>
+/// Read-only client for the open photonic component registry
+/// (https://github.com/aignermax/photonic-registry). Fetches the index,
+/// component manifests, and S-parameter artifacts serverlessly via raw
+/// GitHub URLs, caching every document locally: cached documents are served
+/// without network access, an explicit refresh re-downloads, and network
+/// failures degrade to cached data instead of throwing.
+/// </summary>
+public sealed class RegistryClient
+{
+    /// <summary>Raw base URL of the reference registry repository.</summary>
+    public const string DefaultBaseUrl =
+        "https://raw.githubusercontent.com/aignermax/photonic-registry/main/";
+
+    /// <summary>Repo-relative path of the registry index document.</summary>
+    public const string IndexPath = "index.json";
+
+    private static readonly JsonSerializerOptions JsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly RegistryCache _cache;
+    private readonly string _baseUrl;
+
+    /// <summary>
+    /// Initialises the client.
+    /// </summary>
+    /// <param name="httpClient">Transport; inject a mocked handler in tests.</param>
+    /// <param name="baseUrl">Registry base URL; null uses <see cref="DefaultBaseUrl"/>.</param>
+    /// <param name="cache">Document cache; null uses the default app-data cache.</param>
+    public RegistryClient(HttpClient httpClient, string? baseUrl = null, RegistryCache? cache = null)
+    {
+        _httpClient = httpClient;
+        _baseUrl = (baseUrl ?? DefaultBaseUrl).TrimEnd('/') + "/";
+        _cache = cache ?? new RegistryCache();
+    }
+
+    /// <summary>Fetches the registry index listing all processes and components.</summary>
+    /// <param name="forceRefresh">True bypasses the cache and re-downloads.</param>
+    public Task<RegistryResult<RegistryIndex>> GetIndexAsync(
+        bool forceRefresh = false, CancellationToken cancellationToken = default)
+        => FetchJsonAsync<RegistryIndex>(IndexPath, forceRefresh, cancellationToken);
+
+    /// <summary>
+    /// Fetches a component manifest.
+    /// </summary>
+    /// <param name="componentPath">Repo-relative manifest path as listed in the index
+    /// (e.g. "processes/generic-si220/components/y-branch-1x2/component.json").</param>
+    /// <param name="forceRefresh">True bypasses the cache and re-downloads.</param>
+    public Task<RegistryResult<RegistryComponent>> GetComponentAsync(
+        string componentPath, bool forceRefresh = false, CancellationToken cancellationToken = default)
+        => FetchJsonAsync<RegistryComponent>(componentPath, forceRefresh, cancellationToken);
+
+    /// <summary>
+    /// Fetches an S-parameter artifact of a component.
+    /// </summary>
+    /// <param name="componentPath">Repo-relative manifest path of the owning component.</param>
+    /// <param name="artifactFile">Artifact path relative to the component directory,
+    /// as given by <see cref="RegistryArtifactRef.File"/>.</param>
+    /// <param name="forceRefresh">True bypasses the cache and re-downloads.</param>
+    public Task<RegistryResult<SParameterSpectrum>> GetSpectrumAsync(
+        string componentPath, string artifactFile, bool forceRefresh = false,
+        CancellationToken cancellationToken = default)
+    {
+        var componentDirectory = componentPath.Contains('/')
+            ? componentPath[..componentPath.LastIndexOf('/')]
+            : "";
+        var artifactPath = string.IsNullOrEmpty(componentDirectory)
+            ? artifactFile
+            : $"{componentDirectory}/{artifactFile}";
+        return FetchJsonAsync<SParameterSpectrum>(artifactPath, forceRefresh, cancellationToken);
+    }
+
+    private async Task<RegistryResult<T>> FetchJsonAsync<T>(
+        string relativePath, bool forceRefresh, CancellationToken cancellationToken) where T : class
+    {
+        if (!forceRefresh)
+        {
+            var cached = TryReadCache<T>(relativePath);
+            if (cached != null)
+                return RegistryResult<T>.FromCache(cached);
+        }
+
+        string? downloadError;
+        try
+        {
+            var json = await _httpClient.GetStringAsync(_baseUrl + relativePath, cancellationToken);
+            var value = JsonSerializer.Deserialize<T>(json, JsonOptions);
+            if (value != null)
+            {
+                _cache.Write(relativePath, json);
+                return RegistryResult<T>.FromNetwork(value);
+            }
+            downloadError = $"Registry document '{relativePath}' deserialized to null.";
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or IOException)
+        {
+            downloadError = $"Failed to download registry document '{relativePath}': {ex.Message}";
+        }
+
+        var fallback = TryReadCache<T>(relativePath);
+        return fallback != null
+            ? RegistryResult<T>.FromCache(fallback, downloadError)
+            : RegistryResult<T>.Unavailable(downloadError);
+    }
+
+    /// <summary>Deserializes the cached document, treating corrupt cache entries as cache misses.</summary>
+    private T? TryReadCache<T>(string relativePath) where T : class
+    {
+        var json = _cache.Read(relativePath);
+        if (json == null)
+            return null;
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryComponent.cs
+++ b/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryComponent.cs
@@ -1,0 +1,125 @@
+using System.Text.Json;
+
+namespace CAP_Core.ComponentRegistry;
+
+/// <summary>
+/// Deserialized form of a registry <c>component.json</c> manifest: ports,
+/// design parameters, and references to the artifact tiers (geometry,
+/// simulated S-matrices, fab measurements) with their provenance.
+/// </summary>
+public sealed class RegistryComponent
+{
+    /// <summary>Gets the registry-wide component identifier (kebab-case).</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>Gets the human-readable component name.</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Gets the component description.</summary>
+    public string Description { get; init; } = "";
+
+    /// <summary>Gets the id of the process this component belongs to.</summary>
+    public string Process { get; init; } = "";
+
+    /// <summary>Gets the optical ports (GDSFactory naming: o1, o2, ...).</summary>
+    public List<RegistryPort> Ports { get; init; } = new();
+
+    /// <summary>Gets the physical properties relevant for validation.</summary>
+    public RegistryComponentProperties Properties { get; init; } = new();
+
+    /// <summary>Gets the design parameters (unit encoded in the key, e.g. "length_um").</summary>
+    public Dictionary<string, JsonElement> Parameters { get; init; } = new();
+
+    /// <summary>Gets the geometry artifact description, if any.</summary>
+    public RegistryGeometry? Geometry { get; init; }
+
+    /// <summary>Gets the simulated and measured artifact references.</summary>
+    public RegistryArtifacts Artifacts { get; init; } = new();
+
+    /// <summary>Gets the license identifier of this component's data.</summary>
+    public string License { get; init; } = "";
+}
+
+/// <summary>An optical port of a registry component.</summary>
+public sealed class RegistryPort
+{
+    /// <summary>Gets the port name (o1, o2, ...).</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Gets the port kind (currently always "optical").</summary>
+    public string Kind { get; init; } = "";
+
+    /// <summary>Gets the optional human-readable port description.</summary>
+    public string? Description { get; init; }
+}
+
+/// <summary>Physical properties the registry's CI validates against.</summary>
+public sealed class RegistryComponentProperties
+{
+    /// <summary>Gets whether the component is passive (S-matrix must not amplify).</summary>
+    public bool Passive { get; init; }
+
+    /// <summary>Gets whether the component is reciprocal (S equals its transpose).</summary>
+    public bool Reciprocal { get; init; }
+}
+
+/// <summary>Reference to the tier-1 geometry source of a component.</summary>
+public sealed class RegistryGeometry
+{
+    /// <summary>Gets the geometry format ("gds", "parametric-nazca", "parametric-gdsfactory", "none").</summary>
+    public string Format { get; init; } = "none";
+
+    /// <summary>Gets the repo-relative path to the GDS file or parametric script.</summary>
+    public string? Source { get; init; }
+
+    /// <summary>Gets the GDS cell name, if applicable.</summary>
+    public string? CellName { get; init; }
+}
+
+/// <summary>Groups the artifact references of a component by tier.</summary>
+public sealed class RegistryArtifacts
+{
+    /// <summary>Gets the tier-2 simulated S-matrix artifacts.</summary>
+    public List<RegistryArtifactRef> Simulated { get; init; } = new();
+
+    /// <summary>Gets the tier-3 fab-measured artifacts.</summary>
+    public List<RegistryArtifactRef> Measured { get; init; } = new();
+}
+
+/// <summary>Reference to one artifact file plus its trust status and provenance.</summary>
+public sealed class RegistryArtifactRef
+{
+    /// <summary>Gets the artifact path relative to the component directory.</summary>
+    public string File { get; init; } = "";
+
+    /// <summary>Gets the trust status ("demo", "unverified", "verified", "disputed", "withdrawn").</summary>
+    public string Status { get; init; } = "";
+
+    /// <summary>Gets the provenance record describing how the data was produced.</summary>
+    public RegistryProvenance Provenance { get; init; } = new();
+}
+
+/// <summary>Provenance of an artifact: how, by whom, and from which fab run it was produced.</summary>
+public sealed class RegistryProvenance
+{
+    /// <summary>Gets the method ("analytic-model", "fdtd", "eme", "fem", "measurement").</summary>
+    public string Method { get; init; } = "";
+
+    /// <summary>Gets the tool and version used (e.g. "tidy3d 2.7").</summary>
+    public string? Tool { get; init; }
+
+    /// <summary>Gets the solver settings or measurement conditions.</summary>
+    public string? Settings { get; init; }
+
+    /// <summary>Gets who created the artifact.</summary>
+    public string CreatedBy { get; init; } = "";
+
+    /// <summary>Gets the creation date (ISO format).</summary>
+    public string Date { get; init; } = "";
+
+    /// <summary>Gets the fab that produced the measured device (measurements only).</summary>
+    public string? Fab { get; init; }
+
+    /// <summary>Gets the fabrication run identifier (measurements only).</summary>
+    public string? RunId { get; init; }
+}

--- a/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryIndex.cs
+++ b/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryIndex.cs
@@ -1,0 +1,72 @@
+namespace CAP_Core.ComponentRegistry;
+
+/// <summary>
+/// Deserialized form of the registry's <c>index.json</c> — the single entry point
+/// listing every process and component so clients can render a library view
+/// without fetching each component manifest individually.
+/// </summary>
+public sealed class RegistryIndex
+{
+    /// <summary>Gets the index schema version.</summary>
+    public int SchemaVersion { get; init; }
+
+    /// <summary>Gets the fabrication processes available in the registry.</summary>
+    public List<RegistryIndexProcess> Processes { get; init; } = new();
+
+    /// <summary>Gets the summary entries for all registry components.</summary>
+    public List<RegistryIndexComponent> Components { get; init; } = new();
+}
+
+/// <summary>Summary of a fabrication process listed in the registry index.</summary>
+public sealed class RegistryIndexProcess
+{
+    /// <summary>Gets the process identifier (e.g. "generic-si220").</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>Gets the human-readable process name.</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Gets the process trust status (e.g. "demo").</summary>
+    public string Status { get; init; } = "";
+}
+
+/// <summary>Summary of a component listed in the registry index.</summary>
+public sealed class RegistryIndexComponent
+{
+    /// <summary>Gets the registry-wide component identifier.</summary>
+    public string Id { get; init; } = "";
+
+    /// <summary>Gets the human-readable component name.</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>Gets the component description.</summary>
+    public string Description { get; init; } = "";
+
+    /// <summary>Gets the id of the process this component belongs to.</summary>
+    public string Process { get; init; } = "";
+
+    /// <summary>Gets the number of optical ports.</summary>
+    public int PortCount { get; init; }
+
+    /// <summary>Gets the repo-relative path to the component manifest.</summary>
+    public string Path { get; init; } = "";
+
+    /// <summary>Gets which artifact tiers exist for this component.</summary>
+    public RegistryComponentTiers Tiers { get; init; } = new();
+
+    /// <summary>Gets the best artifact status across all tiers (e.g. "demo", "verified").</summary>
+    public string BestStatus { get; init; } = "";
+}
+
+/// <summary>Flags describing which of the three artifact tiers a component provides.</summary>
+public sealed class RegistryComponentTiers
+{
+    /// <summary>Gets whether tier 1 (geometry) data exists.</summary>
+    public bool Geometry { get; init; }
+
+    /// <summary>Gets whether tier 2 (simulated S-matrix) data exists.</summary>
+    public bool Simulated { get; init; }
+
+    /// <summary>Gets whether tier 3 (fab-measured) data exists.</summary>
+    public bool Measured { get; init; }
+}

--- a/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryResult.cs
+++ b/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/RegistryResult.cs
@@ -1,0 +1,48 @@
+namespace CAP_Core.ComponentRegistry;
+
+/// <summary>Where a <see cref="RegistryResult{T}"/> value came from.</summary>
+public enum RegistryDataSource
+{
+    /// <summary>Freshly downloaded from the registry.</summary>
+    Network,
+
+    /// <summary>Served from the local cache (possibly because the network failed).</summary>
+    Cache,
+
+    /// <summary>Neither network nor cache could provide the data; <c>Value</c> is null.</summary>
+    Unavailable,
+}
+
+/// <summary>
+/// Outcome of a registry fetch. Network failures never throw — callers inspect
+/// <see cref="Source"/> and <see cref="Error"/> instead, so offline operation
+/// degrades gracefully to cached data.
+/// </summary>
+/// <typeparam name="T">The deserialized payload type.</typeparam>
+public sealed class RegistryResult<T> where T : class
+{
+    private RegistryResult(T? value, RegistryDataSource source, string? error)
+    {
+        Value = value;
+        Source = source;
+        Error = error;
+    }
+
+    /// <summary>Gets the payload, or null when <see cref="Source"/> is <see cref="RegistryDataSource.Unavailable"/>.</summary>
+    public T? Value { get; }
+
+    /// <summary>Gets where the payload came from.</summary>
+    public RegistryDataSource Source { get; }
+
+    /// <summary>Gets the network/parse error message, if one occurred (may be set even when cached data was returned).</summary>
+    public string? Error { get; }
+
+    /// <summary>Creates a result for a successful download.</summary>
+    public static RegistryResult<T> FromNetwork(T value) => new(value, RegistryDataSource.Network, null);
+
+    /// <summary>Creates a result served from the local cache.</summary>
+    public static RegistryResult<T> FromCache(T value, string? error = null) => new(value, RegistryDataSource.Cache, error);
+
+    /// <summary>Creates a result for data that is neither online nor cached.</summary>
+    public static RegistryResult<T> Unavailable(string error) => new(null, RegistryDataSource.Unavailable, error);
+}

--- a/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/SParameterSpectrum.cs
+++ b/Connect-A-Pic-Core/ComponentRegistry/RegistryClient/SParameterSpectrum.cs
@@ -1,0 +1,51 @@
+using System.Numerics;
+using System.Text.Json.Serialization;
+
+namespace CAP_Core.ComponentRegistry;
+
+/// <summary>
+/// Sampled complex S-parameter spectra of a registry artifact: a shared
+/// wavelength grid plus one complex spectrum per port pair.
+/// </summary>
+public sealed class SParameterSpectrum
+{
+    /// <summary>Gets the wavelength sample grid in micrometers.</summary>
+    [JsonPropertyName("wavelength_um")]
+    public List<double> WavelengthUm { get; init; } = new();
+
+    /// <summary>Gets the per-port-pair spectra.</summary>
+    public List<SParameterEntry> S { get; init; } = new();
+
+    /// <summary>
+    /// Returns the complex spectrum from <paramref name="fromPort"/> to
+    /// <paramref name="toPort"/>, or null if the artifact contains no such entry.
+    /// The array is index-aligned with <see cref="WavelengthUm"/>.
+    /// </summary>
+    public Complex[]? GetSpectrum(string fromPort, string toPort)
+    {
+        var entry = S.FirstOrDefault(e => e.From == fromPort && e.To == toPort);
+        if (entry == null || entry.Re.Count != WavelengthUm.Count || entry.Im.Count != WavelengthUm.Count)
+            return null;
+
+        var result = new Complex[WavelengthUm.Count];
+        for (int i = 0; i < result.Length; i++)
+            result[i] = new Complex(entry.Re[i], entry.Im[i]);
+        return result;
+    }
+}
+
+/// <summary>One S-parameter spectrum between a pair of ports, split into real and imaginary samples.</summary>
+public sealed class SParameterEntry
+{
+    /// <summary>Gets the source port name.</summary>
+    public string From { get; init; } = "";
+
+    /// <summary>Gets the destination port name.</summary>
+    public string To { get; init; } = "";
+
+    /// <summary>Gets the real parts, index-aligned with the wavelength grid.</summary>
+    public List<double> Re { get; init; } = new();
+
+    /// <summary>Gets the imaginary parts, index-aligned with the wavelength grid.</summary>
+    public List<double> Im { get; init; } = new();
+}

--- a/UnitTests/ComponentRegistry/RegistryClient/FakeRegistryHttpHandler.cs
+++ b/UnitTests/ComponentRegistry/RegistryClient/FakeRegistryHttpHandler.cs
@@ -1,0 +1,44 @@
+using System.Net;
+
+namespace UnitTests.ComponentRegistry;
+
+/// <summary>
+/// HttpMessageHandler serving canned registry documents by repo-relative path,
+/// with switchable offline mode and a request counter for cache assertions.
+/// </summary>
+public sealed class FakeRegistryHttpHandler : HttpMessageHandler
+{
+    private readonly Dictionary<string, string> _documents = new();
+
+    /// <summary>Gets the number of HTTP requests the client actually issued.</summary>
+    public int RequestCount { get; private set; }
+
+    /// <summary>Gets or sets whether every request fails as if the machine were offline.</summary>
+    public bool Offline { get; set; }
+
+    /// <summary>Registers a document under its repo-relative path.</summary>
+    public FakeRegistryHttpHandler WithDocument(string relativePath, string json)
+    {
+        _documents[relativePath] = json;
+        return this;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        if (Offline)
+            throw new HttpRequestException("Simulated network failure.");
+
+        var path = request.RequestUri!.AbsolutePath.TrimStart('/');
+        // Strip the fake host prefix "registry/" used as base URL in tests.
+        var relative = path.StartsWith("registry/") ? path["registry/".Length..] : path;
+        if (_documents.TryGetValue(relative, out var json))
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json),
+            });
+
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+    }
+}

--- a/UnitTests/ComponentRegistry/RegistryClient/RegistryCacheTests.cs
+++ b/UnitTests/ComponentRegistry/RegistryClient/RegistryCacheTests.cs
@@ -1,0 +1,59 @@
+using CAP_Core.ComponentRegistry;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ComponentRegistry;
+
+/// <summary>Tests for <see cref="RegistryCache"/> path handling and round-trips.</summary>
+public sealed class RegistryCacheTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), "lunima-registry-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public void WriteThenRead_RoundTripsNestedPaths()
+    {
+        var cache = new RegistryCache(_root);
+
+        cache.Write("processes/generic-si220/components/x/component.json", "{\"id\":\"x\"}");
+
+        cache.Read("processes/generic-si220/components/x/component.json").ShouldBe("{\"id\":\"x\"}");
+    }
+
+    [Fact]
+    public void Read_MissingEntry_ReturnsNull()
+    {
+        new RegistryCache(_root).Read("index.json").ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("../outside.json")]
+    [InlineData("a/../../outside.json")]
+    [InlineData("")]
+    public void Write_PathEscapingCacheRoot_IsRejected(string relativePath)
+    {
+        var cache = new RegistryCache(_root);
+
+        cache.Write(relativePath, "data");
+
+        cache.Read(relativePath).ShouldBeNull();
+        Directory.Exists(_root).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Write_RootedPath_IsRejected()
+    {
+        var cache = new RegistryCache(_root);
+        var rooted = Path.Combine(Path.GetTempPath(), "lunima-registry-tests", "escape.json");
+
+        cache.Write(rooted, "data");
+
+        File.Exists(rooted).ShouldBeFalse();
+    }
+}

--- a/UnitTests/ComponentRegistry/RegistryClient/RegistryClientTests.cs
+++ b/UnitTests/ComponentRegistry/RegistryClient/RegistryClientTests.cs
@@ -1,0 +1,157 @@
+using CAP_Core.ComponentRegistry;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ComponentRegistry;
+
+/// <summary>Tests for <see cref="RegistryClient"/>: parsing, caching, and offline behavior.</summary>
+public sealed class RegistryClientTests : IDisposable
+{
+    private const string BaseUrl = "https://fake.test/registry/";
+
+    private readonly string _cacheDirectory = Path.Combine(
+        Path.GetTempPath(), "lunima-registry-tests", Guid.NewGuid().ToString("N"));
+
+    private readonly FakeRegistryHttpHandler _handler = new();
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_cacheDirectory))
+            Directory.Delete(_cacheDirectory, recursive: true);
+    }
+
+    private RegistryClient CreateClient() => new(
+        new HttpClient(_handler), BaseUrl, new RegistryCache(_cacheDirectory));
+
+    private FakeRegistryHttpHandler WithAllDocuments() => _handler
+        .WithDocument(RegistryClient.IndexPath, RegistryTestData.IndexJson)
+        .WithDocument(RegistryTestData.YBranchPath, RegistryTestData.YBranchJson)
+        .WithDocument(RegistryTestData.YBranchSpectrumPath, RegistryTestData.YBranchSpectrumJson);
+
+    [Fact]
+    public async Task GetIndexAsync_ReturnsAllFiveDemoComponents()
+    {
+        WithAllDocuments();
+
+        var result = await CreateClient().GetIndexAsync();
+
+        result.Source.ShouldBe(RegistryDataSource.Network);
+        result.Value.ShouldNotBeNull();
+        result.Value!.Components.Count.ShouldBe(5);
+        result.Value.Components.ShouldAllBe(c => c.Process == "generic-si220");
+        result.Value.Components.ShouldContain(c => c.Id == "y-branch-1x2" && c.PortCount == 3);
+        result.Value.Components.ShouldAllBe(c => c.Tiers.Simulated && !c.Tiers.Measured && !c.Tiers.Geometry);
+        result.Value.Processes.ShouldHaveSingleItem().Status.ShouldBe("demo");
+    }
+
+    [Fact]
+    public async Task GetComponentAsync_ParsesManifestWithArtifactsAndProvenance()
+    {
+        WithAllDocuments();
+
+        var result = await CreateClient().GetComponentAsync(RegistryTestData.YBranchPath);
+
+        var component = result.Value.ShouldNotBeNull();
+        component.Id.ShouldBe("y-branch-1x2");
+        component.Ports.Select(p => p.Name).ShouldBe(new[] { "o1", "o2", "o3" });
+        component.Properties.Passive.ShouldBeTrue();
+        component.Properties.Reciprocal.ShouldBeTrue();
+        var artifact = component.Artifacts.Simulated.ShouldHaveSingleItem();
+        artifact.Status.ShouldBe("demo");
+        artifact.File.ShouldBe("simulated/analytic-demo.json");
+        artifact.Provenance.Method.ShouldBe("analytic-model");
+        artifact.Provenance.Date.ShouldBe("2026-07-06");
+        component.Artifacts.Measured.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSpectrumAsync_ReturnsComplexSpectraAlignedWithWavelengths()
+    {
+        WithAllDocuments();
+
+        var result = await CreateClient().GetSpectrumAsync(
+            RegistryTestData.YBranchPath, "simulated/analytic-demo.json");
+
+        var spectrum = result.Value.ShouldNotBeNull();
+        spectrum.WavelengthUm.ShouldBe(new[] { 1.5, 1.55, 1.6 });
+        var s12 = spectrum.GetSpectrum("o1", "o2").ShouldNotBeNull();
+        s12.Length.ShouldBe(3);
+        s12[1].Real.ShouldBe(-0.3, 1e-12);
+        s12[1].Imaginary.ShouldBe(0.4, 1e-12);
+        spectrum.GetSpectrum("o2", "o3").ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SecondCall_IsServedFromCache_WithoutNetworkRequest()
+    {
+        WithAllDocuments();
+        var client = CreateClient();
+
+        (await client.GetIndexAsync()).Source.ShouldBe(RegistryDataSource.Network);
+        var second = await client.GetIndexAsync();
+
+        second.Source.ShouldBe(RegistryDataSource.Cache);
+        second.Value!.Components.Count.ShouldBe(5);
+        _handler.RequestCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ForceRefresh_BypassesCacheAndRedownloads()
+    {
+        WithAllDocuments();
+        var client = CreateClient();
+        await client.GetIndexAsync();
+
+        var refreshed = await client.GetIndexAsync(forceRefresh: true);
+
+        refreshed.Source.ShouldBe(RegistryDataSource.Network);
+        _handler.RequestCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task OfflineWithWarmCache_ServesCachedDataWithoutThrowing()
+    {
+        WithAllDocuments();
+        var client = CreateClient();
+        await client.GetIndexAsync();
+        _handler.Offline = true;
+
+        var offline = await client.GetIndexAsync(forceRefresh: true);
+
+        offline.Source.ShouldBe(RegistryDataSource.Cache);
+        offline.Value!.Components.Count.ShouldBe(5);
+        offline.Error.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task OfflineWithColdCache_ReturnsUnavailableWithoutThrowing()
+    {
+        _handler.Offline = true;
+
+        var result = await CreateClient().GetIndexAsync();
+
+        result.Source.ShouldBe(RegistryDataSource.Unavailable);
+        result.Value.ShouldBeNull();
+        result.Error.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task MalformedJson_ReturnsUnavailableWithoutThrowing()
+    {
+        _handler.WithDocument(RegistryClient.IndexPath, "{ this is not json ]");
+
+        var result = await CreateClient().GetIndexAsync();
+
+        result.Source.ShouldBe(RegistryDataSource.Unavailable);
+        result.Error.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task MissingDocument_ReturnsUnavailableWithoutThrowing()
+    {
+        var result = await CreateClient().GetComponentAsync("processes/nope/component.json");
+
+        result.Source.ShouldBe(RegistryDataSource.Unavailable);
+        result.Error.ShouldNotBeNull();
+    }
+}

--- a/UnitTests/ComponentRegistry/RegistryClient/RegistryTestData.cs
+++ b/UnitTests/ComponentRegistry/RegistryClient/RegistryTestData.cs
@@ -1,0 +1,125 @@
+namespace UnitTests.ComponentRegistry;
+
+/// <summary>
+/// JSON fixtures mirroring the live photonic-registry repository
+/// (github.com/aignermax/photonic-registry) so client tests run without network.
+/// </summary>
+public static class RegistryTestData
+{
+    /// <summary>Index listing the five generic-si220 demo components.</summary>
+    public const string IndexJson = """
+    {
+      "schemaVersion": 1,
+      "processes": [
+        { "id": "generic-si220", "name": "Generic Silicon-on-Insulator 220 nm", "status": "demo" }
+      ],
+      "components": [
+        {
+          "id": "directional-coupler-2x2",
+          "name": "Directional coupler 2x2 (~50/50 at 1550 nm)",
+          "description": "Coupled-mode-theory model.",
+          "process": "generic-si220",
+          "portCount": 4,
+          "path": "processes/generic-si220/components/directional-coupler-2x2/component.json",
+          "tiers": { "geometry": false, "simulated": true, "measured": false },
+          "bestStatus": "demo"
+        },
+        {
+          "id": "mzi-unbalanced-dl40",
+          "name": "Unbalanced Mach-Zehnder interferometer (dL = 40 um)",
+          "description": "Two ideal 50/50 couplers.",
+          "process": "generic-si220",
+          "portCount": 4,
+          "path": "processes/generic-si220/components/mzi-unbalanced-dl40/component.json",
+          "tiers": { "geometry": false, "simulated": true, "measured": false },
+          "bestStatus": "demo"
+        },
+        {
+          "id": "ring-resonator-r10",
+          "name": "All-pass ring resonator (R = 10 um)",
+          "description": "All-pass microring.",
+          "process": "generic-si220",
+          "portCount": 2,
+          "path": "processes/generic-si220/components/ring-resonator-r10/component.json",
+          "tiers": { "geometry": false, "simulated": true, "measured": false },
+          "bestStatus": "demo"
+        },
+        {
+          "id": "straight-waveguide-100um",
+          "name": "Straight waveguide (100 um)",
+          "description": "Single-mode strip waveguide.",
+          "process": "generic-si220",
+          "portCount": 2,
+          "path": "processes/generic-si220/components/straight-waveguide-100um/component.json",
+          "tiers": { "geometry": false, "simulated": true, "measured": false },
+          "bestStatus": "demo"
+        },
+        {
+          "id": "y-branch-1x2",
+          "name": "Y-branch splitter 1x2",
+          "description": "Ideal 50/50 power splitter.",
+          "process": "generic-si220",
+          "portCount": 3,
+          "path": "processes/generic-si220/components/y-branch-1x2/component.json",
+          "tiers": { "geometry": false, "simulated": true, "measured": false },
+          "bestStatus": "demo"
+        }
+      ]
+    }
+    """;
+
+    /// <summary>Repo-relative path of the Y-branch manifest.</summary>
+    public const string YBranchPath = "processes/generic-si220/components/y-branch-1x2/component.json";
+
+    /// <summary>Y-branch component manifest with one simulated demo artifact.</summary>
+    public const string YBranchJson = """
+    {
+      "id": "y-branch-1x2",
+      "name": "Y-branch splitter 1x2",
+      "description": "Ideal 50/50 power splitter with 0.2 dB excess loss.",
+      "process": "generic-si220",
+      "ports": [
+        { "name": "o1", "kind": "optical", "description": "input" },
+        { "name": "o2", "kind": "optical", "description": "output top" },
+        { "name": "o3", "kind": "optical", "description": "output bottom" }
+      ],
+      "properties": { "passive": true, "reciprocal": true },
+      "parameters": { "splitRatio": "50/50", "excessLoss_dB": 0.2 },
+      "geometry": { "format": "none" },
+      "artifacts": {
+        "simulated": [
+          {
+            "file": "simulated/analytic-demo.json",
+            "status": "demo",
+            "provenance": {
+              "method": "analytic-model",
+              "tool": "generate_demo_data.py",
+              "settings": "S21 = S31 = 10^(-0.2/20)/sqrt(2) * prop(5um)",
+              "createdBy": "generate_demo_data.py",
+              "date": "2026-07-06"
+            }
+          }
+        ],
+        "measured": []
+      },
+      "license": "MIT"
+    }
+    """;
+
+    /// <summary>Repo-relative path of the Y-branch spectrum artifact.</summary>
+    public const string YBranchSpectrumPath =
+        "processes/generic-si220/components/y-branch-1x2/simulated/analytic-demo.json";
+
+    /// <summary>Three-point S-parameter spectrum for the Y-branch.</summary>
+    public const string YBranchSpectrumJson = """
+    {
+      "wavelength_um": [1.5, 1.55, 1.6],
+      "s": [
+        { "from": "o1", "to": "o2", "re": [0.5, -0.3, 0.1], "im": [0.2, 0.4, -0.6] },
+        { "from": "o1", "to": "o3", "re": [0.5, -0.3, 0.1], "im": [0.2, 0.4, -0.6] },
+        { "from": "o2", "to": "o1", "re": [0.5, -0.3, 0.1], "im": [0.2, 0.4, -0.6] },
+        { "from": "o3", "to": "o1", "re": [0.5, -0.3, 0.1], "im": [0.2, 0.4, -0.6] }
+      ]
+    }
+    """;
+}


### PR DESCRIPTION
Closes #655.

## Summary
- New vertical slice `Connect-A-Pic-Core/ComponentRegistry/RegistryClient/`: read-only client for the open component registry at https://github.com/aignermax/photonic-registry
- `GetIndexAsync` / `GetComponentAsync` / `GetSpectrumAsync` fetch `index.json`, component manifests and complex S-parameter artifacts via `raw.githubusercontent.com` (serverless, no auth)
- Every document is cached under the app-data folder (`AppDataFolders.LocalApplicationData`, cross-platform): cache-first, explicit `forceRefresh`, and network failures degrade to cached data — `RegistryResult<T>` exposes `Source` (Network/Cache/Unavailable) and `Error` instead of throwing
- Cache rejects rooted/`..` paths so a malicious index can't write outside the cache root
- No UI, no DI wiring — the registry browser panel is follow-up #656

## Tests
- 14 new tests in `UnitTests/ComponentRegistry/RegistryClient/` with fixtures mirroring the live registry and a counting fake `HttpMessageHandler` (no network in tests): parsing of all 5 demo components, artifact provenance, complex spectra, cache-hit/refresh/offline/malformed-JSON behavior, cache path safety
- Full suite via `smart_test.py`: **2902 passed, 0 failed, 5 skipped**; `dotnet build` clean (0 errors, no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)