### PR TITLE
Agent: Add electrical pins to the active components of the bundled PDKs (#519 follow-up)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PhysicalPinDraft.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PhysicalPinDraft.cs
@@ -41,5 +41,13 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper.DTOs
         /// </summary>
         [JsonPropertyName("logicalPinNumber")]
         public int? LogicalPinNumber { get; set; }
+
+        /// <summary>
+        /// Signal domain of the pin: "Optical" (default) or "Electrical".
+        /// Absent/null values in legacy PDKs are treated as optical.
+        /// Electrical pins correspond to GDS layer 1/11 (ElecRec) metal contacts.
+        /// </summary>
+        [JsonPropertyName("pinKind")]
+        public string? PinKind { get; set; }
     }
 }

--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkLoader.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkLoader.cs
@@ -166,6 +166,11 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
                         errors.Add($"[{pdkName}/{compLabel}] Pin must have a name");
                     }
 
+                    if (!CAP_Core.Components.PinKinds.PinKindHelper.TryParse(pin.PinKind, out _))
+                    {
+                        errors.Add($"[{pdkName}/{compLabel}] Pin '{pin.Name}' has invalid pinKind '{pin.PinKind}' (expected 'Optical' or 'Electrical')");
+                    }
+
                     const double tolerance = 1.0;
                     if (pin.OffsetXMicrometers < -tolerance || pin.OffsetXMicrometers > comp.WidthMicrometers + tolerance)
                     {

--- a/CAP-DataAccess/PDKs/demo-pdk.json
+++ b/CAP-DataAccess/PDKs/demo-pdk.json
@@ -232,6 +232,20 @@
           "offsetXMicrometers": 500,
           "offsetYMicrometers": 30,
           "angleDegrees": 0
+        },
+        {
+          "name": "elec1",
+          "offsetXMicrometers": 125,
+          "offsetYMicrometers": 0,
+          "angleDegrees": 270,
+          "pinKind": "Electrical"
+        },
+        {
+          "name": "elec2",
+          "offsetXMicrometers": 375,
+          "offsetYMicrometers": 0,
+          "angleDegrees": 270,
+          "pinKind": "Electrical"
         }
       ],
       "sMatrix": {
@@ -323,6 +337,20 @@
           "offsetXMicrometers": 0,
           "offsetYMicrometers": 27.5,
           "angleDegrees": 180
+        },
+        {
+          "name": "anode",
+          "offsetXMicrometers": 35,
+          "offsetYMicrometers": 0,
+          "angleDegrees": 270,
+          "pinKind": "Electrical"
+        },
+        {
+          "name": "cathode",
+          "offsetXMicrometers": 35,
+          "offsetYMicrometers": 55,
+          "angleDegrees": 90,
+          "pinKind": "Electrical"
         }
       ],
       "sMatrix": {

--- a/CAP-DataAccess/PDKs/siepic-ebeam-pdk.json
+++ b/CAP-DataAccess/PDKs/siepic-ebeam-pdk.json
@@ -10847,8 +10847,9 @@
         {
           "name": "elec",
           "offsetXMicrometers": 50,
-          "offsetYMicrometers": 50,
-          "angleDegrees": 0
+          "offsetYMicrometers": 0,
+          "angleDegrees": 270,
+          "pinKind": "Electrical"
         }
       ],
       "sMatrix": {

--- a/CAP.Avalonia/Commands/CreateConnectionCommand.cs
+++ b/CAP.Avalonia/Commands/CreateConnectionCommand.cs
@@ -2,12 +2,15 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
+using CAP_Core.Components.PinKinds;
 
 namespace CAP.Avalonia.Commands;
 
 /// <summary>
 /// Command for creating a waveguide connection between two pins.
 /// Tracks and restores any connections that were overwritten.
+/// Cross-domain pairs (optical ↔ electrical) are rejected: <see cref="Execute"/>
+/// becomes a no-op, acting as the single choke point for pin-kind enforcement.
 /// </summary>
 public class CreateConnectionCommand : IUndoableCommand
 {
@@ -32,8 +35,18 @@ public class CreateConnectionCommand : IUndoableCommand
 
     public string Description => $"Connect {_startPin.Name} to {_endPin.Name}";
 
+    /// <summary>
+    /// True when both pins belong to the same signal domain and may be connected.
+    /// </summary>
+    public bool ArePinKindsCompatible => PinKindHelper.AreKindsCompatible(_startPin, _endPin);
+
     public void Execute()
     {
+        // Optical ↔ electrical connections are physically meaningless — refuse to create them
+        // regardless of which UI path (drag gesture, click-to-connect, …) issued the command.
+        if (!ArePinKindsCompatible)
+            return;
+
         if (_connection != null && _connectionViewModel != null)
         {
             // Redo: remove any restored connections first, then re-add the new connection

--- a/CAP.Avalonia/Controls/Rendering/PinRenderer.cs
+++ b/CAP.Avalonia/Controls/Rendering/PinRenderer.cs
@@ -36,7 +36,7 @@ internal sealed class PinRenderer
                 context.DrawEllipse(glowBrush, null, new Point(pinX, pinY), pinSize * 1.5, pinSize * 1.5);
             }
 
-            context.DrawEllipse(pinBrush, null, new Point(pinX, pinY), pinSize, pinSize);
+            DrawPinShape(context, pin, pinBrush, pinX, pinY, pinSize);
             DrawPinDirectionIndicator(context, pin, pinX, pinY, isHighlighted, isDimmed);
 
             if (isHighlighted)
@@ -73,11 +73,30 @@ internal sealed class PinRenderer
     {
         if (isHighlighted)
             return new SolidColorBrush(Color.FromArgb(alpha, 0, 255, 255));
+        if (pin.MatterType == MatterType.Electricity)
+            return new SolidColorBrush(Color.FromArgb(alpha, ElectricalPinColor.R, ElectricalPinColor.G, ElectricalPinColor.B));
         if (isConnectMode)
             return new SolidColorBrush(Color.FromArgb(alpha, 255, 200, 0));
         if (pin.LogicalPin != null)
             return new SolidColorBrush(Color.FromArgb(alpha, 100, 200, 100));
         return new SolidColorBrush(Color.FromArgb(alpha, 200, 100, 100));
+    }
+
+    /// <summary>Copper/gold colour marking electrical pins (Issue #519).</summary>
+    private static readonly Color ElectricalPinColor = Color.FromRgb(218, 165, 32);
+
+    /// <summary>
+    /// Draws the pin marker: optical pins as circles, electrical pins as squares
+    /// so the signal domain is visually distinguishable at a glance.
+    /// </summary>
+    private static void DrawPinShape(DrawingContext context, PhysicalPin pin, IBrush brush, double pinX, double pinY, double pinSize)
+    {
+        if (pin.MatterType == MatterType.Electricity)
+        {
+            context.DrawRectangle(brush, null, new Rect(pinX - pinSize, pinY - pinSize, pinSize * 2, pinSize * 2));
+            return;
+        }
+        context.DrawEllipse(brush, null, new Point(pinX, pinY), pinSize, pinSize);
     }
 
     private static void DrawPinDirectionIndicator(DrawingContext context, PhysicalPin pin, double pinX, double pinY, bool isHighlighted, bool isDimmed)

--- a/CAP.Avalonia/Controls/Rendering/PinRenderer.cs
+++ b/CAP.Avalonia/Controls/Rendering/PinRenderer.cs
@@ -13,6 +13,9 @@ namespace CAP.Avalonia.Controls.Rendering;
 /// </summary>
 internal sealed class PinRenderer
 {
+    /// <summary>Copper/gold colour marking electrical pins (Issue #519).</summary>
+    private static readonly Color ElectricalPinColor = Color.FromRgb(218, 165, 32);
+
     /// <summary>
     /// Renders all physical pins of a component.
     /// </summary>
@@ -81,9 +84,6 @@ internal sealed class PinRenderer
             return new SolidColorBrush(Color.FromArgb(alpha, 100, 200, 100));
         return new SolidColorBrush(Color.FromArgb(alpha, 200, 100, 100));
     }
-
-    /// <summary>Copper/gold colour marking electrical pins (Issue #519).</summary>
-    private static readonly Color ElectricalPinColor = Color.FromRgb(218, 165, 32);
 
     /// <summary>
     /// Draws the pin marker: optical pins as circles, electrical pins as squares

--- a/CAP.Avalonia/Gestures/ConnectionGestureRecognizer.cs
+++ b/CAP.Avalonia/Gestures/ConnectionGestureRecognizer.cs
@@ -5,6 +5,7 @@ using CAP.Avalonia.Controls;
 using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.PinKinds;
 
 namespace CAP.Avalonia.Gestures;
 
@@ -76,7 +77,11 @@ public class ConnectionGestureRecognizer : IGestureRecognizer
             targetPin.ParentComponent != _state.ConnectionDragStartPin.ParentComponent)
         {
             if (mainVm != null)
-                mainVm.StatusText = $"Release to connect {_state.ConnectionDragStartPin.Name} to {targetPin.Name}";
+            {
+                mainVm.StatusText = PinKindHelper.AreKindsCompatible(_state.ConnectionDragStartPin, targetPin)
+                    ? $"Release to connect {_state.ConnectionDragStartPin.Name} to {targetPin.Name}"
+                    : $"Cannot connect {PinKindHelper.ToKindName(_state.ConnectionDragStartPin.MatterType)} pin {_state.ConnectionDragStartPin.Name} to {PinKindHelper.ToKindName(targetPin.MatterType)} pin {targetPin.Name}";
+            }
         }
         else
         {
@@ -92,10 +97,18 @@ public class ConnectionGestureRecognizer : IGestureRecognizer
     {
         if (_state.ConnectionDragStartPin == null) return;
 
+        var startPin = _state.ConnectionDragStartPin;
         var targetPin = canvas.HighlightedPin?.Pin;
+        bool isValidTarget = targetPin != null && targetPin != startPin &&
+            targetPin.ParentComponent != startPin.ParentComponent;
 
-        if (targetPin != null && targetPin != _state.ConnectionDragStartPin &&
-            targetPin.ParentComponent != _state.ConnectionDragStartPin.ParentComponent)
+        if (isValidTarget && !PinKindHelper.AreKindsCompatible(startPin, targetPin!))
+        {
+            // Cross-domain connection (optical ↔ electrical) is physically meaningless — reject.
+            if (mainVm != null)
+                mainVm.StatusText = $"Cannot connect {PinKindHelper.ToKindName(startPin.MatterType)} pin {startPin.Name} to {PinKindHelper.ToKindName(targetPin!.MatterType)} pin {targetPin.Name}";
+        }
+        else if (isValidTarget)
         {
             var cmd = new CreateConnectionCommand(canvas, _state.ConnectionDragStartPin, targetPin);
             mainVm?.CommandManager.ExecuteCommand(cmd);

--- a/CAP.Avalonia/Services/PdkTemplateConverter.cs
+++ b/CAP.Avalonia/Services/PdkTemplateConverter.cs
@@ -1,6 +1,7 @@
 using CAP.Avalonia.ViewModels.Library;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.FormulaReading;
+using CAP_Core.Components.PinKinds;
 using CAP_Core.Components.Parametric;
 using CAP_Core.LightCalculation;
 using CAP_DataAccess.Components.ComponentDraftMapper;
@@ -31,7 +32,8 @@ public static class PdkTemplateConverter
             p.Name,
             p.OffsetXMicrometers,
             p.OffsetYMicrometers,
-            p.AngleDegrees
+            p.AngleDegrees,
+            PinKindHelper.Parse(p.PinKind)
         )).ToArray();
 
         // NazcaOriginOffset is required — validated by PdkLoader.

--- a/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
@@ -40,7 +40,7 @@ public static class ComponentTemplates
                 270 => RectSide.Down,
                 _ => RectSide.Right
             };
-            logicalPins.Add(new Pin(def.Name, i, MatterType.Light, side));
+            logicalPins.Add(new Pin(def.Name, i, def.Kind, side));
         }
 
         // Create parts array (simplified: single part)
@@ -196,11 +196,18 @@ public class PinDefinition
     public double OffsetY { get; }
     public double AngleDegrees { get; }
 
-    public PinDefinition(string name, double offsetX, double offsetY, double angleDegrees)
+    /// <summary>
+    /// Signal domain of the pin: <see cref="MatterType.Light"/> (optical, default)
+    /// or <see cref="MatterType.Electricity"/> (electrical metal contact).
+    /// </summary>
+    public MatterType Kind { get; }
+
+    public PinDefinition(string name, double offsetX, double offsetY, double angleDegrees, MatterType kind = MatterType.Light)
     {
         Name = name;
         OffsetX = offsetX;
         OffsetY = offsetY;
         AngleDegrees = angleDegrees;
+        Kind = kind;
     }
 }

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Creation;
+using CAP_Core.Components.PinKinds;
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
@@ -287,15 +288,22 @@ public partial class CanvasInteractionViewModel : ObservableObject
         }
         else
         {
-            if (_connectionStartPin != pin && _connectionStartPin.ParentComponent != pin.ParentComponent)
+            if (_connectionStartPin == pin || _connectionStartPin.ParentComponent == pin.ParentComponent)
+            {
+                UpdateStatus?.Invoke("Cannot connect pin to itself or same component");
+            }
+            else if (!PinKindHelper.AreKindsCompatible(_connectionStartPin, pin))
+            {
+                // Cross-domain connection (optical ↔ electrical) is physically meaningless — reject.
+                UpdateStatus?.Invoke(
+                    $"Cannot connect {PinKindHelper.ToKindName(_connectionStartPin.MatterType)} pin {_connectionStartPin.Name} " +
+                    $"to {PinKindHelper.ToKindName(pin.MatterType)} pin {pin.Name}");
+            }
+            else
             {
                 var cmd = new CreateConnectionCommand(_canvas, _connectionStartPin, pin);
                 _commandManager.ExecuteCommand(cmd);
                 UpdateStatus?.Invoke($"Connected {_connectionStartPin.Name} to {pin.Name}");
-            }
-            else
-            {
-                UpdateStatus?.Invoke("Cannot connect pin to itself or same component");
             }
             _connectionStartPin = null;
         }

--- a/Connect-A-Pic-Core/Components/Core/PhysicalPin.cs
+++ b/Connect-A-Pic-Core/Components/Core/PhysicalPin.cs
@@ -22,6 +22,14 @@ namespace CAP_Core.Components.Core
         /// </summary>
         public Pin LogicalPin { get; set; }
 
+        /// <summary>
+        /// The signal domain of this pin, derived from the linked logical pin.
+        /// Pins without a logical pin are treated as optical (the historic default).
+        /// Because <see cref="LogicalPin"/> is re-linked after cloning, clones
+        /// automatically preserve the kind.
+        /// </summary>
+        public MatterType MatterType => LogicalPin?.MatterType ?? MatterType.Light;
+
         public (double x, double y) GetAbsolutePosition()
         {
             return (

--- a/Connect-A-Pic-Core/Components/PinKinds/PinKindHelper.cs
+++ b/Connect-A-Pic-Core/Components/PinKinds/PinKindHelper.cs
@@ -1,0 +1,72 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Components.PinKinds
+{
+    /// <summary>
+    /// Central helper for the pin-kind (optical vs. electrical) domain distinction.
+    /// Parses the JSON <c>pinKind</c> field into <see cref="MatterType"/> values and
+    /// checks connection compatibility so that optical pins can never be wired to
+    /// electrical pins (Issue #519).
+    /// </summary>
+    public static class PinKindHelper
+    {
+        /// <summary>User-facing name of the optical pin kind (JSON value and UI label).</summary>
+        public const string OpticalKindName = "Optical";
+
+        /// <summary>User-facing name of the electrical pin kind (JSON value and UI label).</summary>
+        public const string ElectricalKindName = "Electrical";
+
+        /// <summary>
+        /// Tries to parse a JSON <c>pinKind</c> value into a <see cref="MatterType"/>.
+        /// Null, empty, or "Optical" (case-insensitive) map to <see cref="MatterType.Light"/>;
+        /// "Electrical" maps to <see cref="MatterType.Electricity"/>. Anything else fails.
+        /// </summary>
+        /// <param name="pinKind">The raw JSON value; may be null for legacy PDKs.</param>
+        /// <param name="matterType">The parsed matter type when parsing succeeds.</param>
+        /// <returns>True when the value is a valid (or absent) pin kind.</returns>
+        public static bool TryParse(string? pinKind, out MatterType matterType)
+        {
+            if (string.IsNullOrWhiteSpace(pinKind)
+                || string.Equals(pinKind, OpticalKindName, StringComparison.OrdinalIgnoreCase))
+            {
+                matterType = MatterType.Light;
+                return true;
+            }
+            if (string.Equals(pinKind, ElectricalKindName, StringComparison.OrdinalIgnoreCase))
+            {
+                matterType = MatterType.Electricity;
+                return true;
+            }
+            matterType = MatterType.None;
+            return false;
+        }
+
+        /// <summary>
+        /// Parses a JSON <c>pinKind</c> value, treating absent values as optical.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the value is not a known pin kind.</exception>
+        public static MatterType Parse(string? pinKind)
+        {
+            if (!TryParse(pinKind, out var matterType))
+            {
+                throw new ArgumentException(
+                    $"Unknown pinKind '{pinKind}'. Expected '{OpticalKindName}' or '{ElectricalKindName}'.",
+                    nameof(pinKind));
+            }
+            return matterType;
+        }
+
+        /// <summary>
+        /// Determines whether two physical pins may be connected: both must belong
+        /// to the same signal domain (optical-to-optical or electrical-to-electrical).
+        /// </summary>
+        public static bool AreKindsCompatible(PhysicalPin first, PhysicalPin second)
+            => first.MatterType == second.MatterType;
+
+        /// <summary>
+        /// Gets the user-facing kind name ("Optical" / "Electrical") for a matter type.
+        /// </summary>
+        public static string ToKindName(MatterType matterType)
+            => matterType == MatterType.Electricity ? ElectricalKindName : OpticalKindName;
+    }
+}

--- a/UnitTests/Components/PinKinds/BundledPdkElectricalPinsTests.cs
+++ b/UnitTests/Components/PinKinds/BundledPdkElectricalPinsTests.cs
@@ -1,0 +1,89 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Components.PinKinds;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.PinKinds
+{
+    /// <summary>
+    /// Verifies that the bundled PDKs declare electrical pins on active components
+    /// (Issue #680, follow-up to #519/#623): Phase Shifter and Photodetector in the
+    /// Demo PDK carry heater/diode contacts, the SiEPIC Bond Pad is purely electrical,
+    /// and all passive components stay purely optical.
+    /// </summary>
+    public class BundledPdkElectricalPinsTests
+    {
+        private static string PdkPath(string fileName) => Path.Combine(
+            Directory.GetCurrentDirectory(),
+            "..", "..", "..", "..",
+            "CAP-DataAccess", "PDKs", fileName);
+
+        private static PdkDraft LoadPdk(string fileName)
+            => new PdkLoader().LoadFromFile(PdkPath(fileName));
+
+        private static MatterType KindOf(PdkComponentDraft comp, string pinName)
+            => PinKindHelper.Parse(comp.Pins.Single(p => p.Name == pinName).PinKind);
+
+        [Fact]
+        public void DemoPdk_PhaseShifter_HasTwoElectricalHeaterContacts()
+        {
+            var pdk = LoadPdk("demo-pdk.json");
+            var phaseShifter = pdk.Components.Single(c => c.Name == "Phase Shifter");
+
+            KindOf(phaseShifter, "elec1").ShouldBe(MatterType.Electricity);
+            KindOf(phaseShifter, "elec2").ShouldBe(MatterType.Electricity);
+            KindOf(phaseShifter, "in").ShouldBe(MatterType.Light);
+            KindOf(phaseShifter, "out").ShouldBe(MatterType.Light);
+        }
+
+        [Fact]
+        public void DemoPdk_Photodetector_HasAnodeAndCathode()
+        {
+            var pdk = LoadPdk("demo-pdk.json");
+            var photodetector = pdk.Components.Single(c => c.Name == "Photodetector");
+
+            KindOf(photodetector, "anode").ShouldBe(MatterType.Electricity);
+            KindOf(photodetector, "cathode").ShouldBe(MatterType.Electricity);
+            KindOf(photodetector, "in").ShouldBe(MatterType.Light);
+        }
+
+        [Fact]
+        public void SiepicPdk_BondPad_IsPurelyElectrical()
+        {
+            var pdk = LoadPdk("siepic-ebeam-pdk.json");
+            var bondPad = pdk.Components.Single(c => c.Name == "Bond Pad");
+
+            bondPad.Pins.ShouldNotBeEmpty();
+            foreach (var pin in bondPad.Pins)
+            {
+                PinKindHelper.Parse(pin.PinKind).ShouldBe(MatterType.Electricity,
+                    $"Bond Pad pin '{pin.Name}' must be electrical");
+            }
+        }
+
+        /// <summary>
+        /// Passive optical devices have no metal contacts, so no bundled component
+        /// outside the known active set may declare an electrical pin.
+        /// </summary>
+        [Theory]
+        [InlineData("demo-pdk.json", "Phase Shifter", "Photodetector")]
+        [InlineData("siepic-ebeam-pdk.json", "Bond Pad")]
+        [InlineData("cornerstone-sin-pdk.json")]
+        public void BundledPdks_PassiveComponents_HaveNoElectricalPins(
+            string pdkFile, params string[] activeComponentNames)
+        {
+            var pdk = LoadPdk(pdkFile);
+
+            var passiveWithElectricalPins = pdk.Components
+                .Where(c => !activeComponentNames.Contains(c.Name))
+                .Where(c => c.Pins.Any(p => PinKindHelper.Parse(p.PinKind) == MatterType.Electricity))
+                .Select(c => c.Name)
+                .ToList();
+
+            passiveWithElectricalPins.ShouldBeEmpty(
+                $"Passive components in {pdkFile} must stay purely optical");
+        }
+    }
+}

--- a/UnitTests/Components/PinKinds/CrossKindConnectionGuardTests.cs
+++ b/UnitTests/Components/PinKinds/CrossKindConnectionGuardTests.cs
@@ -1,0 +1,106 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.PinKinds
+{
+    /// <summary>
+    /// Verifies that optical ↔ electrical connections are rejected on every UI path
+    /// (Issue #519). The drag-gesture path is guarded in <c>ConnectionGestureRecognizer</c>;
+    /// these tests cover the click-to-connect path and the shared
+    /// <see cref="CreateConnectionCommand"/> choke point.
+    /// </summary>
+    public class CrossKindConnectionGuardTests
+    {
+        [Fact]
+        public void CreateConnectionCommand_CrossKindPins_ExecuteIsNoOp()
+        {
+            var canvas = new DesignCanvasViewModel();
+            var (optical, electrical) = PlaceOpticalAndElectricalComponents(canvas);
+
+            var cmd = new CreateConnectionCommand(canvas, optical, electrical);
+            cmd.ArePinKindsCompatible.ShouldBeFalse();
+            cmd.Execute();
+
+            canvas.Connections.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ClickToConnect_CrossKindPins_RejectsAndReportsStatus()
+        {
+            var canvas = new DesignCanvasViewModel();
+            var (optical, electrical) = PlaceOpticalAndElectricalComponents(canvas);
+            var interaction = new CanvasInteractionViewModel(canvas, new CommandManager());
+            string lastStatus = "";
+            interaction.UpdateStatus = s => lastStatus = s;
+            interaction.CurrentMode = InteractionMode.Connect;
+
+            interaction.PinClicked(optical);
+            interaction.PinClicked(electrical);
+
+            canvas.Connections.ShouldBeEmpty();
+            lastStatus.ShouldContain("Cannot connect");
+            lastStatus.ShouldContain("Optical");
+            lastStatus.ShouldContain("Electrical");
+        }
+
+        [Fact]
+        public void ClickToConnect_SameKindPins_CreatesConnection()
+        {
+            var canvas = new DesignCanvasViewModel();
+
+            var componentA = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+            componentA.PhysicalX = 0;
+            componentA.PhysicalY = 0;
+            canvas.AddComponent(componentA, "WaveguideA");
+
+            var componentB = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+            componentB.PhysicalX = 600;
+            componentB.PhysicalY = 0;
+            canvas.AddComponent(componentB, "WaveguideB");
+
+            var interaction = new CanvasInteractionViewModel(canvas, new CommandManager());
+            interaction.CurrentMode = InteractionMode.Connect;
+
+            interaction.PinClicked(componentA.PhysicalPins[1]);
+            interaction.PinClicked(componentB.PhysicalPins[0]);
+
+            canvas.Connections.Count.ShouldBe(1);
+        }
+
+        /// <summary>
+        /// Places two components on the canvas: one with an optical pin and one with an
+        /// electrical (bond-pad style) pin, and returns those two pins.
+        /// </summary>
+        private static (PhysicalPin optical, PhysicalPin electrical) PlaceOpticalAndElectricalComponents(
+            DesignCanvasViewModel canvas)
+        {
+            var opticalComponent = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+            opticalComponent.PhysicalX = 0;
+            opticalComponent.PhysicalY = 0;
+            canvas.AddComponent(opticalComponent, "Waveguide");
+
+            var padComponent = TestComponentFactory.CreateBasicComponent();
+            padComponent.PhysicalX = 600;
+            padComponent.PhysicalY = 0;
+            padComponent.PhysicalPins.Clear();
+            var electricalPin = new PhysicalPin
+            {
+                Name = "m_pin_top",
+                ParentComponent = padComponent,
+                OffsetXMicrometers = 0,
+                OffsetYMicrometers = 0,
+                AngleDegrees = 0,
+                LogicalPin = new Pin("m_pin_top", 0, MatterType.Electricity, RectSide.Up)
+            };
+            padComponent.PhysicalPins.Add(electricalPin);
+            canvas.AddComponent(padComponent, "BondPad");
+
+            return (opticalComponent.PhysicalPins[1], electricalPin);
+        }
+    }
+}

--- a/UnitTests/Components/PinKinds/PdkLoaderPinKindTests.cs
+++ b/UnitTests/Components/PinKinds/PdkLoaderPinKindTests.cs
@@ -1,0 +1,76 @@
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.PinKinds
+{
+    /// <summary>
+    /// Tests the JSON <c>pinKind</c> field on PDK pins (Issue #519):
+    /// legacy PDKs without the field default to optical, "Electrical" is parsed,
+    /// and invalid values are rejected at load time.
+    /// </summary>
+    public class PdkLoaderPinKindTests
+    {
+        private static string BuildPdkJson(string pinJson) => $@"{{
+            ""name"": ""Test PDK"",
+            ""components"": [
+                {{
+                    ""name"": ""Bond Pad"",
+                    ""category"": ""Electrical"",
+                    ""nazcaFunction"": ""ebeam_BondPad"",
+                    ""widthMicrometers"": 100,
+                    ""heightMicrometers"": 100,
+                    ""nazcaOriginOffsetX"": 0, ""nazcaOriginOffsetY"": 50,
+                    ""pins"": [ {pinJson} ]
+                }}
+            ]
+        }}";
+
+        [Fact]
+        public void LoadFromJson_PinWithoutPinKind_DefaultsToNull()
+        {
+            var loader = new PdkLoader();
+            var json = BuildPdkJson(
+                @"{ ""name"": ""a0"", ""offsetXMicrometers"": 0, ""offsetYMicrometers"": 50, ""angleDegrees"": 180 }");
+
+            var pdk = loader.LoadFromJson(json);
+
+            pdk.Components[0].Pins[0].PinKind.ShouldBeNull();
+        }
+
+        [Fact]
+        public void LoadFromJson_ElectricalPinKind_IsParsed()
+        {
+            var loader = new PdkLoader();
+            var json = BuildPdkJson(
+                @"{ ""name"": ""m_pin_top"", ""offsetXMicrometers"": 50, ""offsetYMicrometers"": 0, ""angleDegrees"": 90, ""pinKind"": ""Electrical"" }");
+
+            var pdk = loader.LoadFromJson(json);
+
+            pdk.Components[0].Pins[0].PinKind.ShouldBe("Electrical");
+        }
+
+        [Fact]
+        public void LoadFromJson_OpticalPinKind_IsAccepted()
+        {
+            var loader = new PdkLoader();
+            var json = BuildPdkJson(
+                @"{ ""name"": ""a0"", ""offsetXMicrometers"": 0, ""offsetYMicrometers"": 50, ""angleDegrees"": 180, ""pinKind"": ""Optical"" }");
+
+            var pdk = loader.LoadFromJson(json);
+
+            pdk.Components[0].Pins[0].PinKind.ShouldBe("Optical");
+        }
+
+        [Fact]
+        public void LoadFromJson_InvalidPinKind_ThrowsValidationError()
+        {
+            var loader = new PdkLoader();
+            var json = BuildPdkJson(
+                @"{ ""name"": ""a0"", ""offsetXMicrometers"": 0, ""offsetYMicrometers"": 50, ""angleDegrees"": 180, ""pinKind"": ""Metal"" }");
+
+            var ex = Should.Throw<PdkValidationException>(() => loader.LoadFromJson(json));
+            ex.Errors.ShouldContain(e => e.Contains("pinKind"));
+        }
+    }
+}

--- a/UnitTests/Components/PinKinds/PinKindHelperTests.cs
+++ b/UnitTests/Components/PinKinds/PinKindHelperTests.cs
@@ -1,0 +1,106 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Components.PinKinds;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.PinKinds
+{
+    public class PinKindHelperTests
+    {
+        [Theory]
+        [InlineData(null, MatterType.Light)]
+        [InlineData("", MatterType.Light)]
+        [InlineData("   ", MatterType.Light)]
+        [InlineData("Optical", MatterType.Light)]
+        [InlineData("optical", MatterType.Light)]
+        [InlineData("OPTICAL", MatterType.Light)]
+        [InlineData("Electrical", MatterType.Electricity)]
+        [InlineData("electrical", MatterType.Electricity)]
+        public void TryParse_ValidValues_ReturnsExpectedMatterType(string? pinKind, MatterType expected)
+        {
+            PinKindHelper.TryParse(pinKind, out var matterType).ShouldBeTrue();
+            matterType.ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("Metal")]
+        [InlineData("Light")]
+        [InlineData("DC")]
+        [InlineData("elec")]
+        public void TryParse_InvalidValues_ReturnsFalse(string pinKind)
+        {
+            PinKindHelper.TryParse(pinKind, out _).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Parse_InvalidValue_Throws()
+        {
+            Should.Throw<ArgumentException>(() => PinKindHelper.Parse("Metal"));
+        }
+
+        [Fact]
+        public void Parse_NullDefaultsToOptical()
+        {
+            PinKindHelper.Parse(null).ShouldBe(MatterType.Light);
+        }
+
+        [Theory]
+        [InlineData(MatterType.Light, "Optical")]
+        [InlineData(MatterType.Electricity, "Electrical")]
+        public void ToKindName_MapsMatterTypeToUserFacingName(MatterType matterType, string expected)
+        {
+            PinKindHelper.ToKindName(matterType).ShouldBe(expected);
+        }
+
+        [Fact]
+        public void AreKindsCompatible_SameKind_ReturnsTrue()
+        {
+            var optical1 = CreatePhysicalPin(MatterType.Light);
+            var optical2 = CreatePhysicalPin(MatterType.Light);
+            var electrical1 = CreatePhysicalPin(MatterType.Electricity);
+            var electrical2 = CreatePhysicalPin(MatterType.Electricity);
+
+            PinKindHelper.AreKindsCompatible(optical1, optical2).ShouldBeTrue();
+            PinKindHelper.AreKindsCompatible(electrical1, electrical2).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void AreKindsCompatible_CrossKind_ReturnsFalse()
+        {
+            var optical = CreatePhysicalPin(MatterType.Light);
+            var electrical = CreatePhysicalPin(MatterType.Electricity);
+
+            PinKindHelper.AreKindsCompatible(optical, electrical).ShouldBeFalse();
+            PinKindHelper.AreKindsCompatible(electrical, optical).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void PhysicalPin_WithoutLogicalPin_DefaultsToOptical()
+        {
+            var pin = new PhysicalPin { Name = "a0" };
+            pin.MatterType.ShouldBe(MatterType.Light);
+        }
+
+        [Fact]
+        public void PhysicalPin_DerivesKindFromLogicalPin()
+        {
+            var pin = CreatePhysicalPin(MatterType.Electricity);
+            pin.MatterType.ShouldBe(MatterType.Electricity);
+        }
+
+        [Fact]
+        public void Pin_Clone_PreservesElectricalKind()
+        {
+            var pin = new Pin("m_pin_top", 0, MatterType.Electricity, RectSide.Up);
+            var clone = (Pin)pin.Clone();
+            clone.MatterType.ShouldBe(MatterType.Electricity);
+        }
+
+        private static PhysicalPin CreatePhysicalPin(MatterType matterType) => new()
+        {
+            Name = "p0",
+            LogicalPin = new Pin("p0", 0, matterType, RectSide.Right)
+        };
+    }
+}

--- a/UnitTests/Components/PinKinds/PinKindTemplatePropagationTests.cs
+++ b/UnitTests/Components/PinKinds/PinKindTemplatePropagationTests.cs
@@ -1,0 +1,77 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Components.Core;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.PinKinds
+{
+    /// <summary>
+    /// Verifies that the <c>pinKind</c> JSON field propagates through the whole
+    /// template pipeline (Issue #519): PDK JSON → PdkTemplateConverter →
+    /// ComponentTemplates.CreateFromTemplate → logical + physical pins.
+    /// </summary>
+    public class PinKindTemplatePropagationTests
+    {
+        private const string BondPadPdkJson = @"{
+            ""name"": ""Test PDK"",
+            ""components"": [
+                {
+                    ""name"": ""Bond Pad"",
+                    ""category"": ""Electrical"",
+                    ""nazcaFunction"": ""ebeam_BondPad"",
+                    ""widthMicrometers"": 100,
+                    ""heightMicrometers"": 100,
+                    ""nazcaOriginOffsetX"": 0, ""nazcaOriginOffsetY"": 50,
+                    ""pins"": [
+                        { ""name"": ""m_pin_top"", ""offsetXMicrometers"": 50, ""offsetYMicrometers"": 0, ""angleDegrees"": 90, ""pinKind"": ""Electrical"" },
+                        { ""name"": ""opt_in"", ""offsetXMicrometers"": 0, ""offsetYMicrometers"": 50, ""angleDegrees"": 180 }
+                    ]
+                }
+            ]
+        }";
+
+        [Fact]
+        public void ConvertToTemplate_PropagatesPinKindToPinDefinitions()
+        {
+            var template = LoadBondPadTemplate();
+
+            template.PinDefinitions[0].Kind.ShouldBe(MatterType.Electricity);
+            template.PinDefinitions[1].Kind.ShouldBe(MatterType.Light);
+        }
+
+        [Fact]
+        public void CreateFromTemplate_ElectricalPinDefinition_CreatesElectricalPins()
+        {
+            var template = LoadBondPadTemplate();
+
+            var component = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+
+            var electricalPin = component.PhysicalPins.Single(p => p.Name == "m_pin_top");
+            electricalPin.MatterType.ShouldBe(MatterType.Electricity);
+            electricalPin.LogicalPin.MatterType.ShouldBe(MatterType.Electricity);
+
+            var opticalPin = component.PhysicalPins.Single(p => p.Name == "opt_in");
+            opticalPin.MatterType.ShouldBe(MatterType.Light);
+        }
+
+        [Fact]
+        public void CreateFromTemplate_ClonedComponent_PreservesElectricalPinKind()
+        {
+            var template = LoadBondPadTemplate();
+            var component = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+
+            var clone = (Component)component.Clone();
+
+            var clonedPin = clone.PhysicalPins.Single(p => p.Name == "m_pin_top");
+            clonedPin.MatterType.ShouldBe(MatterType.Electricity);
+        }
+
+        private static ComponentTemplate LoadBondPadTemplate()
+        {
+            var pdk = new PdkLoader().LoadFromJson(BondPadPdkJson);
+            return PdkTemplateConverter.ConvertToTemplate(pdk.Components[0], pdk.Name, null);
+        }
+    }
+}

--- a/UnitTests/Integration/GdsCoordinateExtractionTests.cs
+++ b/UnitTests/Integration/GdsCoordinateExtractionTests.cs
@@ -109,21 +109,27 @@ public class GdsCoordinateExtractionTests
             var doc = JsonDocument.Parse(json!);
             var root = doc.RootElement;
 
-            root.TryGetProperty("database_unit", out _).ShouldBeTrue(
-                "Output JSON must contain 'database_unit'");
-            root.TryGetProperty("cells", out _).ShouldBeTrue(
+            // Schema documented in scripts/extract_gds_coords.py:
+            // { "units": { "user_unit_m", "db_unit_m" }, "cells": [ { "name", "polygons", "paths", "refs" } ] }
+            root.TryGetProperty("units", out var units).ShouldBeTrue(
+                "Output JSON must contain 'units'");
+            units.TryGetProperty("db_unit_m", out _).ShouldBeTrue(
+                "'units' must contain 'db_unit_m'");
+            units.TryGetProperty("user_unit_m", out _).ShouldBeTrue(
+                "'units' must contain 'user_unit_m'");
+            root.TryGetProperty("cells", out var cells).ShouldBeTrue(
                 "Output JSON must contain 'cells'");
 
-            // Each cell must have polygons and paths arrays
-            if (root.TryGetProperty("cells", out var cells))
+            // Each cell must have name, polygons and paths arrays
+            cells.ValueKind.ShouldBe(JsonValueKind.Array, "'cells' must be an array");
+            foreach (var cell in cells.EnumerateArray())
             {
-                foreach (var cell in cells.EnumerateObject())
-                {
-                    cell.Value.TryGetProperty("polygons", out _).ShouldBeTrue(
-                        $"Cell '{cell.Name}' must have 'polygons' array");
-                    cell.Value.TryGetProperty("paths", out _).ShouldBeTrue(
-                        $"Cell '{cell.Name}' must have 'paths' array");
-                }
+                cell.TryGetProperty("name", out _).ShouldBeTrue(
+                    "Each cell must have a 'name'");
+                cell.TryGetProperty("polygons", out _).ShouldBeTrue(
+                    "Each cell must have a 'polygons' array");
+                cell.TryGetProperty("paths", out _).ShouldBeTrue(
+                    "Each cell must have a 'paths' array");
             }
         }
         finally


### PR DESCRIPTION
Automated implementation for #680

That's the earlier background test run finishing — I already re-ran and analyzed the full suite (2996 passed, 2 pre-existing environment failures). Nothing further to do; the work is complete and pushed.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 100,249
- **Estimated cost:** $0.0561 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*