### PR TITLE
(=) gdsfactory export: refuse mixed-process designs with a clear message (#570)

### DIFF
--- a/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
@@ -101,6 +101,26 @@ public partial class GdsFactoryExportViewModel : ObservableObject
             return;
         }
 
+        // A GDS is one fabrication process. Playground lets you place components from different
+        // processes (e.g. CornerStone SiN + SiEPIC SOI) together, but they cannot be exported into
+        // one gdsfactory GDS — the script activates a single PDK and the foreign cells fail to
+        // resolve. Detect this up front and refuse with a clear message instead of a raw Python
+        // crash at runtime (#570).
+        var backendConflicts = GdsFactoryExporter.CollectBackendConflicts(
+            _canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells));
+        if (backendConflicts.Count > 0)
+        {
+            var message =
+                "Cannot export: this design mixes incompatible fabrication processes ("
+                + string.Join(" + ", backendConflicts)
+                + "). A single GDS is one process — keep one PDK's components per design and export "
+                + "each separately. (Playground lets you place mixed components for experimentation, "
+                + "but they can't be exported together.)";
+            StatusText = message;
+            _errorConsole?.LogError(message);
+            return;
+        }
+
         var filePath = await FileDialogService.ShowSaveFileDialogAsync(
             "Export to gdsfactory Python", "py", "Python Files|*.py|All Files|*.*");
         if (filePath == null)

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryExporterTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryExporterTests.cs
@@ -345,6 +345,30 @@ public class GdsFactoryExporterTests
     }
 
     [Fact]
+    public void CollectBackendConflicts_GdsFactoryPlusSiepicUbcpdkCell_ReportsConflict()
+    {
+        // Playground lets the user mix a gdsfactory-native PDK (CornerStone SiN) with a SiEPIC
+        // (ubcpdk) component. The export activates the cspdk PDK, so `gf.get_component('ebeam_…')`
+        // can't resolve the SiEPIC cell → a runtime crash. This must be detected up front (#570).
+        var canvas = new DesignCanvasViewModel();
+        var sin = TestComponentFactory.CreateBasicComponent();
+        sin.Identifier = "SIN1";
+        sin.NazcaFunctionName = "";
+        sin.GdsFactoryFunction = "cspdk.sin300.mmi1x2";
+        canvas.AddComponent(sin, "SiN");
+        var siepic = TestComponentFactory.CreateBasicComponent();
+        siepic.Identifier = "EB1";
+        siepic.NazcaFunctionName = "ebeam_adiabatic_te1550";   // maps to a ubcpdk cell
+        canvas.AddComponent(siepic, "Adiabatic");
+
+        var conflicts = GdsFactoryExporter.CollectBackendConflicts(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells));
+
+        conflicts.ShouldNotBeEmpty();
+        conflicts.ShouldContain(c => c.Contains("cspdk.sin300"));
+    }
+
+    [Fact]
     public void BareGdsFactoryFunction_FallsToStubAndIsReportedUnmapped()
     {
         // A dotless gdsFactoryFunction has no importable module → it must fall through to a


### PR DESCRIPTION
## Problem
In Playground (which bypasses single-process enforcement), a user can place CornerStone SiN (cspdk, gdsfactory-native) and SiEPIC (ubcpdk/SOI) components on one canvas. The gdsfactory export activates a single PDK, so `gf.get_component('ebeam_adiabatic_te1550')` fails against the active `cspdk.sin300` PDK with a raw `ValueError` deep in the generated Python — a cryptic crash.

## Fix
`GdsFactoryExporter.CollectBackendConflicts` already detected this (multiple gdsfactory modules, or a gdsfactory module coexisting with ubcpdk-mapped components) but was never wired into the export. The gdsfactory export now calls it **up front** and refuses with a clear, actionable message (naming the conflicting process) via `StatusText` + the error console, **before** the save dialog — instead of emitting a script that crashes at runtime.

A GDS is one fabrication process; mixing SiN + SOI is not physically one chip, so this is a hard refuse (not a partial export). Same honest-UX pattern as the Nazca-export guard (#675).

## Verification
- New test: `CollectBackendConflicts` flags a cspdk + SiEPIC(ubcpdk) mix.
- Full suite green (2905 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
