### PR TITLE
In-place self-update: download → swap → relaunch (all platforms) — #614, hardened

### DIFF
--- a/.github/workflows/Build_Exe.yaml
+++ b/.github/workflows/Build_Exe.yaml
@@ -250,6 +250,21 @@ jobs:
           name: Lunima-${{ matrix.rid }}-dmg
           path: Lunima-*-${{ matrix.rid }}.dmg
 
+      # Zipped .app for the in-place auto-updater (issue #614). ditto preserves the bundle's
+      # symlinks / extended attributes / signature seal so the on-disk bytes stay valid; the
+      # .dmg above remains the artifact for first-time manual installs.
+      - name: Package .app zip (for in-place auto-update)
+        run: |
+          ZIP="Lunima-${{ steps.version.outputs.version }}-${{ matrix.rid }}.zip"
+          ditto -c -k --sequesterRsrc --keepParent dist/Lunima.app "$ZIP"
+          echo "Created $ZIP"
+
+      - name: Upload .zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Lunima-${{ matrix.rid }}-zip
+          path: Lunima-*-${{ matrix.rid }}.zip
+
   release:
     name: Create Release
     needs: [build, build-msi, build-macos]
@@ -313,6 +328,13 @@ jobs:
         with:
           pattern: Lunima-*-dmg
           path: dmg
+          merge-multiple: true
+
+      - name: Download macOS .zip builds
+        uses: actions/download-artifact@v4
+        with:
+          pattern: Lunima-*-zip
+          path: zip
           merge-multiple: true
 
       - name: Create archives
@@ -429,3 +451,5 @@ jobs:
             Lunima-${{ steps.info.outputs.version }}-linux-x64.tar.gz
             dmg/Lunima-${{ steps.info.outputs.version }}-osx-arm64.dmg
             dmg/Lunima-${{ steps.info.outputs.version }}-osx-x64.dmg
+            zip/Lunima-${{ steps.info.outputs.version }}-osx-arm64.zip
+            zip/Lunima-${{ steps.info.outputs.version }}-osx-x64.zip

--- a/CAP.Avalonia/DI/UpdateFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/UpdateFeatureExtensions.cs
@@ -25,7 +25,9 @@ internal static class UpdateFeatureExtensions
         services.AddSingleton(sp => new UpdateChecker(
             sp.GetRequiredService<HttpClient>(),
             owner: "aignermax",
-            repo: "Connect-A-PIC-Pro"));
+            // Repo was renamed Connect-A-PIC-Pro -> Lunima; query the current name directly rather
+            // than relying on GitHub's rename redirect (which breaks if the old name is reclaimed).
+            repo: "Lunima"));
         services.AddSingleton(sp => new UpdateDownloader(
             sp.GetRequiredService<HttpClient>()));
         services.AddSingleton<IUrlLauncher, PlatformShellLauncher>();

--- a/CAP.Avalonia/DI/UpdateFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/UpdateFeatureExtensions.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.Update;
 using CAP.Avalonia.ViewModels.Update;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,6 +29,8 @@ internal static class UpdateFeatureExtensions
         services.AddSingleton(sp => new UpdateDownloader(
             sp.GetRequiredService<HttpClient>()));
         services.AddSingleton<IUrlLauncher, PlatformShellLauncher>();
+        services.AddSingleton<DetachedUpdaterLauncher>();
+        services.AddSingleton<IInstaller, SelfUpdateInstaller>();
         services.AddSingleton<UpdateViewModel>();
 
         return services;

--- a/CAP.Avalonia/Services/Update/DetachedUpdaterLauncher.cs
+++ b/CAP.Avalonia/Services/Update/DetachedUpdaterLauncher.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+
+namespace CAP.Avalonia.Services.Update;
+
+/// <summary>
+/// Launches a generated updater script as a DETACHED process that outlives the quitting app.
+/// This is the single place in the update feature that constructs a <see cref="ProcessStartInfo"/>
+/// directly (see <c>CrossPlatformProcessLaunchTests.AllowedDirectLaunchFiles</c>): the updater must
+/// survive its parent exiting, so it can't be an awaited <c>ProcessLaunchFactory</c> tool launch.
+/// </summary>
+public class DetachedUpdaterLauncher
+{
+    /// <summary>
+    /// Starts <paramref name="scriptPath"/> detached from the current process. On Windows it runs
+    /// via a hidden PowerShell; on macOS/Linux via <c>nohup bash … &amp;</c> so it keeps running
+    /// after the app quits. Marked <c>virtual</c> so tests can substitute a no-op launcher.
+    /// </summary>
+    public virtual void Launch(string scriptPath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+            };
+            psi.ArgumentList.Add("-NoProfile");
+            psi.ArgumentList.Add("-ExecutionPolicy");
+            psi.ArgumentList.Add("Bypass");
+            psi.ArgumentList.Add("-File");
+            psi.ArgumentList.Add(scriptPath);
+            Process.Start(psi);
+            return;
+        }
+
+        // macOS/Linux: nohup + background so the helper is not killed when the app exits.
+        var shell = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            UseShellExecute = false,
+        };
+        shell.ArgumentList.Add("-c");
+        shell.ArgumentList.Add($"nohup /bin/bash {Quote(scriptPath)} >/dev/null 2>&1 &");
+        Process.Start(shell);
+    }
+
+    private static string Quote(string value) => "'" + value.Replace("'", "'\\''") + "'";
+}

--- a/CAP.Avalonia/Services/Update/DetachedUpdaterLauncher.cs
+++ b/CAP.Avalonia/Services/Update/DetachedUpdaterLauncher.cs
@@ -35,14 +35,16 @@ public class DetachedUpdaterLauncher
             return;
         }
 
-        // macOS/Linux: nohup + background so the helper is not killed when the app exits.
+        // macOS/Linux: nohup + background so the helper is not killed when the app exits. Resolve
+        // bash via env (portable across /bin/bash vs /usr/bin/bash) instead of hardcoding a path.
         var shell = new ProcessStartInfo
         {
-            FileName = "/bin/bash",
+            FileName = "/usr/bin/env",
             UseShellExecute = false,
         };
+        shell.ArgumentList.Add("bash");
         shell.ArgumentList.Add("-c");
-        shell.ArgumentList.Add($"nohup /bin/bash {Quote(scriptPath)} >/dev/null 2>&1 &");
+        shell.ArgumentList.Add($"nohup bash {Quote(scriptPath)} >/dev/null 2>&1 &");
         Process.Start(shell);
     }
 

--- a/CAP.Avalonia/Services/Update/IInstaller.cs
+++ b/CAP.Avalonia/Services/Update/IInstaller.cs
@@ -1,0 +1,24 @@
+namespace CAP.Avalonia.Services.Update;
+
+/// <summary>
+/// Installs a downloaded update over the current installation and relaunches the app.
+/// The download itself is handled by <see cref="UpdateDownloader"/>; this seam owns only the
+/// "replace the installed app and restart" step, which differs per operating system.
+/// </summary>
+public interface IInstaller
+{
+    /// <summary>
+    /// True when an in-place update can be performed right now — the running app's install
+    /// location is known and writable. When false, <paramref name="reason"/> explains why and the
+    /// caller should fall back to a manual installer / the releases page instead of quitting.
+    /// </summary>
+    bool CanInstallInPlace(out string reason);
+
+    /// <summary>
+    /// Writes and launches a DETACHED updater that waits for this process to exit, replaces the
+    /// installed application with the contents of <paramref name="downloadedArchivePath"/>, and
+    /// relaunches the new version. After this returns the caller MUST quit the app so the updater
+    /// can replace files and relaunch.
+    /// </summary>
+    void LaunchUpdater(string downloadedArchivePath);
+}

--- a/CAP.Avalonia/Services/Update/InstallLocation.cs
+++ b/CAP.Avalonia/Services/Update/InstallLocation.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+
+namespace CAP.Avalonia.Services.Update;
+
+/// <summary>
+/// Describes where the running application is installed, so an updater can replace it and relaunch.
+/// </summary>
+public sealed class InstallLocation
+{
+    /// <summary>The directory or bundle to replace — the <c>.app</c> on macOS, the install directory on Windows/Linux.</summary>
+    public string Root { get; }
+
+    /// <summary>Full path to the executable, used to relaunch on Windows/Linux and to locate the bundle on macOS.</summary>
+    public string ExecutablePath { get; }
+
+    /// <summary>PID of the currently running process; the updater waits for it to exit before swapping.</summary>
+    public int ProcessId { get; }
+
+    /// <summary>Initializes a new <see cref="InstallLocation"/>.</summary>
+    public InstallLocation(string root, string executablePath, int processId)
+    {
+        Root = root;
+        ExecutablePath = executablePath;
+        ProcessId = processId;
+    }
+
+    /// <summary>
+    /// Resolves the install location of the running process, or null if it can't be determined
+    /// (e.g. launched via <c>dotnet run</c> from a build output rather than an installed app).
+    /// On macOS the root is the enclosing <c>*.app</c> bundle; on Windows/Linux it is the
+    /// executable's directory.
+    /// </summary>
+    public static InstallLocation? Resolve()
+    {
+        string? exe;
+        try
+        {
+            exe = Process.GetCurrentProcess().MainModule?.FileName;
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(exe) || !File.Exists(exe))
+            return null;
+
+        var pid = Environment.ProcessId;
+
+        if (OperatingSystem.IsMacOS())
+        {
+            var bundle = FindEnclosingAppBundle(exe);
+            return bundle is null ? null : new InstallLocation(bundle, exe, pid);
+        }
+
+        var dir = Path.GetDirectoryName(exe);
+        return string.IsNullOrEmpty(dir) ? null : new InstallLocation(dir, exe, pid);
+    }
+
+    /// <summary>
+    /// Walks up from <paramref name="executablePath"/> to the nearest enclosing <c>*.app</c>
+    /// bundle directory, or null if the executable is not inside a bundle.
+    /// </summary>
+    internal static string? FindEnclosingAppBundle(string executablePath)
+    {
+        var dir = new DirectoryInfo(Path.GetDirectoryName(executablePath) ?? executablePath);
+        while (dir is not null)
+        {
+            if (dir.Name.EndsWith(".app", StringComparison.OrdinalIgnoreCase))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/CAP.Avalonia/Services/Update/InstallLocation.cs
+++ b/CAP.Avalonia/Services/Update/InstallLocation.cs
@@ -70,43 +70,112 @@ public sealed class InstallLocation
         if (string.IsNullOrEmpty(directory))
             return false;
 
-        var norm = Normalize(directory);
+        var target = Canonical(directory);
 
         // Filesystem root (e.g. "/", "C:\").
         var root = Path.GetPathRoot(directory);
-        if (!string.IsNullOrEmpty(root) && Normalize(root) == norm)
+        if (!string.IsNullOrEmpty(root) && Canonical(root) == target)
             return true;
 
-        if (norm == Normalize(Path.GetTempPath()))
+        if (target == Canonical(Path.GetTempPath()))
             return true;
 
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!string.IsNullOrEmpty(home))
-        {
-            if (norm == Normalize(home))
-                return true;
+        if (!string.IsNullOrEmpty(home) && Canonical(home) == target)
+            return true;
 
-            // Standard per-user folders. Downloads has no SpecialFolder enum, so it is matched
-            // by name; the rest resolve through the OS so localized/XDG-redirected paths count too.
-            var shared = new[]
-            {
-                Path.Combine(home, "Downloads"),
-                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
-                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                Environment.GetFolderPath(Environment.SpecialFolder.MyMusic),
-                Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
-                Environment.GetFolderPath(Environment.SpecialFolder.MyVideos),
-            };
-            foreach (var s in shared)
-                if (!string.IsNullOrEmpty(s) && Normalize(s) == norm)
-                    return true;
-        }
+        foreach (var s in SharedSubdirectories(home))
+            if (!string.IsNullOrEmpty(s) && Canonical(s) == target)
+                return true;
 
         return false;
     }
 
-    /// <summary>Case-preserving path normalization for comparison: trims trailing separators.</summary>
-    private static string Normalize(string path) =>
+    /// <summary>
+    /// Standard per-user folders that are never an app's exclusive install root. Resolves through
+    /// the OS SpecialFolder enum (localized/redirected paths included) and, on Linux, honours the
+    /// XDG user-dirs config so e.g. a localized "Téléchargements" download folder is recognised.
+    /// </summary>
+    private static IEnumerable<string> SharedSubdirectories(string? home)
+    {
+        yield return Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+        yield return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        yield return Environment.GetFolderPath(Environment.SpecialFolder.MyMusic);
+        yield return Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+        yield return Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
+
+        // Downloads has no SpecialFolder enum. English default under home…
+        if (!string.IsNullOrEmpty(home))
+            yield return Path.Combine(home, "Downloads");
+
+        // …plus the XDG-configured (possibly localized) download/desktop/documents dirs on Linux.
+        if (OperatingSystem.IsLinux())
+        {
+            foreach (var d in XdgUserDirs())
+                yield return d;
+        }
+    }
+
+    /// <summary>
+    /// Reads the XDG user-dirs (env var first, then <c>~/.config/user-dirs.dirs</c>) and returns the
+    /// resolved Download/Desktop/Documents paths. Best-effort: returns nothing on any parse error.
+    /// </summary>
+    private static IEnumerable<string> XdgUserDirs()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var results = new List<string>();
+
+        void AddFromEnv(string var)
+        {
+            var v = Environment.GetEnvironmentVariable(var);
+            if (!string.IsNullOrEmpty(v)) results.Add(v);
+        }
+        AddFromEnv("XDG_DOWNLOAD_DIR");
+        AddFromEnv("XDG_DESKTOP_DIR");
+        AddFromEnv("XDG_DOCUMENTS_DIR");
+
+        try
+        {
+            var config = Path.Combine(home, ".config", "user-dirs.dirs");
+            if (File.Exists(config))
+            {
+                foreach (var raw in File.ReadAllLines(config))
+                {
+                    var line = raw.Trim();
+                    // Format: XDG_DOWNLOAD_DIR="$HOME/Downloads"
+                    if (!line.StartsWith("XDG_", StringComparison.Ordinal)) continue;
+                    var eq = line.IndexOf('=');
+                    if (eq < 0) continue;
+                    var value = line[(eq + 1)..].Trim().Trim('"');
+                    value = value.Replace("$HOME", home).Replace("${HOME}", home);
+                    if (!string.IsNullOrEmpty(value)) results.Add(value);
+                }
+            }
+        }
+        catch { /* best-effort — the file-by-file updater is the primary safeguard */ }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Canonical path for comparison: absolute, trailing separators trimmed, and symlinks resolved
+    /// to their final target when the path exists (so a symlinked shared dir still matches).
+    /// </summary>
+    private static string Canonical(string path)
+    {
+        try
+        {
+            var full = Path.GetFullPath(path);
+            var resolved = Directory.ResolveLinkTarget(full, returnFinalTarget: true);
+            return Trim(resolved?.FullName ?? full);
+        }
+        catch
+        {
+            return Trim(path);
+        }
+    }
+
+    private static string Trim(string path) =>
         path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     /// <summary>

--- a/CAP.Avalonia/Services/Update/InstallLocation.cs
+++ b/CAP.Avalonia/Services/Update/InstallLocation.cs
@@ -58,6 +58,58 @@ public sealed class InstallLocation
     }
 
     /// <summary>
+    /// True when <paramref name="directory"/> is a shared user directory that the app does not
+    /// own exclusively (the user's home, its standard subfolders like Downloads/Desktop/Documents,
+    /// the temp directory, or a filesystem root). The in-place updater must never treat such a
+    /// directory as a replaceable install root — the Linux portable build is a loose binary whose
+    /// "install dir" is wherever the user dropped it, and replacing/removing the whole directory
+    /// would destroy unrelated files (issue #616).
+    /// </summary>
+    internal static bool IsSharedUserDirectory(string directory)
+    {
+        if (string.IsNullOrEmpty(directory))
+            return false;
+
+        var norm = Normalize(directory);
+
+        // Filesystem root (e.g. "/", "C:\").
+        var root = Path.GetPathRoot(directory);
+        if (!string.IsNullOrEmpty(root) && Normalize(root) == norm)
+            return true;
+
+        if (norm == Normalize(Path.GetTempPath()))
+            return true;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home))
+        {
+            if (norm == Normalize(home))
+                return true;
+
+            // Standard per-user folders. Downloads has no SpecialFolder enum, so it is matched
+            // by name; the rest resolve through the OS so localized/XDG-redirected paths count too.
+            var shared = new[]
+            {
+                Path.Combine(home, "Downloads"),
+                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyMusic),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
+                Environment.GetFolderPath(Environment.SpecialFolder.MyVideos),
+            };
+            foreach (var s in shared)
+                if (!string.IsNullOrEmpty(s) && Normalize(s) == norm)
+                    return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Case-preserving path normalization for comparison: trims trailing separators.</summary>
+    private static string Normalize(string path) =>
+        path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    /// <summary>
     /// Walks up from <paramref name="executablePath"/> to the nearest enclosing <c>*.app</c>
     /// bundle directory, or null if the executable is not inside a bundle.
     /// </summary>

--- a/CAP.Avalonia/Services/Update/SelfUpdateInstaller.cs
+++ b/CAP.Avalonia/Services/Update/SelfUpdateInstaller.cs
@@ -1,0 +1,80 @@
+namespace CAP.Avalonia.Services.Update;
+
+/// <summary>
+/// Cross-platform <see cref="IInstaller"/>: replaces the running installation with a downloaded
+/// archive and relaunches. Resolves the install location, writes the OS-specific updater script,
+/// and hands it to <see cref="DetachedUpdaterLauncher"/> to run after the app quits.
+/// </summary>
+public class SelfUpdateInstaller : IInstaller
+{
+    private readonly DetachedUpdaterLauncher _launcher;
+
+    /// <summary>Initializes a new <see cref="SelfUpdateInstaller"/>.</summary>
+    public SelfUpdateInstaller(DetachedUpdaterLauncher launcher)
+    {
+        _launcher = launcher;
+    }
+
+    /// <inheritdoc/>
+    public bool CanInstallInPlace(out string reason)
+    {
+        var location = InstallLocation.Resolve();
+        if (location is null)
+        {
+            reason = "the app is not running from an installed location (e.g. launched from source)";
+            return false;
+        }
+
+        var parent = Path.GetDirectoryName(location.Root);
+        if (string.IsNullOrEmpty(parent) || !IsDirectoryWritable(parent))
+        {
+            reason = "the install location is not writable without elevation";
+            return false;
+        }
+
+        reason = string.Empty;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void LaunchUpdater(string downloadedArchivePath)
+    {
+        var location = InstallLocation.Resolve()
+            ?? throw new InvalidOperationException("Cannot resolve the install location to update.");
+
+        var script = BuildScript(location, downloadedArchivePath);
+        var extension = OperatingSystem.IsWindows() ? ".ps1" : ".sh";
+        var scriptPath = Path.Combine(
+            Path.GetTempPath(), $"lunima-update-{Guid.NewGuid():N}{extension}");
+        File.WriteAllText(scriptPath, script);
+
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(scriptPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        _launcher.Launch(scriptPath);
+    }
+
+    private static string BuildScript(InstallLocation location, string archivePath)
+    {
+        if (OperatingSystem.IsWindows()) return UpdaterScripts.BuildWindows(location, archivePath);
+        if (OperatingSystem.IsMacOS()) return UpdaterScripts.BuildMacOs(location, archivePath);
+        return UpdaterScripts.BuildLinux(location, archivePath);
+    }
+
+    /// <summary>Returns true if a file can be created in <paramref name="directory"/> (a write probe).</summary>
+    internal static bool IsDirectoryWritable(string directory)
+    {
+        try
+        {
+            var probe = Path.Combine(directory, $".lunima-write-probe-{Guid.NewGuid():N}");
+            using (File.Create(probe)) { }
+            File.Delete(probe);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/CAP.Avalonia/Services/Update/SelfUpdateInstaller.cs
+++ b/CAP.Avalonia/Services/Update/SelfUpdateInstaller.cs
@@ -25,10 +25,20 @@ public class SelfUpdateInstaller : IInstaller
             return false;
         }
 
+        // The macOS bundle swap writes in the parent (moves the .app aside); the Linux file-by-file
+        // updater writes INSIDE the root (its backup dir + the replaced files). Require both to be
+        // writable so a parent-writable-but-root-read-only layout fails the check up front rather
+        // than mid-install.
         var parent = Path.GetDirectoryName(location.Root);
         if (string.IsNullOrEmpty(parent) || !IsDirectoryWritable(parent))
         {
             reason = "the install location is not writable without elevation";
+            return false;
+        }
+
+        if (Directory.Exists(location.Root) && !IsDirectoryWritable(location.Root))
+        {
+            reason = "the install directory is not writable without elevation";
             return false;
         }
 

--- a/CAP.Avalonia/Services/Update/SelfUpdateInstaller.cs
+++ b/CAP.Avalonia/Services/Update/SelfUpdateInstaller.cs
@@ -32,6 +32,16 @@ public class SelfUpdateInstaller : IInstaller
             return false;
         }
 
+        // Never treat a shared user directory (home, Downloads, …) as a replaceable install
+        // root — updating in place there could delete the user's unrelated files (issue #616).
+        // On macOS the root is the .app bundle, which is app-owned, so this never trips there.
+        if (InstallLocation.IsSharedUserDirectory(location.Root))
+        {
+            reason = "the app runs from a shared folder (e.g. Downloads); move it into its own "
+                + "folder to enable in-place updates";
+            return false;
+        }
+
         reason = string.Empty;
         return true;
     }

--- a/CAP.Avalonia/Services/Update/UpdaterScripts.cs
+++ b/CAP.Avalonia/Services/Update/UpdaterScripts.cs
@@ -1,0 +1,158 @@
+using System.Globalization;
+
+namespace CAP.Avalonia.Services.Update;
+
+/// <summary>
+/// Generates the platform-specific updater scripts that replace the installed app and relaunch.
+/// These are pure string builders (no I/O), so the exact commands are unit-testable. The scripts
+/// are run detached by <see cref="DetachedUpdaterLauncher"/> after the app quits.
+/// </summary>
+public static class UpdaterScripts
+{
+    /// <summary>Builds the macOS updater (bash): ditto-extract → de-quarantine → ad-hoc sign → near-atomic swap → relaunch.</summary>
+    public static string BuildMacOs(InstallLocation target, string archivePath) =>
+        MacTemplate
+            .Replace("__OLD_PID__", target.ProcessId.ToString(CultureInfo.InvariantCulture))
+            .Replace("__TARGET__", ShQuote(target.Root))
+            .Replace("__ARCHIVE__", ShQuote(archivePath))
+            .Replace("__EXE_NAME__", ShQuote(Path.GetFileName(target.ExecutablePath)));
+
+    /// <summary>Builds the Linux updater (bash): tar-extract → directory swap → relaunch.</summary>
+    public static string BuildLinux(InstallLocation target, string archivePath) =>
+        LinuxTemplate
+            .Replace("__OLD_PID__", target.ProcessId.ToString(CultureInfo.InvariantCulture))
+            .Replace("__TARGET__", ShQuote(target.Root))
+            .Replace("__ARCHIVE__", ShQuote(archivePath))
+            .Replace("__EXE_NAME__", ShQuote(Path.GetFileName(target.ExecutablePath)));
+
+    /// <summary>Builds the Windows updater (PowerShell): wait for exit → msiexec in-place upgrade → relaunch.</summary>
+    public static string BuildWindows(InstallLocation target, string msiPath) =>
+        WindowsTemplate
+            .Replace("__OLD_PID__", target.ProcessId.ToString(CultureInfo.InvariantCulture))
+            .Replace("__MSI__", PsQuote(msiPath))
+            .Replace("__EXE__", PsQuote(target.ExecutablePath));
+
+    /// <summary>Single-quotes a value for safe use in a POSIX shell (escapes embedded quotes).</summary>
+    internal static string ShQuote(string value) => "'" + value.Replace("'", "'\\''") + "'";
+
+    /// <summary>Single-quotes a value for safe use in PowerShell (doubles embedded quotes).</summary>
+    internal static string PsQuote(string value) => "'" + value.Replace("'", "''") + "'";
+
+    private const string MacTemplate =
+        """
+        #!/bin/bash
+        # Lunima in-place updater (macOS) — generated. Replaces the running .app and relaunches.
+        set -uo pipefail
+        OLD_PID=__OLD_PID__
+        TARGET=__TARGET__
+        ARCHIVE=__ARCHIVE__
+        EXE_NAME=__EXE_NAME__
+        LOG="${TMPDIR:-/tmp}/lunima-update.log"
+        exec >>"$LOG" 2>&1
+        echo "=== lunima update $(date) pid=$OLD_PID target=$TARGET ==="
+        PARENT="$(dirname "$TARGET")"
+        BACKUP="$TARGET.bak.$$"
+        STAGEDIR="$PARENT/.lunima-update.$$"
+
+        rollback() {
+          echo "ROLLBACK: $1"
+          [ -d "$STAGEDIR" ] && rm -rf "$STAGEDIR"
+          if [ ! -e "$TARGET" ] && [ -d "$BACKUP" ]; then mv "$BACKUP" "$TARGET"; fi
+          [ -d "$BACKUP" ] && [ -e "$TARGET" ] && rm -rf "$BACKUP"
+          open -n "$TARGET" 2>/dev/null || true
+          exit 1
+        }
+
+        # 1. wait for the running app to exit (up to ~30s)
+        for _ in $(seq 1 60); do kill -0 "$OLD_PID" 2>/dev/null || break; sleep 0.5; done
+        kill -0 "$OLD_PID" 2>/dev/null && rollback "app did not exit"
+
+        # 2. extract the new bundle beside the target (same volume -> final mv is atomic)
+        mkdir -p "$STAGEDIR" || rollback "mkdir stage failed"
+        ditto -x -k "$ARCHIVE" "$STAGEDIR" || rollback "extract failed"
+        NEW="$(find "$STAGEDIR" -maxdepth 2 -name '*.app' -type d | head -1)"
+        [ -n "$NEW" ] || rollback "no .app found in archive"
+
+        # 3. de-quarantine (prevents the Gatekeeper prompt AND App Translocation)
+        xattr -dr com.apple.quarantine "$NEW" 2>/dev/null || true
+
+        # 4. ad-hoc sign on THIS machine (Apple Silicon needs >= ad-hoc); inside-out, not recursively
+        find "$NEW/Contents" \( -name '*.dylib' -o -name '*.so' \) -print0 2>/dev/null \
+          | xargs -0 -I{} codesign --force --sign - "{}" 2>/dev/null || true
+        [ -f "$NEW/Contents/MacOS/$EXE_NAME" ] && codesign --force --sign - "$NEW/Contents/MacOS/$EXE_NAME" 2>/dev/null || true
+        codesign --force --sign - "$NEW" 2>/dev/null || rollback "codesign failed"
+
+        # 5. near-atomic swap: move old aside, new into place
+        mv "$TARGET" "$BACKUP" || rollback "could not move old bundle aside"
+        mv "$NEW" "$TARGET" || rollback "could not move new bundle into place"
+
+        # 6. relaunch the new version, then clean up
+        open -n "$TARGET" || rollback "relaunch failed"
+        [ -d "$STAGEDIR" ] && rm -rf "$STAGEDIR"
+        rm -rf "$BACKUP"
+        rm -f "$ARCHIVE" 2>/dev/null || true
+        echo "=== update OK ==="
+        """;
+
+    private const string LinuxTemplate =
+        """
+        #!/bin/bash
+        # Lunima in-place updater (Linux) — generated. Replaces the install directory and relaunches.
+        set -uo pipefail
+        OLD_PID=__OLD_PID__
+        TARGET=__TARGET__
+        ARCHIVE=__ARCHIVE__
+        EXE_NAME=__EXE_NAME__
+        LOG="${TMPDIR:-/tmp}/lunima-update.log"
+        exec >>"$LOG" 2>&1
+        echo "=== lunima update $(date) pid=$OLD_PID target=$TARGET ==="
+        PARENT="$(dirname "$TARGET")"
+        BACKUP="$TARGET.bak.$$"
+        STAGEDIR="$PARENT/.lunima-update.$$"
+
+        rollback() {
+          echo "ROLLBACK: $1"
+          [ -d "$STAGEDIR" ] && rm -rf "$STAGEDIR"
+          if [ ! -e "$TARGET" ] && [ -d "$BACKUP" ]; then mv "$BACKUP" "$TARGET"; fi
+          [ -d "$BACKUP" ] && [ -e "$TARGET" ] && rm -rf "$BACKUP"
+          [ -x "$TARGET/$EXE_NAME" ] && ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & )
+          exit 1
+        }
+
+        for _ in $(seq 1 60); do kill -0 "$OLD_PID" 2>/dev/null || break; sleep 0.5; done
+        kill -0 "$OLD_PID" 2>/dev/null && rollback "app did not exit"
+
+        mkdir -p "$STAGEDIR" || rollback "mkdir stage failed"
+        tar -xzf "$ARCHIVE" -C "$STAGEDIR" || rollback "extract failed"
+        # the tarball may hold the files at its root or inside one folder; locate the executable
+        if [ ! -f "$STAGEDIR/$EXE_NAME" ]; then
+          SUB="$(find "$STAGEDIR" -maxdepth 2 -type f -name "$EXE_NAME" | head -1)"
+          [ -n "$SUB" ] && STAGEDIR="$(dirname "$SUB")"
+        fi
+        [ -f "$STAGEDIR/$EXE_NAME" ] || rollback "executable not found in archive"
+        chmod +x "$STAGEDIR/$EXE_NAME" 2>/dev/null || true
+
+        mv "$TARGET" "$BACKUP" || rollback "could not move old install aside"
+        mv "$STAGEDIR" "$TARGET" || rollback "could not move new install into place"
+
+        ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & ) || rollback "relaunch failed"
+        rm -rf "$BACKUP"
+        rm -f "$ARCHIVE" 2>/dev/null || true
+        echo "=== update OK ==="
+        """;
+
+    private const string WindowsTemplate =
+        """
+        # Lunima in-place updater (Windows) — generated. Runs the MSI upgrade and relaunches.
+        $ErrorActionPreference = 'Continue'
+        $targetPid = __OLD_PID__
+        $msi = __MSI__
+        $exe = __EXE__
+        $log = Join-Path $env:TEMP 'lunima-update.log'
+        "=== lunima update $(Get-Date) pid=$targetPid ===" | Out-File -FilePath $log -Append
+        try { Wait-Process -Id $targetPid -Timeout 60 -ErrorAction SilentlyContinue } catch {}
+        $p = Start-Process msiexec -ArgumentList '/i', $msi, '/qb' -Wait -PassThru
+        "msiexec exit $($p.ExitCode)" | Out-File -FilePath $log -Append
+        Start-Process -FilePath $exe
+        """;
+}

--- a/CAP.Avalonia/Services/Update/UpdaterScripts.cs
+++ b/CAP.Avalonia/Services/Update/UpdaterScripts.cs
@@ -9,7 +9,7 @@ namespace CAP.Avalonia.Services.Update;
 /// </summary>
 public static class UpdaterScripts
 {
-    /// <summary>Builds the macOS updater (bash): ditto-extract → de-quarantine → ad-hoc sign → near-atomic swap → relaunch.</summary>
+    /// <summary>Builds the macOS updater (bash): ditto-extract → de-quarantine → deep ad-hoc sign → near-atomic swap → relaunch.</summary>
     public static string BuildMacOs(InstallLocation target, string archivePath) =>
         MacTemplate
             .Replace("__OLD_PID__", target.ProcessId.ToString(CultureInfo.InvariantCulture))
@@ -40,7 +40,7 @@ public static class UpdaterScripts
 
     private const string MacTemplate =
         """
-        #!/bin/bash
+        #!/usr/bin/env bash
         # Lunima in-place updater (macOS) — generated. Replaces the running .app and relaunches.
         set -uo pipefail
         OLD_PID=__OLD_PID__
@@ -53,40 +53,50 @@ public static class UpdaterScripts
         PARENT="$(dirname "$TARGET")"
         BACKUP="$TARGET.bak.$$"
         STAGEDIR="$PARENT/.lunima-update.$$"
+        SWAPPED=0
 
         rollback() {
+          # Only reached after the app has exited (the wait timeout below aborts without calling this).
           echo "ROLLBACK: $1"
           [ -d "$STAGEDIR" ] && rm -rf "$STAGEDIR"
-          if [ ! -e "$TARGET" ] && [ -d "$BACKUP" ]; then mv "$BACKUP" "$TARGET"; fi
-          [ -d "$BACKUP" ] && [ -e "$TARGET" ] && rm -rf "$BACKUP"
+          if [ "$SWAPPED" = "1" ]; then
+            # Swap already happened: move the failed new bundle aside and restore the known-good backup.
+            [ -e "$TARGET" ] && mv "$TARGET" "$TARGET.failed.$$" 2>/dev/null
+            [ -d "$BACKUP" ] && mv "$BACKUP" "$TARGET"
+          fi
+          # Pre-swap failures leave TARGET as the original bundle; relaunch it so a working app survives.
           open -n "$TARGET" 2>/dev/null || true
           exit 1
         }
 
-        # 1. wait for the running app to exit (up to ~30s)
+        # 1. Wait for the running app to exit (~30s). If it never exits, abort WITHOUT relaunching —
+        #    the original is still running, so there is nothing to recover and a 2nd instance would clash.
         for _ in $(seq 1 60); do kill -0 "$OLD_PID" 2>/dev/null || break; sleep 0.5; done
-        kill -0 "$OLD_PID" 2>/dev/null && rollback "app did not exit"
+        if kill -0 "$OLD_PID" 2>/dev/null; then echo "app did not exit; aborting"; exit 1; fi
 
-        # 2. extract the new bundle beside the target (same volume -> final mv is atomic)
+        # 2. Extract the new bundle beside the target (same volume -> the final mv is atomic).
         mkdir -p "$STAGEDIR" || rollback "mkdir stage failed"
         ditto -x -k "$ARCHIVE" "$STAGEDIR" || rollback "extract failed"
         NEW="$(find "$STAGEDIR" -maxdepth 2 -name '*.app' -type d | head -1)"
         [ -n "$NEW" ] || rollback "no .app found in archive"
 
-        # 3. de-quarantine (prevents the Gatekeeper prompt AND App Translocation)
+        # 3. De-quarantine (prevents the Gatekeeper prompt AND App Translocation); verify it cleared.
         xattr -dr com.apple.quarantine "$NEW" 2>/dev/null || true
+        xattr -pr com.apple.quarantine "$NEW" 2>/dev/null | grep -q . && rollback "quarantine not cleared"
 
-        # 4. ad-hoc sign on THIS machine (Apple Silicon needs >= ad-hoc); inside-out, not recursively
-        find "$NEW/Contents" \( -name '*.dylib' -o -name '*.so' \) -print0 2>/dev/null \
-          | xargs -0 -I{} codesign --force --sign - "{}" 2>/dev/null || true
-        [ -f "$NEW/Contents/MacOS/$EXE_NAME" ] && codesign --force --sign - "$NEW/Contents/MacOS/$EXE_NAME" 2>/dev/null || true
-        codesign --force --sign - "$NEW" 2>/dev/null || rollback "codesign failed"
+        # 4. Ad-hoc sign the WHOLE bundle recursively (Apple Silicon requires >= ad-hoc). --deep is
+        #    required: a .NET self-contained bundle carries managed .dll + bare Mach-O helpers
+        #    (e.g. createdump) that a top-level-only seal refuses to cover. Verify BEFORE swapping so
+        #    a bad seal is caught while the old bundle is still in place.
+        codesign --force --deep --sign - "$NEW" || rollback "codesign failed"
+        codesign --verify --deep --strict "$NEW" || rollback "signature verify failed"
 
-        # 5. near-atomic swap: move old aside, new into place
+        # 5. Near-atomic swap: move old aside, new into place.
         mv "$TARGET" "$BACKUP" || rollback "could not move old bundle aside"
         mv "$NEW" "$TARGET" || rollback "could not move new bundle into place"
+        SWAPPED=1
 
-        # 6. relaunch the new version, then clean up
+        # 6. Relaunch the new version, then clean up.
         open -n "$TARGET" || rollback "relaunch failed"
         [ -d "$STAGEDIR" ] && rm -rf "$STAGEDIR"
         rm -rf "$BACKUP"
@@ -96,7 +106,7 @@ public static class UpdaterScripts
 
     private const string LinuxTemplate =
         """
-        #!/bin/bash
+        #!/usr/bin/env bash
         # Lunima in-place updater (Linux) — generated. Replaces the install directory and relaunches.
         set -uo pipefail
         OLD_PID=__OLD_PID__
@@ -108,34 +118,42 @@ public static class UpdaterScripts
         echo "=== lunima update $(date) pid=$OLD_PID target=$TARGET ==="
         PARENT="$(dirname "$TARGET")"
         BACKUP="$TARGET.bak.$$"
-        STAGEDIR="$PARENT/.lunima-update.$$"
+        STAGEROOT="$PARENT/.lunima-update.$$"
+        SWAPPED=0
 
         rollback() {
           echo "ROLLBACK: $1"
-          [ -d "$STAGEDIR" ] && rm -rf "$STAGEDIR"
-          if [ ! -e "$TARGET" ] && [ -d "$BACKUP" ]; then mv "$BACKUP" "$TARGET"; fi
-          [ -d "$BACKUP" ] && [ -e "$TARGET" ] && rm -rf "$BACKUP"
+          [ -d "$STAGEROOT" ] && rm -rf "$STAGEROOT"
+          if [ "$SWAPPED" = "1" ]; then
+            [ -e "$TARGET" ] && mv "$TARGET" "$TARGET.failed.$$" 2>/dev/null
+            [ -d "$BACKUP" ] && mv "$BACKUP" "$TARGET"
+          fi
           [ -x "$TARGET/$EXE_NAME" ] && ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & )
           exit 1
         }
 
+        # Wait for exit; if the app never exits, abort without relaunching (avoids a 2nd instance).
         for _ in $(seq 1 60); do kill -0 "$OLD_PID" 2>/dev/null || break; sleep 0.5; done
-        kill -0 "$OLD_PID" 2>/dev/null && rollback "app did not exit"
+        if kill -0 "$OLD_PID" 2>/dev/null; then echo "app did not exit; aborting"; exit 1; fi
 
-        mkdir -p "$STAGEDIR" || rollback "mkdir stage failed"
-        tar -xzf "$ARCHIVE" -C "$STAGEDIR" || rollback "extract failed"
-        # the tarball may hold the files at its root or inside one folder; locate the executable
-        if [ ! -f "$STAGEDIR/$EXE_NAME" ]; then
-          SUB="$(find "$STAGEDIR" -maxdepth 2 -type f -name "$EXE_NAME" | head -1)"
-          [ -n "$SUB" ] && STAGEDIR="$(dirname "$SUB")"
+        mkdir -p "$STAGEROOT" || rollback "mkdir stage failed"
+        tar -xzf "$ARCHIVE" -C "$STAGEROOT" || rollback "extract failed"
+        # The tarball may hold files at its root or inside one folder; locate the executable.
+        # Keep STAGEROOT for cleanup and track the located dir separately so cleanup never orphans it.
+        NEWDIR="$STAGEROOT"
+        if [ ! -f "$STAGEROOT/$EXE_NAME" ]; then
+          SUB="$(find "$STAGEROOT" -maxdepth 2 -type f -name "$EXE_NAME" | head -1)"
+          [ -n "$SUB" ] && NEWDIR="$(dirname "$SUB")"
         fi
-        [ -f "$STAGEDIR/$EXE_NAME" ] || rollback "executable not found in archive"
-        chmod +x "$STAGEDIR/$EXE_NAME" 2>/dev/null || true
+        [ -f "$NEWDIR/$EXE_NAME" ] || rollback "executable not found in archive"
+        chmod +x "$NEWDIR/$EXE_NAME" 2>/dev/null || true
 
         mv "$TARGET" "$BACKUP" || rollback "could not move old install aside"
-        mv "$STAGEDIR" "$TARGET" || rollback "could not move new install into place"
+        mv "$NEWDIR" "$TARGET" || rollback "could not move new install into place"
+        SWAPPED=1
 
         ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & ) || rollback "relaunch failed"
+        [ -d "$STAGEROOT" ] && rm -rf "$STAGEROOT"
         rm -rf "$BACKUP"
         rm -f "$ARCHIVE" 2>/dev/null || true
         echo "=== update OK ==="

--- a/CAP.Avalonia/Services/Update/UpdaterScripts.cs
+++ b/CAP.Avalonia/Services/Update/UpdaterScripts.cs
@@ -104,10 +104,16 @@ public static class UpdaterScripts
         echo "=== update OK ==="
         """;
 
+    // The Linux build is a portable single-file binary, so TARGET is wherever the user put it —
+    // possibly a folder that also holds unrelated files. The updater therefore replaces ONLY the
+    // files the new release ships (the entries under NEWDIR), file by file, and never moves or
+    // removes the TARGET directory itself. Any file in TARGET that is not part of the release is
+    // left untouched; the backup holds only the app files we replaced, so cleaning it up can
+    // never delete the user's data (issue #616).
     private const string LinuxTemplate =
         """
         #!/usr/bin/env bash
-        # Lunima in-place updater (Linux) — generated. Replaces the install directory and relaunches.
+        # Lunima in-place updater (Linux) — generated. Replaces the app's files in place and relaunches.
         set -uo pipefail
         OLD_PID=__OLD_PID__
         TARGET=__TARGET__
@@ -117,17 +123,23 @@ public static class UpdaterScripts
         exec >>"$LOG" 2>&1
         echo "=== lunima update $(date) pid=$OLD_PID target=$TARGET ==="
         PARENT="$(dirname "$TARGET")"
-        BACKUP="$TARGET.bak.$$"
+        BACKUP="$TARGET/.lunima-backup.$$"
         STAGEROOT="$PARENT/.lunima-update.$$"
-        SWAPPED=0
+
+        cleanup_stage() { [ -d "$STAGEROOT" ] && rm -rf "$STAGEROOT"; }
 
         rollback() {
           echo "ROLLBACK: $1"
-          [ -d "$STAGEROOT" ] && rm -rf "$STAGEROOT"
-          if [ "$SWAPPED" = "1" ]; then
-            [ -e "$TARGET" ] && mv "$TARGET" "$TARGET.failed.$$" 2>/dev/null
-            [ -d "$BACKUP" ] && mv "$BACKUP" "$TARGET"
+          # Restore every file we backed up over whatever partial install is in place.
+          if [ -d "$BACKUP" ]; then
+            ( cd "$BACKUP" && find . -mindepth 1 -maxdepth 1 -print0 ) | while IFS= read -r -d '' n; do
+              n="${n#./}"
+              rm -rf "$TARGET/$n" 2>/dev/null
+              mv "$BACKUP/$n" "$TARGET/$n" 2>/dev/null
+            done
+            rm -rf "$BACKUP"
           fi
+          cleanup_stage
           [ -x "$TARGET/$EXE_NAME" ] && ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & )
           exit 1
         }
@@ -136,25 +148,30 @@ public static class UpdaterScripts
         for _ in $(seq 1 60); do kill -0 "$OLD_PID" 2>/dev/null || break; sleep 0.5; done
         if kill -0 "$OLD_PID" 2>/dev/null; then echo "app did not exit; aborting"; exit 1; fi
 
-        mkdir -p "$STAGEROOT" || rollback "mkdir stage failed"
-        tar -xzf "$ARCHIVE" -C "$STAGEROOT" || rollback "extract failed"
+        mkdir -p "$STAGEROOT" || { echo "mkdir stage failed"; exit 1; }
+        tar -xzf "$ARCHIVE" -C "$STAGEROOT" || { cleanup_stage; echo "extract failed"; exit 1; }
         # The tarball may hold files at its root or inside one folder; locate the executable.
-        # Keep STAGEROOT for cleanup and track the located dir separately so cleanup never orphans it.
         NEWDIR="$STAGEROOT"
         if [ ! -f "$STAGEROOT/$EXE_NAME" ]; then
           SUB="$(find "$STAGEROOT" -maxdepth 2 -type f -name "$EXE_NAME" | head -1)"
           [ -n "$SUB" ] && NEWDIR="$(dirname "$SUB")"
         fi
-        [ -f "$NEWDIR/$EXE_NAME" ] || rollback "executable not found in archive"
-        chmod +x "$NEWDIR/$EXE_NAME" 2>/dev/null || true
+        [ -f "$NEWDIR/$EXE_NAME" ] || { cleanup_stage; echo "executable not found in archive"; exit 1; }
 
-        mv "$TARGET" "$BACKUP" || rollback "could not move old install aside"
-        mv "$NEWDIR" "$TARGET" || rollback "could not move new install into place"
-        SWAPPED=1
+        # Replace the release's files one by one; back up only what we overwrite.
+        mkdir -p "$BACKUP" || { cleanup_stage; echo "mkdir backup failed"; exit 1; }
+        ( cd "$NEWDIR" && find . -mindepth 1 -maxdepth 1 -print0 ) | while IFS= read -r -d '' n; do
+          n="${n#./}"
+          if [ -e "$TARGET/$n" ]; then
+            mv "$TARGET/$n" "$BACKUP/$n" || rollback "backup of $n failed"
+          fi
+          mv "$NEWDIR/$n" "$TARGET/$n" || rollback "install of $n failed"
+        done
+        chmod +x "$TARGET/$EXE_NAME" 2>/dev/null || true
 
         ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & ) || rollback "relaunch failed"
-        [ -d "$STAGEROOT" ] && rm -rf "$STAGEROOT"
         rm -rf "$BACKUP"
+        cleanup_stage
         rm -f "$ARCHIVE" 2>/dev/null || true
         echo "=== update OK ==="
         """;

--- a/CAP.Avalonia/Services/Update/UpdaterScripts.cs
+++ b/CAP.Avalonia/Services/Update/UpdaterScripts.cs
@@ -91,10 +91,13 @@ public static class UpdaterScripts
         codesign --force --deep --sign - "$NEW" || rollback "codesign failed"
         codesign --verify --deep --strict "$NEW" || rollback "signature verify failed"
 
-        # 5. Near-atomic swap: move old aside, new into place.
+        # 5. Near-atomic swap: move old aside, new into place. Set SWAPPED as soon as the old
+        #    bundle has moved — if the SECOND mv fails, TARGET no longer exists, and the rollback
+        #    must restore from BACKUP (which the SWAPPED branch does). Setting it only after both
+        #    moves would strand the working app at BACKUP with TARGET gone.
         mv "$TARGET" "$BACKUP" || rollback "could not move old bundle aside"
-        mv "$NEW" "$TARGET" || rollback "could not move new bundle into place"
         SWAPPED=1
+        mv "$NEW" "$TARGET" || rollback "could not move new bundle into place"
 
         # 6. Relaunch the new version, then clean up.
         open -n "$TARGET" || rollback "relaunch failed"
@@ -130,14 +133,20 @@ public static class UpdaterScripts
 
         rollback() {
           echo "ROLLBACK: $1"
-          # Restore every file we backed up over whatever partial install is in place.
+          # Restore every file we backed up over whatever partial install is in place. Use process
+          # substitution (not a pipe) so this loop runs in THIS shell, and track failures so a file
+          # that cannot be restored is not then deleted with the backup (it stays recoverable).
+          restore_failed=0
           if [ -d "$BACKUP" ]; then
-            ( cd "$BACKUP" && find . -mindepth 1 -maxdepth 1 -print0 ) | while IFS= read -r -d '' n; do
+            while IFS= read -r -d '' n; do
               n="${n#./}"
               rm -rf "$TARGET/$n" 2>/dev/null
-              mv "$BACKUP/$n" "$TARGET/$n" 2>/dev/null
-            done
-            rm -rf "$BACKUP"
+              if ! mv "$BACKUP/$n" "$TARGET/$n" 2>/dev/null; then
+                echo "WARN: could not restore $n; kept in $BACKUP"
+                restore_failed=1
+              fi
+            done < <(cd "$BACKUP" && find . -mindepth 1 -maxdepth 1 -print0)
+            if [ "$restore_failed" = "0" ]; then rm -rf "$BACKUP"; else echo "backup kept at $BACKUP"; fi
           fi
           cleanup_stage
           [ -x "$TARGET/$EXE_NAME" ] && ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & )
@@ -158,15 +167,18 @@ public static class UpdaterScripts
         fi
         [ -f "$NEWDIR/$EXE_NAME" ] || { cleanup_stage; echo "executable not found in archive"; exit 1; }
 
-        # Replace the release's files one by one; back up only what we overwrite.
+        # Replace the release's files one by one; back up only what we overwrite. Process
+        # substitution (not a pipe) keeps this loop in THIS shell — a piped `while` runs in a
+        # subshell, where rollback's `exit` would only leave the subshell and the script would
+        # then fall through to the success path (relaunching twice, printing "update OK").
         mkdir -p "$BACKUP" || { cleanup_stage; echo "mkdir backup failed"; exit 1; }
-        ( cd "$NEWDIR" && find . -mindepth 1 -maxdepth 1 -print0 ) | while IFS= read -r -d '' n; do
+        while IFS= read -r -d '' n; do
           n="${n#./}"
           if [ -e "$TARGET/$n" ]; then
             mv "$TARGET/$n" "$BACKUP/$n" || rollback "backup of $n failed"
           fi
           mv "$NEWDIR/$n" "$TARGET/$n" || rollback "install of $n failed"
-        done
+        done < <(cd "$NEWDIR" && find . -mindepth 1 -maxdepth 1 -print0)
         chmod +x "$TARGET/$EXE_NAME" 2>/dev/null || true
 
         ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & ) || rollback "relaunch failed"

--- a/CAP.Avalonia/Services/UpdateChecker.cs
+++ b/CAP.Avalonia/Services/UpdateChecker.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using CAP_Core.Update;
 
@@ -99,6 +100,34 @@ public class UpdateChecker
             a.Name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
             ?? release.Assets.FirstOrDefault(a =>
             a.Name.EndsWith(".AppImage", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Finds the release asset used for an <b>in-place auto-update</b> on the current OS/arch:
+    /// the arch-specific zipped <c>.app</c> on macOS, the <c>.msi</c> on Windows, the
+    /// <c>.tar.gz</c> on Linux. Distinct from <see cref="FindPlatformAsset"/>, which selects the
+    /// artifact for a first-time manual install (the macOS <c>.dmg</c>). Returns null when the
+    /// release carries no suitable auto-update archive (e.g. an older release without the zip),
+    /// so the caller can fall back to the manual installer.
+    /// </summary>
+    public static GitHubReleaseAsset? FindAutoUpdateAsset(GitHubReleaseInfo release)
+    {
+        if (OperatingSystem.IsWindows())
+            return release.Assets.FirstOrDefault(a =>
+                a.Name.EndsWith(".msi", StringComparison.OrdinalIgnoreCase));
+
+        if (OperatingSystem.IsMacOS())
+        {
+            var rid = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "osx-arm64" : "osx-x64";
+            return release.Assets.FirstOrDefault(a =>
+                a.Name.Contains(rid, StringComparison.OrdinalIgnoreCase) &&
+                a.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+        }
+
+        // Linux
+        return release.Assets.FirstOrDefault(a =>
+            a.Name.Contains("linux", StringComparison.OrdinalIgnoreCase) &&
+            a.Name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/CAP.Avalonia/Services/UpdateChecker.cs
+++ b/CAP.Avalonia/Services/UpdateChecker.cs
@@ -90,10 +90,18 @@ public class UpdateChecker
                 a.Name.EndsWith(".msi", StringComparison.OrdinalIgnoreCase));
 
         if (OperatingSystem.IsMacOS())
+        {
+            // Prefer the .dmg matching the current arch (both osx-arm64 and osx-x64 ship together),
+            // then fall back to any .dmg/.pkg so an unusual naming still yields something.
+            var rid = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "osx-arm64" : "osx-x64";
             return release.Assets.FirstOrDefault(a =>
-                a.Name.EndsWith(".dmg", StringComparison.OrdinalIgnoreCase))
+                    a.Name.Contains(rid, StringComparison.OrdinalIgnoreCase) &&
+                    a.Name.EndsWith(".dmg", StringComparison.OrdinalIgnoreCase))
                 ?? release.Assets.FirstOrDefault(a =>
-                a.Name.EndsWith(".pkg", StringComparison.OrdinalIgnoreCase));
+                    a.Name.EndsWith(".dmg", StringComparison.OrdinalIgnoreCase))
+                ?? release.Assets.FirstOrDefault(a =>
+                    a.Name.EndsWith(".pkg", StringComparison.OrdinalIgnoreCase));
+        }
 
         // Linux
         return release.Assets.FirstOrDefault(a =>
@@ -113,8 +121,10 @@ public class UpdateChecker
     public static GitHubReleaseAsset? FindAutoUpdateAsset(GitHubReleaseInfo release)
     {
         if (OperatingSystem.IsWindows())
-            return release.Assets.FirstOrDefault(a =>
-                a.Name.EndsWith(".msi", StringComparison.OrdinalIgnoreCase));
+            // Windows in-place self-update is deferred (#614 follow-up): msiexec installs to its own
+            // perMachine location, so a portable/zip install would be silently misrouted and the
+            // stale exe relaunched. Returning null makes the caller fall back to the manual MSI upgrade.
+            return null;
 
         if (OperatingSystem.IsMacOS())
         {

--- a/CAP.Avalonia/Services/UpdateDownloader.cs
+++ b/CAP.Avalonia/Services/UpdateDownloader.cs
@@ -1,11 +1,11 @@
-using System.Diagnostics;
 using System.Net.Http;
 using CAP_Core.Update;
 
 namespace CAP.Avalonia.Services;
 
 /// <summary>
-/// Downloads an MSI installer from a GitHub release asset URL with progress reporting.
+/// Downloads a release artifact (installer or app archive) from a GitHub release asset URL,
+/// with progress reporting. The temp file's extension is derived from the asset filename.
 /// </summary>
 public class UpdateDownloader
 {
@@ -23,8 +23,8 @@ public class UpdateDownloader
     /// reporting fractional progress (0.0–1.0) via <paramref name="progress"/>.
     /// The temporary file extension is derived from the asset filename in <paramref name="downloadUrl"/>.
     /// </summary>
-    /// <returns>Local file path to the downloaded installer.</returns>
-    public async Task<string> DownloadMsiAsync(
+    /// <returns>Local file path to the downloaded artifact.</returns>
+    public async Task<string> DownloadInstallerAsync(
         string downloadUrl,
         long expectedSize,
         IProgress<double> progress,
@@ -57,29 +57,6 @@ public class UpdateDownloader
         }
 
         return tempPath;
-    }
-
-    /// <summary>
-    /// Runs the downloaded Windows MSI via <c>msiexec /i &lt;path&gt;</c>. The caller shuts the
-    /// application down afterwards so the installer can replace the running files.
-    /// No-op on non-Windows platforms — macOS/Linux open the downloaded installer through
-    /// <see cref="IUrlLauncher"/>, which resolves the launch command even on a PATH-less
-    /// Finder/Dock launch.
-    /// </summary>
-    /// <param name="installerPath">Full path to the downloaded MSI.</param>
-    public static void LaunchInstaller(string installerPath)
-    {
-        if (!OperatingSystem.IsWindows())
-            return;
-
-        var psi = new ProcessStartInfo
-        {
-            FileName = "msiexec.exe",
-            UseShellExecute = true,
-        };
-        psi.ArgumentList.Add("/i");
-        psi.ArgumentList.Add(installerPath);
-        Process.Start(psi);
     }
 
     /// <summary>

--- a/CAP.Avalonia/Services/UpdateDownloader.cs
+++ b/CAP.Avalonia/Services/UpdateDownloader.cs
@@ -60,43 +60,26 @@ public class UpdateDownloader
     }
 
     /// <summary>
-    /// Launches the downloaded installer.
-    /// <list type="bullet">
-    ///   <item><description>Windows — invokes <c>msiexec /i &lt;path&gt;</c> via <see cref="ProcessStartInfo.ArgumentList"/>.</description></item>
-    ///   <item><description>macOS — opens the <c>.dmg</c> or <c>.pkg</c> with <c>open</c> for manual installation.</description></item>
-    ///   <item><description>Other platforms — no-op (caller should redirect to the releases page).</description></item>
-    /// </list>
+    /// Runs the downloaded Windows MSI via <c>msiexec /i &lt;path&gt;</c>. The caller shuts the
+    /// application down afterwards so the installer can replace the running files.
+    /// No-op on non-Windows platforms — macOS/Linux open the downloaded installer through
+    /// <see cref="IUrlLauncher"/>, which resolves the launch command even on a PATH-less
+    /// Finder/Dock launch.
     /// </summary>
-    /// <param name="installerPath">Full path to the downloaded installer file.</param>
+    /// <param name="installerPath">Full path to the downloaded MSI.</param>
     public static void LaunchInstaller(string installerPath)
     {
-        if (OperatingSystem.IsWindows())
-        {
-            var psi = new ProcessStartInfo
-            {
-                FileName = "msiexec.exe",
-                UseShellExecute = true,
-            };
-            psi.ArgumentList.Add("/i");
-            psi.ArgumentList.Add(installerPath);
-            Process.Start(psi);
+        if (!OperatingSystem.IsWindows())
             return;
-        }
 
-        if (OperatingSystem.IsMacOS())
+        var psi = new ProcessStartInfo
         {
-            // Open the .dmg / .pkg for the user — they complete the install manually.
-            var psi = new ProcessStartInfo
-            {
-                FileName = "open",
-                UseShellExecute = false,
-            };
-            psi.ArgumentList.Add(installerPath);
-            Process.Start(psi);
-            return;
-        }
-
-        // Linux and other platforms: no automated installer launch — caller should open browser.
+            FileName = "msiexec.exe",
+            UseShellExecute = true,
+        };
+        psi.ArgumentList.Add("/i");
+        psi.ArgumentList.Add(installerPath);
+        Process.Start(psi);
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls.ApplicationLifetimes;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.Update;
 using CAP_Core.Update;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -18,6 +19,7 @@ public partial class UpdateViewModel : ObservableObject
     private readonly UpdateDownloader _downloader;
     private readonly UserPreferencesService _preferences;
     private readonly IUrlLauncher _urlLauncher;
+    private readonly IInstaller _installer;
     private readonly SemanticVersion _currentVersion;
 
     private GitHubReleaseInfo? _availableRelease;
@@ -56,12 +58,14 @@ public partial class UpdateViewModel : ObservableObject
         UpdateChecker updateChecker,
         UpdateDownloader downloader,
         UserPreferencesService preferences,
-        IUrlLauncher urlLauncher)
+        IUrlLauncher urlLauncher,
+        IInstaller installer)
     {
         _updateChecker = updateChecker;
         _downloader = downloader;
         _preferences = preferences;
         _urlLauncher = urlLauncher;
+        _installer = installer;
         _currentVersion = ResolveCurrentVersion();
     }
 
@@ -116,37 +120,34 @@ public partial class UpdateViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Downloads the platform installer from the available release. On Windows it runs the MSI
-    /// and shuts the app down so the installer can replace it; on macOS/Linux it opens the
-    /// downloaded installer for the user to complete the install and leaves the app running.
+    /// Downloads the update and applies it. When the app can update in place (installed from a
+    /// writable location and the release ships an auto-update archive) it downloads that archive,
+    /// launches a detached updater that swaps the installation and relaunches the new version, then
+    /// quits. Otherwise it falls back to the manual installer / releases page so the user is never
+    /// left without a path forward.
     /// </summary>
     [RelayCommand]
     private async Task InstallUpdate()
     {
         if (_availableRelease == null || IsDownloading) return;
 
-        // Platform-aware: .dmg on macOS, .msi on Windows, .tar.gz on Linux.
-        // (FindMsiAsset is platform-blind and would hand macOS the Windows .msi — see #610.)
-        var installerAsset = UpdateChecker.FindPlatformAsset(_availableRelease);
-        if (installerAsset == null)
+        var canSelfUpdate = _installer.CanInstallInPlace(out _);
+        var autoUpdateAsset = canSelfUpdate ? UpdateChecker.FindAutoUpdateAsset(_availableRelease) : null;
+
+        // Fall back to the manual installer (macOS .dmg, Windows .msi, …) when in-place update
+        // isn't possible or the release carries no auto-update archive.
+        var asset = autoUpdateAsset ?? UpdateChecker.FindPlatformAsset(_availableRelease);
+        var selfUpdate = autoUpdateAsset != null;
+
+        if (asset == null)
         {
-            // No installer for this platform - open GitHub releases page in browser
-            StatusText = "Opening GitHub releases page in browser...";
-            try
-            {
-                var releaseUrl = $"https://github.com/aignermax/Lunima/releases/tag/{_availableRelease.TagName}";
-                _urlLauncher.Open(releaseUrl);
-            }
-            catch (Exception ex)
-            {
-                StatusText = $"Could not open browser: {ex.Message}";
-            }
+            OpenReleasesPageInBrowser();
             return;
         }
 
         IsDownloading = true;
         DownloadProgress = 0;
-        StatusText = "Downloading update...";
+        StatusText = selfUpdate ? "Downloading update..." : "Downloading installer...";
 
         try
         {
@@ -156,37 +157,64 @@ public partial class UpdateViewModel : ObservableObject
                 StatusText = $"Downloading... {p:P0}";
             });
 
-            var installerPath = await _downloader.DownloadMsiAsync(
-                installerAsset.BrowserDownloadUrl, installerAsset.Size, progress);
+            var downloadedPath = await _downloader.DownloadInstallerAsync(
+                asset.BrowserDownloadUrl, asset.Size, progress);
 
-            if (OperatingSystem.IsWindows())
+            if (selfUpdate)
             {
-                // Windows: run the MSI, which needs the running app to close so it can replace it.
-                StatusText = "Download complete. Launching installer...";
-                UpdateDownloader.LaunchInstaller(installerPath);
+                // Swap the installation in place and relaunch. The detached updater waits for this
+                // process to exit before replacing files, so we shut down immediately after.
+                StatusText = "Installing update and restarting...";
+                _installer.LaunchUpdater(downloadedPath);
                 ShutdownApplication();
+                return;
             }
-            else
-            {
-                // macOS/Linux: open the .dmg/.tar.gz via the PATH-safe launcher and leave the app
-                // running — the user completes the install manually. Auto-quitting here (and the
-                // bare `open` that has no shell PATH under a Finder/Dock launch) is what made the
-                // previous flow read as a crash (#610).
-                _urlLauncher.OpenFileOrDirectory(installerPath);
-                // Builds are unsigned (no Apple Developer ID yet), so first launch trips Gatekeeper.
-                // Guide the user through the right-click → Open bypass rather than leaving them at the wall.
-                StatusText = "Update downloaded — the installer is opening. Quit Lunima and drag the new "
-                    + "version into Applications. It's unsigned, so on first launch right-click it and "
-                    + "choose Open to get past macOS's \"developer cannot be verified\" warning.";
-            }
+
+            ApplyManualInstaller(downloadedPath);
         }
         catch (Exception ex)
         {
-            StatusText = $"Download failed: {ex.Message}";
+            StatusText = $"Update failed: {ex.Message}";
         }
         finally
         {
             IsDownloading = false;
+        }
+    }
+
+    /// <summary>
+    /// Manual fallback when an in-place update isn't possible: on Windows launch the MSI (which
+    /// needs the app to close), otherwise open the downloaded installer and guide the user through
+    /// the unsigned-build Gatekeeper bypass.
+    /// </summary>
+    private void ApplyManualInstaller(string installerPath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            StatusText = "Download complete. Launching installer...";
+            _urlLauncher.OpenFileOrDirectory(installerPath);
+            ShutdownApplication();
+            return;
+        }
+
+        _urlLauncher.OpenFileOrDirectory(installerPath);
+        StatusText = "Update downloaded — the installer is opening. Quit Lunima and drag the new "
+            + "version into Applications. It's unsigned, so on first launch right-click it and "
+            + "choose Open to get past macOS's \"developer cannot be verified\" warning.";
+    }
+
+    /// <summary>Opens the GitHub releases page for the available release in the default browser.</summary>
+    private void OpenReleasesPageInBrowser()
+    {
+        StatusText = "Opening GitHub releases page in browser...";
+        try
+        {
+            var releaseUrl = $"https://github.com/aignermax/Lunima/releases/tag/{_availableRelease!.TagName}";
+            _urlLauncher.Open(releaseUrl);
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Could not open browser: {ex.Message}";
         }
     }
 

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -173,8 +173,11 @@ public partial class UpdateViewModel : ObservableObject
                 // bare `open` that has no shell PATH under a Finder/Dock launch) is what made the
                 // previous flow read as a crash (#610).
                 _urlLauncher.OpenFileOrDirectory(installerPath);
-                StatusText = "Update downloaded — opening the installer. "
-                    + "Quit Lunima, then drag the new version into your Applications folder.";
+                // Builds are unsigned (no Apple Developer ID yet), so first launch trips Gatekeeper.
+                // Guide the user through the right-click → Open bypass rather than leaving them at the wall.
+                StatusText = "Update downloaded — the installer is opening. Quit Lunima and drag the new "
+                    + "version into Applications. It's unsigned, so on first launch right-click it and "
+                    + "choose Open to get past macOS's \"developer cannot be verified\" warning.";
             }
         }
         catch (Exception ex)

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -308,10 +308,17 @@ public partial class UpdateViewModel : ObservableObject
 
     private static void ShutdownApplication()
     {
-        if (global::Avalonia.Application.Current?.ApplicationLifetime
-            is IClassicDesktopStyleApplicationLifetime desktop)
+        var app = global::Avalonia.Application.Current;
+        if (app?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.Shutdown();
+            return;
         }
+
+        // A running app with no desktop lifetime (e.g. a single-view host): the detached updater is
+        // already waiting for this process to exit, so exit hard rather than leaving it to time out.
+        // When Application.Current is null (unit tests / headless) do nothing — never kill the host.
+        if (app is not null)
+            Environment.Exit(0);
     }
 }

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -124,10 +124,12 @@ public partial class UpdateViewModel : ObservableObject
     {
         if (_availableRelease == null || IsDownloading) return;
 
-        var msiAsset = UpdateChecker.FindMsiAsset(_availableRelease);
-        if (msiAsset == null)
+        // Platform-aware: .dmg on macOS, .msi on Windows, .tar.gz on Linux.
+        // (FindMsiAsset is platform-blind and would hand macOS the Windows .msi — see #610.)
+        var installerAsset = UpdateChecker.FindPlatformAsset(_availableRelease);
+        if (installerAsset == null)
         {
-            // No MSI found - open GitHub releases page in browser
+            // No installer for this platform - open GitHub releases page in browser
             StatusText = "Opening GitHub releases page in browser...";
             try
             {
@@ -153,11 +155,11 @@ public partial class UpdateViewModel : ObservableObject
                 StatusText = $"Downloading... {p:P0}";
             });
 
-            var msiPath = await _downloader.DownloadMsiAsync(
-                msiAsset.BrowserDownloadUrl, msiAsset.Size, progress);
+            var installerPath = await _downloader.DownloadMsiAsync(
+                installerAsset.BrowserDownloadUrl, installerAsset.Size, progress);
 
             StatusText = "Download complete. Launching installer...";
-            UpdateDownloader.LaunchInstaller(msiPath);
+            UpdateDownloader.LaunchInstaller(installerPath);
 
             ShutdownApplication();
         }

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -116,8 +116,9 @@ public partial class UpdateViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Downloads the MSI from the available release and launches the installer,
-    /// then shuts down the application.
+    /// Downloads the platform installer from the available release. On Windows it runs the MSI
+    /// and shuts the app down so the installer can replace it; on macOS/Linux it opens the
+    /// downloaded installer for the user to complete the install and leaves the app running.
     /// </summary>
     [RelayCommand]
     private async Task InstallUpdate()
@@ -158,10 +159,23 @@ public partial class UpdateViewModel : ObservableObject
             var installerPath = await _downloader.DownloadMsiAsync(
                 installerAsset.BrowserDownloadUrl, installerAsset.Size, progress);
 
-            StatusText = "Download complete. Launching installer...";
-            UpdateDownloader.LaunchInstaller(installerPath);
-
-            ShutdownApplication();
+            if (OperatingSystem.IsWindows())
+            {
+                // Windows: run the MSI, which needs the running app to close so it can replace it.
+                StatusText = "Download complete. Launching installer...";
+                UpdateDownloader.LaunchInstaller(installerPath);
+                ShutdownApplication();
+            }
+            else
+            {
+                // macOS/Linux: open the .dmg/.tar.gz via the PATH-safe launcher and leave the app
+                // running — the user completes the install manually. Auto-quitting here (and the
+                // bare `open` that has no shell PATH under a Finder/Dock launch) is what made the
+                // previous flow read as a crash (#610).
+                _urlLauncher.OpenFileOrDirectory(installerPath);
+                StatusText = "Update downloaded — opening the installer. "
+                    + "Quit Lunima, then drag the new version into your Applications folder.";
+            }
         }
         catch (Exception ex)
         {

--- a/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Update/UpdateViewModel.cs
@@ -155,7 +155,10 @@ public partial class UpdateViewModel : ObservableObject
             var progress = new Progress<double>(p =>
             {
                 DownloadProgress = p;
-                StatusText = $"Downloading... {p:P0}";
+                // Progress callbacks run off the UI thread; guard on IsDownloading so a late one
+                // can't clobber the terminal status set after the download finishes.
+                if (IsDownloading)
+                    StatusText = $"Downloading... {p:P0}";
             });
 
             downloadedPath = await _downloader.DownloadInstallerAsync(

--- a/UnitTests/Architecture/CrossPlatformProcessLaunchTests.cs
+++ b/UnitTests/Architecture/CrossPlatformProcessLaunchTests.cs
@@ -50,8 +50,10 @@ public class CrossPlatformProcessLaunchTests
         // 1. Sanctioned abstractions
         "Connect-A-Pic-Core/Export/ProcessLaunchFactory.cs",
         "CAP.Avalonia/Services/PlatformShellLauncher.cs",
+        // The single sanctioned launcher for the self-update feature: it must start a DETACHED
+        // helper that outlives the quitting app, which a ProcessLaunchFactory (awaited) launch can't.
+        "CAP.Avalonia/Services/Update/DetachedUpdaterLauncher.cs",
         // 2. Grandfathered platform-aware launchers (pre-existing — do NOT add new entries here)
-        "CAP.Avalonia/Services/UpdateDownloader.cs",
         "CAP.Avalonia/Services/PythonResolution.cs",
         "CAP.Avalonia/Services/Solvers/PythonModeSolverService.cs",
     };

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.Controls.Canvas.ComponentPreview;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.Update;
 using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Analysis;
 using CAP.Avalonia.ViewModels.Analysis.OnaAnalysis;
@@ -60,7 +61,8 @@ public static class MainViewModelTestHelper
             new UpdateChecker(new HttpClient(), "aignermax", "Connect-A-PIC-Pro"),
             new UpdateDownloader(new HttpClient()),
             preferencesService,
-            Mock.Of<IUrlLauncher>());
+            Mock.Of<IUrlLauncher>(),
+            Mock.Of<IInstaller>());
         var photonTorchVm = new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas);
         var verilogAVm = new VerilogAExportViewModel(new VerilogAExporter(), new VerilogAFileWriter(), canvas);
 

--- a/UnitTests/Update/InstallLocationTests.cs
+++ b/UnitTests/Update/InstallLocationTests.cs
@@ -1,0 +1,31 @@
+using CAP.Avalonia.Services.Update;
+using Shouldly;
+
+namespace UnitTests.Update;
+
+public class InstallLocationTests
+{
+    [Fact]
+    public void FindEnclosingAppBundle_ExecutableInsideBundle_ReturnsBundleRoot()
+    {
+        const string exe = "/Applications/Lunima.app/Contents/MacOS/CAP.Desktop";
+
+        InstallLocation.FindEnclosingAppBundle(exe).ShouldBe("/Applications/Lunima.app");
+    }
+
+    [Fact]
+    public void FindEnclosingAppBundle_NestedBundlePath_ReturnsNearestBundle()
+    {
+        const string exe = "/Users/me/Downloads/Lunima.app/Contents/MacOS/CAP.Desktop";
+
+        InstallLocation.FindEnclosingAppBundle(exe).ShouldBe("/Users/me/Downloads/Lunima.app");
+    }
+
+    [Fact]
+    public void FindEnclosingAppBundle_NotInsideBundle_ReturnsNull()
+    {
+        const string exe = "/usr/local/bin/Lunima";
+
+        InstallLocation.FindEnclosingAppBundle(exe).ShouldBeNull();
+    }
+}

--- a/UnitTests/Update/InstallLocationTests.cs
+++ b/UnitTests/Update/InstallLocationTests.cs
@@ -35,4 +35,49 @@ public class InstallLocationTests
 
         InstallLocation.FindEnclosingAppBundle(exe).ShouldBeNull();
     }
+
+    // ── Shared-directory guard (issue #616 data-loss fix) ──────────────────────
+    // The Linux portable build is a loose binary; its "install dir" is wherever the
+    // user put it — often a shared folder. Replacing/removing that whole directory
+    // would delete unrelated files. These pin the directories the updater must refuse.
+
+    [Fact]
+    public void IsSharedUserDirectory_HomeItself_IsTrue()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home)) return;   // CI without a home — skip
+
+        InstallLocation.IsSharedUserDirectory(home).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSharedUserDirectory_DownloadsUnderHome_IsTrue()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home)) return;
+
+        var downloads = Path.Combine(home, "Downloads");
+        InstallLocation.IsSharedUserDirectory(downloads).ShouldBeTrue();
+        // Trailing separator must not defeat the check.
+        InstallLocation.IsSharedUserDirectory(downloads + Path.DirectorySeparatorChar).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSharedUserDirectory_TempAndFilesystemRoot_AreTrue()
+    {
+        InstallLocation.IsSharedUserDirectory(Path.GetTempPath()).ShouldBeTrue();
+        InstallLocation.IsSharedUserDirectory(
+            Path.GetPathRoot(Environment.CurrentDirectory)!).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSharedUserDirectory_DedicatedAppFolder_IsFalse()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home)) return;
+
+        // A folder the user created for the app alone is a legitimate install root.
+        InstallLocation.IsSharedUserDirectory(Path.Combine(home, "Apps", "Lunima")).ShouldBeFalse();
+        InstallLocation.IsSharedUserDirectory(Path.Combine(home, "Downloads", "Lunima")).ShouldBeFalse();
+    }
 }

--- a/UnitTests/Update/LinuxUpdaterExecutionTests.cs
+++ b/UnitTests/Update/LinuxUpdaterExecutionTests.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using CAP.Avalonia.Services.Update;
+using Shouldly;
+
+namespace UnitTests.Update;
+
+/// <summary>
+/// Runs the generated Linux updater script for real against a sandbox install directory and
+/// asserts the data-loss fix (issue #616): the app's own files are replaced, but unrelated
+/// files sharing the directory survive, and no backup/stage folder is left behind. bash-only,
+/// so it runs on the Linux CI runner and macOS, and is skipped on Windows.
+/// </summary>
+public class LinuxUpdaterExecutionTests
+{
+    [Fact]
+    public void BuildLinux_Run_ReplacesAppFilesButKeepsUnrelatedFiles()
+    {
+        if (OperatingSystem.IsWindows()) return;   // no bash
+
+        var sandbox = Path.Combine(Path.GetTempPath(), $"lunima-upd-{Guid.NewGuid():N}");
+        var target = Path.Combine(sandbox, "install");
+        Directory.CreateDirectory(target);
+        try
+        {
+            const string exeName = "Lunima";
+            // Old install: the app executable + a native lib + an UNRELATED user file.
+            File.WriteAllText(Path.Combine(target, exeName), "#!/bin/sh\nexit 0\n");   // old version
+            File.WriteAllText(Path.Combine(target, "libSkiaSharp.so"), "OLD-LIB");
+            File.WriteAllText(Path.Combine(target, "my_notes.txt"), "PRECIOUS USER DATA");
+            MakeExecutable(Path.Combine(target, exeName));
+
+            // New release tarball: updated executable + updated lib + a brand-new file. NO notes.
+            var stage = Path.Combine(sandbox, "release");
+            Directory.CreateDirectory(stage);
+            File.WriteAllText(Path.Combine(stage, exeName), "#!/bin/sh\n# NEW\nexit 0\n");
+            File.WriteAllText(Path.Combine(stage, "libSkiaSharp.so"), "NEW-LIB");
+            File.WriteAllText(Path.Combine(stage, "README.md"), "new in this release");
+            var archive = Path.Combine(sandbox, "lunima.tar.gz");
+            Run("tar", $"-czf \"{archive}\" -C \"{stage}\" .", sandbox);
+
+            // Dead PID so the wait-for-exit loop returns immediately.
+            var target_ = new InstallLocation(target, Path.Combine(target, exeName), DeadPid());
+            var script = UpdaterScripts.BuildLinux(target_, archive);
+            var scriptPath = Path.Combine(sandbox, "update.sh");
+            File.WriteAllText(scriptPath, script);
+            MakeExecutable(scriptPath);
+
+            Run("bash", $"\"{scriptPath}\"", sandbox);
+
+            // App files updated…
+            File.ReadAllText(Path.Combine(target, exeName)).ShouldContain("# NEW");
+            File.ReadAllText(Path.Combine(target, "libSkiaSharp.so")).ShouldBe("NEW-LIB");
+            File.Exists(Path.Combine(target, "README.md")).ShouldBeTrue();
+            // …unrelated file preserved — the whole point of #616.
+            File.ReadAllText(Path.Combine(target, "my_notes.txt")).ShouldBe("PRECIOUS USER DATA");
+            // No backup/stage litter left behind.
+            Directory.GetFileSystemEntries(target, ".lunima-backup*").ShouldBeEmpty();
+            Directory.GetFileSystemEntries(sandbox, ".lunima-update*").ShouldBeEmpty();
+        }
+        finally
+        {
+            try { Directory.Delete(sandbox, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static int DeadPid()
+    {
+        // Spawn a trivial process, wait for it to exit, reuse its (now-dead) PID.
+        var p = Process.Start(new ProcessStartInfo("true") { UseShellExecute = false });
+        p!.WaitForExit();
+        return p.Id;
+    }
+
+    private static void MakeExecutable(string path) =>
+        File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+            | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+    private static void Run(string file, string args, string cwd)
+    {
+        using var p = Process.Start(new ProcessStartInfo(file, args)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = cwd,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        })!;
+        p.WaitForExit(30_000);
+    }
+}

--- a/UnitTests/Update/LinuxUpdaterExecutionTests.cs
+++ b/UnitTests/Update/LinuxUpdaterExecutionTests.cs
@@ -63,6 +63,73 @@ public class LinuxUpdaterExecutionTests
         }
     }
 
+    [Fact]
+    public void BuildLinux_Run_MkdirBackupFailure_AbortsWithoutReportingSuccess()
+    {
+        if (OperatingSystem.IsWindows()) return;   // no bash
+
+        var sandbox = Path.Combine(Path.GetTempPath(), $"lunima-upd-ro-{Guid.NewGuid():N}");
+        var target = Path.Combine(sandbox, "install");
+        Directory.CreateDirectory(target);
+        try
+        {
+            const string exeName = "Lunima";
+            File.WriteAllText(Path.Combine(target, exeName), "#!/bin/sh\n# OLD\nexit 0\n");
+            File.WriteAllText(Path.Combine(target, "my_notes.txt"), "PRECIOUS USER DATA");
+            MakeExecutable(Path.Combine(target, exeName));
+
+            var stage = Path.Combine(sandbox, "release");
+            Directory.CreateDirectory(stage);
+            File.WriteAllText(Path.Combine(stage, exeName), "#!/bin/sh\n# NEW\nexit 0\n");
+            var archive = Path.Combine(sandbox, "lunima.tar.gz");
+            Run("tar", $"-czf \"{archive}\" -C \"{stage}\" .", sandbox);
+
+            var loc = new InstallLocation(target, Path.Combine(target, exeName), DeadPid());
+            var scriptPath = Path.Combine(sandbox, "update.sh");
+            File.WriteAllText(scriptPath, UpdaterScripts.BuildLinux(loc, archive));
+            MakeExecutable(scriptPath);
+
+            // Make the target read-only so the backup mkdir (inside target) fails — the updater
+            // must abort cleanly, never printing success and never touching the user's files.
+            File.SetUnixFileMode(target, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            try
+            {
+                RunCapture("bash", $"\"{scriptPath}\"", sandbox);
+            }
+            finally
+            {
+                File.SetUnixFileMode(target,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+
+            var log = File.ReadAllText(Path.Combine(sandbox, "lunima-update.log"));
+            log.ShouldNotContain("=== update OK ===");
+            // Nothing was replaced; the original files are intact.
+            File.ReadAllText(Path.Combine(target, exeName)).ShouldContain("# OLD");
+            File.ReadAllText(Path.Combine(target, "my_notes.txt")).ShouldBe("PRECIOUS USER DATA");
+        }
+        finally
+        {
+            try { Directory.Delete(sandbox, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static void RunCapture(string file, string args, string cwd)
+    {
+        var psi = new ProcessStartInfo(file, args)
+        {
+            UseShellExecute = false,
+            WorkingDirectory = cwd,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+        psi.Environment["TMPDIR"] = cwd;   // isolate the script's log to this sandbox
+        using var p = Process.Start(psi)!;
+        p.StandardOutput.ReadToEnd();
+        p.StandardError.ReadToEnd();
+        p.WaitForExit(30_000);
+    }
+
     private static int DeadPid()
     {
         // Spawn a trivial process, wait for it to exit, reuse its (now-dead) PID.

--- a/UnitTests/Update/SelfUpdateInstallerTests.cs
+++ b/UnitTests/Update/SelfUpdateInstallerTests.cs
@@ -1,0 +1,21 @@
+using CAP.Avalonia.Services.Update;
+using Shouldly;
+
+namespace UnitTests.Update;
+
+public class SelfUpdateInstallerTests
+{
+    [Fact]
+    public void IsDirectoryWritable_TempDirectory_ReturnsTrue()
+    {
+        SelfUpdateInstaller.IsDirectoryWritable(Path.GetTempPath()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsDirectoryWritable_NonexistentDirectory_ReturnsFalse()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"lunima-missing-{Guid.NewGuid():N}", "deeper");
+
+        SelfUpdateInstaller.IsDirectoryWritable(missing).ShouldBeFalse();
+    }
+}

--- a/UnitTests/Update/UpdateCheckerTests.cs
+++ b/UnitTests/Update/UpdateCheckerTests.cs
@@ -142,6 +142,46 @@ public class UpdateCheckerTests
         }
     };
 
+    [Fact]
+    public void FindAutoUpdateAsset_PicksCurrentOsAutoUpdateArtifact()
+    {
+        var asset = UpdateChecker.FindAutoUpdateAsset(ReleaseWithAutoUpdateAssets());
+
+        asset.ShouldNotBeNull();
+        if (OperatingSystem.IsWindows())
+            asset!.Name.EndsWith(".msi").ShouldBeTrue();
+        else if (OperatingSystem.IsMacOS())
+            asset!.Name.EndsWith(".zip").ShouldBeTrue();
+        else
+            asset!.Name.EndsWith(".tar.gz").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FindAutoUpdateAsset_OnMac_ChoosesTheArchAppZip_NotTheWindowsZip()
+    {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        var asset = UpdateChecker.FindAutoUpdateAsset(ReleaseWithAutoUpdateAssets());
+
+        asset.ShouldNotBeNull();
+        asset!.Name.ShouldContain("osx");   // the macOS .app zip, never the Windows portable .zip
+    }
+
+    /// <summary>A release carrying every auto-update artifact: the macOS arch zips, the Linux
+    /// tarball, the Windows portable zip, and the Windows MSI, all at once.</summary>
+    private static GitHubReleaseInfo ReleaseWithAutoUpdateAssets() => new()
+    {
+        TagName = "v0.9.0",
+        Assets = new List<GitHubReleaseAsset>
+        {
+            new() { Name = "Lunima-0.9.0-osx-arm64.zip", BrowserDownloadUrl = "https://example.com/a.zip" },
+            new() { Name = "Lunima-0.9.0-osx-x64.zip", BrowserDownloadUrl = "https://example.com/b.zip" },
+            new() { Name = "Lunima-0.9.0-linux-x64.tar.gz", BrowserDownloadUrl = "https://example.com/c.tar.gz" },
+            new() { Name = "Lunima-0.9.0-win-x64.zip", BrowserDownloadUrl = "https://example.com/d.zip" },
+            new() { Name = "Lunima-Setup-0.9.0.msi", BrowserDownloadUrl = "https://example.com/e.msi" },
+        }
+    };
+
     [Theory]
     [InlineData("v1.5.0", "1.4.0", true)]   // release newer
     [InlineData("v1.5.0", "1.5.0", false)]  // same version

--- a/UnitTests/Update/UpdateCheckerTests.cs
+++ b/UnitTests/Update/UpdateCheckerTests.cs
@@ -147,13 +147,21 @@ public class UpdateCheckerTests
     {
         var asset = UpdateChecker.FindAutoUpdateAsset(ReleaseWithAutoUpdateAssets());
 
-        asset.ShouldNotBeNull();
         if (OperatingSystem.IsWindows())
-            asset!.Name.EndsWith(".msi").ShouldBeTrue();
+        {
+            // Windows in-place self-update is deferred; the ViewModel falls back to the manual MSI.
+            asset.ShouldBeNull();
+        }
         else if (OperatingSystem.IsMacOS())
+        {
+            asset.ShouldNotBeNull();
             asset!.Name.EndsWith(".zip").ShouldBeTrue();
+        }
         else
+        {
+            asset.ShouldNotBeNull();
             asset!.Name.EndsWith(".tar.gz").ShouldBeTrue();
+        }
     }
 
     [Fact]

--- a/UnitTests/Update/UpdateCheckerTests.cs
+++ b/UnitTests/Update/UpdateCheckerTests.cs
@@ -97,6 +97,51 @@ public class UpdateCheckerTests
         UpdateChecker.FindMsiAsset(release).ShouldBeNull();
     }
 
+    [Fact]
+    public void FindPlatformAsset_MultiPlatformRelease_PicksCurrentOsInstaller()
+    {
+        var release = ReleaseWithAllPlatformAssets();
+
+        var asset = UpdateChecker.FindPlatformAsset(release);
+
+        asset.ShouldNotBeNull();
+        if (OperatingSystem.IsWindows())
+            asset!.Name.EndsWith(".msi").ShouldBeTrue();
+        else if (OperatingSystem.IsMacOS())
+            asset!.Name.EndsWith(".dmg").ShouldBeTrue();
+        else
+            asset!.Name.EndsWith(".tar.gz").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void FindPlatformAsset_OnNonWindows_NeverReturnsTheWindowsMsi()
+    {
+        // Regression for #610: on macOS/Linux the updater used the platform-blind
+        // FindMsiAsset, which matched the Windows .msi shipped alongside the .dmg/.tar.gz.
+        // It downloaded that .msi, handed it to the OS (which cannot install it), and quit
+        // the app — presenting as a crash with the update never applied.
+        if (OperatingSystem.IsWindows()) return;
+
+        var asset = UpdateChecker.FindPlatformAsset(ReleaseWithAllPlatformAssets());
+
+        asset.ShouldNotBeNull();
+        asset!.Name.EndsWith(".msi").ShouldBeFalse();
+    }
+
+    /// <summary>Mirrors a real Lunima release: a Windows .msi, a Windows portable .zip,
+    /// a macOS .dmg, and a Linux .tar.gz, all present at once.</summary>
+    private static GitHubReleaseInfo ReleaseWithAllPlatformAssets() => new()
+    {
+        TagName = "v0.9.0",
+        Assets = new List<GitHubReleaseAsset>
+        {
+            new() { Name = "Lunima-0.9.0-linux-x64.tar.gz", BrowserDownloadUrl = "https://example.com/Lunima-0.9.0-linux-x64.tar.gz" },
+            new() { Name = "Lunima-0.9.0-osx-arm64.dmg",    BrowserDownloadUrl = "https://example.com/Lunima-0.9.0-osx-arm64.dmg" },
+            new() { Name = "Lunima-0.9.0-win-x64.zip",      BrowserDownloadUrl = "https://example.com/Lunima-0.9.0-win-x64.zip" },
+            new() { Name = "Lunima-Setup-0.9.0.msi",        BrowserDownloadUrl = "https://example.com/Lunima-Setup-0.9.0.msi" },
+        }
+    };
+
     [Theory]
     [InlineData("v1.5.0", "1.4.0", true)]   // release newer
     [InlineData("v1.5.0", "1.5.0", false)]  // same version

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -271,6 +271,7 @@ public class UpdateViewModelTests
     {
         // With an installed, writable location AND an auto-update archive for this OS, Download must
         // perform an in-place update: hand the downloaded archive to the installer, not the browser.
+        if (OperatingSystem.IsWindows()) return; // Windows in-place self-update is deferred (manual MSI)
         var installer = new FakeInstaller { CanUpdate = true };
         var urlLauncher = new FakeUrlLauncher();
         var vm = CreateViewModelForDownload(AutoUpdateReleaseJson, urlLauncher, installer);

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.Update;
 using CAP.Avalonia.ViewModels.Update;
 using CAP_Core.Update;
 using Shouldly;
@@ -46,7 +47,8 @@ public class UpdateViewModelTests
         string responseJson,
         HttpStatusCode statusCode = HttpStatusCode.OK,
         string? tempPrefsPath = null,
-        IUrlLauncher? urlLauncher = null)
+        IUrlLauncher? urlLauncher = null,
+        IInstaller? installer = null)
     {
         var handler = new FakeHttpMessageHandler(
             new HttpResponseMessage(statusCode)
@@ -61,7 +63,7 @@ public class UpdateViewModelTests
         var prefs = tempPrefsPath != null
             ? new UserPreferencesService(tempPrefsPath)
             : new UserPreferencesService(Path.GetTempFileName());
-        return new UpdateViewModel(checker, downloader, prefs, urlLauncher ?? new FakeUrlLauncher());
+        return new UpdateViewModel(checker, downloader, prefs, urlLauncher ?? new FakeUrlLauncher(), installer ?? new FakeInstaller());
     }
 
     [Fact]
@@ -133,7 +135,7 @@ public class UpdateViewModelTests
             var httpClient = new HttpClient(handler);
             var checker = new UpdateChecker(httpClient, "owner", "repo");
             var downloader = new UpdateDownloader(httpClient);
-            var vm = new UpdateViewModel(checker, downloader, prefs, new FakeUrlLauncher());
+            var vm = new UpdateViewModel(checker, downloader, prefs, new FakeUrlLauncher(), new FakeInstaller());
 
             await vm.CheckForUpdatesCommand.ExecuteAsync(null);
 
@@ -159,7 +161,7 @@ public class UpdateViewModelTests
                 });
             var httpClient = new HttpClient(handler);
             var vm = new UpdateViewModel(
-                new UpdateChecker(httpClient, "o", "r"), new UpdateDownloader(httpClient), prefs, new FakeUrlLauncher());
+                new UpdateChecker(httpClient, "o", "r"), new UpdateDownloader(httpClient), prefs, new FakeUrlLauncher(), new FakeInstaller());
 
             await vm.CheckForUpdatesCommand.ExecuteAsync(null);
             vm.UpdateAvailable.ShouldBeTrue();
@@ -191,7 +193,7 @@ public class UpdateViewModelTests
                 });
             var httpClient = new HttpClient(handler);
             var vm = new UpdateViewModel(
-                new UpdateChecker(httpClient, "o", "r"), new UpdateDownloader(httpClient), prefs, new FakeUrlLauncher());
+                new UpdateChecker(httpClient, "o", "r"), new UpdateDownloader(httpClient), prefs, new FakeUrlLauncher(), new FakeInstaller());
 
             await vm.CheckForUpdatesCommand.ExecuteAsync(null);
             vm.UpdateAvailable.ShouldBeTrue();
@@ -264,6 +266,44 @@ public class UpdateViewModelTests
             File.Delete(urlLauncher.LastOpenedPath!);
     }
 
+    [Fact]
+    public async Task InstallUpdate_WhenSelfUpdatePossible_LaunchesUpdaterWithDownloadedArchive()
+    {
+        // With an installed, writable location AND an auto-update archive for this OS, Download must
+        // perform an in-place update: hand the downloaded archive to the installer, not the browser.
+        var installer = new FakeInstaller { CanUpdate = true };
+        var urlLauncher = new FakeUrlLauncher();
+        var vm = CreateViewModelForDownload(AutoUpdateReleaseJson, urlLauncher, installer);
+
+        await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+        vm.UpdateAvailable.ShouldBeTrue();
+
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+        installer.LaunchedArchivePath.ShouldNotBeNull();   // the in-place updater was launched
+        urlLauncher.LastOpenedUrl.ShouldBeNull();          // not the browser fallback
+        urlLauncher.LastOpenedPath.ShouldBeNull();         // not the manual open-installer path
+
+        if (installer.LaunchedArchivePath is not null && File.Exists(installer.LaunchedArchivePath))
+            File.Delete(installer.LaunchedArchivePath);
+    }
+
+    private const string AutoUpdateReleaseJson = """
+        {
+          "tag_name": "v99.0.0",
+          "name": "Version 99.0.0",
+          "body": "Auto-update release.",
+          "prerelease": false,
+          "published_at": "2099-01-01T00:00:00Z",
+          "assets": [
+            { "name": "Lunima-99.0.0-osx-arm64.zip", "browser_download_url": "https://example.com/Lunima-99.0.0-osx-arm64.zip", "size": 4, "content_type": "application/zip" },
+            { "name": "Lunima-99.0.0-osx-x64.zip", "browser_download_url": "https://example.com/Lunima-99.0.0-osx-x64.zip", "size": 4, "content_type": "application/zip" },
+            { "name": "Lunima-99.0.0-linux-x64.tar.gz", "browser_download_url": "https://example.com/Lunima-99.0.0-linux-x64.tar.gz", "size": 4, "content_type": "application/gzip" },
+            { "name": "Lunima-Setup-99.0.0.msi", "browser_download_url": "https://example.com/Lunima-Setup-99.0.0.msi", "size": 4, "content_type": "application/x-msi" }
+          ]
+        }
+        """;
+
     private const string MultiPlatformReleaseJson = """
         {
           "tag_name": "v99.0.0",
@@ -279,14 +319,16 @@ public class UpdateViewModelTests
         }
         """;
 
-    private static UpdateViewModel CreateViewModelForDownload(string releaseJson, IUrlLauncher urlLauncher)
+    private static UpdateViewModel CreateViewModelForDownload(
+        string releaseJson, IUrlLauncher urlLauncher, IInstaller? installer = null)
     {
         var httpClient = new HttpClient(new ReleaseThenBinaryHandler(releaseJson));
         return new UpdateViewModel(
             new UpdateChecker(httpClient, "owner", "repo"),
             new UpdateDownloader(httpClient),
             new UserPreferencesService(Path.GetTempFileName()),
-            urlLauncher);
+            urlLauncher,
+            installer ?? new FakeInstaller());
     }
 
     /// <summary>Returns the release JSON for the GitHub API call and a few bytes for any other
@@ -331,6 +373,22 @@ public class UpdateViewModelTests
         {
             LastRevealedPath = path;
         }
+    }
+
+    /// <summary>Test double for <see cref="IInstaller"/>: records the launch and lets a test
+    /// toggle whether in-place update is available.</summary>
+    private sealed class FakeInstaller : IInstaller
+    {
+        public bool CanUpdate { get; set; }
+        public string? LaunchedArchivePath { get; private set; }
+
+        public bool CanInstallInPlace(out string reason)
+        {
+            reason = CanUpdate ? string.Empty : "test: in-place update disabled";
+            return CanUpdate;
+        }
+
+        public void LaunchUpdater(string downloadedArchivePath) => LaunchedArchivePath = downloadedArchivePath;
     }
 
     // --- Skip for Today tests ---
@@ -482,7 +540,8 @@ public class UpdateViewModelTests
             new UpdateChecker(httpClient, "owner", "repo"),
             new UpdateDownloader(httpClient),
             prefs,
-            new FakeUrlLauncher());
+            new FakeUrlLauncher(),
+            new FakeInstaller());
     }
 
     private sealed class FakeHttpMessageHandler : HttpMessageHandler

--- a/UnitTests/Update/UpdateViewModelTests.cs
+++ b/UnitTests/Update/UpdateViewModelTests.cs
@@ -239,6 +239,78 @@ public class UpdateViewModelTests
         urlLauncher.LastOpenedUrl.ShouldBe("https://github.com/aignermax/Lunima/releases/tag/v99.0.0");
     }
 
+    [Fact]
+    public async Task InstallUpdate_OnMacOrLinux_OpensDownloadedInstallerViaLauncher()
+    {
+        // #610: on macOS/Linux the update downloads the platform installer (.dmg/.tar.gz) and
+        // opens it through the PATH-safe launcher — it must not fall back to the browser, and
+        // (unlike Windows) it must not auto-quit the app.
+        if (OperatingSystem.IsWindows()) return; // the Windows branch runs msiexec; not exercised on the Linux CI runner
+
+        var urlLauncher = new FakeUrlLauncher();
+        var vm = CreateViewModelForDownload(MultiPlatformReleaseJson, urlLauncher);
+
+        await vm.CheckForUpdatesCommand.ExecuteAsync(null);
+        vm.UpdateAvailable.ShouldBeTrue();
+
+        await vm.InstallUpdateCommand.ExecuteAsync(null);
+
+        urlLauncher.LastOpenedPath.ShouldNotBeNull();   // installer opened via the launcher
+        urlLauncher.LastOpenedUrl.ShouldBeNull();       // not the browser fallback
+        var expectedExtension = OperatingSystem.IsMacOS() ? ".dmg" : ".tar.gz";
+        urlLauncher.LastOpenedPath!.EndsWith(expectedExtension).ShouldBeTrue();
+
+        if (File.Exists(urlLauncher.LastOpenedPath!))
+            File.Delete(urlLauncher.LastOpenedPath!);
+    }
+
+    private const string MultiPlatformReleaseJson = """
+        {
+          "tag_name": "v99.0.0",
+          "name": "Version 99.0.0",
+          "body": "Major update.",
+          "prerelease": false,
+          "published_at": "2099-01-01T00:00:00Z",
+          "assets": [
+            { "name": "Lunima-99.0.0-osx-arm64.dmg", "browser_download_url": "https://example.com/Lunima-99.0.0-osx-arm64.dmg", "size": 4, "content_type": "application/octet-stream" },
+            { "name": "Lunima-99.0.0-linux-x64.tar.gz", "browser_download_url": "https://example.com/Lunima-99.0.0-linux-x64.tar.gz", "size": 4, "content_type": "application/gzip" },
+            { "name": "Lunima-Setup-99.0.0.msi", "browser_download_url": "https://example.com/Lunima-Setup-99.0.0.msi", "size": 4, "content_type": "application/x-msi" }
+          ]
+        }
+        """;
+
+    private static UpdateViewModel CreateViewModelForDownload(string releaseJson, IUrlLauncher urlLauncher)
+    {
+        var httpClient = new HttpClient(new ReleaseThenBinaryHandler(releaseJson));
+        return new UpdateViewModel(
+            new UpdateChecker(httpClient, "owner", "repo"),
+            new UpdateDownloader(httpClient),
+            new UserPreferencesService(Path.GetTempFileName()),
+            urlLauncher);
+    }
+
+    /// <summary>Returns the release JSON for the GitHub API call and a few bytes for any other
+    /// (asset download) URL, with a fresh response each call so the download stream is readable.</summary>
+    private sealed class ReleaseThenBinaryHandler : HttpMessageHandler
+    {
+        private readonly string _releaseJson;
+
+        public ReleaseThenBinaryHandler(string releaseJson) => _releaseJson = releaseJson;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var isApi = request.RequestUri!.Host.Contains("api.github.com");
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = isApi
+                    ? new StringContent(_releaseJson)
+                    : new ByteArrayContent(new byte[] { 1, 2, 3, 4 }),
+            };
+            return Task.FromResult(response);
+        }
+    }
+
     private sealed class FakeUrlLauncher : IUrlLauncher
     {
         public string? LastOpenedUrl { get; private set; }

--- a/UnitTests/Update/UpdaterScriptsTests.cs
+++ b/UnitTests/Update/UpdaterScriptsTests.cs
@@ -19,16 +19,17 @@ public class UpdaterScriptsTests
     {
         var script = UpdaterScripts.BuildMacOs(MacTarget(), "/tmp/Lunima_Update_abc.zip");
 
-        script.ShouldStartWith("#!/bin/bash");
+        script.ShouldStartWith("#!/usr/bin/env bash");
         script.ShouldContain("OLD_PID=4242");
         script.ShouldContain("TARGET='/Applications/Lunima.app'");
         script.ShouldContain("ARCHIVE='/tmp/Lunima_Update_abc.zip'");
         script.ShouldContain("ditto -x -k");                    // extract preserving the bundle seal
         script.ShouldContain("xattr -dr com.apple.quarantine"); // no Gatekeeper prompt / translocation
-        script.ShouldContain("codesign --force --sign -");      // ad-hoc sign on the target machine
+        script.ShouldContain("codesign --force --deep --sign -");   // recursive ad-hoc sign (covers nested .NET code)
+        script.ShouldContain("codesign --verify --deep --strict");  // verify the seal BEFORE swapping
         script.ShouldContain("open -n");                        // relaunch a fresh instance
         script.ShouldContain("rollback");                       // has a rollback path
-        script.ShouldNotContain("--deep");                      // signing must not use deprecated --deep
+        script.ShouldContain("SWAPPED=1");                      // rollback distinguishes pre/post-swap
         script.ShouldNotContain("cp -R");                       // never cp -R a bundle (corrupts signature)
     }
 
@@ -51,7 +52,7 @@ public class UpdaterScriptsTests
 
         var script = UpdaterScripts.BuildLinux(target, "/tmp/lunima.tar.gz");
 
-        script.ShouldStartWith("#!/bin/bash");
+        script.ShouldStartWith("#!/usr/bin/env bash");
         script.ShouldContain("OLD_PID=55");
         script.ShouldContain("TARGET='/opt/lunima'");
         script.ShouldContain("EXE_NAME='Lunima'");

--- a/UnitTests/Update/UpdaterScriptsTests.cs
+++ b/UnitTests/Update/UpdaterScriptsTests.cs
@@ -1,0 +1,77 @@
+using CAP.Avalonia.Services.Update;
+using Shouldly;
+
+namespace UnitTests.Update;
+
+/// <summary>
+/// Verifies the generated updater scripts embed the right values and use the safe swap recipe.
+/// These are the risky part of the self-updater, so they're pinned with unit tests.
+/// </summary>
+public class UpdaterScriptsTests
+{
+    private static InstallLocation MacTarget() => new(
+        "/Applications/Lunima.app",
+        "/Applications/Lunima.app/Contents/MacOS/CAP.Desktop",
+        4242);
+
+    [Fact]
+    public void BuildMacOs_UsesDittoDequarantineAdHocSignAtomicSwapAndRelaunch()
+    {
+        var script = UpdaterScripts.BuildMacOs(MacTarget(), "/tmp/Lunima_Update_abc.zip");
+
+        script.ShouldStartWith("#!/bin/bash");
+        script.ShouldContain("OLD_PID=4242");
+        script.ShouldContain("TARGET='/Applications/Lunima.app'");
+        script.ShouldContain("ARCHIVE='/tmp/Lunima_Update_abc.zip'");
+        script.ShouldContain("ditto -x -k");                    // extract preserving the bundle seal
+        script.ShouldContain("xattr -dr com.apple.quarantine"); // no Gatekeeper prompt / translocation
+        script.ShouldContain("codesign --force --sign -");      // ad-hoc sign on the target machine
+        script.ShouldContain("open -n");                        // relaunch a fresh instance
+        script.ShouldContain("rollback");                       // has a rollback path
+        script.ShouldNotContain("--deep");                      // signing must not use deprecated --deep
+        script.ShouldNotContain("cp -R");                       // never cp -R a bundle (corrupts signature)
+    }
+
+    [Fact]
+    public void BuildMacOs_SingleQuotesPathsWithSpacesAndEmbeddedQuotes()
+    {
+        var target = new InstallLocation(
+            "/Apps/My Lunima.app", "/Apps/My Lunima.app/Contents/MacOS/CAP.Desktop", 7);
+
+        var script = UpdaterScripts.BuildMacOs(target, "/tmp/o'brien.zip");
+
+        script.ShouldContain("TARGET='/Apps/My Lunima.app'");
+        script.ShouldContain(@"ARCHIVE='/tmp/o'\''brien.zip'");   // POSIX single-quote escaping
+    }
+
+    [Fact]
+    public void BuildLinux_ExtractsTarballSwapsDirAndRelaunches()
+    {
+        var target = new InstallLocation("/opt/lunima", "/opt/lunima/Lunima", 55);
+
+        var script = UpdaterScripts.BuildLinux(target, "/tmp/lunima.tar.gz");
+
+        script.ShouldStartWith("#!/bin/bash");
+        script.ShouldContain("OLD_PID=55");
+        script.ShouldContain("TARGET='/opt/lunima'");
+        script.ShouldContain("EXE_NAME='Lunima'");
+        script.ShouldContain("tar -xzf");
+        script.ShouldContain("rollback");
+    }
+
+    [Fact]
+    public void BuildWindows_WaitsForExitRunsMsiexecAndRelaunches()
+    {
+        var target = new InstallLocation(
+            @"C:\Program Files\Lunima", @"C:\Program Files\Lunima\Lunima.exe", 99);
+
+        var script = UpdaterScripts.BuildWindows(target, @"C:\Temp\Lunima-Setup.msi");
+
+        script.ShouldContain("$targetPid = 99");
+        script.ShouldContain("Wait-Process");
+        script.ShouldContain("Start-Process msiexec");
+        script.ShouldContain(@"$msi = 'C:\Temp\Lunima-Setup.msi'");
+        script.ShouldContain(@"$exe = 'C:\Program Files\Lunima\Lunima.exe'");
+        script.ShouldContain("Start-Process -FilePath $exe");
+    }
+}

--- a/UnitTests/Update/UpdaterScriptsTests.cs
+++ b/UnitTests/Update/UpdaterScriptsTests.cs
@@ -46,7 +46,7 @@ public class UpdaterScriptsTests
     }
 
     [Fact]
-    public void BuildLinux_ExtractsTarballSwapsDirAndRelaunches()
+    public void BuildLinux_ReplacesFilesInPlaceWithoutMovingOrRemovingTargetDir()
     {
         var target = new InstallLocation("/opt/lunima", "/opt/lunima/Lunima", 55);
 
@@ -58,6 +58,12 @@ public class UpdaterScriptsTests
         script.ShouldContain("EXE_NAME='Lunima'");
         script.ShouldContain("tar -xzf");
         script.ShouldContain("rollback");
+        // Data-loss guard (#616): the target directory is a possibly-shared folder, so the
+        // updater must replace the release's files one by one — never move or remove the whole
+        // TARGET directory (that would take unrelated files with it).
+        script.ShouldNotContain("mv \"$TARGET\" ");   // no whole-directory move-aside
+        script.ShouldNotContain("rm -rf \"$TARGET\""); // no whole-directory delete
+        script.ShouldContain("find . -mindepth 1 -maxdepth 1 -print0"); // per-entry replace loop
     }
 
     [Fact]


### PR DESCRIPTION
Supersedes #616 (fork branch, can't push fixes there directly). Same feature, rebased on current main, with the review findings fixed.

## What
In-place self-update: on a new release the app downloads it, swaps the installed app, and relaunches — no manual reinstall. macOS (.app bundle swap), Linux (portable binary, file-by-file replace), Windows (msiexec; currently gated off in `UpdateChecker` per its comment).

## The Linux data-loss bug (issue the user flagged) — fixed
The original Linux updater did a whole-directory swap (`mv "$TARGET"` aside → `mv` new in → `rm -rf` backup). But the Linux build is a **portable single-file binary**, so `InstallLocation.Root` is just the folder the user dropped it in — often a shared one. Running the updater from `~/Downloads` moved the entire Downloads folder aside and `rm -rf`'d it, taking every unrelated file with it.

Two-layer fix:
1. **Guard** (`InstallLocation.IsSharedUserDirectory` + `CanInstallInPlace`): refuses to update in the home dir, its standard subfolders, the temp dir or a filesystem root; symlink-canonicalized and honouring the XDG user-dirs config (localized/redirected Downloads). Falls back to the browser-download path.
2. **File-by-file replace**: the Linux script now replaces only the files the release ships (the tar entries), backing up just what it overwrites — it never moves or removes the target directory, so unrelated files are untouched. No hand-maintained file list; the set is whatever the tarball contains.

## Review findings fixed (code-review pass)
- **CRITICAL**: install loop ran behind a pipe → a `rollback` inside it only exited the subshell and the script fell through to success (double relaunch, "update OK" after a failed install). Now process substitution.
- macOS: `SWAPPED` set too late → a failed 2nd move stranded the app. Fixed.
- Linux rollback rm-rf'd the backup even after a failed restore → lost that file. Now keeps it.
- Writability probe now checks the install root, not just the parent.

## Tests
Shared-dir guard cases, script-structure assertions, and **real bash execution tests**: an unrelated file survives a normal update, and a read-only target aborts cleanly without reporting success or touching the user's files. Full suite green (2964).

🤖 Generated with [Claude Code](https://claude.com/claude-code)