### PR TITLE
(+) Nazca export: ask before silently dropping gdsfactory-native components (#570)

### DIFF
--- a/CAP.Avalonia/Services/GdsFactoryExport/NazcaExportGuard.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/NazcaExportGuard.cs
@@ -1,0 +1,43 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+
+namespace CAP.Avalonia.Services.GdsFactoryExport;
+
+/// <summary>
+/// Detects gdsfactory-native components in a design before a Nazca export. Such components
+/// (a module-qualified <see cref="Component.GdsFactoryFunction"/>, e.g. "cspdk.sin300.mmi1x2")
+/// cannot be expressed in a Nazca script and would be silently omitted — so the Nazca export
+/// asks the user to confirm (or switch to the gdsfactory export) rather than dropping them
+/// quietly (#570 field test).
+/// </summary>
+public static class NazcaExportGuard
+{
+    /// <summary>
+    /// Returns every gdsfactory-native component in the design (walking group children), i.e.
+    /// components carrying a module-qualified <see cref="Component.GdsFactoryFunction"/>. Empty
+    /// for a pure Nazca design.
+    /// </summary>
+    public static IReadOnlyList<Component> CollectGdsFactoryNativeComponents(DesignCanvasViewModel canvas)
+    {
+        var result = new List<Component>();
+        foreach (var vm in canvas.Components)
+        {
+            var comp = vm.Component;
+            if (comp is ComponentGroup group)
+            {
+                foreach (var child in group.GetAllComponentsRecursive())
+                    if (IsGdsFactoryNative(child))
+                        result.Add(child);
+            }
+            else if (IsGdsFactoryNative(comp))
+            {
+                result.Add(comp);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>True when the component carries a module-qualified gdsfactory factory name.</summary>
+    private static bool IsGdsFactoryNative(Component c) =>
+        !string.IsNullOrWhiteSpace(c.GdsFactoryFunction) && c.GdsFactoryFunction!.Contains('.');
+}

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -1326,6 +1326,34 @@ public partial class FileOperationsViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// When the design contains gdsfactory-native components (a Nazca script can't express
+    /// them), asks the user whether to export to Nazca anyway (omitting them) or switch to the
+    /// gdsfactory export. Returns true to proceed with the Nazca export, false to cancel.
+    /// A pure Nazca design (or a headless run with no message box) proceeds without prompting.
+    /// </summary>
+    private async Task<bool> ConfirmNazcaExportDropsGdsFactoryComponentsAsync()
+    {
+        var gdsFactory = CAP.Avalonia.Services.GdsFactoryExport.NazcaExportGuard
+            .CollectGdsFactoryNativeComponents(_canvas);
+        if (gdsFactory.Count == 0 || MessageBoxService == null)
+            return true;
+
+        var message =
+            $"{gdsFactory.Count} component(s) in this design are gdsfactory-native (e.g. CornerStone "
+            + "SiN) and cannot be written to a Nazca script — they would be omitted from the export. "
+            + "Use the gdsfactory export to include them.\n\nExport to Nazca anyway?";
+        // Button 0 = switch to gdsfactory (cancel this Nazca export); button 1 = proceed anyway.
+        const int exportAnywayIndex = 1;
+        var choice = await MessageBoxService.ShowChoicePromptAsync(
+            message, "gdsfactory components will be omitted",
+            new[] { "Use gdsfactory export instead", "Export to Nazca anyway" });
+
+        if (choice != exportAnywayIndex)
+            UpdateStatus?.Invoke("Nazca export cancelled — use the gdsfactory export for this design.");
+        return choice == exportAnywayIndex;
+    }
+
     [RelayCommand]
     private async Task ExportNazca()
     {
@@ -1340,6 +1368,12 @@ public partial class FileOperationsViewModel : ObservableObject
             UpdateStatus?.Invoke("Nothing to export - add some components first");
             return;
         }
+
+        // A gdsfactory-native design (e.g. CornerStone SiN) cannot be expressed in a Nazca
+        // script — those components would be silently omitted. Make the user choose consciously:
+        // continue anyway, or switch to the gdsfactory export that can include them (#570).
+        if (!await ConfirmNazcaExportDropsGdsFactoryComponentsAsync())
+            return;
 
         var filePath = await FileDialogService.ShowSaveFileDialogAsync(
             "Export to Nazca Python",

--- a/UnitTests/Export/GdsFactoryExport/NazcaExportGuardTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/NazcaExportGuardTests.cs
@@ -1,0 +1,57 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
+using CAP.Avalonia.ViewModels.Canvas;
+using Shouldly;
+
+namespace UnitTests.Export.GdsFactoryExport;
+
+/// <summary>
+/// Tests the pre-Nazca-export detection of gdsfactory-native components — the components a
+/// Nazca script cannot express and that must not be dropped silently (#570 field test).
+/// </summary>
+public class NazcaExportGuardTests
+{
+    private static CAP_Core.Components.Core.Component MakeComponent(
+        string id, string? gdsFactoryFunction, string nazcaFunction = "")
+    {
+        var c = TestComponentFactory.CreateBasicComponent();
+        c.Identifier = id;
+        c.NazcaFunctionName = nazcaFunction;
+        c.GdsFactoryFunction = gdsFactoryFunction;
+        return c;
+    }
+
+    [Fact]
+    public void CollectGdsFactoryNativeComponents_ReturnsOnlyModuleQualifiedGdsFactoryComponents()
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.AddComponent(MakeComponent("SIN1", "cspdk.sin300.mmi1x2"), "SiN MMI");
+        canvas.AddComponent(MakeComponent("NZ1", null, "ebeam_y_1550"), "Y");
+        canvas.AddComponent(MakeComponent("BARE", "straight"), "bare");   // dotless: not gdsfactory-native
+
+        var found = NazcaExportGuard.CollectGdsFactoryNativeComponents(canvas);
+
+        found.Select(c => c.Identifier).ShouldBe(new[] { "SIN1" });
+    }
+
+    [Fact]
+    public void CollectGdsFactoryNativeComponents_PureNazcaDesign_ReturnsEmpty()
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.AddComponent(MakeComponent("NZ1", null, "ebeam_y_1550"), "Y");
+
+        NazcaExportGuard.CollectGdsFactoryNativeComponents(canvas).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CollectGdsFactoryNativeComponents_FindsGroupChildren()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var group = new CAP_Core.Components.Core.ComponentGroup("Grp");
+        group.AddChild(MakeComponent("SINCHILD", "cspdk.sin300.straight"));
+        canvas.AddComponent(group, "Group");
+
+        var found = NazcaExportGuard.CollectGdsFactoryNativeComponents(canvas);
+
+        found.Select(c => c.Identifier).ShouldContain("SINCHILD");
+    }
+}


### PR DESCRIPTION
## Problem
A gdsfactory-native design (e.g. CornerStone SiN) cannot be expressed in a Nazca script, so the Nazca exporter omits those components — **silently**. To the user it looked like the Nazca export "just worked" while the SiN components vanished from the GDS, with no hint that the gdsfactory export was the right tool.

## Fix
When the design contains gdsfactory-native components, the Nazca export now **asks up front**:
- **"Use gdsfactory export instead"** → cancels the Nazca export (and a status line points to the gdsfactory export).
- **"Export to Nazca anyway"** → proceeds, omitting them (a conscious choice).

A pure Nazca design is unaffected (no prompt).

- New `NazcaExportGuard.CollectGdsFactoryNativeComponents(canvas)`: a pure, testable detector for components carrying a module-qualified `GdsFactoryFunction` (walks group children).
- `FileOperationsViewModel.ExportNazca` prompts via the existing `MessageBoxService` before writing the script.

## Why this instead of mixed-backend interop (#646/#647)
For a **pure** gdsfactory design the correct tool is the gdsfactory export (already complete). The mixed-backend merge (#646) is a separate, narrower feature (gdsfactory-native + hand-written Nazca *overrides* in one process). The real UX gap was that Nazca export silently produced an incomplete GDS — this steers the user to the right export instead.

## Verification
- New tests: detector returns only module-qualified gdsfactory components (incl. group children), empty for a pure Nazca design.
- Export-area suite green (117); full suite green apart from known parallel-load flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
