### PR TITLE
(=) Canvas grid: gdsfactory-native components preview via gdsfactory, not synthesized Nazca name (#570)

### DIFF
--- a/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewRenderService.cs
+++ b/CAP.Avalonia/Controls/Canvas/ComponentPreview/GdsPreviewRenderService.cs
@@ -140,18 +140,29 @@ public sealed class GdsPreviewRenderService
         if (rawCode != null)
             return $"rawcode|{ComputeRawCodeHash(rawCode)}|{comp.Width:F2}|{comp.Height:F2}";
 
+        // gdsfactory-native components (e.g. CornerStone SiN) take precedence over the Nazca
+        // function: on placement they are given a *synthesized* nazcaFunction ("nazca_<name>",
+        // for grouping/save) that no Nazca script can render — so keying on it would route the
+        // preview to the Nazca path and draw nothing. A module-qualified GdsFactoryFunction is
+        // the real render identity, so check it first (#570 field test — blank canvas grid).
+        if (IsGdsFactoryNative(comp.Component))
+            return $"gdsfactory|{comp.Component.GdsFactoryFunction}|{comp.Width:F2}|{comp.Height:F2}";
+
         var fn = comp.Component.NazcaFunctionName;
         if (!string.IsNullOrWhiteSpace(fn))
             return $"{fn}|{comp.Width:F2}|{comp.Height:F2}";
 
-        // gdsfactory-native component (e.g. CornerStone SiN): no Nazca function, render via the
-        // gdsfactory factory instead so it gets a real geometry preview rather than a rectangle (#570).
-        var gdsFn = comp.Component.GdsFactoryFunction;
-        if (!string.IsNullOrWhiteSpace(gdsFn))
-            return $"gdsfactory|{gdsFn}|{comp.Width:F2}|{comp.Height:F2}";
-
         return null;
     }
+
+    /// <summary>
+    /// True when the component is gdsfactory-native: it carries a module-qualified
+    /// <see cref="Component.GdsFactoryFunction"/> (e.g. "cspdk.sin300.mmi1x2"). Such components
+    /// render via the gdsfactory back-end, never Nazca — even if they also carry a synthesized
+    /// nazcaFunction fallback from placement.
+    /// </summary>
+    private static bool IsGdsFactoryNative(CAP_Core.Components.Core.Component comp) =>
+        !string.IsNullOrWhiteSpace(comp.GdsFactoryFunction) && comp.GdsFactoryFunction!.Contains('.');
 
     private static string ComputeRawCodeHash(string code)
     {
@@ -181,9 +192,9 @@ public sealed class GdsPreviewRenderService
             {
                 result = await _previewService.RenderRawCodeAsync(rawCode);
             }
-            else if (string.IsNullOrWhiteSpace(comp.Component.NazcaFunctionName)
-                     && !string.IsNullOrWhiteSpace(comp.Component.GdsFactoryFunction))
+            else if (IsGdsFactoryNative(comp.Component))
             {
+                // Precedence over the (possibly synthesized) nazcaFunction — see BuildCacheKey.
                 result = await RenderGdsFactoryAsync(comp.Component.GdsFactoryFunction);
             }
             else

--- a/UnitTests/Canvas/ComponentPreview/GdsPreviewRenderServiceTests.cs
+++ b/UnitTests/Canvas/ComponentPreview/GdsPreviewRenderServiceTests.cs
@@ -74,6 +74,22 @@ public sealed class GdsPreviewRenderServiceTests
     }
 
     [Fact]
+    public void BuildCacheKey_GdsFactoryNativeComponent_WithSynthesizedNazcaName_StillReturnsGdsfactoryKey()
+    {
+        // On placement, a gdsfactory-native component is given a synthesized nazcaFunction
+        // ("nazca_<name>") that no Nazca script can render. The gdsfactory factory must take
+        // precedence so the placed component previews via gdsfactory, not a dead Nazca call —
+        // otherwise the canvas grid stays blank (#570 field test).
+        var comp = TestComponentFactory.CreateComponentViewModel(nazcaFunctionName: "nazca_mmi1x2");
+        comp.Component.GdsFactoryFunction = "cspdk.sin300.mmi1x2";
+
+        var key = GdsPreviewRenderService.BuildCacheKey(comp);
+
+        key.ShouldNotBeNull();
+        key!.ShouldStartWith("gdsfactory|cspdk.sin300.mmi1x2|");
+    }
+
+    [Fact]
     public async Task GetGeometry_GdsFactoryKey_RendersViaGdsFactoryServiceNotNazca()
     {
         // A gdsfactory-native render identity must be resolved by the gdsfactory preview


### PR DESCRIPTION
## Problem
Placed CornerStone SiN components render **no preview in the canvas grid**, even though the component-library thumbnails render fine.

**Root cause:** on placement, `ComponentTemplates.CreateFromTemplate` gives a gdsfactory-native component a **synthesized** `nazcaFunction` (`nazca_<name>`, needed for grouping/clipboard/save). The canvas preview (`BuildCacheKey` / `FetchAndCacheAsync`) keyed on `NazcaFunctionName` **first**, so it routed the render to the Nazca path — which has no such function — and drew nothing. The library thumbnail renders straight off the *template* (whose `nazcaFunction` is still null), so it correctly took the gdsfactory path. Hence "library shows it, grid doesn't".

## Fix
A module-qualified `GdsFactoryFunction` is the real render identity, so `BuildCacheKey` and `FetchAndCacheAsync` now check it **before** the (possibly synthesized) `nazcaFunction`. Nazca components are unaffected — they never carry a `GdsFactoryFunction`.

## Verification
- New test: a component with **both** a synthesized `nazcaFunction` and a `GdsFactoryFunction` builds the gdsfactory cache key (the exact placed-component state that was blank).
- Full suite green (2901).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
