### PR TITLE
(+) Transient & Eye/BER analysis dock: first-class simulation mode (#570/#535)

### DIFF
--- a/CAP.Avalonia/DI/CanvasAndPanelExtensions.cs
+++ b/CAP.Avalonia/DI/CanvasAndPanelExtensions.cs
@@ -1,5 +1,6 @@
 using CAP.Avalonia.Controls.Canvas.ComponentPreview;
 using CAP.Avalonia.ViewModels.Analysis;
+using CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
 using CAP.Avalonia.ViewModels.Analysis.OnaAnalysis;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Diagnostics;
@@ -55,6 +56,7 @@ internal static class CanvasAndPanelExtensions
         services.AddTransient<ArchitectureReportViewModel>();
         services.AddTransient<PdkConsistencyViewModel>();
         services.AddTransient<TimeDomainViewModel>();
+        services.AddTransient<EyeDiagramViewModel>();
 
         // Selection-driven component property editors (right panel). Order matters:
         // most specific first, generic fallback last. ComponentEditorFactory walks them
@@ -75,6 +77,7 @@ internal static class CanvasAndPanelExtensions
         // Panel host singletons
         services.AddSingleton<LeftPanelViewModel>();
         services.AddSingleton<RightPanelViewModel>();
+        services.AddSingleton<AnalysisDockViewModel>();
         services.AddSingleton<BottomPanelViewModel>();
 
         return services;

--- a/CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramPlotBuilder.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramPlotBuilder.cs
@@ -1,0 +1,88 @@
+using CAP_Core.Analysis.EyeDiagram;
+using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Series;
+
+namespace CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
+
+/// <summary>
+/// Pure mapping helpers that turn an <see cref="EyeHistogram"/> into an OxyPlot
+/// heat-map (persistence display). Mirrors <c>TimeTracePlotBuilder</c>'s dark
+/// theme; kept free of ViewModel state so the histogram→plot mapping is testable.
+/// </summary>
+internal static class EyeDiagramPlotBuilder
+{
+    /// <summary>Seconds-to-picoseconds factor for the time axis.</summary>
+    private const double SecondsToPicoseconds = 1e12;
+
+    /// <summary>Number of colours in the heat-map palette.</summary>
+    private const int PaletteSize = 200;
+
+    private static readonly OxyColor PlotForeground = OxyColor.Parse("#E0E0E0");
+    private static readonly OxyColor PlotAxisline = OxyColor.Parse("#808080");
+
+    /// <summary>
+    /// Builds the eye-diagram heat map: X = time offset within the bit period (ps),
+    /// Y = power, colour = log-scaled sample count (persistence).
+    /// </summary>
+    /// <param name="histogram">Histogram produced by <see cref="EyeDiagramBuilder"/>.</param>
+    public static PlotModel BuildPlotModel(EyeHistogram histogram)
+    {
+        var model = CreateEmptyPlotModel();
+
+        // Log-scale the counts so faint traces stay visible next to dense rails.
+        var data = new double[histogram.TimeBinCount, histogram.AmplitudeBinCount];
+        for (int t = 0; t < histogram.TimeBinCount; t++)
+            for (int a = 0; a < histogram.AmplitudeBinCount; a++)
+                data[t, a] = Math.Log10(1 + histogram.Counts[t, a]);
+
+        model.Axes.Add(new LinearColorAxis
+        {
+            Position = AxisPosition.Right,
+            Palette = OxyPalettes.Hot(PaletteSize),
+            LowColor = OxyColors.Black,
+            IsAxisVisible = false,
+        });
+
+        model.Series.Add(new HeatMapSeries
+        {
+            X0 = 0,
+            X1 = histogram.BitPeriodSeconds * SecondsToPicoseconds,
+            Y0 = histogram.MinAmplitude,
+            Y1 = histogram.MaxAmplitude,
+            Data = data,
+            Interpolate = true,
+            RenderMethod = HeatMapRenderMethod.Bitmap,
+        });
+
+        model.InvalidatePlot(true);
+        return model;
+    }
+
+    /// <summary>Creates an empty, dark-themed eye-diagram plot model with labelled axes.</summary>
+    public static PlotModel CreateEmptyPlotModel()
+    {
+        var model = new PlotModel
+        {
+            Title = "Eye Diagram",
+            Background = OxyColors.Black,
+            TextColor = PlotForeground,
+            TitleColor = PlotForeground,
+            PlotAreaBorderColor = PlotAxisline,
+        };
+        model.Axes.Add(CreateAxis(AxisPosition.Bottom, "Time in bit period (ps)"));
+        model.Axes.Add(CreateAxis(AxisPosition.Left, "Power |E(t)|²"));
+        return model;
+    }
+
+    private static LinearAxis CreateAxis(AxisPosition position, string title) => new()
+    {
+        Position = position,
+        Title = title,
+        TextColor = PlotForeground,
+        TitleColor = PlotForeground,
+        TicklineColor = PlotAxisline,
+        AxislineColor = PlotAxisline,
+        AxislineStyle = LineStyle.Solid,
+    };
+}

--- a/CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramViewModel.cs
@@ -1,0 +1,211 @@
+using System.Globalization;
+using CAP_Core.Analysis.EyeDiagram;
+using CAP_Core.LightCalculation.TimeDomainSimulation;
+using CAP.Avalonia.ViewModels.Canvas;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using OxyPlot;
+
+namespace CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
+
+/// <summary>
+/// ViewModel for the eye-diagram / BER panel (#535). Drives a PRBS-modulated
+/// transient simulation (#527 pipeline), folds the strongest output trace into
+/// an eye histogram, and reports Q-factor / BER with a receiver noise model.
+/// </summary>
+public partial class EyeDiagramViewModel : ObservableObject
+{
+    private const double GigabitsToBits = 1e9;
+    private const double SecondsToPicoseconds = 1e12;
+
+    /// <summary>Receiver electrical bandwidth as a fraction of the bit rate (typical NRZ receiver).</summary>
+    private const double ReceiverBandwidthFactor = 0.75;
+
+    private const double CenterWavelengthNm = TimeDomainSimulator.DefaultCenterWavelengthNm;
+    private const double SpanNm = TimeDomainSimulator.DefaultSpanNm;
+    private const int FreqPoints = TimeDomainSimulator.DefaultNPoints;
+
+    /// <summary>Selectable PRBS pattern orders.</summary>
+    public IReadOnlyList<PrbsOrder> PrbsOrders { get; } =
+        new[] { PrbsOrder.Prbs7, PrbsOrder.Prbs11, PrbsOrder.Prbs23 };
+
+    [ObservableProperty]
+    private double _bitRateGbps = 25;
+
+    [ObservableProperty]
+    private PrbsOrder _selectedPrbsOrder = PrbsOrder.Prbs7;
+
+    /// <summary>Decision threshold as a fraction of the trace amplitude range (0…1).</summary>
+    [ObservableProperty]
+    private double _thresholdRelative = 0.5;
+
+    [ObservableProperty]
+    private bool _isRunning;
+
+    [ObservableProperty]
+    private string _statusText = "";
+
+    /// <summary>Formatted eye metrics (Q, BER, height, width, jitter) shown beside the plot.</summary>
+    [ObservableProperty]
+    private string _metricsText = "";
+
+    /// <summary>OxyPlot heat-map model of the eye persistence display.</summary>
+    [ObservableProperty]
+    private PlotModel _plotModel = EyeDiagramPlotBuilder.CreateEmptyPlotModel();
+
+    /// <summary>True once a completed eye analysis is available to plot/export.</summary>
+    public bool HasResult => _lastHistogram != null;
+
+    /// <summary>File dialog service for CSV export. Set by MainViewModel.</summary>
+    public Services.IFileDialogService? FileDialogService { get; set; }
+
+    private readonly CAP_Core.ErrorConsoleService? _errorConsole;
+    private DesignCanvasViewModel? _canvas;
+    private EyeHistogram? _lastHistogram;
+
+    /// <summary>Initializes a new instance of <see cref="EyeDiagramViewModel"/>.</summary>
+    /// <param name="errorConsole">Optional service for error logging.</param>
+    public EyeDiagramViewModel(CAP_Core.ErrorConsoleService? errorConsole = null)
+    {
+        _errorConsole = errorConsole;
+    }
+
+    /// <summary>Configures the panel with the current canvas context.</summary>
+    /// <param name="canvas">Canvas providing components and connections.</param>
+    public void Configure(DesignCanvasViewModel? canvas)
+    {
+        _canvas = canvas;
+        StatusText = "";
+        MetricsText = "";
+        _lastHistogram = null;
+        PlotModel = EyeDiagramPlotBuilder.CreateEmptyPlotModel();
+        OnPropertyChanged(nameof(HasResult));
+    }
+
+    /// <summary>Runs the PRBS transient simulation and updates the eye plot and metrics.</summary>
+    [RelayCommand]
+    private async Task RunEyeAnalysis()
+    {
+        if (_canvas == null || _canvas.Components.Count == 0)
+        {
+            StatusText = "No circuit loaded.";
+            return;
+        }
+        if (IsRunning) return;
+
+        IsRunning = true;
+        StatusText = "Running PRBS transient simulation…";
+        MetricsText = "";
+        _lastHistogram = null;
+
+        try
+        {
+            var (histogram, metrics) = await Task.Run(RunAnalysisCore);
+            _lastHistogram = histogram;
+            PlotModel = EyeDiagramPlotBuilder.BuildPlotModel(histogram);
+            MetricsText = FormatMetrics(metrics);
+            OnPropertyChanged(nameof(HasResult));
+            StatusText = "Done";
+        }
+        catch (InvalidOperationException ex)
+        {
+            StatusText = $"Cannot run: {ex.Message}";
+            _errorConsole?.LogError($"Eye-diagram analysis blocked: {ex.Message}", ex);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _errorConsole?.LogError($"Eye-diagram analysis failed: {ex.Message}", ex);
+            StatusText = $"Failed: {ex.Message}";
+        }
+        finally
+        {
+            IsRunning = false;
+        }
+    }
+
+    /// <summary>Exports the eye histogram to a CSV file.</summary>
+    [RelayCommand]
+    private async Task ExportCsv()
+    {
+        if (_lastHistogram == null) return;
+
+        try
+        {
+            string? path = null;
+            if (FileDialogService != null)
+            {
+                path = await FileDialogService.ShowSaveFileDialogAsync(
+                    "Export Eye Histogram", "csv", "CSV Files|*.csv|All Files|*.*");
+            }
+            if (path == null)
+            {
+                StatusText = "Export cancelled";
+                return;
+            }
+
+            await File.WriteAllTextAsync(path, _lastHistogram.ToCsv());
+            StatusText = $"Exported to {Path.GetFileName(path)}";
+        }
+        catch (Exception ex)
+        {
+            _errorConsole?.LogError($"Eye histogram export failed: {ex.Message}", ex);
+            StatusText = $"Export failed: {ex.Message}";
+        }
+    }
+
+    private (EyeHistogram Histogram, EyeMetrics Metrics) RunAnalysisCore()
+    {
+        var (simulator, ports) = TransientCircuitFactory.Create(_canvas!);
+
+        double bitRateHz = BitRateGbps * GigabitsToBits;
+        var sweepDef = TimeSignalDefinition.FromWavelengthSweep(CenterWavelengthNm, SpanNm, FreqPoints);
+        var plan = EyeSimulationPlan.Create(
+            bitRateHz, sweepDef.SampleRateHz, PrbsGenerator.PatternLength(SelectedPrbsOrder));
+
+        var bits = PrbsGenerator.GenerateBits(SelectedPrbsOrder, plan.BitCount);
+        var timeDef = new TimeSignalDefinition(sweepDef.SampleRateHz, plan.TotalSamples);
+
+        var signals = new Dictionary<Guid, double[]>();
+        foreach (var used in ports.GetUsedExternalInputs())
+        {
+            double amplitude = Math.Sqrt(used.Input.InFlowPower.Magnitude);
+            signals[used.AttachedComponentPinId] = PrbsGenerator.ToNrzSamples(bits, plan.SamplesPerBit, amplitude);
+        }
+        if (signals.Count == 0)
+            throw new InvalidOperationException("No light source found — place an input coupler.");
+
+        var result = simulator.Run(signals, timeDef, CenterWavelengthNm, SpanNm, FreqPoints);
+        var trace = SelectStrongestTrace(result);
+
+        // No time bin can be finer than one sample, otherwise bins stay empty.
+        int timeBins = Math.Min(EyeDiagramBuilder.DefaultTimeBins, plan.SamplesPerBit);
+        var histogram = EyeDiagramBuilder.Build(
+            trace, timeDef.SampleRateHz, plan.BitPeriodSeconds, timeBins);
+        double threshold = histogram.MinAmplitude
+            + ThresholdRelative * (histogram.MaxAmplitude - histogram.MinAmplitude);
+        var noise = new NoiseModel { BandwidthHz = ReceiverBandwidthFactor * bitRateHz };
+        var metrics = BerEstimator.Estimate(
+            trace, timeDef.SampleRateHz, plan.BitPeriodSeconds, threshold, noise, timeBins);
+
+        return (histogram, metrics);
+    }
+
+    private static double[] SelectStrongestTrace(TimeDomainResult result)
+    {
+        if (result.PinTraces.Count == 0)
+            throw new InvalidOperationException("Simulation produced no output traces.");
+        return result.PinTraces.Values.OrderByDescending(t => t.Length == 0 ? 0 : t.Max()).First();
+    }
+
+    private static string FormatMetrics(EyeMetrics metrics)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        return string.Join(Environment.NewLine,
+            string.Format(inv, "Q factor:       {0:F2}", metrics.QFactor),
+            string.Format(inv, "BER (est.):     {0:E2}", metrics.BerEstimate),
+            string.Format(inv, "Eye height:     {0:E3}", metrics.EyeHeight),
+            string.Format(inv, "Eye width:      {0:F2} ps", metrics.EyeWidthSeconds * SecondsToPicoseconds),
+            string.Format(inv, "RMS jitter:     {0:F3} ps", metrics.RmsJitterSeconds * SecondsToPicoseconds),
+            string.Format(inv, "Optimal sample: {0:F2} ps", metrics.OptimalSampleOffsetSeconds * SecondsToPicoseconds));
+    }
+}

--- a/CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramViewModel.cs
@@ -100,17 +100,19 @@ public partial class EyeDiagramViewModel : ObservableObject
 
         try
         {
-            var (histogram, metrics) = await Task.Run(RunAnalysisCore);
-            _lastHistogram = histogram;
-            PlotModel = EyeDiagramPlotBuilder.BuildPlotModel(histogram);
-            MetricsText = FormatMetrics(metrics);
+            var outcome = await Task.Run(RunAnalysisCore);
+            if (outcome.Error != null || outcome.Histogram == null)
+            {
+                // Expected "can't run" conditions (no light source / no output traces) are surfaced
+                // as a status, not thrown — so they don't break under the debugger (#535/#570).
+                StatusText = outcome.Error ?? "Eye analysis produced no result.";
+                return;
+            }
+            _lastHistogram = outcome.Histogram;
+            PlotModel = EyeDiagramPlotBuilder.BuildPlotModel(outcome.Histogram);
+            MetricsText = FormatMetrics(outcome.Metrics!);   // non-null when Histogram != null
             OnPropertyChanged(nameof(HasResult));
             StatusText = "Done";
-        }
-        catch (InvalidOperationException ex)
-        {
-            StatusText = $"Cannot run: {ex.Message}";
-            _errorConsole?.LogError($"Eye-diagram analysis blocked: {ex.Message}", ex);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -153,7 +155,11 @@ public partial class EyeDiagramViewModel : ObservableObject
         }
     }
 
-    private (EyeHistogram Histogram, EyeMetrics Metrics) RunAnalysisCore()
+    /// <summary>Outcome of an eye run: either a result, or a user-facing <see cref="Error"/>
+    /// for an expected "can't run" condition (no light source / no output traces).</summary>
+    private sealed record EyeRunOutcome(EyeHistogram? Histogram, EyeMetrics? Metrics, string? Error);
+
+    private EyeRunOutcome RunAnalysisCore()
     {
         var (simulator, ports) = TransientCircuitFactory.Create(_canvas!);
 
@@ -172,9 +178,12 @@ public partial class EyeDiagramViewModel : ObservableObject
             signals[used.AttachedComponentPinId] = PrbsGenerator.ToNrzSamples(bits, plan.SamplesPerBit, amplitude);
         }
         if (signals.Count == 0)
-            throw new InvalidOperationException("No light source found — place an input coupler.");
+            return new EyeRunOutcome(null, null, "No light source found — place an input coupler (e.g. a grating/edge coupler).");
 
         var result = simulator.Run(signals, timeDef, CenterWavelengthNm, SpanNm, FreqPoints);
+        if (result.PinTraces.Count == 0)
+            return new EyeRunOutcome(null, null,
+                "The circuit produced no output traces — connect an output path from the light source to a detector/output.");
         var trace = SelectStrongestTrace(result);
 
         // No time bin can be finer than one sample, otherwise bins stay empty.
@@ -187,15 +196,12 @@ public partial class EyeDiagramViewModel : ObservableObject
         var metrics = BerEstimator.Estimate(
             trace, timeDef.SampleRateHz, plan.BitPeriodSeconds, threshold, noise, timeBins);
 
-        return (histogram, metrics);
+        return new EyeRunOutcome(histogram, metrics, null);
     }
 
-    private static double[] SelectStrongestTrace(TimeDomainResult result)
-    {
-        if (result.PinTraces.Count == 0)
-            throw new InvalidOperationException("Simulation produced no output traces.");
-        return result.PinTraces.Values.OrderByDescending(t => t.Length == 0 ? 0 : t.Max()).First();
-    }
+    /// <summary>Picks the highest-peak output trace. The caller guarantees at least one exists.</summary>
+    private static double[] SelectStrongestTrace(TimeDomainResult result) =>
+        result.PinTraces.Values.OrderByDescending(t => t.Length == 0 ? 0 : t.Max()).First();
 
     private static string FormatMetrics(EyeMetrics metrics)
     {

--- a/CAP.Avalonia/ViewModels/Analysis/SimulationMode.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/SimulationMode.cs
@@ -1,0 +1,10 @@
+namespace CAP.Avalonia.ViewModels.Analysis;
+
+/// <summary>How the design is simulated when Run (L) is invoked.</summary>
+public enum SimulationMode
+{
+    /// <summary>Continuous-wave frequency-domain steady state (default).</summary>
+    Cw,
+    /// <summary>Time-domain transient: pulse response / eye-diagram basis.</summary>
+    Transient,
+}

--- a/CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs
@@ -1,10 +1,4 @@
-using System.Numerics;
-using CAP_Core.Components;
-using CAP_Core.Components.Core;
-using CAP_Core.Components.ComponentHelpers;
-using CAP_Core.ExternalPorts;
 using CAP_Core.Grid;
-using CAP_Core.LightCalculation;
 using CAP_Core.LightCalculation.TimeDomainSimulation;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -170,51 +164,13 @@ public partial class TimeDomainViewModel : ObservableObject
 
     private TimeDomainResult RunSimulationCore()
     {
-        var tileManager = new ComponentListTileManager();
-        foreach (var compVm in _canvas!.Components)
-            tileManager.AddComponent(compVm.Component);
-
-        var portManager = new PhysicalExternalPortManager();
-        ConfigureLightSources(portManager);
-
-        var gridManager = GridManager.CreateForSimulation(
-            tileManager, _canvas.ConnectionManager, portManager);
-
-        var builder = new SystemMatrixBuilder(gridManager);
-        var simulator = new TimeDomainSimulator(builder);
+        var (simulator, portManager) = TransientCircuitFactory.Create(_canvas!);
 
         var timeDef = TimeSignalDefinition.FromWavelengthSweep(
             CenterWavelengthNm, SpanNm, FreqPoints);
 
         var inputSignals = BuildInputSignals(portManager, timeDef);
         return simulator.Run(inputSignals, timeDef, CenterWavelengthNm, SpanNm, FreqPoints);
-    }
-
-    private void ConfigureLightSources(PhysicalExternalPortManager portManager)
-    {
-        foreach (var compVm in _canvas!.Components)
-        {
-            if (compVm.TemplateName == null) continue;
-            if (!compVm.TemplateName.Contains("Coupler", StringComparison.OrdinalIgnoreCase)) continue;
-            if (compVm.TemplateName.Contains("Directional", StringComparison.OrdinalIgnoreCase)) continue;
-
-            var laserConfig = compVm.LaserConfig;
-            double power = laserConfig?.InputPower ?? 1.0;
-            var laserType = laserConfig?.WavelengthNm == StandardWaveLengths.GreenNM
-                ? LaserType.Green
-                : laserConfig?.WavelengthNm == StandardWaveLengths.BlueNM
-                    ? LaserType.Blue
-                    : LaserType.Red;
-
-            foreach (var pin in compVm.Component.PhysicalPins)
-            {
-                if (pin.LogicalPin?.MatterType != MatterType.Light) continue;
-                var input = new ExternalInput(
-                    $"src_{compVm.Component.Identifier}_{pin.Name}",
-                    laserType, 0, new Complex(power, 0));
-                portManager.AddLightSource(input, pin.LogicalPin.IDInFlow);
-            }
-        }
     }
 
     private Dictionary<Guid, double[]> BuildInputSignals(

--- a/CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs
@@ -42,13 +42,6 @@ public partial class TimeDomainViewModel : ObservableObject
     [ObservableProperty]
     private bool _isRunning;
 
-    /// <summary>
-    /// True = Time Domain (Transient) mode active; False = Frequency Domain (CW) mode active.
-    /// Controls which simulation mode is visible in the panel.
-    /// </summary>
-    [ObservableProperty]
-    private bool _isTimeDomainMode = true;
-
     [ObservableProperty]
     private string _statusText = "";
 

--- a/CAP.Avalonia/ViewModels/Analysis/TransientCircuitFactory.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/TransientCircuitFactory.cs
@@ -1,0 +1,70 @@
+using System.Numerics;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.ExternalPorts;
+using CAP_Core.Grid;
+using CAP_Core.LightCalculation;
+using CAP_Core.LightCalculation.TimeDomainSimulation;
+using CAP.Avalonia.ViewModels.Canvas;
+
+namespace CAP.Avalonia.ViewModels.Analysis;
+
+/// <summary>
+/// Builds a <see cref="TimeDomainSimulator"/> plus the external light-source
+/// ports for the current canvas. Shared by the transient panel (#527) and the
+/// eye-diagram panel (#535) so both drive the identical circuit setup.
+/// </summary>
+internal static class TransientCircuitFactory
+{
+    /// <summary>
+    /// Creates the simulator and the port manager holding all configured light sources.
+    /// Every non-directional coupler on the canvas is treated as a laser input.
+    /// </summary>
+    /// <param name="canvas">Canvas providing components and connections.</param>
+    public static (TimeDomainSimulator Simulator, PhysicalExternalPortManager Ports) Create(
+        DesignCanvasViewModel canvas)
+    {
+        var tileManager = new ComponentListTileManager();
+        foreach (var compVm in canvas.Components)
+            tileManager.AddComponent(compVm.Component);
+
+        var portManager = new PhysicalExternalPortManager();
+        ConfigureLightSources(canvas, portManager);
+
+        var gridManager = GridManager.CreateForSimulation(
+            tileManager, canvas.ConnectionManager, portManager);
+
+        var builder = new SystemMatrixBuilder(gridManager);
+        return (new TimeDomainSimulator(builder), portManager);
+    }
+
+    /// <summary>Registers a light source on every light pin of each input coupler.</summary>
+    private static void ConfigureLightSources(
+        DesignCanvasViewModel canvas, PhysicalExternalPortManager portManager)
+    {
+        foreach (var compVm in canvas.Components)
+        {
+            if (compVm.TemplateName == null) continue;
+            if (!compVm.TemplateName.Contains("Coupler", StringComparison.OrdinalIgnoreCase)) continue;
+            if (compVm.TemplateName.Contains("Directional", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var laserConfig = compVm.LaserConfig;
+            double power = laserConfig?.InputPower ?? 1.0;
+            var laserType = laserConfig?.WavelengthNm == StandardWaveLengths.GreenNM
+                ? LaserType.Green
+                : laserConfig?.WavelengthNm == StandardWaveLengths.BlueNM
+                    ? LaserType.Blue
+                    : LaserType.Red;
+
+            foreach (var pin in compVm.Component.PhysicalPins)
+            {
+                if (pin.LogicalPin?.MatterType != MatterType.Light) continue;
+                var input = new ExternalInput(
+                    $"src_{compVm.Component.Identifier}_{pin.Name}",
+                    laserType, 0, new Complex(power, 0));
+                portManager.AddLightSource(input, pin.LogicalPin.IDInFlow);
+            }
+        }
+    }
+}

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -56,6 +56,22 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private CAP.Avalonia.ViewModels.Analysis.SimulationMode _simulationMode = CAP.Avalonia.ViewModels.Analysis.SimulationMode.Cw;
 
+    /// <summary>
+    /// Zero-based index view of <see cref="SimulationMode"/> (0 = Cw, 1 = Transient) for the
+    /// toolbar <c>ComboBox</c>, which binds <c>SelectedIndex</c> directly with no converter.
+    /// </summary>
+    public int SimulationModeIndex
+    {
+        get => (int)SimulationMode;
+        set => SimulationMode = (CAP.Avalonia.ViewModels.Analysis.SimulationMode)value;
+    }
+
+    /// <summary>Keeps <see cref="SimulationModeIndex"/> in sync when <see cref="SimulationMode"/> changes.</summary>
+    partial void OnSimulationModeChanged(CAP.Avalonia.ViewModels.Analysis.SimulationMode value)
+    {
+        OnPropertyChanged(nameof(SimulationModeIndex));
+    }
+
     public Commands.CommandManager CommandManager { get; }
     public SimulationService Simulation { get; }
 
@@ -746,6 +762,13 @@ public partial class MainViewModel : ObservableObject
     private async Task RunSimulation()
     {
         if (_isSimulating) return;
+
+        if (SimulationMode == CAP.Avalonia.ViewModels.Analysis.SimulationMode.Transient)
+        {
+            BottomPanel.Analysis.OpenTransient();
+            await BottomPanel.Analysis.Transient.RunTransientCommand.ExecuteAsync(null);
+            return;
+        }
 
         // Toggle off if overlay is already showing
         if (Canvas.ShowPowerFlow)

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -765,6 +765,14 @@ public partial class MainViewModel : ObservableObject
 
         if (SimulationMode == CAP.Avalonia.ViewModels.Analysis.SimulationMode.Transient)
         {
+            // Clear any stale CW power-flow overlay so it doesn't render on top of
+            // the transient results (matches the CW toggle-off below).
+            if (Canvas.ShowPowerFlow)
+            {
+                Canvas.ShowPowerFlow = false;
+                Canvas.PowerFlowVisualizer.IsEnabled = false;
+            }
+
             BottomPanel.Analysis.OpenTransient();
             await BottomPanel.Analysis.Transient.RunTransientCommand.ExecuteAsync(null);
             return;

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -52,6 +52,10 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private bool _isPlayground;
 
+    /// <summary>Active simulation mode; the toolbar selector binds here and Run(L) dispatches on it.</summary>
+    [ObservableProperty]
+    private CAP.Avalonia.ViewModels.Analysis.SimulationMode _simulationMode = CAP.Avalonia.ViewModels.Analysis.SimulationMode.Cw;
+
     public Commands.CommandManager CommandManager { get; }
     public SimulationService Simulation { get; }
 

--- a/CAP.Avalonia/ViewModels/Panels/AnalysisDockViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/AnalysisDockViewModel.cs
@@ -21,6 +21,21 @@ public partial class AnalysisDockViewModel : ObservableObject
     [ObservableProperty]
     private int _selectedTabIndex;
 
+    /// <summary>Minimum dock content height (px) when dragging the resize grip.</summary>
+    public const double MinDockHeight = 120;
+
+    /// <summary>Maximum dock content height (px) when dragging the resize grip.</summary>
+    public const double MaxDockHeight = 640;
+
+    /// <summary>User-adjustable height (px) of the dock's content area; driven by the resize grip.</summary>
+    [ObservableProperty]
+    private double _dockHeight = 260;
+
+    /// <summary>Sets <see cref="DockHeight"/> to <paramref name="height"/>, clamped to
+    /// [<see cref="MinDockHeight"/>, <see cref="MaxDockHeight"/>].</summary>
+    public void SetDockHeight(double height) =>
+        DockHeight = System.Math.Clamp(height, MinDockHeight, MaxDockHeight);
+
     /// <summary>Initializes a new instance of <see cref="AnalysisDockViewModel"/>.</summary>
     /// <param name="transient">Transient (time-domain) analysis tab ViewModel.</param>
     /// <param name="eye">Eye-diagram / BER analysis tab ViewModel.</param>

--- a/CAP.Avalonia/ViewModels/Panels/AnalysisDockViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/AnalysisDockViewModel.cs
@@ -1,0 +1,50 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CAP.Avalonia.ViewModels.Analysis;
+using CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
+using CAP.Avalonia.ViewModels.Canvas;
+
+namespace CAP.Avalonia.ViewModels.Panels;
+
+/// <summary>Bottom analysis dock: collapsible host for the Transient and Eye/BER tabs (#570/#535).</summary>
+public partial class AnalysisDockViewModel : ObservableObject
+{
+    /// <summary>Transient (time-domain) analysis tab.</summary>
+    public TimeDomainViewModel Transient { get; }
+
+    /// <summary>Eye-diagram / BER analysis tab.</summary>
+    public EyeDiagramViewModel Eye { get; }
+
+    [ObservableProperty]
+    private bool _isVisible;
+
+    [ObservableProperty]
+    private int _selectedTabIndex;
+
+    /// <summary>Initializes a new instance of <see cref="AnalysisDockViewModel"/>.</summary>
+    /// <param name="transient">Transient (time-domain) analysis tab ViewModel.</param>
+    /// <param name="eye">Eye-diagram / BER analysis tab ViewModel.</param>
+    public AnalysisDockViewModel(TimeDomainViewModel transient, EyeDiagramViewModel eye)
+    {
+        Transient = transient;
+        Eye = eye;
+    }
+
+    /// <summary>Wires both tabs to the active design canvas.</summary>
+    public void Configure(DesignCanvasViewModel canvas)
+    {
+        Transient.Configure(canvas);
+        Eye.Configure(canvas);
+    }
+
+    /// <summary>Opens the dock on the Transient tab (called when Run is invoked in Transient mode).</summary>
+    public void OpenTransient()
+    {
+        SelectedTabIndex = 0;
+        IsVisible = true;
+    }
+
+    /// <summary>Toggles the dock's visibility.</summary>
+    [RelayCommand]
+    private void Toggle() => IsVisible = !IsVisible;
+}

--- a/CAP.Avalonia/ViewModels/Panels/BottomPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/BottomPanelViewModel.cs
@@ -30,6 +30,11 @@ public partial class BottomPanelViewModel : ObservableObject
     /// </summary>
     public ErrorConsoleViewModel ErrorConsole { get; }
 
+    /// <summary>
+    /// ViewModel for the collapsible transient/eye-diagram analysis dock (#570/#535).
+    /// </summary>
+    public AnalysisDockViewModel Analysis { get; }
+
     [ObservableProperty]
     private string _statusText = "Ready";
 
@@ -41,11 +46,13 @@ public partial class BottomPanelViewModel : ObservableObject
         CommandManager commandManager,
         WaveguideLengthViewModel waveguideLength,
         ElementLockViewModel elementLock,
-        ErrorConsoleViewModel errorConsole)
+        ErrorConsoleViewModel errorConsole,
+        AnalysisDockViewModel analysis)
     {
         WaveguideLength = waveguideLength;
         ElementLock = elementLock;
         ErrorConsole = errorConsole;
+        Analysis = analysis;
 
         // Configure ViewModels that need canvas and command manager
         ElementLock.Configure(canvas, commandManager);

--- a/CAP.Avalonia/ViewModels/Panels/BottomPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/BottomPanelViewModel.cs
@@ -56,6 +56,7 @@ public partial class BottomPanelViewModel : ObservableObject
 
         // Configure ViewModels that need canvas and command manager
         ElementLock.Configure(canvas, commandManager);
+        Analysis.Configure(canvas);
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs
@@ -108,11 +108,6 @@ public partial class RightPanelViewModel : ObservableObject
     /// </summary>
     public AiAssistantViewModel AiAssistant { get; }
 
-    /// <summary>
-    /// ViewModel for the time-domain (transient) simulation panel.
-    /// </summary>
-    public TimeDomainViewModel TimeDomain { get; }
-
     private readonly ComponentEditorFactory _editorFactory;
     private readonly DesignCanvasViewModel _canvas;
 
@@ -148,8 +143,7 @@ public partial class RightPanelViewModel : ObservableObject
         PdkConsistencyViewModel pdkConsistency,
         AiAssistantViewModel aiAssistant,
         OnaSweepViewModel onaAnalysis,
-        ComponentEditorFactory editorFactory,
-        TimeDomainViewModel timeDomain)
+        ComponentEditorFactory editorFactory)
     {
         _preferencesService = preferencesService;
         _editorFactory = editorFactory;
@@ -166,14 +160,12 @@ public partial class RightPanelViewModel : ObservableObject
         ArchitectureReport = architectureReport;
         PdkConsistency = pdkConsistency;
         AiAssistant = aiAssistant;
-        TimeDomain = timeDomain;
         OnaAnalysis = onaAnalysis;
 
         // Configure ViewModels that need canvas reference
         RoutingDiagnostics.Configure(canvas);
         DimensionValidator.Configure(canvas);
         CompressLayout.Configure(canvas);
-        TimeDomain.Configure(canvas);
         OnaAnalysis.Configure(canvas);
 
         // Drive the per-component property editor from canvas selection.

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -81,6 +81,14 @@
                               Width="16" Height="16" Foreground="LightGreen"/>
                 </Button>
 
+                <!-- Simulation mode: CW vs Transient. Run (L) executes the active mode. -->
+                <ComboBox Width="120" Margin="2" VerticalAlignment="Center"
+                          SelectedIndex="{Binding SimulationModeIndex}"
+                          ToolTip.Tip="Simulation mode: CW (steady-state) or Transient (time-domain). Run (L) executes this mode.">
+                    <ComboBoxItem>CW</ComboBoxItem>
+                    <ComboBoxItem>Transient</ComboBoxItem>
+                </ComboBox>
+
                 <Separator Width="1" Background="Gray" Margin="10,5"/>
 
                 <!-- Undo/Redo -->

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -340,6 +340,9 @@
             </StackPanel>
         </Border>
 
+        <!-- Analysis Dock Panel (collapsible, above the Error Console, #570/#535) -->
+        <panels:AnalysisDockPanel DockPanel.Dock="Bottom"/>
+
         <!-- Left Panel - Hierarchy + Component Library -->
         <Grid DockPanel.Dock="Left" ColumnDefinitions="*,Auto" Name="LeftPanelGrid">
             <Border Grid.Column="0"
@@ -793,9 +796,6 @@
 
                     <!-- Design Checks Panel -->
                     <panels:DesignChecksPanel/>
-
-                    <!-- Time-Domain (Transient) Simulation Panel -->
-                    <panels:TimeDomainPanel/>
 
                     <!-- Element Lock Panel -->
                     <Separator Margin="0,20,0,10" Background="#3d3d3d"/>

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -50,6 +50,7 @@ public partial class MainWindow : Window
                     onaEditorProvider.OpenSweepAsync = analyzer => OpenOnaAnalyzerWindow(analyzer, vm);
                 vm.RightPanel.RoutingDiagnostics.FileDialogService = vm.FileDialogService;
                 vm.BottomPanel.Analysis.Transient.FileDialogService = vm.FileDialogService;
+                vm.BottomPanel.Analysis.Eye.FileDialogService = vm.FileDialogService;
                 ExportDialogWiring.Wire(vm, this, vm.ErrorConsole);
                 vm.ViewportControl.GetViewportSize = GetActualViewportSize;
 

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -49,7 +49,7 @@ public partial class MainWindow : Window
                 if (onaEditorProvider != null)
                     onaEditorProvider.OpenSweepAsync = analyzer => OpenOnaAnalyzerWindow(analyzer, vm);
                 vm.RightPanel.RoutingDiagnostics.FileDialogService = vm.FileDialogService;
-                vm.RightPanel.TimeDomain.FileDialogService = vm.FileDialogService;
+                vm.BottomPanel.Analysis.Transient.FileDialogService = vm.FileDialogService;
                 ExportDialogWiring.Wire(vm, this, vm.ErrorConsole);
                 vm.ViewportControl.GetViewportSize = GetActualViewportSize;
 

--- a/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml
@@ -27,8 +27,18 @@
                 </Button>
             </DockPanel>
 
-            <!-- Content area: only shown when IsVisible is true -->
-            <Border IsVisible="{Binding BottomPanel.Analysis.IsVisible}" Height="240" Background="#161616">
+            <!-- Resize grip: drag to change the dock height (#570 field feedback). -->
+            <Border x:Name="ResizeGrip"
+                    IsVisible="{Binding BottomPanel.Analysis.IsVisible}"
+                    Height="5" Background="#3d3d3d" Cursor="SizeNorthSouth"
+                    ToolTip.Tip="Drag to resize the analysis dock"
+                    PointerPressed="ResizeGrip_PointerPressed"
+                    PointerMoved="ResizeGrip_PointerMoved"
+                    PointerReleased="ResizeGrip_PointerReleased"/>
+
+            <!-- Content area: only shown when IsVisible is true; height is user-adjustable. -->
+            <Border IsVisible="{Binding BottomPanel.Analysis.IsVisible}"
+                    Height="{Binding BottomPanel.Analysis.DockHeight}" Background="#161616">
                 <TabControl SelectedIndex="{Binding BottomPanel.Analysis.SelectedTabIndex}">
                     <TabItem Header="Transient">
                         <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml
@@ -1,0 +1,48 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:CAP.Avalonia.ViewModels"
+             xmlns:panels="using:CAP.Avalonia.Views.Panels"
+             x:Class="CAP.Avalonia.Views.Panels.AnalysisDockPanel"
+             x:DataType="vm:MainViewModel">
+
+    <!-- Analysis dock (collapsible, above the Error Console, #570/#535).
+         Hosts the Transient and Eye/BER tabs re-homed from the properties panel. -->
+    <Border Background="#161616" BorderThickness="0,1,0,0" BorderBrush="#3d3d3d">
+        <StackPanel>
+            <!-- Header bar: always visible, click to toggle -->
+            <DockPanel Height="26" Background="#252526">
+                <Button Command="{Binding BottomPanel.Analysis.ToggleCommand}"
+                        Background="Transparent"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        Height="26" Padding="8,0"
+                        ToolTip.Tip="Toggle analysis dock">
+                    <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                        <TextBlock Text="▶" Foreground="Gray" FontSize="9" VerticalAlignment="Center"
+                                   IsVisible="{Binding BottomPanel.Analysis.IsVisible, Converter={x:Static BoolConverters.Not}}"/>
+                        <TextBlock Text="▼" Foreground="Gray" FontSize="9" VerticalAlignment="Center"
+                                   IsVisible="{Binding BottomPanel.Analysis.IsVisible}"/>
+                        <TextBlock Text="Analysis" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Button>
+            </DockPanel>
+
+            <!-- Content area: only shown when IsVisible is true -->
+            <Border IsVisible="{Binding BottomPanel.Analysis.IsVisible}" Height="240" Background="#161616">
+                <TabControl SelectedIndex="{Binding BottomPanel.Analysis.SelectedTabIndex}">
+                    <TabItem Header="Transient">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <panels:TimeDomainPanel/>
+                        </ScrollViewer>
+                    </TabItem>
+                    <TabItem Header="Eye / BER">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <panels:EyeDiagramPanel/>
+                        </ScrollViewer>
+                    </TabItem>
+                </TabControl>
+            </Border>
+        </StackPanel>
+    </Border>
+
+</UserControl>

--- a/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml.cs
+++ b/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+
+namespace CAP.Avalonia.Views.Panels;
+
+/// <summary>
+/// Collapsible bottom dock hosting the Transient and Eye/BER analysis tabs (#570/#535).
+/// DataContext is inherited from MainWindow (MainViewModel).
+/// </summary>
+public partial class AnalysisDockPanel : UserControl
+{
+    /// <summary>Initializes the AnalysisDockPanel.</summary>
+    public AnalysisDockPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml.cs
+++ b/CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml.cs
@@ -1,16 +1,55 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using CAP.Avalonia.ViewModels;
 
 namespace CAP.Avalonia.Views.Panels;
 
 /// <summary>
 /// Collapsible bottom dock hosting the Transient and Eye/BER analysis tabs (#570/#535).
-/// DataContext is inherited from MainWindow (MainViewModel).
+/// DataContext is inherited from MainWindow (MainViewModel). The top edge carries a resize
+/// grip that drags the dock's content height (#570 field feedback).
 /// </summary>
 public partial class AnalysisDockPanel : UserControl
 {
+    private bool _resizing;
+    private double _startPointerY;
+    private double _startHeight;
+
     /// <summary>Initializes the AnalysisDockPanel.</summary>
     public AnalysisDockPanel()
     {
         InitializeComponent();
+    }
+
+    private ViewModels.Panels.AnalysisDockViewModel? Dock =>
+        (DataContext as MainViewModel)?.BottomPanel?.Analysis;
+
+    private void ResizeGrip_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        var dock = Dock;
+        if (dock == null || this.GetVisualRoot() is not Visual root) return;
+        _resizing = true;
+        _startPointerY = e.GetPosition(root).Y;
+        _startHeight = dock.DockHeight;
+        e.Pointer.Capture(sender as IInputElement);
+        e.Handled = true;
+    }
+
+    private void ResizeGrip_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_resizing || Dock is not { } dock || this.GetVisualRoot() is not Visual root) return;
+        // The grip sits at the dock's top edge; dragging up (smaller Y) grows the dock.
+        var currentY = e.GetPosition(root).Y;
+        dock.SetDockHeight(_startHeight - (currentY - _startPointerY));
+        e.Handled = true;
+    }
+
+    private void ResizeGrip_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        _resizing = false;
+        e.Pointer.Capture(null);
+        e.Handled = true;
     }
 }

--- a/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
@@ -14,29 +14,28 @@
             Q-factor and BER with shot / thermal / RIN receiver noise.
         </TextBlock>
 
-        <!-- Bit rate -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Bit rate (Gbps):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.BitRateGbps}"
-                           Minimum="1" Maximum="1000" Increment="5"
-                           Width="110" FormatString="F1"/>
-        </StackPanel>
-
-        <!-- PRBS pattern -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="PRBS pattern:" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <ComboBox ItemsSource="{Binding BottomPanel.Analysis.Eye.PrbsOrders}"
-                      SelectedItem="{Binding BottomPanel.Analysis.Eye.SelectedPrbsOrder}"
-                      Width="110"/>
-        </StackPanel>
-
-        <!-- Decision threshold -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBlock Text="Threshold (rel.):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.ThresholdRelative}"
-                           Minimum="0.05" Maximum="0.95" Increment="0.05"
-                           Width="110" FormatString="F2"/>
-        </StackPanel>
+        <!-- Parameters: laid out side-by-side (wraps as the dock narrows) so the wide dock
+             width is used and each field is wide enough to show its full value (#570 feedback). -->
+        <WrapPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="Bit rate (Gbps)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.BitRateGbps}"
+                               Minimum="1" Maximum="1000" Increment="5"
+                               Width="150" FormatString="F1"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="PRBS pattern" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <ComboBox ItemsSource="{Binding BottomPanel.Analysis.Eye.PrbsOrders}"
+                          SelectedItem="{Binding BottomPanel.Analysis.Eye.SelectedPrbsOrder}"
+                          Width="130"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="Threshold (rel.)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.ThresholdRelative}"
+                               Minimum="0.05" Maximum="0.95" Increment="0.05"
+                               Width="130" FormatString="F2"/>
+            </StackPanel>
+        </WrapPanel>
 
         <!-- Run button -->
         <Button Content="Run Eye Analysis"

--- a/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
@@ -6,23 +6,22 @@
              x:DataType="vm:MainViewModel">
 
     <UserControl.Styles>
-        <!-- Compact, half-height inputs/buttons for the dense analysis dock (#570 feedback). -->
+        <!-- Compact inputs for the dense analysis dock (#570 feedback): no spinner buttons
+             (type values; arrow keys still increment), natural height, centered content so the
+             number is not clipped. Do NOT force Height on NumericUpDown — it clips the inner text. -->
         <Style Selector="NumericUpDown">
-            <Setter Property="Height" Value="24"/>
-            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="ShowButtonSpinner" Value="False"/>
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Padding" Value="4,0"/>
+            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="ComboBox">
-            <Setter Property="Height" Value="24"/>
-            <Setter Property="MinHeight" Value="24"/>
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Padding" Value="6,0"/>
+            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.analysis">
-            <Setter Property="Height" Value="24"/>
-            <Setter Property="MinHeight" Value="24"/>
-            <Setter Property="Padding" Value="10,0"/>
+            <Setter Property="Padding" Value="10,3"/>
             <Setter Property="FontSize" Value="11"/>
         </Style>
     </UserControl.Styles>

--- a/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
@@ -5,68 +5,85 @@
              x:Class="CAP.Avalonia.Views.Panels.EyeDiagramPanel"
              x:DataType="vm:MainViewModel">
 
-    <StackPanel>
-        <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
-        <TextBlock Text="Eye Diagram / BER:" Foreground="Orchid" Margin="0,0,0,5" FontWeight="SemiBold"/>
+    <UserControl.Styles>
+        <!-- Compact, half-height inputs/buttons for the dense analysis dock (#570 feedback). -->
+        <Style Selector="NumericUpDown">
+            <Setter Property="Height" Value="24"/>
+            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Padding" Value="4,0"/>
+        </Style>
+        <Style Selector="ComboBox">
+            <Setter Property="Height" Value="24"/>
+            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Padding" Value="6,0"/>
+        </Style>
+        <Style Selector="Button.analysis">
+            <Setter Property="Height" Value="24"/>
+            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="Padding" Value="10,0"/>
+            <Setter Property="FontSize" Value="11"/>
+        </Style>
+    </UserControl.Styles>
 
-        <TextBlock Foreground="Gray" FontSize="10" Margin="0,0,0,8" TextWrapping="Wrap">
-            PRBS-modulated transient simulation → eye persistence heat map,
-            Q-factor and BER with shot / thermal / RIN receiver noise.
+    <StackPanel Margin="6,4">
+        <!-- No heading/separator: the tab header already reads "Eye / BER". -->
+        <TextBlock Foreground="Gray" FontSize="9" Margin="0,0,0,4" TextWrapping="Wrap">
+            PRBS-modulated transient → eye persistence heat map, Q-factor and BER (shot/thermal/RIN noise).
         </TextBlock>
 
-        <!-- Parameters: laid out side-by-side (wraps as the dock narrows) so the wide dock
-             width is used and each field is wide enough to show its full value (#570 feedback). -->
-        <WrapPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="Bit rate (Gbps)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+        <!-- Parameters + Run: laid out horizontally, wrapping responsively (right, then down). -->
+        <WrapPanel Orientation="Horizontal">
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="Bit rate (Gbps)" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.BitRateGbps}"
-                               Minimum="1" Maximum="1000" Increment="5"
-                               Width="150" FormatString="F1"/>
+                               Minimum="1" Maximum="1000" Increment="5" Width="120" FormatString="F1"/>
             </StackPanel>
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="PRBS pattern" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="PRBS pattern" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <ComboBox ItemsSource="{Binding BottomPanel.Analysis.Eye.PrbsOrders}"
                           SelectedItem="{Binding BottomPanel.Analysis.Eye.SelectedPrbsOrder}"
-                          Width="130"/>
+                          Width="110"/>
             </StackPanel>
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="Threshold (rel.)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="Threshold (rel.)" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.ThresholdRelative}"
-                               Minimum="0.05" Maximum="0.95" Increment="0.05"
-                               Width="130" FormatString="F2"/>
+                               Minimum="0.05" Maximum="0.95" Increment="0.05" Width="110" FormatString="F2"/>
+            </StackPanel>
+            <!-- Run sits to the right of the fields; the spacer aligns it with the field row. -->
+            <StackPanel Margin="0,0,12,4" VerticalAlignment="Bottom">
+                <TextBlock Text=" " FontSize="9" Margin="0,0,0,1"/>
+                <Button Content="Run Eye Analysis" Classes="analysis" Background="#5d3d5d"
+                        Command="{Binding BottomPanel.Analysis.Eye.RunEyeAnalysisCommand}"
+                        IsEnabled="{Binding BottomPanel.Analysis.Eye.IsRunning, Converter={x:Static BoolConverters.Not}}"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,0,4" VerticalAlignment="Bottom"
+                        IsVisible="{Binding BottomPanel.Analysis.Eye.HasResult}">
+                <TextBlock Text=" " FontSize="9" Margin="0,0,0,1"/>
+                <Button Content="Export CSV" Classes="analysis" Background="#3d3d5d"
+                        Command="{Binding BottomPanel.Analysis.Eye.ExportCsvCommand}"/>
             </StackPanel>
         </WrapPanel>
 
-        <!-- Run button -->
-        <Button Content="Run Eye Analysis"
-                Command="{Binding BottomPanel.Analysis.Eye.RunEyeAnalysisCommand}"
-                Width="140" Margin="0,0,0,5" Background="#5d3d5d"
-                IsEnabled="{Binding BottomPanel.Analysis.Eye.IsRunning, Converter={x:Static BoolConverters.Not}}"/>
-
         <!-- Status -->
         <TextBlock Text="{Binding BottomPanel.Analysis.Eye.StatusText}"
-                   Foreground="Gray" FontSize="10" Margin="0,0,0,4"
+                   Foreground="Gray" FontSize="9" Margin="0,2,0,2"
                    IsVisible="{Binding BottomPanel.Analysis.Eye.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                    TextWrapping="Wrap"/>
 
         <!-- Eye heat map -->
         <Border Background="#1a1a1a" BorderBrush="#3d3d3d" BorderThickness="1"
-                Height="220" Margin="0,4,0,0"
+                Height="200" Margin="0,2,0,0"
                 IsVisible="{Binding BottomPanel.Analysis.Eye.HasResult}">
             <oxy:PlotView Model="{Binding BottomPanel.Analysis.Eye.PlotModel}" Background="Transparent"/>
         </Border>
 
         <!-- Numeric eye metrics -->
         <TextBlock Text="{Binding BottomPanel.Analysis.Eye.MetricsText}"
-                   Foreground="Orchid" FontFamily="Consolas" FontSize="10" Margin="0,4,0,0"
+                   Foreground="Orchid" FontFamily="Consolas" FontSize="10" Margin="0,2,0,0"
                    IsVisible="{Binding BottomPanel.Analysis.Eye.MetricsText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                    TextWrapping="NoWrap"/>
-
-        <!-- Export -->
-        <Button Content="Export CSV"
-                Command="{Binding BottomPanel.Analysis.Eye.ExportCsvCommand}"
-                Width="110" Margin="0,5,0,0" Background="#3d3d5d"
-                IsVisible="{Binding BottomPanel.Analysis.Eye.HasResult}"/>
     </StackPanel>
 
 </UserControl>

--- a/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
@@ -1,0 +1,73 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:CAP.Avalonia.ViewModels"
+             xmlns:oxy="using:OxyPlot.Avalonia"
+             x:Class="CAP.Avalonia.Views.Panels.EyeDiagramPanel"
+             x:DataType="vm:MainViewModel">
+
+    <StackPanel>
+        <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
+        <TextBlock Text="Eye Diagram / BER:" Foreground="Orchid" Margin="0,0,0,5" FontWeight="SemiBold"/>
+
+        <TextBlock Foreground="Gray" FontSize="10" Margin="0,0,0,8" TextWrapping="Wrap">
+            PRBS-modulated transient simulation → eye persistence heat map,
+            Q-factor and BER with shot / thermal / RIN receiver noise.
+        </TextBlock>
+
+        <!-- Bit rate -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+            <TextBlock Text="Bit rate (Gbps):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
+            <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.BitRateGbps}"
+                           Minimum="1" Maximum="1000" Increment="5"
+                           Width="110" FormatString="F1"/>
+        </StackPanel>
+
+        <!-- PRBS pattern -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+            <TextBlock Text="PRBS pattern:" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
+            <ComboBox ItemsSource="{Binding BottomPanel.Analysis.Eye.PrbsOrders}"
+                      SelectedItem="{Binding BottomPanel.Analysis.Eye.SelectedPrbsOrder}"
+                      Width="110"/>
+        </StackPanel>
+
+        <!-- Decision threshold -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="Threshold (rel.):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
+            <NumericUpDown Value="{Binding BottomPanel.Analysis.Eye.ThresholdRelative}"
+                           Minimum="0.05" Maximum="0.95" Increment="0.05"
+                           Width="110" FormatString="F2"/>
+        </StackPanel>
+
+        <!-- Run button -->
+        <Button Content="Run Eye Analysis"
+                Command="{Binding BottomPanel.Analysis.Eye.RunEyeAnalysisCommand}"
+                Width="140" Margin="0,0,0,5" Background="#5d3d5d"
+                IsEnabled="{Binding BottomPanel.Analysis.Eye.IsRunning, Converter={x:Static BoolConverters.Not}}"/>
+
+        <!-- Status -->
+        <TextBlock Text="{Binding BottomPanel.Analysis.Eye.StatusText}"
+                   Foreground="Gray" FontSize="10" Margin="0,0,0,4"
+                   IsVisible="{Binding BottomPanel.Analysis.Eye.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                   TextWrapping="Wrap"/>
+
+        <!-- Eye heat map -->
+        <Border Background="#1a1a1a" BorderBrush="#3d3d3d" BorderThickness="1"
+                Height="220" Margin="0,4,0,0"
+                IsVisible="{Binding BottomPanel.Analysis.Eye.HasResult}">
+            <oxy:PlotView Model="{Binding BottomPanel.Analysis.Eye.PlotModel}" Background="Transparent"/>
+        </Border>
+
+        <!-- Numeric eye metrics -->
+        <TextBlock Text="{Binding BottomPanel.Analysis.Eye.MetricsText}"
+                   Foreground="Orchid" FontFamily="Consolas" FontSize="10" Margin="0,4,0,0"
+                   IsVisible="{Binding BottomPanel.Analysis.Eye.MetricsText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                   TextWrapping="NoWrap"/>
+
+        <!-- Export -->
+        <Button Content="Export CSV"
+                Command="{Binding BottomPanel.Analysis.Eye.ExportCsvCommand}"
+                Width="110" Margin="0,5,0,0" Background="#3d3d5d"
+                IsVisible="{Binding BottomPanel.Analysis.Eye.HasResult}"/>
+    </StackPanel>
+
+</UserControl>

--- a/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml
@@ -5,23 +5,29 @@
              x:Class="CAP.Avalonia.Views.Panels.EyeDiagramPanel"
              x:DataType="vm:MainViewModel">
 
+    <UserControl.Resources>
+        <!-- Drives the min height of NumericUpDown / TextBox / ComboBox; Fluent default 32 px made
+             the number fields look twice as tall as the Run button. 26 px matches the compact
+             analysis buttons and keeps the spinner buttons visible + text un-clipped (#570). -->
+        <x:Double x:Key="TextControlThemeMinHeight">26</x:Double>
+    </UserControl.Resources>
+
     <UserControl.Styles>
-        <!-- Compact inputs for the dense analysis dock (#570 feedback): no spinner buttons
-             (type values; arrow keys still increment), natural height, centered content so the
-             number is not clipped. Do NOT force Height on NumericUpDown — it clips the inner text. -->
+        <!-- Compact inputs: spinner buttons kept (just smaller, via the reduced min height),
+             centered content so the number is not clipped. -->
         <Style Selector="NumericUpDown">
-            <Setter Property="ShowButtonSpinner" Value="False"/>
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="Padding" Value="6,0"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="ComboBox">
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="Padding" Value="6,0"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.analysis">
-            <Setter Property="Padding" Value="10,3"/>
+            <Setter Property="Height" Value="26"/>
+            <Setter Property="Padding" Value="10,0"/>
             <Setter Property="FontSize" Value="11"/>
         </Style>
     </UserControl.Styles>

--- a/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml.cs
+++ b/CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml.cs
@@ -1,0 +1,16 @@
+using Avalonia.Controls;
+
+namespace CAP.Avalonia.Views.Panels;
+
+/// <summary>
+/// Panel for eye-diagram / BER analysis of the transient simulation (#535).
+/// DataContext is inherited from MainWindow (MainViewModel).
+/// </summary>
+public partial class EyeDiagramPanel : UserControl
+{
+    /// <summary>Initializes the EyeDiagramPanel.</summary>
+    public EyeDiagramPanel()
+    {
+        InitializeComponent();
+    }
+}

--- a/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
@@ -7,111 +7,117 @@
              x:DataType="vm:MainViewModel">
 
     <UserControl.Styles>
-        <!-- Dark hover-tracker so its text is readable on the dark theme,
-             mirroring the ONA window's tracker style. -->
+        <!-- Dark hover-tracker so its text is readable on the dark theme. -->
         <Style Selector="oxy|TrackerControl">
             <Setter Property="Background" Value="#2D2D2D"/>
             <Setter Property="LineStroke" Value="#A0A0A0"/>
         </Style>
+        <!-- Compact, half-height inputs/buttons for the dense analysis dock (#570 feedback). -->
+        <Style Selector="NumericUpDown">
+            <Setter Property="Height" Value="24"/>
+            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Padding" Value="4,0"/>
+        </Style>
+        <Style Selector="Button.analysis">
+            <Setter Property="Height" Value="24"/>
+            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="Padding" Value="10,0"/>
+            <Setter Property="FontSize" Value="11"/>
+        </Style>
     </UserControl.Styles>
 
-    <StackPanel>
-        <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
-        <TextBlock Text="Transient (Time-Domain):" Foreground="Plum" Margin="0,0,0,5" FontWeight="SemiBold"/>
-
-        <TextBlock Foreground="Gray" FontSize="10" Margin="0,0,0,8" TextWrapping="Wrap">
-            IFFT of S-parameters → impulse response → convolve with Gaussian pulse.
-            Linear circuits only (Phase 1).
+    <StackPanel Margin="6,4">
+        <!-- No heading/separator: the tab header already reads "Transient". -->
+        <TextBlock Foreground="Gray" FontSize="9" Margin="0,0,0,4" TextWrapping="Wrap">
+            IFFT of S-parameters → impulse response → convolve with Gaussian pulse. Linear circuits only.
         </TextBlock>
 
-        <!-- Parameters: side-by-side (wraps as the dock narrows) so the wide dock width is used
-             and each field is wide enough to show its full value (#570 feedback). Sweep params
-             first, then the Gaussian pulse params. -->
-        <WrapPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="λ centre (nm)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+        <!-- Parameters + Run: laid out horizontally, wrapping responsively (right, then down). -->
+        <WrapPanel Orientation="Horizontal">
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="λ centre (nm)" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.CenterWavelengthNm}"
-                               Minimum="800" Maximum="2000" Increment="10"
-                               Width="140" FormatString="F0"/>
+                               Minimum="800" Maximum="2000" Increment="10" Width="118" FormatString="F0"/>
             </StackPanel>
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="Span (nm)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="Span (nm)" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.SpanNm}"
-                               Minimum="1" Maximum="500" Increment="10"
-                               Width="130" FormatString="F0"/>
+                               Minimum="1" Maximum="500" Increment="10" Width="110" FormatString="F0"/>
             </StackPanel>
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="Freq. points" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="Freq. points" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.FreqPoints}"
-                               Minimum="16" Maximum="1024" Increment="64"
-                               Width="130" FormatString="F0"/>
+                               Minimum="16" Maximum="1024" Increment="64" Width="110" FormatString="F0"/>
             </StackPanel>
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="Pulse centre (ps)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="Pulse centre (ps)" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseCenterPs}"
-                               Minimum="0" Maximum="100" Increment="0.5"
-                               Width="140" FormatString="F2"/>
+                               Minimum="0" Maximum="100" Increment="0.5" Width="118" FormatString="F2"/>
             </StackPanel>
-            <StackPanel Margin="0,0,16,6">
-                <TextBlock Text="Pulse σ width (ps)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+            <StackPanel Margin="0,0,12,4">
+                <TextBlock Text="Pulse σ width (ps)" Foreground="Gray" FontSize="9" Margin="0,0,0,1"/>
                 <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseSigmaPs}"
-                               Minimum="0.01" Maximum="50" Increment="0.1"
-                               Width="140" FormatString="F2"/>
+                               Minimum="0.01" Maximum="50" Increment="0.1" Width="118" FormatString="F2"/>
+            </StackPanel>
+            <!-- Run sits to the right of the fields; the spacer aligns it with the field row. -->
+            <StackPanel Margin="0,0,12,4" VerticalAlignment="Bottom">
+                <TextBlock Text=" " FontSize="9" Margin="0,0,0,1"/>
+                <Button Content="Run Transient" Classes="analysis" Background="#5d3d5d"
+                        Command="{Binding BottomPanel.Analysis.Transient.RunTransientCommand}"
+                        IsEnabled="{Binding BottomPanel.Analysis.Transient.IsRunning, Converter={x:Static BoolConverters.Not}}"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,0,4" VerticalAlignment="Bottom"
+                        IsVisible="{Binding BottomPanel.Analysis.Transient.HasResult}">
+                <TextBlock Text=" " FontSize="9" Margin="0,0,0,1"/>
+                <Button Content="Export CSV" Classes="analysis" Background="#3d3d5d"
+                        Command="{Binding BottomPanel.Analysis.Transient.ExportCsvCommand}"/>
             </StackPanel>
         </WrapPanel>
 
-        <!-- Run button -->
-        <Button Content="Run Transient"
-                Command="{Binding BottomPanel.Analysis.Transient.RunTransientCommand}"
-                Width="140" Margin="0,0,0,5" Background="#5d3d5d"
-                IsEnabled="{Binding BottomPanel.Analysis.Transient.IsRunning, Converter={x:Static BoolConverters.Not}}"/>
-
         <!-- Status -->
         <TextBlock Text="{Binding BottomPanel.Analysis.Transient.StatusText}"
-                   Foreground="Gray" FontSize="10" Margin="0,0,0,4"
+                   Foreground="Gray" FontSize="9" Margin="0,2,0,2"
                    IsVisible="{Binding BottomPanel.Analysis.Transient.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                    TextWrapping="Wrap"/>
 
-        <!-- Waveform plot: power vs time, one series per output pin.
-             Zoom/pan via OxyPlot default axes; cursor read-out via tracker. -->
+        <!-- Waveform plot: power vs time, one series per output pin. -->
         <Border Background="#1a1a1a" BorderBrush="#3d3d3d" BorderThickness="1"
-                Height="220" Margin="0,4,0,0"
+                Height="200" Margin="0,2,0,0"
                 IsVisible="{Binding BottomPanel.Analysis.Transient.HasResult}">
             <oxy:PlotView Model="{Binding BottomPanel.Analysis.Transient.PlotModel}" Background="Transparent"/>
         </Border>
 
-        <!-- Per-pin visibility toggles (legend). -->
+        <!-- Per-pin visibility toggles (legend): flow horizontally, wrap down (responsive). -->
         <ItemsControl ItemsSource="{Binding BottomPanel.Analysis.Transient.Series}"
-                      Margin="0,4,0,0"
+                      Margin="0,2,0,0"
                       IsVisible="{Binding BottomPanel.Analysis.Transient.HasResult}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="trace:TimeTraceSeriesViewModel">
-                    <CheckBox IsChecked="{Binding IsVisible}" Margin="0,0,0,1">
-                        <StackPanel Orientation="Horizontal" Spacing="6">
-                            <Border Width="12" Height="12" CornerRadius="2"
-                                    VerticalAlignment="Center"
-                                    Background="{Binding ColorHex}"/>
+                    <CheckBox IsChecked="{Binding IsVisible}" Margin="0,0,10,1">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <Border Width="10" Height="10" CornerRadius="2"
+                                    VerticalAlignment="Center" Background="{Binding ColorHex}"/>
                             <TextBlock Text="{Binding Label}" Foreground="LightGray"
-                                       FontSize="10" VerticalAlignment="Center"/>
+                                       FontSize="9" VerticalAlignment="Center"/>
                         </StackPanel>
                     </CheckBox>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
 
-        <!-- Peak-power summary table (kept from the original text output). -->
-        <ScrollViewer MaxHeight="120" Margin="0,4,0,0"
+        <!-- Peak-power summary table. -->
+        <ScrollViewer MaxHeight="110" Margin="0,2,0,0"
                       IsVisible="{Binding BottomPanel.Analysis.Transient.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
             <TextBlock Text="{Binding BottomPanel.Analysis.Transient.ResultText}"
                        Foreground="Plum" FontFamily="Consolas" FontSize="10"
                        TextWrapping="NoWrap"/>
         </ScrollViewer>
-
-        <!-- Export -->
-        <Button Content="Export CSV"
-                Command="{Binding BottomPanel.Analysis.Transient.ExportCsvCommand}"
-                Width="110" Margin="0,5,0,0" Background="#3d3d5d"
-                IsVisible="{Binding BottomPanel.Analysis.Transient.HasResult}"/>
     </StackPanel>
 
 </UserControl>

--- a/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
@@ -6,23 +6,30 @@
              x:Class="CAP.Avalonia.Views.Panels.TimeDomainPanel"
              x:DataType="vm:MainViewModel">
 
+    <UserControl.Resources>
+        <!-- Drives the min height of NumericUpDown / TextBox / ComboBox in this panel. The Fluent
+             default is 32 px, which is what made the number fields look twice as tall as the Run
+             button; 26 px matches the compact analysis buttons (#570 feedback). Shrinking this
+             (rather than forcing Height) keeps the spinner buttons visible and the text un-clipped. -->
+        <x:Double x:Key="TextControlThemeMinHeight">26</x:Double>
+    </UserControl.Resources>
+
     <UserControl.Styles>
         <!-- Dark hover-tracker so its text is readable on the dark theme. -->
         <Style Selector="oxy|TrackerControl">
             <Setter Property="Background" Value="#2D2D2D"/>
             <Setter Property="LineStroke" Value="#A0A0A0"/>
         </Style>
-        <!-- Compact inputs for the dense analysis dock (#570 feedback): no spinner buttons
-             (type values; arrow keys still increment), natural height, centered content so the
-             number is not clipped. Do NOT force Height on NumericUpDown — it clips the inner text. -->
+        <!-- Compact inputs: spinner buttons kept (just smaller, via the reduced min height),
+             centered content so the number is not clipped. -->
         <Style Selector="NumericUpDown">
-            <Setter Property="ShowButtonSpinner" Value="False"/>
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="Padding" Value="6,0"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.analysis">
-            <Setter Property="Padding" Value="10,3"/>
+            <Setter Property="Height" Value="26"/>
+            <Setter Property="Padding" Value="10,0"/>
             <Setter Property="FontSize" Value="11"/>
         </Style>
     </UserControl.Styles>

--- a/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
@@ -24,45 +24,41 @@
             Linear circuits only (Phase 1).
         </TextBlock>
 
-        <!-- Sweep parameters -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="λ centre (nm):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.CenterWavelengthNm}"
-                           Minimum="800" Maximum="2000" Increment="10"
-                           Width="110" FormatString="F0"/>
-        </StackPanel>
-
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Span (nm):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.SpanNm}"
-                           Minimum="1" Maximum="500" Increment="10"
-                           Width="110" FormatString="F0"/>
-        </StackPanel>
-
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Freq. points:" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.FreqPoints}"
-                           Minimum="16" Maximum="1024" Increment="64"
-                           Width="110" FormatString="F0"/>
-        </StackPanel>
-
-        <!-- Pulse parameters -->
-        <Separator Margin="0,8,0,8" Background="#2d2d2d"/>
-        <TextBlock Text="Gaussian input pulse:" Foreground="Gray" FontSize="10" Margin="0,0,0,4"/>
-
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
-            <TextBlock Text="Centre (ps):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseCenterPs}"
-                           Minimum="0" Maximum="100" Increment="0.5"
-                           Width="110" FormatString="F2"/>
-        </StackPanel>
-
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBlock Text="σ width (ps):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseSigmaPs}"
-                           Minimum="0.01" Maximum="50" Increment="0.1"
-                           Width="110" FormatString="F2"/>
-        </StackPanel>
+        <!-- Parameters: side-by-side (wraps as the dock narrows) so the wide dock width is used
+             and each field is wide enough to show its full value (#570 feedback). Sweep params
+             first, then the Gaussian pulse params. -->
+        <WrapPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="λ centre (nm)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.CenterWavelengthNm}"
+                               Minimum="800" Maximum="2000" Increment="10"
+                               Width="140" FormatString="F0"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="Span (nm)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.SpanNm}"
+                               Minimum="1" Maximum="500" Increment="10"
+                               Width="130" FormatString="F0"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="Freq. points" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.FreqPoints}"
+                               Minimum="16" Maximum="1024" Increment="64"
+                               Width="130" FormatString="F0"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="Pulse centre (ps)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseCenterPs}"
+                               Minimum="0" Maximum="100" Increment="0.5"
+                               Width="140" FormatString="F2"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,16,6">
+                <TextBlock Text="Pulse σ width (ps)" Foreground="Gray" FontSize="10" Margin="0,0,0,2"/>
+                <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseSigmaPs}"
+                               Minimum="0.01" Maximum="50" Increment="0.1"
+                               Width="140" FormatString="F2"/>
+            </StackPanel>
+        </WrapPanel>
 
         <!-- Run button -->
         <Button Content="Run Transient"

--- a/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
@@ -19,27 +19,6 @@
         <Separator Margin="0,20,0,10" Background="#3d3d3d"/>
         <TextBlock Text="Transient (Time-Domain):" Foreground="Plum" Margin="0,0,0,5" FontWeight="SemiBold"/>
 
-        <!-- Mode selector: flips between frequency-domain and time-domain without restart -->
-        <TextBlock Text="Simulation mode:" Foreground="Gray" FontSize="10" Margin="0,0,0,4"/>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8" Spacing="10">
-            <RadioButton Content="Frequency Domain (CW)"
-                         GroupName="TimeDomainMode"
-                         IsChecked="{Binding RightPanel.TimeDomain.IsTimeDomainMode, Converter={x:Static BoolConverters.Not}}"
-                         Foreground="LightGray" FontSize="10"/>
-            <RadioButton Content="Time Domain (Transient)"
-                         GroupName="TimeDomainMode"
-                         IsChecked="{Binding RightPanel.TimeDomain.IsTimeDomainMode}"
-                         Foreground="Plum" FontSize="10"/>
-        </StackPanel>
-
-        <!-- Frequency Domain hint (shown when CW mode is selected) -->
-        <TextBlock Foreground="Gray" FontSize="10" TextWrapping="Wrap" Margin="0,0,0,8"
-                   IsVisible="{Binding RightPanel.TimeDomain.IsTimeDomainMode, Converter={x:Static BoolConverters.Not}}">
-            Use "Run Simulation" (L key) for CW frequency-domain steady-state analysis.
-        </TextBlock>
-
-        <!-- Time-Domain controls (shown when Transient mode is selected) -->
-        <StackPanel IsVisible="{Binding RightPanel.TimeDomain.IsTimeDomainMode}">
         <TextBlock Foreground="Gray" FontSize="10" Margin="0,0,0,8" TextWrapping="Wrap">
             IFFT of S-parameters → impulse response → convolve with Gaussian pulse.
             Linear circuits only (Phase 1).
@@ -48,21 +27,21 @@
         <!-- Sweep parameters -->
         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
             <TextBlock Text="λ centre (nm):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding RightPanel.TimeDomain.CenterWavelengthNm}"
+            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.CenterWavelengthNm}"
                            Minimum="800" Maximum="2000" Increment="10"
                            Width="110" FormatString="F0"/>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
             <TextBlock Text="Span (nm):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding RightPanel.TimeDomain.SpanNm}"
+            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.SpanNm}"
                            Minimum="1" Maximum="500" Increment="10"
                            Width="110" FormatString="F0"/>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
             <TextBlock Text="Freq. points:" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding RightPanel.TimeDomain.FreqPoints}"
+            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.FreqPoints}"
                            Minimum="16" Maximum="1024" Increment="64"
                            Width="110" FormatString="F0"/>
         </StackPanel>
@@ -73,42 +52,42 @@
 
         <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
             <TextBlock Text="Centre (ps):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding RightPanel.TimeDomain.PulseCenterPs}"
+            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseCenterPs}"
                            Minimum="0" Maximum="100" Increment="0.5"
                            Width="110" FormatString="F2"/>
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
             <TextBlock Text="σ width (ps):" Foreground="Gray" VerticalAlignment="Center" Width="100"/>
-            <NumericUpDown Value="{Binding RightPanel.TimeDomain.PulseSigmaPs}"
+            <NumericUpDown Value="{Binding BottomPanel.Analysis.Transient.PulseSigmaPs}"
                            Minimum="0.01" Maximum="50" Increment="0.1"
                            Width="110" FormatString="F2"/>
         </StackPanel>
 
         <!-- Run button -->
         <Button Content="Run Transient"
-                Command="{Binding RightPanel.TimeDomain.RunTransientCommand}"
+                Command="{Binding BottomPanel.Analysis.Transient.RunTransientCommand}"
                 Width="140" Margin="0,0,0,5" Background="#5d3d5d"
-                IsEnabled="{Binding RightPanel.TimeDomain.IsRunning, Converter={x:Static BoolConverters.Not}}"/>
+                IsEnabled="{Binding BottomPanel.Analysis.Transient.IsRunning, Converter={x:Static BoolConverters.Not}}"/>
 
         <!-- Status -->
-        <TextBlock Text="{Binding RightPanel.TimeDomain.StatusText}"
+        <TextBlock Text="{Binding BottomPanel.Analysis.Transient.StatusText}"
                    Foreground="Gray" FontSize="10" Margin="0,0,0,4"
-                   IsVisible="{Binding RightPanel.TimeDomain.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                   IsVisible="{Binding BottomPanel.Analysis.Transient.StatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                    TextWrapping="Wrap"/>
 
         <!-- Waveform plot: power vs time, one series per output pin.
              Zoom/pan via OxyPlot default axes; cursor read-out via tracker. -->
         <Border Background="#1a1a1a" BorderBrush="#3d3d3d" BorderThickness="1"
                 Height="220" Margin="0,4,0,0"
-                IsVisible="{Binding RightPanel.TimeDomain.HasResult}">
-            <oxy:PlotView Model="{Binding RightPanel.TimeDomain.PlotModel}" Background="Transparent"/>
+                IsVisible="{Binding BottomPanel.Analysis.Transient.HasResult}">
+            <oxy:PlotView Model="{Binding BottomPanel.Analysis.Transient.PlotModel}" Background="Transparent"/>
         </Border>
 
         <!-- Per-pin visibility toggles (legend). -->
-        <ItemsControl ItemsSource="{Binding RightPanel.TimeDomain.Series}"
+        <ItemsControl ItemsSource="{Binding BottomPanel.Analysis.Transient.Series}"
                       Margin="0,4,0,0"
-                      IsVisible="{Binding RightPanel.TimeDomain.HasResult}">
+                      IsVisible="{Binding BottomPanel.Analysis.Transient.HasResult}">
             <ItemsControl.ItemTemplate>
                 <DataTemplate x:DataType="trace:TimeTraceSeriesViewModel">
                     <CheckBox IsChecked="{Binding IsVisible}" Margin="0,0,0,1">
@@ -126,18 +105,17 @@
 
         <!-- Peak-power summary table (kept from the original text output). -->
         <ScrollViewer MaxHeight="120" Margin="0,4,0,0"
-                      IsVisible="{Binding RightPanel.TimeDomain.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-            <TextBlock Text="{Binding RightPanel.TimeDomain.ResultText}"
+                      IsVisible="{Binding BottomPanel.Analysis.Transient.ResultText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <TextBlock Text="{Binding BottomPanel.Analysis.Transient.ResultText}"
                        Foreground="Plum" FontFamily="Consolas" FontSize="10"
                        TextWrapping="NoWrap"/>
         </ScrollViewer>
 
         <!-- Export -->
         <Button Content="Export CSV"
-                Command="{Binding RightPanel.TimeDomain.ExportCsvCommand}"
+                Command="{Binding BottomPanel.Analysis.Transient.ExportCsvCommand}"
                 Width="110" Margin="0,5,0,0" Background="#3d3d5d"
-                IsVisible="{Binding RightPanel.TimeDomain.HasResult}"/>
-        </StackPanel><!-- end Time-Domain controls -->
+                IsVisible="{Binding BottomPanel.Analysis.Transient.HasResult}"/>
     </StackPanel>
 
 </UserControl>

--- a/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml
@@ -12,17 +12,17 @@
             <Setter Property="Background" Value="#2D2D2D"/>
             <Setter Property="LineStroke" Value="#A0A0A0"/>
         </Style>
-        <!-- Compact, half-height inputs/buttons for the dense analysis dock (#570 feedback). -->
+        <!-- Compact inputs for the dense analysis dock (#570 feedback): no spinner buttons
+             (type values; arrow keys still increment), natural height, centered content so the
+             number is not clipped. Do NOT force Height on NumericUpDown — it clips the inner text. -->
         <Style Selector="NumericUpDown">
-            <Setter Property="Height" Value="24"/>
-            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="ShowButtonSpinner" Value="False"/>
             <Setter Property="FontSize" Value="11"/>
-            <Setter Property="Padding" Value="4,0"/>
+            <Setter Property="Padding" Value="6,2"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
         <Style Selector="Button.analysis">
-            <Setter Property="Height" Value="24"/>
-            <Setter Property="MinHeight" Value="24"/>
-            <Setter Property="Padding" Value="10,0"/>
+            <Setter Property="Padding" Value="10,3"/>
             <Setter Property="FontSize" Value="11"/>
         </Style>
     </UserControl.Styles>

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/BerEstimator.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/BerEstimator.cs
@@ -1,0 +1,176 @@
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// Estimates Q-factor and bit-error rate from a folded time-domain trace.
+/// At each time offset within the bit period the samples are split by the
+/// decision threshold into mark/space populations; Q = (μ₁ − μ₀)/(σ₁ + σ₀)
+/// and BER = ½·erfc(Q/√2). The optimal sampling instant is where Q peaks.
+/// </summary>
+public static class BerEstimator
+{
+    /// <summary>Q at which the eye is considered "open" (BER ≈ 1e-3); used for the eye-width metric.</summary>
+    public const double MinOpenQFactor = 3.09;
+
+    /// <summary>Cap for reported Q when the populations are noise-free (avoids Infinity in the UI).</summary>
+    public const double MaxReportedQFactor = 1000;
+
+    /// <summary>Minimum samples per level (mark/space) for a statistically usable time bin.</summary>
+    private const int MinSamplesPerLevel = 3;
+
+    /// <summary>
+    /// Estimates the eye metrics of <paramref name="trace"/> folded at <paramref name="bitPeriodSeconds"/>.
+    /// </summary>
+    /// <param name="trace">Intensity trace |E(t)|² from the transient simulation.</param>
+    /// <param name="sampleRateHz">Sample rate of the trace in Hz.</param>
+    /// <param name="bitPeriodSeconds">Bit period in seconds.</param>
+    /// <param name="decisionThreshold">Decision threshold in trace amplitude units.</param>
+    /// <param name="noise">Optional receiver noise added in quadrature to the measured spread.</param>
+    /// <param name="timeBins">Number of time offsets evaluated within the bit period.</param>
+    /// <param name="skipBits">Leading bits skipped (convolution transient).</param>
+    /// <returns>Metrics at the optimal sampling instant; a closed eye yields Q = 0 and BER = 0.5.</returns>
+    public static EyeMetrics Estimate(
+        double[] trace,
+        double sampleRateHz,
+        double bitPeriodSeconds,
+        double decisionThreshold,
+        NoiseModel? noise = null,
+        int timeBins = EyeDiagramBuilder.DefaultTimeBins,
+        int skipBits = EyeDiagramBuilder.DefaultSkipBits)
+    {
+        if (trace == null) throw new ArgumentNullException(nameof(trace));
+        if (sampleRateHz <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        if (bitPeriodSeconds <= 0) throw new ArgumentOutOfRangeException(nameof(bitPeriodSeconds));
+        if (timeBins < 1) throw new ArgumentOutOfRangeException(nameof(timeBins));
+
+        double dt = 1.0 / sampleRateHz;
+        int startSample = Math.Min((int)(skipBits * bitPeriodSeconds * sampleRateHz), trace.Length);
+
+        var bins = FoldIntoBins(trace, startSample, dt, bitPeriodSeconds, timeBins);
+        var qPerBin = bins.Select(b => BinQFactor(b, decisionThreshold, noise)).ToArray();
+
+        int bestBin = ArgMax(qPerBin);
+        double bestQ = qPerBin[bestBin];
+        if (bestQ <= 0)
+            return new EyeMetrics(0, 0.5, 0, 0, 0, 0);
+
+        double binWidth = bitPeriodSeconds / timeBins;
+        double eyeWidth = qPerBin.Count(q => q >= MinOpenQFactor) * binWidth;
+        double eyeHeight = EyeHeightAt(bins[bestBin], decisionThreshold, noise);
+        double jitter = RmsCrossingJitter(trace, startSample, dt, bitPeriodSeconds, decisionThreshold);
+        double ber = 0.5 * Erfc(bestQ / Math.Sqrt(2));
+
+        return new EyeMetrics(bestQ, ber, eyeHeight, eyeWidth, jitter, (bestBin + 0.5) * binWidth);
+    }
+
+    private static List<double>[] FoldIntoBins(
+        double[] trace, int startSample, double dt, double bitPeriodSeconds, int timeBins)
+    {
+        var bins = new List<double>[timeBins];
+        for (int i = 0; i < timeBins; i++) bins[i] = new List<double>();
+
+        for (int n = startSample; n < trace.Length; n++)
+        {
+            double offset = (n * dt) % bitPeriodSeconds;
+            int bin = Math.Min((int)(offset / bitPeriodSeconds * timeBins), timeBins - 1);
+            bins[bin].Add(trace[n]);
+        }
+        return bins;
+    }
+
+    /// <summary>Q of a single time bin, or 0 if either level has too few samples.</summary>
+    private static double BinQFactor(List<double> samples, double threshold, NoiseModel? noise)
+    {
+        var (ok, mu0, sigma0, mu1, sigma1) = LevelStatistics(samples, threshold, noise);
+        if (!ok) return 0;
+
+        double sigmaSum = sigma0 + sigma1;
+        if (sigmaSum <= 0) return MaxReportedQFactor;
+        return Math.Min((mu1 - mu0) / sigmaSum, MaxReportedQFactor);
+    }
+
+    private static double EyeHeightAt(List<double> samples, double threshold, NoiseModel? noise)
+    {
+        const double SigmaMargin = 3.0;
+        var (ok, mu0, sigma0, mu1, sigma1) = LevelStatistics(samples, threshold, noise);
+        if (!ok) return 0;
+        return (mu1 - SigmaMargin * sigma1) - (mu0 + SigmaMargin * sigma0);
+    }
+
+    /// <summary>Mark/space means and standard deviations (noise added in quadrature).</summary>
+    private static (bool Ok, double Mu0, double Sigma0, double Mu1, double Sigma1) LevelStatistics(
+        List<double> samples, double threshold, NoiseModel? noise)
+    {
+        var zeros = samples.Where(v => v < threshold).ToList();
+        var ones = samples.Where(v => v >= threshold).ToList();
+        if (zeros.Count < MinSamplesPerLevel || ones.Count < MinSamplesPerLevel)
+            return (false, 0, 0, 0, 0);
+
+        var (mu0, sigma0) = MeanAndStd(zeros);
+        var (mu1, sigma1) = MeanAndStd(ones);
+
+        if (noise != null)
+        {
+            sigma0 = Quadrature(sigma0, noise.TotalSigmaOpticalPower(mu0));
+            sigma1 = Quadrature(sigma1, noise.TotalSigmaOpticalPower(mu1));
+        }
+        return (true, mu0, sigma0, mu1, sigma1);
+    }
+
+    /// <summary>
+    /// RMS spread of the threshold-crossing instants around their mean position
+    /// within the bit period (crossings are folded to [−T/2, T/2) about the boundary).
+    /// </summary>
+    private static double RmsCrossingJitter(
+        double[] trace, int startSample, double dt, double bitPeriodSeconds, double threshold)
+    {
+        var offsets = new List<double>();
+        for (int n = Math.Max(startSample, 1); n < trace.Length; n++)
+        {
+            double v0 = trace[n - 1], v1 = trace[n];
+            if ((v0 - threshold) * (v1 - threshold) >= 0 || v0 == v1) continue;
+
+            double crossing = ((n - 1) + (threshold - v0) / (v1 - v0)) * dt;
+            double offset = crossing % bitPeriodSeconds;
+            if (offset > bitPeriodSeconds / 2) offset -= bitPeriodSeconds;
+            offsets.Add(offset);
+        }
+        if (offsets.Count < 2) return 0;
+
+        double mean = offsets.Average();
+        return Math.Sqrt(offsets.Average(o => (o - mean) * (o - mean)));
+    }
+
+    private static (double Mean, double Std) MeanAndStd(List<double> values)
+    {
+        double mean = values.Average();
+        double variance = values.Average(v => (v - mean) * (v - mean));
+        return (mean, Math.Sqrt(variance));
+    }
+
+    private static double Quadrature(double a, double b) => Math.Sqrt(a * a + b * b);
+
+    private static int ArgMax(double[] values)
+    {
+        int best = 0;
+        for (int i = 1; i < values.Length; i++)
+            if (values[i] > values[best]) best = i;
+        return best;
+    }
+
+    /// <summary>
+    /// Complementary error function via the Chebyshev-fitted approximation of
+    /// Numerical Recipes (erfcc); fractional accuracy better than 1.2e-7 for all x,
+    /// which is adequate down to BER levels far below 1e-15.
+    /// </summary>
+    /// <param name="x">Argument.</param>
+    public static double Erfc(double x)
+    {
+        double z = Math.Abs(x);
+        double t = 1.0 / (1.0 + 0.5 * z);
+        double ans = t * Math.Exp(-z * z - 1.26551223 +
+            t * (1.00002368 + t * (0.37409196 + t * (0.09678418 +
+            t * (-0.18628806 + t * (0.27886807 + t * (-1.13520398 +
+            t * (1.48851587 + t * (-0.82215223 + t * 0.17087277)))))))));
+        return x >= 0 ? ans : 2.0 - ans;
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/BerEstimator.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/BerEstimator.cs
@@ -43,7 +43,7 @@ public static class BerEstimator
         if (timeBins < 1) throw new ArgumentOutOfRangeException(nameof(timeBins));
 
         double dt = 1.0 / sampleRateHz;
-        int startSample = Math.Min((int)(skipBits * bitPeriodSeconds * sampleRateHz), trace.Length);
+        int startSample = EyeFolding.StartSample(skipBits, bitPeriodSeconds, sampleRateHz, trace.Length);
 
         var bins = FoldIntoBins(trace, startSample, dt, bitPeriodSeconds, timeBins);
         var qPerBin = bins.Select(b => BinQFactor(b, decisionThreshold, noise)).ToArray();
@@ -70,8 +70,7 @@ public static class BerEstimator
 
         for (int n = startSample; n < trace.Length; n++)
         {
-            double offset = (n * dt) % bitPeriodSeconds;
-            int bin = Math.Min((int)(offset / bitPeriodSeconds * timeBins), timeBins - 1);
+            int bin = EyeFolding.TimeBin(n, dt, bitPeriodSeconds, timeBins);
             bins[bin].Add(trace[n]);
         }
         return bins;

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeDiagramBuilder.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeDiagramBuilder.cs
@@ -1,0 +1,82 @@
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// Folds a time-domain intensity trace at the bit-period boundary and
+/// accumulates the overlaid slices into a 2D persistence histogram
+/// (time offset within bit period × amplitude).
+/// </summary>
+public static class EyeDiagramBuilder
+{
+    /// <summary>Default number of time bins per bit period.</summary>
+    public const int DefaultTimeBins = 64;
+
+    /// <summary>Default number of amplitude bins.</summary>
+    public const int DefaultAmplitudeBins = 64;
+
+    /// <summary>Bits skipped at the trace start to discard the convolution transient.</summary>
+    public const int DefaultSkipBits = 2;
+
+    /// <summary>
+    /// Builds the eye histogram from a trace sampled at <paramref name="sampleRateHz"/>.
+    /// </summary>
+    /// <param name="trace">Intensity trace |E(t)|² from the transient simulation.</param>
+    /// <param name="sampleRateHz">Sample rate of the trace in Hz.</param>
+    /// <param name="bitPeriodSeconds">Bit period to fold at (seconds).</param>
+    /// <param name="timeBins">Number of time bins per bit period.</param>
+    /// <param name="amplitudeBins">Number of amplitude bins.</param>
+    /// <param name="skipBits">Leading bits to skip (convolution transient).</param>
+    public static EyeHistogram Build(
+        double[] trace,
+        double sampleRateHz,
+        double bitPeriodSeconds,
+        int timeBins = DefaultTimeBins,
+        int amplitudeBins = DefaultAmplitudeBins,
+        int skipBits = DefaultSkipBits)
+    {
+        ValidateArguments(trace, sampleRateHz, bitPeriodSeconds, timeBins, amplitudeBins);
+
+        double dt = 1.0 / sampleRateHz;
+        int startSample = Math.Min((int)(skipBits * bitPeriodSeconds * sampleRateHz), trace.Length);
+
+        (double min, double max) = AmplitudeRange(trace, startSample);
+        double ampSpan = max - min;
+        var counts = new int[timeBins, amplitudeBins];
+
+        for (int n = startSample; n < trace.Length; n++)
+        {
+            double offset = (n * dt) % bitPeriodSeconds;
+            int timeBin = Math.Min((int)(offset / bitPeriodSeconds * timeBins), timeBins - 1);
+
+            int ampBin = ampSpan <= 0
+                ? 0
+                : Math.Min((int)((trace[n] - min) / ampSpan * amplitudeBins), amplitudeBins - 1);
+
+            counts[timeBin, ampBin]++;
+        }
+
+        return new EyeHistogram(counts, bitPeriodSeconds, min, max);
+    }
+
+    private static void ValidateArguments(
+        double[] trace, double sampleRateHz, double bitPeriodSeconds, int timeBins, int amplitudeBins)
+    {
+        if (trace == null) throw new ArgumentNullException(nameof(trace));
+        if (trace.Length == 0) throw new ArgumentException("Trace must not be empty.", nameof(trace));
+        if (sampleRateHz <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        if (bitPeriodSeconds <= 0) throw new ArgumentOutOfRangeException(nameof(bitPeriodSeconds));
+        if (timeBins < 1) throw new ArgumentOutOfRangeException(nameof(timeBins));
+        if (amplitudeBins < 1) throw new ArgumentOutOfRangeException(nameof(amplitudeBins));
+    }
+
+    private static (double Min, double Max) AmplitudeRange(double[] trace, int startSample)
+    {
+        double min = double.PositiveInfinity, max = double.NegativeInfinity;
+        for (int n = startSample; n < trace.Length; n++)
+        {
+            if (trace[n] < min) min = trace[n];
+            if (trace[n] > max) max = trace[n];
+        }
+        if (double.IsInfinity(min)) { min = 0; max = 0; }
+        return (min, max);
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeDiagramBuilder.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeDiagramBuilder.cs
@@ -36,7 +36,7 @@ public static class EyeDiagramBuilder
         ValidateArguments(trace, sampleRateHz, bitPeriodSeconds, timeBins, amplitudeBins);
 
         double dt = 1.0 / sampleRateHz;
-        int startSample = Math.Min((int)(skipBits * bitPeriodSeconds * sampleRateHz), trace.Length);
+        int startSample = EyeFolding.StartSample(skipBits, bitPeriodSeconds, sampleRateHz, trace.Length);
 
         (double min, double max) = AmplitudeRange(trace, startSample);
         double ampSpan = max - min;
@@ -44,8 +44,7 @@ public static class EyeDiagramBuilder
 
         for (int n = startSample; n < trace.Length; n++)
         {
-            double offset = (n * dt) % bitPeriodSeconds;
-            int timeBin = Math.Min((int)(offset / bitPeriodSeconds * timeBins), timeBins - 1);
+            int timeBin = EyeFolding.TimeBin(n, dt, bitPeriodSeconds, timeBins);
 
             int ampBin = ampSpan <= 0
                 ? 0

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeFolding.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeFolding.cs
@@ -1,0 +1,35 @@
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// Shared time-domain folding math used by <see cref="EyeDiagramBuilder"/> and
+/// <see cref="BerEstimator"/> so both fold a trace at the bit-period boundary
+/// identically. Pure de-duplication — no behavior differs from the previous
+/// per-class implementations.
+/// </summary>
+internal static class EyeFolding
+{
+    /// <summary>
+    /// Index of the first trace sample to include after skipping
+    /// <paramref name="skipBits"/> leading bits (discards the convolution transient).
+    /// </summary>
+    /// <param name="skipBits">Leading bits to skip.</param>
+    /// <param name="bitPeriodSeconds">Bit period in seconds.</param>
+    /// <param name="sampleRateHz">Sample rate of the trace in Hz.</param>
+    /// <param name="traceLength">Length of the trace, used as an upper bound.</param>
+    public static int StartSample(int skipBits, double bitPeriodSeconds, double sampleRateHz, int traceLength)
+        => Math.Min((int)(skipBits * bitPeriodSeconds * sampleRateHz), traceLength);
+
+    /// <summary>
+    /// Time-bin index for sample index <paramref name="sampleIndex"/> when the trace is
+    /// folded at <paramref name="bitPeriodSeconds"/> into <paramref name="timeBins"/> bins.
+    /// </summary>
+    /// <param name="sampleIndex">Absolute sample index in the trace.</param>
+    /// <param name="dt">Sample period in seconds (1 / sample rate).</param>
+    /// <param name="bitPeriodSeconds">Bit period in seconds.</param>
+    /// <param name="timeBins">Number of time bins per bit period.</param>
+    public static int TimeBin(int sampleIndex, double dt, double bitPeriodSeconds, int timeBins)
+    {
+        double offset = (sampleIndex * dt) % bitPeriodSeconds;
+        return Math.Min((int)(offset / bitPeriodSeconds * timeBins), timeBins - 1);
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeHistogram.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeHistogram.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+using System.Text;
+
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// 2D persistence histogram of an eye diagram: sample counts binned by time
+/// offset within the bit period (rows) and by amplitude (columns).
+/// </summary>
+public class EyeHistogram
+{
+    /// <summary>Counts[timeBin, amplitudeBin] — number of trace samples falling into that cell.</summary>
+    public int[,] Counts { get; }
+
+    /// <summary>Number of time bins spanning one bit period.</summary>
+    public int TimeBinCount => Counts.GetLength(0);
+
+    /// <summary>Number of amplitude bins spanning [<see cref="MinAmplitude"/>, <see cref="MaxAmplitude"/>].</summary>
+    public int AmplitudeBinCount => Counts.GetLength(1);
+
+    /// <summary>Bit period in seconds (width of the eye window).</summary>
+    public double BitPeriodSeconds { get; }
+
+    /// <summary>Lower edge of the amplitude axis.</summary>
+    public double MinAmplitude { get; }
+
+    /// <summary>Upper edge of the amplitude axis.</summary>
+    public double MaxAmplitude { get; }
+
+    /// <summary>Initializes a new instance of <see cref="EyeHistogram"/>.</summary>
+    /// <param name="counts">Pre-filled count grid [timeBin, amplitudeBin].</param>
+    /// <param name="bitPeriodSeconds">Bit period in seconds.</param>
+    /// <param name="minAmplitude">Lower amplitude edge.</param>
+    /// <param name="maxAmplitude">Upper amplitude edge.</param>
+    public EyeHistogram(int[,] counts, double bitPeriodSeconds, double minAmplitude, double maxAmplitude)
+    {
+        Counts = counts ?? throw new ArgumentNullException(nameof(counts));
+        BitPeriodSeconds = bitPeriodSeconds;
+        MinAmplitude = minAmplitude;
+        MaxAmplitude = maxAmplitude;
+    }
+
+    /// <summary>
+    /// Serializes the histogram to CSV (invariant culture): one row per time bin,
+    /// first column = time-bin centre in seconds, remaining columns = counts per
+    /// amplitude bin. The header row lists the amplitude-bin centres.
+    /// </summary>
+    public string ToCsv()
+    {
+        var sb = new StringBuilder();
+        var inv = CultureInfo.InvariantCulture;
+
+        sb.Append("time_s");
+        for (int a = 0; a < AmplitudeBinCount; a++)
+            sb.Append(',').Append(AmplitudeBinCenter(a).ToString("G9", inv));
+        sb.AppendLine();
+
+        for (int t = 0; t < TimeBinCount; t++)
+        {
+            sb.Append(TimeBinCenter(t).ToString("G9", inv));
+            for (int a = 0; a < AmplitudeBinCount; a++)
+                sb.Append(',').Append(Counts[t, a].ToString(inv));
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Centre time (seconds within the bit period) of time bin <paramref name="timeBin"/>.</summary>
+    /// <param name="timeBin">Time-bin index.</param>
+    public double TimeBinCenter(int timeBin)
+        => (timeBin + 0.5) * BitPeriodSeconds / TimeBinCount;
+
+    /// <summary>Centre amplitude of amplitude bin <paramref name="amplitudeBin"/>.</summary>
+    /// <param name="amplitudeBin">Amplitude-bin index.</param>
+    public double AmplitudeBinCenter(int amplitudeBin)
+        => MinAmplitude + (amplitudeBin + 0.5) * (MaxAmplitude - MinAmplitude) / AmplitudeBinCount;
+}

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeMetrics.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeMetrics.cs
@@ -1,0 +1,18 @@
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// Numeric summary of an eye diagram at the optimal sampling instant.
+/// </summary>
+/// <param name="QFactor">Q = (μ₁ − μ₀) / (σ₁ + σ₀) at the optimal sampling instant.</param>
+/// <param name="BerEstimate">Estimated bit-error rate = ½·erfc(Q/√2).</param>
+/// <param name="EyeHeight">Vertical eye opening (μ₁ − 3σ₁) − (μ₀ + 3σ₀) in trace amplitude units; ≤ 0 means closed.</param>
+/// <param name="EyeWidthSeconds">Horizontal span of the bit period where the eye stays open (Q ≥ 3.09, i.e. BER ≤ 1e-3).</param>
+/// <param name="RmsJitterSeconds">RMS deviation of the threshold-crossing times from the bit boundary.</param>
+/// <param name="OptimalSampleOffsetSeconds">Time offset within the bit period where Q is maximal.</param>
+public record EyeMetrics(
+    double QFactor,
+    double BerEstimate,
+    double EyeHeight,
+    double EyeWidthSeconds,
+    double RmsJitterSeconds,
+    double OptimalSampleOffsetSeconds);

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeSimulationPlan.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/EyeSimulationPlan.cs
@@ -1,0 +1,70 @@
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// Maps a user-chosen bit rate onto the fixed sample grid of a transient
+/// simulation: how many samples per bit, how many bits fit within the sample
+/// budget, and the resulting (grid-aligned) bit period.
+/// </summary>
+public class EyeSimulationPlan
+{
+    /// <summary>Fewest samples per bit for a meaningful eye (below this the bit rate exceeds the simulated bandwidth).</summary>
+    public const int MinSamplesPerBit = 4;
+
+    /// <summary>Fewest bits required for meaningful eye statistics.</summary>
+    public const int MinBits = 16;
+
+    /// <summary>Upper bound on total samples so pattern length × oversampling stays tractable (2^20).</summary>
+    public const int MaxTotalSamples = 1 << 20;
+
+    /// <summary>Samples per bit period (integer, so bit boundaries align with the sample grid).</summary>
+    public int SamplesPerBit { get; }
+
+    /// <summary>Number of bits actually simulated (pattern may be truncated to fit the sample budget).</summary>
+    public int BitCount { get; }
+
+    /// <summary>Total samples = <see cref="BitCount"/> × <see cref="SamplesPerBit"/>.</summary>
+    public int TotalSamples => BitCount * SamplesPerBit;
+
+    /// <summary>Grid-aligned bit period in seconds = SamplesPerBit / sample rate.</summary>
+    public double BitPeriodSeconds { get; }
+
+    private EyeSimulationPlan(int samplesPerBit, int bitCount, double bitPeriodSeconds)
+    {
+        SamplesPerBit = samplesPerBit;
+        BitCount = bitCount;
+        BitPeriodSeconds = bitPeriodSeconds;
+    }
+
+    /// <summary>
+    /// Creates a plan for the given bit rate on a sample grid of <paramref name="sampleRateHz"/>.
+    /// </summary>
+    /// <param name="bitRateHz">Target bit rate in bit/s.</param>
+    /// <param name="sampleRateHz">Simulation sample rate in Hz (from the wavelength sweep bandwidth).</param>
+    /// <param name="patternBits">Full PRBS pattern length; truncated if it exceeds the sample budget.</param>
+    /// <exception cref="InvalidOperationException">
+    /// If the bit rate is too high (fewer than <see cref="MinSamplesPerBit"/> samples per bit)
+    /// or too low (fewer than <see cref="MinBits"/> bits fit into <see cref="MaxTotalSamples"/>).
+    /// </exception>
+    public static EyeSimulationPlan Create(double bitRateHz, double sampleRateHz, int patternBits)
+    {
+        if (bitRateHz <= 0) throw new ArgumentOutOfRangeException(nameof(bitRateHz));
+        if (sampleRateHz <= 0) throw new ArgumentOutOfRangeException(nameof(sampleRateHz));
+        if (patternBits <= 0) throw new ArgumentOutOfRangeException(nameof(patternBits));
+
+        double idealSamplesPerBit = sampleRateHz / bitRateHz;
+        int samplesPerBit = (int)Math.Round(idealSamplesPerBit);
+
+        if (samplesPerBit < MinSamplesPerBit)
+            throw new InvalidOperationException(
+                $"Bit rate too high: only {idealSamplesPerBit:F1} samples per bit at the simulated bandwidth " +
+                $"(need ≥ {MinSamplesPerBit}). Lower the bit rate or widen the wavelength span.");
+
+        int bitCount = Math.Min(patternBits, MaxTotalSamples / samplesPerBit);
+        if (bitCount < MinBits)
+            throw new InvalidOperationException(
+                $"Bit rate too low: only {bitCount} bits fit into the sample budget " +
+                $"(need ≥ {MinBits}). Increase the bit rate.");
+
+        return new EyeSimulationPlan(samplesPerBit, bitCount, samplesPerBit / sampleRateHz);
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/NoiseModel.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/NoiseModel.cs
@@ -1,0 +1,60 @@
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// Additive Gaussian receiver-noise model for direct detection: photodiode shot
+/// noise, thermal (Johnson) noise of the load, and laser RIN. All contributions
+/// are computed as photocurrent standard deviations and converted back to
+/// optical-power units via the responsivity, so they can be combined directly
+/// with the optical eye-diagram amplitudes.
+/// </summary>
+public class NoiseModel
+{
+    private const double ElementaryChargeCoulomb = 1.602176634e-19;
+    private const double BoltzmannJoulePerKelvin = 1.380649e-23;
+    private const double DecibelsPerDecade = 10.0;
+
+    /// <summary>Photodiode responsivity in A/W (typical InGaAs PIN ≈ 0.8).</summary>
+    public double ResponsivityAPerW { get; init; } = 0.8;
+
+    /// <summary>Receiver electrical bandwidth in Hz (typically ≈ 0.75 × bit rate).</summary>
+    public double BandwidthHz { get; init; } = 18.75e9;
+
+    /// <summary>Laser relative intensity noise in dB/Hz (typical DFB ≈ −145).</summary>
+    public double RinDbPerHz { get; init; } = -145;
+
+    /// <summary>Receiver temperature in Kelvin.</summary>
+    public double TemperatureKelvin { get; init; } = 300;
+
+    /// <summary>Transimpedance / load resistance in Ohm.</summary>
+    public double LoadResistanceOhm { get; init; } = 50;
+
+    /// <summary>Shot-noise photocurrent σ in A at the given optical power: σ² = 2·q·R·P·B.</summary>
+    /// <param name="opticalPowerW">Received optical power in W (clamped at 0).</param>
+    public double ShotNoiseSigmaAmpere(double opticalPowerW)
+        => Math.Sqrt(2 * ElementaryChargeCoulomb * ResponsivityAPerW * Math.Max(opticalPowerW, 0) * BandwidthHz);
+
+    /// <summary>Thermal-noise photocurrent σ in A: σ² = 4·k·T·B / R_load.</summary>
+    public double ThermalNoiseSigmaAmpere()
+        => Math.Sqrt(4 * BoltzmannJoulePerKelvin * TemperatureKelvin * BandwidthHz / LoadResistanceOhm);
+
+    /// <summary>RIN photocurrent σ in A: σ² = 10^(RIN/10) · (R·P)² · B.</summary>
+    /// <param name="opticalPowerW">Received optical power in W (clamped at 0).</param>
+    public double RinNoiseSigmaAmpere(double opticalPowerW)
+    {
+        double photocurrent = ResponsivityAPerW * Math.Max(opticalPowerW, 0);
+        return Math.Sqrt(Math.Pow(10, RinDbPerHz / DecibelsPerDecade) * photocurrent * photocurrent * BandwidthHz);
+    }
+
+    /// <summary>
+    /// Total noise σ expressed in optical-power units (W): the quadrature sum of
+    /// shot, thermal, and RIN photocurrent noise divided by the responsivity.
+    /// </summary>
+    /// <param name="opticalPowerW">Received optical power in W at the sampling instant.</param>
+    public double TotalSigmaOpticalPower(double opticalPowerW)
+    {
+        double shot = ShotNoiseSigmaAmpere(opticalPowerW);
+        double thermal = ThermalNoiseSigmaAmpere();
+        double rin = RinNoiseSigmaAmpere(opticalPowerW);
+        return Math.Sqrt(shot * shot + thermal * thermal + rin * rin) / ResponsivityAPerW;
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/EyeDiagram/PrbsGenerator.cs
+++ b/Connect-A-Pic-Core/Analysis/EyeDiagram/PrbsGenerator.cs
@@ -1,0 +1,89 @@
+namespace CAP_Core.Analysis.EyeDiagram;
+
+/// <summary>
+/// Standard PRBS (pseudo-random binary sequence) polynomial orders per ITU-T O.150.
+/// The enum value equals the shift-register length n; the pattern repeats every 2^n − 1 bits.
+/// </summary>
+public enum PrbsOrder
+{
+    /// <summary>x⁷ + x⁶ + 1 — 127-bit pattern.</summary>
+    Prbs7 = 7,
+
+    /// <summary>x¹¹ + x⁹ + 1 — 2047-bit pattern.</summary>
+    Prbs11 = 11,
+
+    /// <summary>x²³ + x¹⁸ + 1 — 8 388 607-bit pattern.</summary>
+    Prbs23 = 23,
+}
+
+/// <summary>
+/// Generates PRBS bit patterns via a Fibonacci LFSR and expands them into
+/// NRZ (non-return-to-zero) sample streams for transient simulation.
+/// </summary>
+public static class PrbsGenerator
+{
+    /// <summary>Second feedback tap (first tap is the register length itself).</summary>
+    private const int Prbs7SecondTap = 6;
+    private const int Prbs11SecondTap = 9;
+    private const int Prbs23SecondTap = 18;
+
+    /// <summary>Full pattern length 2^n − 1 for the given order.</summary>
+    /// <param name="order">PRBS order.</param>
+    public static int PatternLength(PrbsOrder order) => (1 << (int)order) - 1;
+
+    /// <summary>
+    /// Generates the first <paramref name="bitCount"/> bits of the PRBS pattern.
+    /// The LFSR is seeded with all ones, so the sequence is deterministic.
+    /// </summary>
+    /// <param name="order">PRBS order (register length and taps).</param>
+    /// <param name="bitCount">Number of bits to emit (may be less than the full pattern length).</param>
+    public static bool[] GenerateBits(PrbsOrder order, int bitCount)
+    {
+        if (bitCount <= 0) throw new ArgumentOutOfRangeException(nameof(bitCount));
+
+        int length = (int)order;
+        int secondTap = order switch
+        {
+            PrbsOrder.Prbs7 => Prbs7SecondTap,
+            PrbsOrder.Prbs11 => Prbs11SecondTap,
+            PrbsOrder.Prbs23 => Prbs23SecondTap,
+            _ => throw new ArgumentOutOfRangeException(nameof(order)),
+        };
+
+        // Fibonacci LFSR: bit i of `state` holds register stage i+1; seed = all ones.
+        // feedback = stage(length) XOR stage(secondTap); new bit shifts in at stage 1.
+        uint mask = (1u << length) - 1;
+        uint state = mask;
+        var bits = new bool[bitCount];
+        for (int i = 0; i < bitCount; i++)
+        {
+            bits[i] = (state & 1) == 1;
+            uint feedback = ((state >> (length - 1)) ^ (state >> (secondTap - 1))) & 1;
+            state = ((state << 1) | feedback) & mask;
+        }
+        return bits;
+    }
+
+    /// <summary>
+    /// Expands a bit pattern into an NRZ sample stream: each bit is held constant
+    /// for <paramref name="samplesPerBit"/> samples at <paramref name="amplitude"/> (one) or 0 (zero).
+    /// </summary>
+    /// <param name="bits">Bit pattern to expand.</param>
+    /// <param name="samplesPerBit">Samples per bit period (≥ 1).</param>
+    /// <param name="amplitude">Sample value representing a logical one.</param>
+    public static double[] ToNrzSamples(bool[] bits, int samplesPerBit, double amplitude)
+    {
+        if (bits == null) throw new ArgumentNullException(nameof(bits));
+        if (samplesPerBit < 1) throw new ArgumentOutOfRangeException(nameof(samplesPerBit));
+
+        var samples = new double[bits.Length * samplesPerBit];
+        for (int bit = 0; bit < bits.Length; bit++)
+        {
+            if (!bits[bit]) continue;
+            int start = bit * samplesPerBit;
+            for (int s = 0; s < samplesPerBit; s++)
+                samples[start + s] = amplitude;
+        }
+        return samples;
+    }
+}

--- a/UnitTests/Analysis/EyeDiagram/BerEstimatorTests.cs
+++ b/UnitTests/Analysis/EyeDiagram/BerEstimatorTests.cs
@@ -1,0 +1,135 @@
+using CAP_Core.Analysis.EyeDiagram;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.EyeDiagram;
+
+public class BerEstimatorTests
+{
+    private const double SampleRate = 1e12;
+    private const int SamplesPerBit = 16;
+    private const double BitPeriod = SamplesPerBit / SampleRate;
+    private const int TimeBins = 16;
+    private const int BitCount = 127;
+
+    /// <summary>PRBS-7 NRZ trace with seeded additive Gaussian noise (deterministic).</summary>
+    private static double[] NoisyNrzTrace(double amplitude, double noiseSigma, int seed = 42)
+    {
+        var bits = PrbsGenerator.GenerateBits(PrbsOrder.Prbs7, BitCount);
+        var samples = PrbsGenerator.ToNrzSamples(bits, SamplesPerBit, amplitude);
+        var rng = new Random(seed);
+        for (int i = 0; i < samples.Length; i++)
+            samples[i] += NextGaussian(rng) * noiseSigma;
+        return samples;
+    }
+
+    private static double NextGaussian(Random rng)
+    {
+        double u1 = 1.0 - rng.NextDouble();
+        double u2 = rng.NextDouble();
+        return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+    }
+
+    private static EyeMetrics Estimate(double[] trace, double threshold, NoiseModel? noise = null)
+        => BerEstimator.Estimate(trace, SampleRate, BitPeriod, threshold, noise, TimeBins);
+
+    [Theory]
+    [InlineData(0.0, 1.0)]
+    [InlineData(1.0, 0.15729921)]
+    [InlineData(-1.0, 1.84270079)]
+    [InlineData(3.0, 2.209e-5)]
+    public void Erfc_MatchesReferenceValues(double x, double expected)
+    {
+        BerEstimator.Erfc(x).ShouldBe(expected, Math.Max(Math.Abs(expected) * 1e-5, 1e-9));
+    }
+
+    [Fact]
+    public void CleanEye_HasHighQAndNegligibleBer()
+    {
+        // Back-to-back link: clean two-level signal with tiny spread → BER ≪ 1e-12.
+        var trace = NoisyNrzTrace(amplitude: 1.0, noiseSigma: 0.01);
+
+        var metrics = Estimate(trace, threshold: 0.5);
+
+        metrics.QFactor.ShouldBeGreaterThan(7.0);
+        metrics.BerEstimate.ShouldBeLessThan(1e-12);
+        metrics.EyeHeight.ShouldBeGreaterThan(0.5);
+    }
+
+    [Fact]
+    public void Ber_IncreasesMonotonicallyWithAttenuation()
+    {
+        // Fixed receiver noise, shrinking signal → BER must rise monotonically.
+        const double NoiseSigma = 0.05;
+        var berByAmplitude = new[] { 1.0, 0.5, 0.25 }
+            .Select(amp => Estimate(NoisyNrzTrace(amp, NoiseSigma), threshold: amp / 2).BerEstimate)
+            .ToArray();
+
+        berByAmplitude[1].ShouldBeGreaterThan(berByAmplitude[0]);
+        berByAmplitude[2].ShouldBeGreaterThan(berByAmplitude[1]);
+    }
+
+    [Fact]
+    public void NoiseModel_RaisesBerComparedToNoiselessEstimate()
+    {
+        var trace = NoisyNrzTrace(amplitude: 1.0, noiseSigma: 0.01);
+        var heavyNoise = new NoiseModel
+        {
+            BandwidthHz = 18.75e9,
+            RinDbPerHz = -100, // very noisy laser → RIN dominates
+        };
+
+        var without = Estimate(trace, threshold: 0.5);
+        var with = Estimate(trace, threshold: 0.5, heavyNoise);
+
+        with.QFactor.ShouldBeLessThan(without.QFactor);
+        with.BerEstimate.ShouldBeGreaterThanOrEqualTo(without.BerEstimate);
+    }
+
+    [Fact]
+    public void ClosedEye_ReturnsQZeroAndBerHalf()
+    {
+        var trace = Enumerable.Repeat(1.0, BitCount * SamplesPerBit).ToArray();
+
+        var metrics = Estimate(trace, threshold: 0.5);
+
+        metrics.QFactor.ShouldBe(0);
+        metrics.BerEstimate.ShouldBe(0.5);
+        metrics.EyeWidthSeconds.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CleanEye_IsOpenAcrossTheFullBitPeriod()
+    {
+        var trace = NoisyNrzTrace(amplitude: 1.0, noiseSigma: 0.01);
+
+        var metrics = Estimate(trace, threshold: 0.5);
+
+        metrics.EyeWidthSeconds.ShouldBeGreaterThanOrEqualTo(0.9 * BitPeriod);
+        metrics.OptimalSampleOffsetSeconds.ShouldBeInRange(0, BitPeriod);
+    }
+
+    [Fact]
+    public void CleanEye_HasNegligibleJitter()
+    {
+        // Ideal NRZ transitions cross the threshold at identical interpolated
+        // instants each bit, so the RMS jitter must be far below one sample.
+        var trace = NoisyNrzTrace(amplitude: 1.0, noiseSigma: 0.001);
+
+        var metrics = Estimate(trace, threshold: 0.5);
+
+        metrics.RmsJitterSeconds.ShouldBeLessThan(1.0 / SampleRate);
+    }
+
+    [Fact]
+    public void EmptyLevel_YieldsClosedEyeInsteadOfCrashing()
+    {
+        // All-zeros trace with noise: no marks above threshold anywhere.
+        var trace = NoisyNrzTrace(amplitude: 0.0, noiseSigma: 0.001);
+
+        var metrics = Estimate(trace, threshold: 0.5);
+
+        metrics.QFactor.ShouldBe(0);
+        metrics.BerEstimate.ShouldBe(0.5);
+    }
+}

--- a/UnitTests/Analysis/EyeDiagram/EyeDiagramBuilderTests.cs
+++ b/UnitTests/Analysis/EyeDiagram/EyeDiagramBuilderTests.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using CAP_Core.Analysis.EyeDiagram;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.EyeDiagram;
+
+public class EyeDiagramBuilderTests
+{
+    private const double SampleRate = 1e12;
+    private const int SamplesPerBit = 20;
+    private const double BitPeriod = SamplesPerBit / SampleRate;
+
+    private static double[] AlternatingNrzTrace(int bitCount, double amplitude = 1.0)
+    {
+        var bits = Enumerable.Range(0, bitCount).Select(i => i % 2 == 0).ToArray();
+        return PrbsGenerator.ToNrzSamples(bits, SamplesPerBit, amplitude);
+    }
+
+    [Fact]
+    public void Build_TotalCountsEqualNonSkippedSamples()
+    {
+        var trace = AlternatingNrzTrace(bitCount: 32);
+
+        var histogram = EyeDiagramBuilder.Build(trace, SampleRate, BitPeriod, skipBits: 2);
+
+        int total = 0;
+        for (int t = 0; t < histogram.TimeBinCount; t++)
+            for (int a = 0; a < histogram.AmplitudeBinCount; a++)
+                total += histogram.Counts[t, a];
+
+        total.ShouldBe(trace.Length - 2 * SamplesPerBit);
+    }
+
+    [Fact]
+    public void Build_TwoLevelSignal_OccupiesOnlyExtremeAmplitudeBins()
+    {
+        var trace = AlternatingNrzTrace(bitCount: 32);
+
+        var histogram = EyeDiagramBuilder.Build(trace, SampleRate, BitPeriod, amplitudeBins: 8);
+
+        for (int t = 0; t < histogram.TimeBinCount; t++)
+            for (int a = 1; a < histogram.AmplitudeBinCount - 1; a++)
+                histogram.Counts[t, a].ShouldBe(0, $"unexpected count in middle bin ({t},{a})");
+    }
+
+    [Fact]
+    public void Build_AmplitudeRange_MatchesTraceExtremes()
+    {
+        var trace = AlternatingNrzTrace(bitCount: 32, amplitude: 2.5);
+
+        var histogram = EyeDiagramBuilder.Build(trace, SampleRate, BitPeriod);
+
+        histogram.MinAmplitude.ShouldBe(0);
+        histogram.MaxAmplitude.ShouldBe(2.5);
+        histogram.BitPeriodSeconds.ShouldBe(BitPeriod);
+    }
+
+    [Fact]
+    public void Build_ConstantTrace_PutsAllCountsInFirstAmplitudeBin()
+    {
+        var trace = Enumerable.Repeat(1.0, 200).ToArray();
+
+        var histogram = EyeDiagramBuilder.Build(trace, SampleRate, BitPeriod, skipBits: 0);
+
+        int firstBinTotal = 0;
+        for (int t = 0; t < histogram.TimeBinCount; t++)
+            firstBinTotal += histogram.Counts[t, 0];
+        firstBinTotal.ShouldBe(200);
+    }
+
+    [Fact]
+    public void Build_EmptyTrace_Throws()
+    {
+        Should.Throw<ArgumentException>(
+            () => EyeDiagramBuilder.Build(Array.Empty<double>(), SampleRate, BitPeriod));
+    }
+
+    [Fact]
+    public void ToCsv_UsesInvariantCulture_RegardlessOfThreadCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            var trace = AlternatingNrzTrace(bitCount: 32, amplitude: 1.5);
+            var histogram = EyeDiagramBuilder.Build(trace, SampleRate, BitPeriod);
+
+            var csv = histogram.ToCsv();
+
+            csv.ShouldStartWith("time_s");
+            csv.ShouldNotContain(";");
+            // German decimal comma would corrupt the comma-separated layout:
+            // every row must have exactly AmplitudeBinCount + 1 columns.
+            var firstDataRow = csv.Split('\n')[1].TrimEnd('\r');
+            firstDataRow.Split(',').Length.ShouldBe(histogram.AmplitudeBinCount + 1);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}

--- a/UnitTests/Analysis/EyeDiagram/EyeSimulationPlanTests.cs
+++ b/UnitTests/Analysis/EyeDiagram/EyeSimulationPlanTests.cs
@@ -1,0 +1,67 @@
+using CAP_Core.Analysis.EyeDiagram;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.EyeDiagram;
+
+public class EyeSimulationPlanTests
+{
+    private const double SampleRate = 12.5e12; // ~100 nm span around 1550 nm
+
+    [Fact]
+    public void Create_25Gbps_Yields500SamplesPerBit()
+    {
+        var plan = EyeSimulationPlan.Create(25e9, SampleRate, patternBits: 127);
+
+        plan.SamplesPerBit.ShouldBe(500);
+        plan.BitCount.ShouldBe(127);
+        plan.TotalSamples.ShouldBe(127 * 500);
+        plan.BitPeriodSeconds.ShouldBe(500 / SampleRate, 1e-20);
+    }
+
+    [Fact]
+    public void Create_BitPeriodAlignsWithSampleGrid()
+    {
+        var plan = EyeSimulationPlan.Create(30e9, SampleRate, patternBits: 127);
+
+        // Bit period must be an integer number of samples so folding is exact.
+        (plan.BitPeriodSeconds * SampleRate).ShouldBe(plan.SamplesPerBit, 1e-9);
+    }
+
+    [Fact]
+    public void Create_PatternExceedingSampleBudget_IsTruncated()
+    {
+        int prbs23Length = PrbsGenerator.PatternLength(PrbsOrder.Prbs23);
+
+        var plan = EyeSimulationPlan.Create(25e9, SampleRate, prbs23Length);
+
+        plan.BitCount.ShouldBeLessThan(prbs23Length);
+        plan.TotalSamples.ShouldBeLessThanOrEqualTo(EyeSimulationPlan.MaxTotalSamples);
+    }
+
+    [Fact]
+    public void Create_BitRateAboveBandwidth_Throws()
+    {
+        // 5 Tbps on a 12.5 THz grid → 2.5 samples/bit → too few.
+        Should.Throw<InvalidOperationException>(
+            () => EyeSimulationPlan.Create(5e12, SampleRate, 127));
+    }
+
+    [Fact]
+    public void Create_BitRateTooLowForSampleBudget_Throws()
+    {
+        // 1 Mbps → 12.5e6 samples/bit → fewer than MinBits fit into the budget.
+        Should.Throw<InvalidOperationException>(
+            () => EyeSimulationPlan.Create(1e6, SampleRate, 127));
+    }
+
+    [Theory]
+    [InlineData(0, SampleRate, 127)]
+    [InlineData(25e9, 0, 127)]
+    [InlineData(25e9, SampleRate, 0)]
+    public void Create_InvalidArguments_Throw(double bitRate, double sampleRate, int patternBits)
+    {
+        Should.Throw<ArgumentOutOfRangeException>(
+            () => EyeSimulationPlan.Create(bitRate, sampleRate, patternBits));
+    }
+}

--- a/UnitTests/Analysis/EyeDiagram/NoiseModelTests.cs
+++ b/UnitTests/Analysis/EyeDiagram/NoiseModelTests.cs
@@ -1,0 +1,89 @@
+using CAP_Core.Analysis.EyeDiagram;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.EyeDiagram;
+
+public class NoiseModelTests
+{
+    private static NoiseModel CreateModel() => new()
+    {
+        ResponsivityAPerW = 0.8,
+        BandwidthHz = 18.75e9,
+        RinDbPerHz = -145,
+        TemperatureKelvin = 300,
+        LoadResistanceOhm = 50,
+    };
+
+    [Fact]
+    public void ShotNoise_GrowsWithSquareRootOfPower()
+    {
+        var model = CreateModel();
+
+        double sigma1 = model.ShotNoiseSigmaAmpere(1e-3);
+        double sigma4 = model.ShotNoiseSigmaAmpere(4e-3);
+
+        sigma4.ShouldBe(2 * sigma1, sigma1 * 1e-9);
+    }
+
+    [Fact]
+    public void ShotNoise_MatchesTextbookFormula()
+    {
+        var model = CreateModel();
+
+        // σ² = 2 q R P B with q = 1.602e-19, R = 0.8, P = 1 mW, B = 18.75 GHz
+        double expected = Math.Sqrt(2 * 1.602176634e-19 * 0.8 * 1e-3 * 18.75e9);
+        model.ShotNoiseSigmaAmpere(1e-3).ShouldBe(expected, expected * 1e-9);
+    }
+
+    [Fact]
+    public void ThermalNoise_IsIndependentOfPower()
+    {
+        var model = CreateModel();
+
+        double expected = Math.Sqrt(4 * 1.380649e-23 * 300 * 18.75e9 / 50);
+        model.ThermalNoiseSigmaAmpere().ShouldBe(expected, expected * 1e-9);
+    }
+
+    [Fact]
+    public void RinNoise_ScalesLinearlyWithPower()
+    {
+        var model = CreateModel();
+
+        double sigma1 = model.RinNoiseSigmaAmpere(1e-3);
+        double sigma2 = model.RinNoiseSigmaAmpere(2e-3);
+
+        sigma2.ShouldBe(2 * sigma1, sigma1 * 1e-9);
+    }
+
+    [Fact]
+    public void TotalSigma_AtZeroPower_ReducesToThermalNoise()
+    {
+        var model = CreateModel();
+
+        double expected = model.ThermalNoiseSigmaAmpere() / model.ResponsivityAPerW;
+        model.TotalSigmaOpticalPower(0).ShouldBe(expected, expected * 1e-9);
+    }
+
+    [Fact]
+    public void TotalSigma_IncreasesMonotonicallyWithPower()
+    {
+        var model = CreateModel();
+
+        double low = model.TotalSigmaOpticalPower(1e-4);
+        double mid = model.TotalSigmaOpticalPower(1e-3);
+        double high = model.TotalSigmaOpticalPower(1e-2);
+
+        mid.ShouldBeGreaterThan(low);
+        high.ShouldBeGreaterThan(mid);
+    }
+
+    [Fact]
+    public void NegativePower_IsClampedToZero()
+    {
+        var model = CreateModel();
+
+        model.ShotNoiseSigmaAmpere(-1).ShouldBe(0);
+        model.RinNoiseSigmaAmpere(-1).ShouldBe(0);
+    }
+}

--- a/UnitTests/Analysis/EyeDiagram/PrbsGeneratorTests.cs
+++ b/UnitTests/Analysis/EyeDiagram/PrbsGeneratorTests.cs
@@ -1,0 +1,85 @@
+using CAP_Core.Analysis.EyeDiagram;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.EyeDiagram;
+
+public class PrbsGeneratorTests
+{
+    [Theory]
+    [InlineData(PrbsOrder.Prbs7, 127)]
+    [InlineData(PrbsOrder.Prbs11, 2047)]
+    [InlineData(PrbsOrder.Prbs23, 8_388_607)]
+    public void PatternLength_MatchesTwoToTheNMinusOne(PrbsOrder order, int expected)
+    {
+        PrbsGenerator.PatternLength(order).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateBits_Prbs7_IsBalancedOverOnePeriod()
+    {
+        var bits = PrbsGenerator.GenerateBits(PrbsOrder.Prbs7, 127);
+
+        // Maximal-length LFSR: 2^(n-1) ones and 2^(n-1) - 1 zeros per period.
+        bits.Count(b => b).ShouldBe(64);
+        bits.Count(b => !b).ShouldBe(63);
+    }
+
+    [Fact]
+    public void GenerateBits_Prbs7_RepeatsWithPeriod127()
+    {
+        var bits = PrbsGenerator.GenerateBits(PrbsOrder.Prbs7, 254);
+
+        for (int i = 0; i < 127; i++)
+            bits[i + 127].ShouldBe(bits[i], $"bit {i} differs from bit {i + 127}");
+    }
+
+    [Fact]
+    public void GenerateBits_Prbs7_DoesNotRepeatEarlierThanFullPeriod()
+    {
+        var bits = PrbsGenerator.GenerateBits(PrbsOrder.Prbs7, 127);
+
+        // A maximal-length LFSR has cyclic period exactly 127: no cyclic shift
+        // of the period maps the sequence onto itself.
+        bits.Distinct().Count().ShouldBe(2);
+        Enumerable.Range(1, 126).Any(shift =>
+            Enumerable.Range(0, 127).All(i => bits[i] == bits[(i + shift) % 127]))
+            .ShouldBeFalse("sequence repeated with a cyclic period shorter than 127");
+    }
+
+    [Fact]
+    public void GenerateBits_IsDeterministic()
+    {
+        var first = PrbsGenerator.GenerateBits(PrbsOrder.Prbs11, 500);
+        var second = PrbsGenerator.GenerateBits(PrbsOrder.Prbs11, 500);
+
+        first.ShouldBe(second);
+    }
+
+    [Fact]
+    public void GenerateBits_InvalidBitCount_Throws()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(
+            () => PrbsGenerator.GenerateBits(PrbsOrder.Prbs7, 0));
+    }
+
+    [Fact]
+    public void ToNrzSamples_ExpandsEachBitToSamplesPerBit()
+    {
+        var bits = new[] { true, false, true };
+
+        var samples = PrbsGenerator.ToNrzSamples(bits, samplesPerBit: 4, amplitude: 2.5);
+
+        samples.Length.ShouldBe(12);
+        samples.Take(4).ShouldAllBe(s => s == 2.5);
+        samples.Skip(4).Take(4).ShouldAllBe(s => s == 0.0);
+        samples.Skip(8).ShouldAllBe(s => s == 2.5);
+    }
+
+    [Fact]
+    public void ToNrzSamples_InvalidSamplesPerBit_Throws()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(
+            () => PrbsGenerator.ToNrzSamples(new[] { true }, 0, 1.0));
+    }
+}

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -149,8 +149,7 @@ public static class MainViewModelTestHelper
             new ComponentEditorFactory(new IComponentEditorProvider[]
             {
                 new GenericComponentEditorProvider()
-            }),
-            new TimeDomainViewModel());
+            }));
     }
 
     /// <summary>

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -5,6 +5,7 @@ using CAP.Avalonia.Controls.Canvas.ComponentPreview;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Analysis;
+using CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
 using CAP.Avalonia.ViewModels.Analysis.OnaAnalysis;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Diagnostics;
@@ -168,6 +169,7 @@ public static class MainViewModelTestHelper
             commandManager,
             new WaveguideLengthViewModel(),
             new ElementLockViewModel(),
-            new ErrorConsoleViewModel(errorConsoleService));
+            new ErrorConsoleViewModel(errorConsoleService),
+            new AnalysisDockViewModel(new TimeDomainViewModel(), new EyeDiagramViewModel()));
     }
 }

--- a/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
+++ b/UnitTests/ViewModels/PanelWidthPersistenceTests.cs
@@ -77,8 +77,7 @@ public class PanelWidthPersistenceTests : IDisposable
             new ComponentEditorFactory(new IComponentEditorProvider[]
             {
                 new GenericComponentEditorProvider()
-            }),
-            new TimeDomainViewModel());
+            }));
 
     [Fact]
     public void LeftPanelWidth_DefaultsTo220()

--- a/UnitTests/ViewModels/Panels/AnalysisDockViewModelTests.cs
+++ b/UnitTests/ViewModels/Panels/AnalysisDockViewModelTests.cs
@@ -1,0 +1,38 @@
+using CAP.Avalonia.ViewModels.Analysis;
+using CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
+using CAP.Avalonia.ViewModels.Panels;
+using Shouldly;
+
+namespace UnitTests.ViewModels.Panels;
+
+public class AnalysisDockViewModelTests
+{
+    private static AnalysisDockViewModel Make() =>
+        new(new TimeDomainViewModel(), new EyeDiagramViewModel());
+
+    [Fact]
+    public void StartsCollapsed_OnTransientTab()
+    {
+        var vm = Make();
+        vm.IsVisible.ShouldBeFalse();
+        vm.SelectedTabIndex.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Toggle_FlipsVisibility()
+    {
+        var vm = Make();
+        vm.ToggleCommand.Execute(null);
+        vm.IsVisible.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OpenTransient_ShowsDockOnTransientTab()
+    {
+        var vm = Make();
+        vm.SelectedTabIndex = 1;
+        vm.OpenTransient();
+        vm.IsVisible.ShouldBeTrue();
+        vm.SelectedTabIndex.ShouldBe(0);
+    }
+}

--- a/UnitTests/ViewModels/Panels/AnalysisDockViewModelTests.cs
+++ b/UnitTests/ViewModels/Panels/AnalysisDockViewModelTests.cs
@@ -35,4 +35,16 @@ public class AnalysisDockViewModelTests
         vm.IsVisible.ShouldBeTrue();
         vm.SelectedTabIndex.ShouldBe(0);
     }
+
+    [Fact]
+    public void SetDockHeight_ClampsToMinAndMax()
+    {
+        var vm = Make();
+        vm.SetDockHeight(10_000);
+        vm.DockHeight.ShouldBe(AnalysisDockViewModel.MaxDockHeight);
+        vm.SetDockHeight(1);
+        vm.DockHeight.ShouldBe(AnalysisDockViewModel.MinDockHeight);
+        vm.SetDockHeight(300);
+        vm.DockHeight.ShouldBe(300);
+    }
 }

--- a/UnitTests/ViewModels/SimulationModeTests.cs
+++ b/UnitTests/ViewModels/SimulationModeTests.cs
@@ -1,0 +1,15 @@
+using CAP.Avalonia.ViewModels.Analysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels;
+
+public class SimulationModeTests
+{
+    [Fact]
+    public void MainViewModel_DefaultsToCwMode()
+    {
+        var vm = UnitTests.Helpers.MainViewModelTestHelper.CreateMainViewModel();
+        vm.SimulationMode.ShouldBe(SimulationMode.Cw);
+    }
+}

--- a/UnitTests/ViewModels/SimulationModeTests.cs
+++ b/UnitTests/ViewModels/SimulationModeTests.cs
@@ -20,6 +20,7 @@ public class SimulationModeTests
     {
         var vm = UnitTests.Helpers.MainViewModelTestHelper.CreateMainViewModel();
         vm.SimulationMode = SimulationMode.Transient;
+        vm.Canvas.ShowPowerFlow = true; // simulate a stale CW overlay left on from a previous run
 
         await ((IAsyncRelayCommand)vm.RunSimulationCommand).ExecuteAsync(null);
 

--- a/UnitTests/ViewModels/SimulationModeTests.cs
+++ b/UnitTests/ViewModels/SimulationModeTests.cs
@@ -1,4 +1,6 @@
+using System.Threading.Tasks;
 using CAP.Avalonia.ViewModels.Analysis;
+using CommunityToolkit.Mvvm.Input;
 using Shouldly;
 using Xunit;
 
@@ -11,5 +13,18 @@ public class SimulationModeTests
     {
         var vm = UnitTests.Helpers.MainViewModelTestHelper.CreateMainViewModel();
         vm.SimulationMode.ShouldBe(SimulationMode.Cw);
+    }
+
+    [Fact]
+    public async Task Run_InTransientMode_OpensAnalysisDock_NotCwOverlay()
+    {
+        var vm = UnitTests.Helpers.MainViewModelTestHelper.CreateMainViewModel();
+        vm.SimulationMode = SimulationMode.Transient;
+
+        await ((IAsyncRelayCommand)vm.RunSimulationCommand).ExecuteAsync(null);
+
+        vm.BottomPanel.Analysis.IsVisible.ShouldBeTrue();
+        vm.BottomPanel.Analysis.SelectedTabIndex.ShouldBe(0);
+        vm.Canvas.ShowPowerFlow.ShouldBeFalse();
     }
 }

--- a/docs/superpowers/plans/2026-07-07-transient-eye-analysis-dock.md
+++ b/docs/superpowers/plans/2026-07-07-transient-eye-analysis-dock.md
@@ -1,0 +1,362 @@
+# Transient & Eye/BER Analysis Dock — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move transient simulation out of the properties panel into a first-class `SimulationMode` (toolbar CW/Transient selector) with a bottom **Analysis dock** hosting Transient + Eye/BER tabs, adopting #627's self-contained eye/BER core instead of its stale right-panel wiring.
+
+**Architecture:** Reuse existing cores unchanged. Promote the CW/Transient flag from a view-only `TimeDomainViewModel.IsTimeDomainMode` to a shared `MainViewModel.SimulationMode`. Add an `AnalysisDockViewModel` under `BottomPanel` (mirroring `ErrorConsoleViewModel`) that owns the transient + eye sub-VMs and the collapsible/tab state. Re-point the transient view and #627's eye view onto that dock; delete the right-panel transient section.
+
+**Tech Stack:** C# / .NET 10 / Avalonia 11 / CommunityToolkit.Mvvm (`[ObservableProperty]`, `[RelayCommand]`); xUnit + Shouldly + Moq; OxyPlot.
+
+## Global Constraints
+
+- Reuse cores verbatim — **no** transient/eye algorithm changes.
+- Max 250 lines per NEW file; XML docs on public members; `_camelCase` fields, PascalCase members.
+- DI registrations go in the relevant `CAP.Avalonia/DI/*Extensions.cs` method, not raw in `App.axaml.cs`.
+- Tests via `python3 tools/smart_test.py <pattern>` (never `dotnet test`). Windows: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" <pattern>`.
+- Adopt #627 files from branch `origin/agent/issue-535-1783014086` via `git checkout <branch> -- <path>`. Do **not** adopt #627's stale hunks: its `GdsPreviewRenderService` change in `CanvasAndPanelExtensions.cs` (main's two-backend version is newer) and its right-panel `RightPanelViewModel`/`MainWindow.axaml` eye wiring.
+- Error Console dock is untouched (stays its own dock).
+- Branch: `feat/transient-eye-analysis-dock` (already created; spec committed).
+
+---
+
+### Task 1: Adopt the Eye/BER core + its tests
+
+**Files:**
+- Create (cherry-pick from `origin/agent/issue-535-1783014086`): `Connect-A-Pic-Core/Analysis/EyeDiagram/{PrbsGenerator,EyeSimulationPlan,EyeDiagramBuilder,EyeHistogram,BerEstimator,EyeMetrics,NoiseModel}.cs`
+- Test (cherry-pick): `UnitTests/Analysis/EyeDiagram/{PrbsGeneratorTests,EyeSimulationPlanTests,EyeDiagramBuilderTests,BerEstimatorTests,NoiseModelTests}.cs`
+
+**Interfaces produced (namespace `CAP_Core.Analysis.EyeDiagram`, all BCL-only deps):**
+- `enum PrbsOrder { Prbs7=7, Prbs11=11, Prbs23=23 }`; `PrbsGenerator.GenerateBits(order,bitCount)`, `.ToNrzSamples(bits,samplesPerBit,amplitude)`, `.PatternLength(order)`.
+- `EyeSimulationPlan.Create(bitRateHz, sampleRateHz, patternLength)` → props `SamplesPerBit/BitCount/TotalSamples/BitPeriodSeconds`.
+- `EyeDiagramBuilder.Build(trace,sampleRateHz,bitPeriodSeconds,timeBins,amplitudeBins,skipBits)` → `EyeHistogram`.
+- `BerEstimator.Estimate(...)` → `record EyeMetrics(QFactor,BerEstimate,EyeHeight,EyeWidthSeconds,RmsJitterSeconds,OptimalSampleOffsetSeconds)`.
+- `NoiseModel` (Gaussian receiver noise).
+
+- [ ] **Step 1: Cherry-pick the core + tests**
+```bash
+git checkout origin/agent/issue-535-1783014086 -- \
+  Connect-A-Pic-Core/Analysis/EyeDiagram/PrbsGenerator.cs \
+  Connect-A-Pic-Core/Analysis/EyeDiagram/EyeSimulationPlan.cs \
+  Connect-A-Pic-Core/Analysis/EyeDiagram/EyeDiagramBuilder.cs \
+  Connect-A-Pic-Core/Analysis/EyeDiagram/EyeHistogram.cs \
+  Connect-A-Pic-Core/Analysis/EyeDiagram/BerEstimator.cs \
+  Connect-A-Pic-Core/Analysis/EyeDiagram/EyeMetrics.cs \
+  Connect-A-Pic-Core/Analysis/EyeDiagram/NoiseModel.cs \
+  UnitTests/Analysis/EyeDiagram/PrbsGeneratorTests.cs \
+  UnitTests/Analysis/EyeDiagram/EyeSimulationPlanTests.cs \
+  UnitTests/Analysis/EyeDiagram/EyeDiagramBuilderTests.cs \
+  UnitTests/Analysis/EyeDiagram/BerEstimatorTests.cs \
+  UnitTests/Analysis/EyeDiagram/NoiseModelTests.cs
+```
+
+- [ ] **Step 2: Build** — `dotnet build ConnectAPICPro.sln -clp:ErrorsOnly`. Expected: 0 errors (the core is BCL-only and self-contained; a running app may lock `CAP.Desktop.dll` — that copy error is benign).
+
+- [ ] **Step 3: Run the eye-core tests** — `py "$env:USERPROFILE\.cap-tools\smart_test.py" EyeDiagram` (also matches `Prbs`, `Ber`, `NoiseModel`). Expected: all pass. If a test references a core symbol not cherry-picked, cherry-pick that file too.
+
+- [ ] **Step 4: Commit** — `git commit -m "(+) Adopt eye/BER analysis core from #627 (#535)"`
+
+---
+
+### Task 2: Promote CW/Transient to a shared `SimulationMode`
+
+**Files:**
+- Create: `CAP.Avalonia/ViewModels/Analysis/SimulationMode.cs`
+- Modify: `CAP.Avalonia/ViewModels/MainViewModel.cs` (add the observable mode property near the other top-level state, ~line 56)
+- Modify: `CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs` (delete the view-only `_isTimeDomainMode`/`IsTimeDomainMode`, line 50 — confirmed no C# reads it)
+- Test: `UnitTests/ViewModels/SimulationModeTests.cs`
+
+**Interfaces produced:**
+- `enum SimulationMode { Cw, Transient }`
+- `MainViewModel.SimulationMode` (`[ObservableProperty]`, default `SimulationMode.Cw`).
+
+- [ ] **Step 1: Create the enum**
+```csharp
+namespace CAP.Avalonia.ViewModels.Analysis;
+
+/// <summary>How the design is simulated when Run (L) is invoked.</summary>
+public enum SimulationMode
+{
+    /// <summary>Continuous-wave frequency-domain steady state (default).</summary>
+    Cw,
+    /// <summary>Time-domain transient: pulse response / eye-diagram basis.</summary>
+    Transient,
+}
+```
+
+- [ ] **Step 2: Write the failing test** (`SimulationModeTests.cs`)
+```csharp
+using CAP.Avalonia.ViewModels.Analysis;
+using Shouldly;
+
+namespace UnitTests.ViewModels;
+
+public class SimulationModeTests
+{
+    [Fact]
+    public void MainViewModel_DefaultsToCwMode()
+    {
+        var vm = UnitTests.Helpers.MainViewModelTestHelper.Create();
+        vm.SimulationMode.ShouldBe(SimulationMode.Cw);
+    }
+}
+```
+(Use the existing `MainViewModelTestHelper` — confirm its factory method name via `UnitTests/Helpers/MainViewModelTestHelper.cs`; adjust `Create()` to the real helper API.)
+
+- [ ] **Step 3: Run — expect FAIL** (`SimulationMode` property missing): `py "...smart_test.py" SimulationMode`.
+
+- [ ] **Step 4: Add the property to MainViewModel**
+```csharp
+/// <summary>Active simulation mode; the toolbar selector binds here and Run(L) dispatches on it.</summary>
+[ObservableProperty]
+private CAP.Avalonia.ViewModels.Analysis.SimulationMode _simulationMode = CAP.Avalonia.ViewModels.Analysis.SimulationMode.Cw;
+```
+
+- [ ] **Step 5: Delete the dead flag** in `TimeDomainViewModel.cs` — remove the `[ObservableProperty] private bool _isTimeDomainMode = true;` (line ~50). (Its only consumers are the two radio buttons + `IsVisible` in `TimeDomainPanel.axaml`, which Task 5 removes.)
+
+- [ ] **Step 6: Build + run test — expect PASS.**
+
+- [ ] **Step 7: Commit** — `git commit -m "(~) Promote CW/Transient to shared MainViewModel.SimulationMode (#570)"`
+
+---
+
+### Task 3: Adopt TransientCircuitFactory + Eye VM; build the Analysis dock VM
+
+**Files:**
+- Create (cherry-pick): `CAP.Avalonia/ViewModels/Analysis/TransientCircuitFactory.cs`, `CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramViewModel.cs`, `CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramPlotBuilder.cs`
+- Modify: `CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs` (refactor `RunSimulationCore`'s inline circuit setup + delete private `ConfigureLightSources` → call `TransientCircuitFactory.Create(_canvas!)`, per #627's diff)
+- Create: `CAP.Avalonia/ViewModels/Panels/AnalysisDockViewModel.cs`
+- Modify: `CAP.Avalonia/ViewModels/Panels/BottomPanelViewModel.cs` (expose `Analysis`), `CAP.Avalonia/DI/CanvasAndPanelExtensions.cs` (register `EyeDiagramViewModel` + `AnalysisDockViewModel`)
+- Test: `UnitTests/ViewModels/Panels/AnalysisDockViewModelTests.cs`
+
+**Interfaces consumed:** `TransientCircuitFactory.Create(DesignCanvasViewModel) → (TimeDomainSimulator, PhysicalExternalPortManager)`; `TimeDomainViewModel` (ctor `(ErrorConsoleService?)`, `Configure(canvas)`, `RunTransientCommand`); `EyeDiagramViewModel` (ctor `(ErrorConsoleService?)`, `Configure(canvas)`, `RunEyeAnalysisCommand`).
+
+**Interfaces produced:**
+- `AnalysisDockViewModel(TimeDomainViewModel transient, EyeDiagramViewModel eye)` with: `TimeDomainViewModel Transient`, `EyeDiagramViewModel Eye`, `[ObservableProperty] bool IsVisible` (default false), `[ObservableProperty] int SelectedTabIndex` (0=Transient), `[RelayCommand] void Toggle()`, `void Configure(DesignCanvasViewModel canvas)` (forwards to both), `void OpenTransient()` (sets `IsVisible=true; SelectedTabIndex=0`).
+- `BottomPanelViewModel.Analysis` (property).
+
+- [ ] **Step 1: Cherry-pick the three VM files**
+```bash
+git checkout origin/agent/issue-535-1783014086 -- \
+  CAP.Avalonia/ViewModels/Analysis/TransientCircuitFactory.cs \
+  CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramViewModel.cs \
+  CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramPlotBuilder.cs
+```
+
+- [ ] **Step 2: Refactor `TimeDomainViewModel.RunSimulationCore`** to use the factory (mirrors #627). Replace the inline `ComponentListTileManager`/`GridManager`/`SystemMatrixBuilder`/`TimeDomainSimulator` block **and** delete the private `ConfigureLightSources(...)` method (lines ~178-225), substituting:
+```csharp
+var (simulator, portManager) = TransientCircuitFactory.Create(_canvas!);
+```
+Keep the rest of `RunSimulationCore` (pulse build, `simulator.Run(...)`, result plotting) unchanged.
+
+- [ ] **Step 3: Write the failing test** (`AnalysisDockViewModelTests.cs`)
+```csharp
+using CAP.Avalonia.ViewModels.Analysis;
+using CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
+using CAP.Avalonia.ViewModels.Panels;
+using Shouldly;
+
+namespace UnitTests.ViewModels.Panels;
+
+public class AnalysisDockViewModelTests
+{
+    private static AnalysisDockViewModel Make() =>
+        new(new TimeDomainViewModel(), new EyeDiagramViewModel());
+
+    [Fact]
+    public void StartsCollapsed_OnTransientTab()
+    {
+        var vm = Make();
+        vm.IsVisible.ShouldBeFalse();
+        vm.SelectedTabIndex.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Toggle_FlipsVisibility()
+    {
+        var vm = Make();
+        vm.ToggleCommand.Execute(null);
+        vm.IsVisible.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void OpenTransient_ShowsDockOnTransientTab()
+    {
+        var vm = Make();
+        vm.SelectedTabIndex = 1;
+        vm.OpenTransient();
+        vm.IsVisible.ShouldBeTrue();
+        vm.SelectedTabIndex.ShouldBe(0);
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect FAIL** (`AnalysisDockViewModel` missing): `py "...smart_test.py" AnalysisDockViewModel`.
+
+- [ ] **Step 5: Implement `AnalysisDockViewModel`** (mirror `ErrorConsoleViewModel`'s IsVisible/Toggle pattern)
+```csharp
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CAP.Avalonia.ViewModels.Analysis;
+using CAP.Avalonia.ViewModels.Analysis.EyeDiagram;
+using CAP.Avalonia.ViewModels.Canvas;
+
+namespace CAP.Avalonia.ViewModels.Panels;
+
+/// <summary>Bottom analysis dock: collapsible host for the Transient and Eye/BER tabs (#570/#535).</summary>
+public partial class AnalysisDockViewModel : ObservableObject
+{
+    /// <summary>Transient (time-domain) analysis tab.</summary>
+    public TimeDomainViewModel Transient { get; }
+    /// <summary>Eye-diagram / BER analysis tab.</summary>
+    public EyeDiagramViewModel Eye { get; }
+
+    [ObservableProperty] private bool _isVisible;
+    [ObservableProperty] private int _selectedTabIndex;
+
+    public AnalysisDockViewModel(TimeDomainViewModel transient, EyeDiagramViewModel eye)
+    {
+        Transient = transient;
+        Eye = eye;
+    }
+
+    /// <summary>Wires both tabs to the active design canvas.</summary>
+    public void Configure(DesignCanvasViewModel canvas)
+    {
+        Transient.Configure(canvas);
+        Eye.Configure(canvas);
+    }
+
+    /// <summary>Opens the dock on the Transient tab (called when Run is invoked in Transient mode).</summary>
+    public void OpenTransient()
+    {
+        SelectedTabIndex = 0;
+        IsVisible = true;
+    }
+
+    [RelayCommand]
+    private void Toggle() => IsVisible = !IsVisible;
+}
+```
+
+- [ ] **Step 6: Expose on `BottomPanelViewModel`** — add `public AnalysisDockViewModel Analysis { get; }`, a ctor parameter `AnalysisDockViewModel analysis`, and assign it (mirror the existing `ErrorConsole` wiring at lines 31/44/48).
+
+- [ ] **Step 7: DI** — in `CanvasAndPanelExtensions.cs`, add (do NOT touch the `GdsPreviewRenderService` registration): `services.AddTransient<EyeDiagramViewModel>();` (next to the `TimeDomainViewModel` line ~57) and `services.AddSingleton<AnalysisDockViewModel>();` (next to `BottomPanelViewModel`, ~line 78).
+
+- [ ] **Step 8: Build + run test — expect PASS.**
+
+- [ ] **Step 9: Commit** — `git commit -m "(+) Analysis dock VM + adopt TransientCircuitFactory & EyeDiagramViewModel from #627 (#535/#570)"`
+
+---
+
+### Task 4: Run-dispatch by mode + open dock on transient run
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/MainViewModel.cs` (`RunSimulation`/`ExecuteSimulation`, lines 741-796; the design canvas `Configure` at ~176 to also configure the Analysis dock)
+- Test: `UnitTests/ViewModels/SimulationModeTests.cs` (extend)
+
+**Interfaces consumed:** `MainViewModel.SimulationMode` (Task 2), `BottomPanel.Analysis` (Task 3), `BottomPanel.Analysis.Transient.RunTransientCommand`, `AnalysisDockViewModel.OpenTransient()`.
+
+- [ ] **Step 1: Write the failing test** — Run in Transient mode opens the dock and does not toggle the CW power overlay.
+```csharp
+[Fact]
+public async Task Run_InTransientMode_OpensAnalysisDock_NotCwOverlay()
+{
+    var vm = UnitTests.Helpers.MainViewModelTestHelper.Create();
+    vm.SimulationMode = SimulationMode.Transient;
+
+    await ((CommunityToolkit.Mvvm.Input.IAsyncRelayCommand)vm.RunSimulationCommand).ExecuteAsync(null);
+
+    vm.BottomPanel.Analysis.IsVisible.ShouldBeTrue();
+    vm.BottomPanel.Analysis.SelectedTabIndex.ShouldBe(0);
+    vm.Canvas.ShowPowerFlow.ShouldBeFalse();   // CW overlay not triggered in transient mode
+}
+```
+(Confirm `RunSimulationCommand` is an `IAsyncRelayCommand`; adjust the cast/`ExecuteAsync` to the generated type.)
+
+- [ ] **Step 2: Run — expect FAIL** (transient mode still runs CW path).
+
+- [ ] **Step 3: Branch the Run entry point.** In `RunSimulation()` (line 741), before the CW toggle logic, add:
+```csharp
+if (SimulationMode == CAP.Avalonia.ViewModels.Analysis.SimulationMode.Transient)
+{
+    BottomPanel.Analysis.OpenTransient();
+    await BottomPanel.Analysis.Transient.RunTransientCommand.ExecuteAsync(null);
+    return;
+}
+```
+Leave the existing CW toggle/`ExecuteSimulation` path for `Cw`.
+
+- [ ] **Step 4: Configure the dock with the canvas.** Where the canvas is wired (`MainViewModel` ~line 176, alongside `RightPanel` config), add `BottomPanel.Analysis.Configure(_canvas);` so both tabs get the canvas. (Verify `_canvas` field name in context.)
+
+- [ ] **Step 5: Build + run test — expect PASS.** Also run the existing CW test path if present to confirm `Cw` mode is unchanged.
+
+- [ ] **Step 6: Add the toolbar selector** (`MainWindow.axaml`, inside the horizontal toolbar StackPanel, right after the Run button at line 82, before the `<Separator>` at 84):
+```xml
+<!-- Simulation mode: CW vs Transient. Run (L) executes the active mode. -->
+<ComboBox Width="120" Margin="2" VerticalAlignment="Center"
+          SelectedIndex="{Binding SimulationMode, Converter={x:Static conv:SimulationModeIndexConverter.Instance}}"
+          ToolTip.Tip="Simulation mode: CW (steady-state) or Transient (time-domain). Run (L) executes this mode.">
+    <ComboBoxItem>CW</ComboBoxItem>
+    <ComboBoxItem>Transient</ComboBoxItem>
+</ComboBox>
+```
+If a value converter is undesirable, instead bind two `RadioButton`s to `SimulationMode` via a shared enum-to-bool converter, or expose `bool IsTransientMode => SimulationMode == Transient` with a setter on MainViewModel and bind the ComboBox `SelectedIndex` to a plain `int SimulationModeIndex` property. **Simplest:** add `public int SimulationModeIndex { get => (int)SimulationMode; set => SimulationMode = (SimulationMode)value; }` to MainViewModel (raise `OnPropertyChanged` in the `SimulationMode` partial `OnSimulationModeChanged`) and bind `SelectedIndex="{Binding SimulationModeIndex}"` — no converter needed. Use this approach.
+
+- [ ] **Step 7: Build. Commit** — `git commit -m "(+) Run dispatches by SimulationMode; toolbar CW/Transient selector (#570)"`
+
+---
+
+### Task 5: Views — Analysis dock panel, re-home transient + eye, remove from right panel
+
+**Files:**
+- Create: `CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml(.cs)`
+- Modify: `CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml` (strip mode radios/CW hint; re-point bindings)
+- Adopt + re-point: `CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml(.cs)`
+- Modify: `CAP.Avalonia/Views/MainWindow.axaml` (remove `<panels:TimeDomainPanel/>` at 790; add the dock at the bottom next to the Error Console dock)
+- Modify: `CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs` (remove `TimeDomain` property/ctor-param/assign/Configure at lines 114/152/169/176)
+
+**Interfaces consumed:** `BottomPanel.Analysis.Transient.*`, `BottomPanel.Analysis.Eye.*`, `BottomPanel.Analysis.IsVisible`, `BottomPanel.Analysis.ToggleCommand`, `BottomPanel.Analysis.SelectedTabIndex`.
+
+- [ ] **Step 1: Adopt the Eye view**
+```bash
+git checkout origin/agent/issue-535-1783014086 -- \
+  CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml \
+  CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml.cs
+```
+
+- [ ] **Step 2: Re-point `TimeDomainPanel.axaml`** — delete the "Simulation mode" label + the two `RadioButton`s (lines 22-33) and the CW hint `TextBlock` (lines 35-39). Unwrap the `IsVisible`-gated `<StackPanel IsVisible="{Binding RightPanel.TimeDomain.IsTimeDomainMode}">` (line 42) — the content is always shown inside the tab now. Change every `RightPanel.TimeDomain.` binding to `BottomPanel.Analysis.Transient.` (params, `RunTransientCommand`, `IsRunning`, `StatusText`, `HasResult`, `PlotModel`, `Series`, `ResultText`, `ExportCsvCommand`). Keep `x:DataType="vm:MainViewModel"`.
+
+- [ ] **Step 3: Re-point `EyeDiagramPanel.axaml`** — change every `RightPanel.EyeDiagram.` binding to `BottomPanel.Analysis.Eye.` (`BitRateGbps`, `PrbsOrders`, `SelectedPrbsOrder`, `ThresholdRelative`, `RunEyeAnalysisCommand`, `IsRunning`, `StatusText`, `HasResult`, `PlotModel`, `MetricsText`, `ExportCsvCommand`). Keep `x:DataType="vm:MainViewModel"`.
+
+- [ ] **Step 4: Create `AnalysisDockPanel.axaml`** — mirror the Error Console dock (`MainWindow.axaml:263-333`): a `Border` with a header `DockPanel` (toggle `Button` bound to `BottomPanel.Analysis.ToggleCommand`, `▶`/`▼` chevrons on `BottomPanel.Analysis.IsVisible`, label "Analysis"), and a collapsible content `Border IsVisible="{Binding BottomPanel.Analysis.IsVisible}" Height="240"` containing a `TabControl SelectedIndex="{Binding BottomPanel.Analysis.SelectedTabIndex}"` with two `TabItem`s: Header "Transient" → `<panels:TimeDomainPanel/>`; Header "Eye / BER" → `<panels:EyeDiagramPanel/>`. `x:DataType="vm:MainViewModel"`.
+
+- [ ] **Step 5: Host the dock in `MainWindow.axaml`** — add `<panels:AnalysisDockPanel/>` at the bottom, docked above/next to the existing Error Console dock (both `DockPanel.Dock="Bottom"`; place the Analysis dock so it stacks with the console). Remove `<panels:TimeDomainPanel/>` at line 790.
+
+- [ ] **Step 6: Remove TimeDomain from RightPanel** — in `RightPanelViewModel.cs` delete the `TimeDomain` property (114), ctor param (152), assignment (169), and `TimeDomain.Configure(canvas)` (176). `TimeDomainViewModel` stays DI-registered (now consumed by `AnalysisDockViewModel`).
+
+- [ ] **Step 7: Build** — `dotnet build ConnectAPICPro.sln -clp:ErrorsOnly`. Fix binding/namespace errors. Expected: 0 errors (ignore a `CAP.Desktop.dll` lock from a running app).
+
+- [ ] **Step 8: Run the app briefly** (`run` skill / `dotnet run --project CAP.Desktop`) and confirm: properties panel has no transient section; toolbar has the CW/Transient selector; switching to Transient + Run opens the bottom Analysis dock with the waveform; the Eye/BER tab renders its empty plot. Capture a screenshot if the UI-screenshot harness is available.
+
+- [ ] **Step 9: Commit** — `git commit -m "(+) Analysis dock panel; re-home transient + eye; remove transient from properties (#570/#535)"`
+
+---
+
+### Task 6: Full-suite verification + supersede #627
+
+**Files:** none (verification + housekeeping).
+
+- [ ] **Step 1: Full suite** — `py "$env:USERPROFILE\.cap-tools\smart_test.py"`. Expected: green apart from the known parallel-load flakes (`PhotonTorchScriptExecution`, `GdsExportAlignment`, `ComponentSettingsDialogSolverStatus`); confirm any failure passes in isolation.
+
+- [ ] **Step 2: Grep for stragglers** — no remaining `RightPanel.TimeDomain` / `RightPanel.EyeDiagram` bindings; no `IsTimeDomainMode` references. `git grep -n "RightPanel.TimeDomain\|RightPanel.EyeDiagram\|IsTimeDomainMode"` → empty.
+
+- [ ] **Step 3: PR** — open a PR (base `main`) summarizing: transient re-homed to the Analysis dock, first-class CW/Transient mode, #627 eye/BER adopted into the dock. Note that **#627 should be closed as superseded** (its core lives on here; its right-panel wiring is intentionally dropped).
+
+---
+
+## Notes for the executor
+- The `MainViewModelTestHelper` factory and the exact generated command types (`RunSimulationCommand`, `RunTransientCommand`) must be confirmed against the real files when writing tests — adjust casts accordingly.
+- Do not re-run `git checkout <branch> -- …` for files already adopted in an earlier task.
+- If a cherry-picked file fails to compile against current main (namespace/signature drift), adapt the file to main — do not roll main back.
+</content>

--- a/docs/superpowers/specs/2026-07-07-transient-eye-analysis-dock-design.md
+++ b/docs/superpowers/specs/2026-07-07-transient-eye-analysis-dock-design.md
@@ -1,0 +1,146 @@
+# Transient & Eye/BER Analysis Dock — Design Spec
+
+**Date:** 2026-07-07
+**Issue(s):** relocation of the Transient (#600/#601) panel + integration of Eye/BER (#535/#627)
+**Status:** design — awaiting approval
+
+## Goal
+
+Turn the transient (time-domain) simulation from a permanent, out-of-place section in the
+**properties panel** into a first-class **simulation mode** with a proper **analysis home**, and
+fold the Eye-diagram/BER work (agent PR #627) into that same home instead of adding a second
+right-panel section. One coherent change that supersedes both current placements.
+
+## Personas served
+
+- **Mirko** (full-stack system simulation toward a photonic CPU): time-domain → eye/BER is a real
+  pipeline stage; a dedicated, growable analysis area with a clear mode concept fits his
+  "simulate on all levels" goal.
+- **Peter** (precision, Figma-like flow): non-modal, inline results (canvas stays visible), exact
+  numeric controls. He dislikes modal dialogs — the bottom dock is non-modal.
+- **Priya/Ingrid** (secondary): a legible power-vs-time / eye plot is demo-friendly and a hook for
+  later measurement comparison. No change makes the tool incomprehensible to Ingrid.
+
+Chosen primary purpose (confirmed with the user): **signal integrity / eye-diagram precursor.**
+
+## Scope
+
+**In scope**
+1. A **`SimulationMode`** concept (CW / Transient) surfaced as a compact selector next to the
+   toolbar Run button; the Run action (L) dispatches by the active mode.
+2. A new **bottom Analysis dock** — a collapsible bottom region (mirroring the existing Error
+   Console dock), separate from and leaving the Error Console untouched — hosting a `TabControl`
+   with a **Transient** tab and an **Eye/BER** tab.
+3. **Re-home** the existing transient UI (params, run, waveform plot, per-pin legend, peak table,
+   CSV export) from `TimeDomainPanel` in the right panel into the dock's **Transient** tab.
+4. **Adopt** #627's self-contained Eye/BER work into the dock's **Eye/BER** tab.
+5. **Remove** the transient section from the right/properties panel; **do not** adopt #627's
+   right-panel placement of the Eye panel.
+
+**Out of scope (YAGNI / non-goals)**
+- No change to the transient or eye/BER **algorithms** (Core is reused verbatim).
+- No rewrite of `TimeDomainViewModel` or `EyeDiagramViewModel` logic — this is re-hosting + a
+  mode-state promotion + placement.
+- No new eye/BER features beyond what #627 already implemented.
+- Error Console behavior is unchanged (stays its own dock/toggle).
+- No FDTD/Tidy3D modes yet (the `SimulationMode` enum is designed to allow them later, but only
+  CW and Transient are implemented now).
+
+## Architecture
+
+### Components
+
+- **`SimulationMode` (enum: `Cw`, `Transient`)** + a small owner of the current mode. Today the
+  flag lives as `RightPanel.TimeDomain.IsTimeDomainMode`; it is promoted to a shared, top-level
+  state exposed to the toolbar. The transient VM reads the mode rather than owning it.
+- **Toolbar mode selector** (in `MainWindow.axaml`, next to `RunSimulationCommand`): a compact
+  two-way selector (CW | Transient). Switching to Transient opens the Analysis dock on the
+  Transient tab. The existing Run button/`L` binding runs the active mode.
+- **Bottom Analysis dock** — new view `AnalysisDockPanel.axaml` + a `BottomPanel.Analysis`
+  sub-ViewModel that holds the tab state (`SelectedTab`, `IsVisible`, toggle command), collapsible
+  like the Error Console. Contains a `TabControl`:
+  - **Transient tab** — hosts the existing transient controls + plot (moved from `TimeDomainPanel`).
+  - **Eye/BER tab** — hosts #627's `EyeDiagramPanel` content.
+- **Reused core (unchanged):**
+  - `Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/*` (transient).
+  - `Connect-A-Pic-Core/Analysis/EyeDiagram/*` (from #627: `PrbsGenerator`, `NoiseModel`,
+    `EyeDiagramBuilder`, `BerEstimator`, `EyeMetrics`, `EyeHistogram`, `EyeSimulationPlan`).
+- **Reused/adopted ViewModels:**
+  - `TimeDomainViewModel` (transient) — re-parented under the Analysis dock; loses the
+    `IsTimeDomainMode` flag (moves to the shared `SimulationMode`).
+  - `EyeDiagramViewModel` + `EyeDiagramPlotBuilder` + `TransientCircuitFactory` (from #627) —
+    adopted as-is; `EyeDiagramPanel.axaml` view re-parented into the Eye/BER tab.
+
+### What we adopt from #627 vs discard
+
+**Adopt (new, self-contained, no conflict with main):**
+- `Connect-A-Pic-Core/Analysis/EyeDiagram/*` + their unit tests.
+- `CAP.Avalonia/ViewModels/Analysis/EyeDiagram/EyeDiagramViewModel.cs`,
+  `EyeDiagramPlotBuilder.cs`, `CAP.Avalonia/ViewModels/Analysis/TransientCircuitFactory.cs`.
+- `CAP.Avalonia/Views/Panels/EyeDiagramPanel.axaml(.cs)` — content reused, but hosted in the
+  Analysis dock's Eye/BER tab, not the right panel.
+
+**Discard from #627 (superseded by this design):**
+- Its right-panel wiring: additions to `RightPanelViewModel` and the right-panel section in
+  `MainWindow.axaml`. We wire the Eye panel into the Analysis dock instead.
+- Its stale (77-commits-behind) versions of shared files (`MainViewModel`, `TimeDomainViewModel`,
+  `CanvasAndPanelExtensions`) — we integrate the adopted pieces onto current main rather than
+  taking #627's copies. `TransientCircuitFactory` (the one genuinely shared extraction) is taken
+  as a new file.
+
+### Data flow
+
+1. User picks **CW** or **Transient** in the toolbar selector → updates `SimulationMode`.
+2. **Run (L):**
+   - CW → existing steady-state simulation (unchanged).
+   - Transient → `TimeDomainViewModel.RunTransient` (existing) → result renders in the Transient
+     tab; the Analysis dock opens to that tab.
+3. **Eye/BER tab:** its own `Run Eye Analysis` (from #627) drives the circuit via
+   `TransientCircuitFactory` + PRBS/noise → histogram → eye plot + BER metric. Independent of the
+   transient tab's single-pulse run, but shares the same circuit/simulator setup.
+
+## Files
+
+**New**
+- `CAP.Avalonia/Views/Panels/AnalysisDockPanel.axaml(.cs)` — the bottom dock with the TabControl.
+- `CAP.Avalonia/ViewModels/Analysis/SimulationMode.cs` — the enum.
+- Analysis-dock sub-ViewModel (tab/visibility state) under `CAP.Avalonia/ViewModels/Panels/`.
+- Adopted from #627: `Connect-A-Pic-Core/Analysis/EyeDiagram/*` (+ tests),
+  `.../Analysis/EyeDiagram/EyeDiagramViewModel.cs`, `EyeDiagramPlotBuilder.cs`,
+  `.../Analysis/TransientCircuitFactory.cs`, `Views/Panels/EyeDiagramPanel.axaml(.cs)`.
+
+**Modified**
+- `CAP.Avalonia/Views/MainWindow.axaml` — add toolbar mode selector; remove
+  `<panels:TimeDomainPanel/>` from the right panel (~line 790); add the Analysis dock at the bottom.
+- `CAP.Avalonia/ViewModels/MainViewModel.cs` — own/expose `SimulationMode`; wire Run dispatch and
+  dock-open-on-transient.
+- `CAP.Avalonia/ViewModels/Panels/RightPanelViewModel.cs` — drop the transient wiring (mode flag
+  moves out).
+- `CAP.Avalonia/ViewModels/Analysis/TimeDomainViewModel.cs` — read shared `SimulationMode` instead
+  of owning `IsTimeDomainMode`; otherwise unchanged.
+- `CAP.Avalonia/Views/Panels/TimeDomainPanel.axaml` — becomes the Transient-tab content (mode
+  radio buttons removed; params/plot kept).
+- `CAP.Avalonia/DI/CanvasAndPanelExtensions.cs` (or the relevant DI extension) — register the
+  Analysis dock VM + `EyeDiagramViewModel`.
+
+## Testing
+
+- **Mode dispatch:** Run in Transient mode invokes the transient run (not CW) and opens the
+  Analysis dock on the Transient tab; Run in CW mode invokes the CW path.
+- **Mode state:** toggling the toolbar selector updates `SimulationMode`; the transient VM reflects
+  it (no stale `IsTimeDomainMode`).
+- **Dock:** the Analysis dock toggles/collapses independently of the Error Console; tab selection
+  works.
+- **Eye/BER core:** #627's existing unit tests (`PrbsGeneratorTests`, `NoiseModelTests`,
+  `EyeDiagramBuilderTests`, `BerEstimatorTests`, `EyeSimulationPlanTests`) are adopted and must pass.
+- No physics/algorithm tests change — Core is reused.
+
+## Conflict-avoidance rationale
+
+Both the current transient placement (#601) and #627's eye placement put a full analysis section in
+the right/properties panel. Doing the relocation and the eye integration **separately** would
+force a double conflict on the same shared files (`TimeDomainViewModel`, `MainViewModel`,
+`MainWindow.axaml`, `RightPanelViewModel`). This design does both **once**: it builds the bottom
+Analysis dock, re-homes transient, and adopts #627's self-contained core + eye VM into the dock —
+so #627's stale right-panel wiring is simply not used, and there is a single integration window.
+On merge, #627 is closed as superseded (its valuable code lives on in the dock).


### PR DESCRIPTION
## What
Moves transient (time-domain) simulation out of the properties panel into a first-class **simulation mode** with a bottom **Analysis dock**, and folds in the Eye/BER work from #627 — one coherent change instead of two conflicting right-panel sections.

- **Toolbar:** a CW/Transient selector next to Run; Run (L) dispatches by the active `SimulationMode`. CW path unchanged.
- **Bottom Analysis dock** (separate from the Error Console, mirroring its collapsible pattern) with **Transient** + **Eye / BER** tabs. Canvas stays visible.
- **Transient** re-homed out of the properties panel into the Transient tab; the properties panel is decluttered.
- **Eye/BER (#627):** its self-contained core (`CAP_Core.Analysis.EyeDiagram.*`), `EyeDiagramViewModel`, `EyeDiagramPlotBuilder` and `TransientCircuitFactory` are **adopted** into the dock's Eye/BER tab; #627's stale right-panel wiring is **discarded**. #627 should be closed as superseded.

## How (per the plan, subagent-driven, 6 tasks)
1. Adopt eye/BER core + tests. 2. Promote CW/Transient to `MainViewModel.SimulationMode`, delete the view-only `IsTimeDomainMode`. 3. Adopt `TransientCircuitFactory` + `EyeDiagramViewModel`/`PlotBuilder`; build `AnalysisDockViewModel` (collapsible, tabbed); DI + `BottomPanelViewModel.Analysis`. 4. Run-dispatch by mode + toolbar selector. 5. Analysis dock panel + re-home transient/eye views + remove from properties + drop `RightPanel.TimeDomain`. 6. Verify.

No transient/eye **algorithm** changes — cores reused verbatim. `git grep RightPanel.TimeDomain|RightPanel.EyeDiagram|IsTimeDomainMode` is empty.

## Verification
Full suite green (2951 passed, 0 failed; 5 known flakes skipped). Per-task spec+quality reviews all clean. Runtime layout of the dock is not yet visually confirmed (AXAML — see reviewer note).

Design spec: `docs/superpowers/specs/2026-07-07-transient-eye-analysis-dock-design.md`; plan: `docs/superpowers/plans/2026-07-07-transient-eye-analysis-dock.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
