### PR TITLE
(=) GDS preview: don't persist failed renders as empty markers (#570)

### DIFF
--- a/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewKey.cs
+++ b/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewKey.cs
@@ -11,7 +11,10 @@ namespace CAP.Avalonia.Controls.Canvas.ComponentPreview;
 public readonly record struct GdsPreviewKey(string? Module, string? Function, string? Parameters)
 {
     /// <summary>Bump to invalidate every cached entry (format or render-semantics change).</summary>
-    public const int FormatVersion = 2;
+    // v3: failed renders are no longer persisted as empty markers, so any poisoned "empty"
+    // entries written under v2 (from a transient broken/half-provisioned interpreter) are
+    // discarded and re-rendered cleanly (#570 field test).
+    public const int FormatVersion = 3;
 
     /// <summary>ASCII unit separator — never appears in module/function/parameter strings.</summary>
     private const char FieldSeparator = (char)31;

--- a/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewRenderService.cs
+++ b/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewRenderService.cs
@@ -269,9 +269,20 @@ public sealed class GdsPreviewRenderService
                 _diskCache.Write(key, result);
                 _memGeometry.Set(cacheKey, result);
             }
+            else if (result.Success)
+            {
+                // A genuinely empty render (0 polygons) — persist the empty marker so we don't
+                // keep re-rendering a component that has no geometry.
+                _diskCache.WriteEmpty(key);
+                _memGeometry.Set(cacheKey, null);
+            }
             else
             {
-                _diskCache.WriteEmpty(key);
+                // The render FAILED (Python/env/script error — e.g. cspdk not yet installed, a
+                // broken or half-provisioned interpreter). Do NOT persist: a transient env failure
+                // must not poison the disk cache permanently, or the component stays blank forever
+                // even after the env is fixed. Remember null for this session only (like the catch
+                // block below), so the next launch retries. (#570 field test.)
                 _memGeometry.Set(cacheKey, null);
             }
             RaisePreviewLoaded();

--- a/UnitTests/Canvas/ComponentPreview/GdsPreviewRenderServiceTests.cs
+++ b/UnitTests/Canvas/ComponentPreview/GdsPreviewRenderServiceTests.cs
@@ -275,6 +275,60 @@ public sealed class GdsPreviewRenderServiceTests
     }
 
     [Fact]
+    public async Task GetGeometry_RenderFails_IsNotPersisted_AndRetriesOnNextInstance()
+    {
+        // A failed render (broken/half-provisioned interpreter) must NOT be persisted as an
+        // empty marker — otherwise the component stays blank forever, even after the env is
+        // fixed. A fresh instance must re-attempt the render (#570 field test).
+        var diskDir = Path.Combine(Path.GetTempPath(), "lunima-fail-" + Guid.NewGuid().ToString("N"));
+        var key = new GdsPreviewKey("m", "f", "p");
+
+        var failing = new Mock<NazcaComponentPreviewService>("py", "s.py", (TimeSpan?)null, (ProcessLaunchFactory?)null);
+        failing.Setup(s => s.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NazcaPreviewResult.Fail("interpreter not ready"));
+        var svc1 = new GdsPreviewRenderService(failing.Object, new GdsPreviewDiskCache(diskDir));
+        svc1.TryGetGeometry(key);
+        await svc1.WaitForPendingAsync();
+
+        // A new instance (e.g. after the env is fixed) must render, not serve a persisted "empty".
+        var ok = new Mock<NazcaComponentPreviewService>("py", "s.py", (TimeSpan?)null, (ProcessLaunchFactory?)null);
+        ok.Setup(s => s.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Ok());
+        var svc2 = new GdsPreviewRenderService(ok.Object, new GdsPreviewDiskCache(diskDir));
+        svc2.TryGetGeometry(key);
+        await svc2.WaitForPendingAsync();
+
+        svc2.TryGetGeometry(key).ShouldNotBeNull();
+        ok.Verify(s => s.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        try { Directory.Delete(diskDir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task GetGeometry_GenuinelyEmptyRender_PersistsEmpty_NoRetry()
+    {
+        // A successful render with 0 polygons is genuinely empty (not a failure) — persist it so
+        // a second instance does not pointlessly re-render nothing.
+        var diskDir = Path.Combine(Path.GetTempPath(), "lunima-empty-" + Guid.NewGuid().ToString("N"));
+        var key = new GdsPreviewKey("m", "f", "p");
+
+        var empty = new Mock<NazcaComponentPreviewService>("py", "s.py", (TimeSpan?)null, (ProcessLaunchFactory?)null);
+        empty.Setup(s => s.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NazcaPreviewResult { Success = true, Polygons = new List<NazcaPreviewPolygon>() });
+        var svc1 = new GdsPreviewRenderService(empty.Object, new GdsPreviewDiskCache(diskDir));
+        svc1.TryGetGeometry(key);
+        await svc1.WaitForPendingAsync();
+
+        var mock2 = new Mock<NazcaComponentPreviewService>("py", "s.py", (TimeSpan?)null, (ProcessLaunchFactory?)null);
+        var svc2 = new GdsPreviewRenderService(mock2.Object, new GdsPreviewDiskCache(diskDir));
+        svc2.TryGetGeometry(key);
+        await svc2.WaitForPendingAsync();
+        mock2.Verify(s => s.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        try { Directory.Delete(diskDir, true); } catch { }
+    }
+
+    [Fact]
     public async Task GetGeometry_SecondInstance_ServesFromDisk_NoRender()
     {
         var diskDir = Path.Combine(Path.GetTempPath(), "lunima-svc-" + Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
## Problem
After the gdsfactory preview routing (#669) landed, the component library showed previews for **some** CornerStone SiN components but not others, and placed components stayed blank in the canvas grid.

**Root cause:** the geometry **disk cache** persisted an empty marker for *every* non-successful render — including outright render **failures** (a broken / half-provisioned / missing-`cspdk` interpreter), not just genuinely-empty geometry. Any component whose render happened to fail during a transient env problem (e.g. the managed env being rebuilt, or `cspdk` not yet installed) was **poisoned permanently**: the empty marker was served from disk forever, with no retry, even after the env was fixed. Components that rendered while the env was healthy kept their real geometry — hence "some but not all". (Confirmed on disk: 12 `v2-` 9-byte empty markers in the preview cache.)

## Fix
Only persist an empty marker for a **successful** render that returned 0 polygons (genuinely empty). A **failed** render (`Success == false`) is now remembered for the session only — exactly as the catch block already did for exceptions — so the next launch retries once the env is healthy. `GdsPreviewKey.FormatVersion` bumped **2 → 3** so existing poisoned v2 markers are discarded and re-rendered cleanly (auto-heals without manual cache clearing).

The canvas grid uses the in-memory cache (not disk), so a restart already clears its per-session nulls; this fixes the persistent **library-thumbnail** poisoning and prevents recurrence for both.

## Verification
- All 10 SiN cells render fine through `render_gdsfactory_preview.py` against cspdk 1.4.4 — the failures were transient env state, not the pipeline.
- New tests: a failed render is not persisted and a fresh instance retries; a genuinely-empty render is persisted and not re-rendered.
- Full suite green (2900).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
