### PR TITLE
(=) Nazca-export gdsfactory prompt: center dialog buttons + open the gdsfactory export (#570)

### DIFF
--- a/CAP.Avalonia/Services/MessageBoxService.cs
+++ b/CAP.Avalonia/Services/MessageBoxService.cs
@@ -161,8 +161,10 @@ public class MessageBoxService : IMessageBoxService
             var button = new Button
             {
                 Content = buttonLabels[i],
-                Height = 32,
-                Padding = new Thickness(12, 0),
+                MinHeight = 32,
+                Padding = new Thickness(12, 6),
+                VerticalContentAlignment = VerticalAlignment.Center,
+                HorizontalContentAlignment = HorizontalAlignment.Center,
                 Background = new SolidColorBrush(Color.Parse(i == 0 ? "#0d6efd" : "#3d3d3d")),
                 Foreground = Brushes.White
             };

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -215,6 +215,8 @@ public partial class MainViewModel : ObservableObject
         GdsFactoryExport = gdsFactoryExport;
         // gdsfactory export honours gdsfactory-backend overrides from the design's store.
         GdsFactoryExport.OverridesProvider = () => FileOperations.StoredNazcaOverrides;
+        // Let a Nazca export that hits gdsfactory-native components hand off to the gdsfactory export.
+        FileOperations.RequestGdsFactoryExport = () => GdsFactoryExport.Export();
         ExportMenu = new ExportMenuViewModel(new IExportFormat[]
         {
             new NazcaExportFormat(FileOperations.ExportNazcaCommand),

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -148,6 +148,13 @@ public partial class FileOperationsViewModel : ObservableObject
     /// </summary>
     public Func<Type?, Task>? ShowSettingsWindow { get; set; }
 
+    /// <summary>
+    /// Launches the gdsfactory export flow. Wired by <see cref="MainViewModel"/>; invoked when
+    /// the user, prompted about gdsfactory-native components in a Nazca export, chooses to use
+    /// the gdsfactory export instead. Null in headless contexts.
+    /// </summary>
+    public Func<Task>? RequestGdsFactoryExport { get; set; }
+
     /// <summary>Initializes a new instance of <see cref="FileOperationsViewModel"/>.</summary>
     public FileOperationsViewModel(
         DesignCanvasViewModel canvas,
@@ -1343,15 +1350,22 @@ public partial class FileOperationsViewModel : ObservableObject
             $"{gdsFactory.Count} component(s) in this design are gdsfactory-native (e.g. CornerStone "
             + "SiN) and cannot be written to a Nazca script — they would be omitted from the export. "
             + "Use the gdsfactory export to include them.\n\nExport to Nazca anyway?";
-        // Button 0 = switch to gdsfactory (cancel this Nazca export); button 1 = proceed anyway.
+        const int switchToGdsFactoryIndex = 0;
         const int exportAnywayIndex = 1;
         var choice = await MessageBoxService.ShowChoicePromptAsync(
             message, "gdsfactory components will be omitted",
             new[] { "Use gdsfactory export instead", "Export to Nazca anyway" });
 
-        if (choice != exportAnywayIndex)
+        if (choice == exportAnywayIndex)
+            return true;
+
+        // "Use gdsfactory export instead" — cancel this Nazca export and open the gdsfactory
+        // export flow so the user isn't left with nothing happening. A dismissed dialog just cancels.
+        if (choice == switchToGdsFactoryIndex && RequestGdsFactoryExport != null)
+            await RequestGdsFactoryExport();
+        else
             UpdateStatus?.Invoke("Nazca export cancelled — use the gdsfactory export for this design.");
-        return choice == exportAnywayIndex;
+        return false;
     }
 
     [RelayCommand]


### PR DESCRIPTION
Two field-test fixes to the prompt added in #675:

1. **Dialog buttons sat too high.** The choice-dialog buttons used `Padding (12,0)` + a fixed `Height` with no content alignment, so the label rode too high inside the button. Now centered (`VerticalContentAlignment`/`HorizontalContentAlignment` = Center, `MinHeight` + symmetric `Padding (12,6)`). Applies to every `ShowChoicePromptAsync` dialog.

2. **"Use gdsfactory export instead" did nothing.** It only cancelled the Nazca export. It now launches the gdsfactory export flow: `FileOperationsViewModel` gains a `RequestGdsFactoryExport` callback, wired in `MainViewModel` to `GdsFactoryExport.Export()` (the existing gdsfactory export command). A dismissed dialog still just cancels; "Export to Nazca anyway" proceeds as before.

Full suite green (2904).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
