### PR TITLE
(=) PDK Offset Editor: Check-All / Try-Fix-All route through gdsfactory path (#570)

### DIFF
--- a/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.Calibration.cs
+++ b/CAP.Avalonia/ViewModels/PdkOffset/PdkOffsetEditorViewModel.Calibration.cs
@@ -316,12 +316,14 @@ public partial class PdkOffsetEditorViewModel
         }
     }
 
-    private async Task<NazcaPreviewResult?> RenderForBatch(PdkComponentDraft draft, CancellationToken token)
+    internal async Task<NazcaPreviewResult?> RenderForBatch(PdkComponentDraft draft, CancellationToken token)
     {
         try
         {
-            var (module, function) = ResolveModuleAndFunction(draft.NazcaFunction);
-            return await _previewService!.RenderAsync(module, function, draft.NazcaParameters, token);
+            // Same render routing as the interactive path: gdsfactory-native components go through
+            // the gdsfactory back-end, not the Nazca demo.() path — otherwise Check-All / Try-Fix-All
+            // report every gdsfactory component as RenderFailed (#570).
+            return await RenderDraftAsync(draft, token);
         }
         catch (OperationCanceledException) { return null; }
         catch (Exception ex)

--- a/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
+++ b/UnitTests/PdkOffset/PdkOffsetEditorViewModelTests.cs
@@ -1,9 +1,12 @@
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.PdkOffset;
+using CAP_Core.Export;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
 using Shouldly;
 using System.IO;
+using System.Threading;
 
 namespace UnitTests.PdkOffset;
 
@@ -30,6 +33,38 @@ public class PdkOffsetEditorViewModelTests
         source.ShouldContain("import cspdk.sin300");
         source.ShouldContain("component = gf.get_component('mmi1x2')");
         source.ShouldNotContain("demo.()");   // the broken empty-function Nazca call
+    }
+
+    [Fact]
+    public async Task RenderForBatch_GdsFactoryNativeDraft_RoutesToGdsFactoryService_NotNazca()
+    {
+        // Check-All / Try-Fix-All render via RenderForBatch. It must use the same gdsfactory
+        // routing as the interactive path — otherwise every gdsfactory component reports
+        // RenderFailed ("module 'nazca.demofab' has no attribute ''") in the batch (#570).
+        var nazca = new Mock<NazcaComponentPreviewService>(
+            "py", "nazca.py", (System.TimeSpan?)null, (ProcessLaunchFactory?)null);
+        var gf = new Mock<NazcaComponentPreviewService>(
+            "py", "gf.py", (System.TimeSpan?)null, (ProcessLaunchFactory?)null);
+        gf.Setup(s => s.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NazcaPreviewResult { Success = true });
+
+        var vm = new PdkOffsetEditorViewModel(
+            new PdkLoader(), new PdkJsonSaver(), new PdkManagerViewModel(), nazca.Object, gf.Object);
+        var draft = new PdkComponentDraft
+        {
+            Name = "SiN MMI",
+            NazcaFunction = "",
+            GdsFactoryFunction = "cspdk.sin300.mmi1x2",
+        };
+
+        var result = await vm.RenderForBatch(draft, CancellationToken.None);
+
+        result.ShouldNotBeNull();
+        result!.Success.ShouldBeTrue();
+        gf.Verify(s => s.RenderRawCodeAsync(
+            It.Is<string>(c => c.Contains("gf.get_component('mmi1x2')")), It.IsAny<CancellationToken>()), Times.Once);
+        nazca.Verify(s => s.RenderAsync(
+            It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static PdkDraft BuildTestPdk(string pdkName = "Test PDK") => new()


### PR DESCRIPTION
## Problem
Follow-up to #669. The interactive single-component render in the PDK Offset Editor was routed to the gdsfactory back-end, but the **batch loop** behind **Check-All / Try-Fix-All** still rendered every component via the Nazca `demo.()` path. For a gdsfactory-native PDK (CornerStone SiN) that meant all 12 components reported **RenderFailed** — `module 'nazca.demofab' has no attribute ''` — even though opening each one individually rendered and calibrated fine (the green-check single-fix worked).

## Fix
`RenderForBatch` now delegates to the shared `RenderDraftAsync`, so the single and batch paths use the same routing: gdsfactory-native drafts render via the gdsfactory back-end, Nazca drafts via Nazca. One render path, no divergence.

## Verification
- New test: `RenderForBatch` with a gdsfactory-native draft calls the gdsfactory service (`get_component` code) and never the Nazca `RenderAsync`.
- Full suite green apart from 3 pre-existing parallel-load env flakes (`PhotonTorchScriptExecution`, `GdsExportAlignment`, `ComponentSettingsDialogSolverStatus`) — all green when run in isolation, and none touch the changed area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
