### PR TITLE
Electrical connections export as metal traces (#682, part 1)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
@@ -61,10 +61,32 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
                 return MetalTraceStyle.Default;
 
             var definitions = active.MemberPdkNames
-                .Select(name => loadedPdks.FirstOrDefault(
-                    d => string.Equals(d.Name, name, System.StringComparison.OrdinalIgnoreCase))?.Process);
+                .Select(name => FindByName(loadedPdks, name, d => d.Name)?.Process);
 
             return Resolve(definitions);
+        }
+
+        /// <summary>
+        /// Finds the item whose name matches (ordinal, case-insensitive) — the PDK/member-draft
+        /// name lookup this resolver, the Fabrication Process dialog
+        /// (<c>ProcessManagementViewModel.ActiveProcess</c>) and the MainWindow PDK-path wiring
+        /// all need, previously copy-pasted in each (#682/#686 review).
+        /// </summary>
+        /// <param name="items">Candidates to search; null yields no match.</param>
+        /// <param name="name">The name to match.</param>
+        /// <param name="getName">Extracts the comparable name from an item.</param>
+        public static T? FindByName<T>(IEnumerable<T>? items, string name, Func<T, string?> getName)
+            where T : class
+        {
+            if (items == null)
+                return null;
+
+            foreach (var item in items)
+            {
+                if (string.Equals(getName(item), name, System.StringComparison.OrdinalIgnoreCase))
+                    return item;
+            }
+            return null;
         }
 
         private static MetalTraceStyle BuildStyle(ProcessDefinition process, ProcessXsection metal)

--- a/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
@@ -70,11 +70,7 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
         private static MetalTraceStyle BuildStyle(ProcessDefinition process, ProcessXsection metal)
         {
             var width = metal.WidthUm > 0 ? metal.WidthUm : MetalTraceStyle.DefaultWidthUm;
-
-            var layerName = metal.Layers?.FirstOrDefault();
-            var layer = layerName == null
-                ? null
-                : process.Layers?.FirstOrDefault(l => l.Name == layerName);
+            var layer = ResolveLayer(process, metal);
 
             return new MetalTraceStyle
             {
@@ -82,6 +78,29 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
                 GdsLayer = layer?.Layer ?? MetalTraceStyle.DefaultGdsLayer,
                 GdsDatatype = layer?.Datatype ?? 0,
             };
+        }
+
+        /// <summary>
+        /// Finds the GDS layer for a metal cross-section: first the layer it explicitly lists,
+        /// otherwise a metal-named layer in the stack (so a user can just add a "METAL" layer
+        /// and a metal xsection without wiring them together). Null falls back to the default.
+        /// </summary>
+        private static ProcessLayer? ResolveLayer(ProcessDefinition process, ProcessXsection metal)
+        {
+            var layers = process.Layers;
+            if (layers == null || layers.Count == 0)
+                return null;
+
+            var layerName = metal.Layers?.FirstOrDefault();
+            if (layerName != null)
+            {
+                var named = layers.FirstOrDefault(l => l.Name == layerName);
+                if (named != null)
+                    return named;
+            }
+
+            return layers.FirstOrDefault(
+                l => l.Name != null && l.Name.Contains("METAL", System.StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
@@ -1,0 +1,87 @@
+using CAP_Core.Components.Process;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP_DataAccess.Components.ComponentDraftMapper
+{
+    /// <summary>
+    /// Resolves the <see cref="MetalTraceStyle"/> for an electrical routing trace from a
+    /// fabrication process: it picks the process's metal cross-section
+    /// (<see cref="XsectionKind.Metal"/>) and maps its width and first referenced layer to a
+    /// GDS layer/datatype. When no process declares a metal cross-section it returns
+    /// <see cref="MetalTraceStyle.Default"/> so electrical connections are still drawn on a
+    /// distinct metal layer instead of the optical waveguide layer (issue #682).
+    /// </summary>
+    public static class MetalTraceStyleResolver
+    {
+        /// <summary>
+        /// Resolves the metal trace style from the member process definitions of the active
+        /// process. The first metal cross-section found (in the given order) wins; its listed
+        /// layer name is looked up in that same process's layer stack for the GDS layer/datatype.
+        /// </summary>
+        /// <param name="processes">Process definitions of the active process's member PDKs.</param>
+        /// <returns>The resolved style, or <see cref="MetalTraceStyle.Default"/> when none defines metal.</returns>
+        public static MetalTraceStyle Resolve(IEnumerable<ProcessDefinition?>? processes)
+        {
+            if (processes == null)
+                return MetalTraceStyle.Default;
+
+            foreach (var process in processes)
+            {
+                if (process == null)
+                    continue;
+
+                var metal = process.Xsections?.FirstOrDefault(x => x.Kind == XsectionKind.Metal);
+                if (metal == null)
+                    continue;
+
+                return BuildStyle(process, metal);
+            }
+
+            return MetalTraceStyle.Default;
+        }
+
+        /// <summary>Convenience overload for a single process definition.</summary>
+        /// <param name="process">The process definition, or null.</param>
+        public static MetalTraceStyle Resolve(ProcessDefinition? process) =>
+            Resolve(process == null ? null : new[] { process });
+
+        /// <summary>
+        /// Resolves the metal trace style for a design's active process by matching its member
+        /// PDK names against the loaded PDK drafts and reading their process definitions — the
+        /// same lookup the Fabrication Process dialog uses. Returns
+        /// <see cref="MetalTraceStyle.Default"/> for Playground / no selection / no metal xsection.
+        /// </summary>
+        /// <param name="active">The design's active process selection.</param>
+        /// <param name="loadedPdks">All currently loaded PDK drafts.</param>
+        public static MetalTraceStyle Resolve(
+            ActiveProcessSelection? active, IReadOnlyList<PdkDraft> loadedPdks)
+        {
+            if (active == null || loadedPdks == null)
+                return MetalTraceStyle.Default;
+
+            var definitions = active.MemberPdkNames
+                .Select(name => loadedPdks.FirstOrDefault(
+                    d => string.Equals(d.Name, name, System.StringComparison.OrdinalIgnoreCase))?.Process);
+
+            return Resolve(definitions);
+        }
+
+        private static MetalTraceStyle BuildStyle(ProcessDefinition process, ProcessXsection metal)
+        {
+            var width = metal.WidthUm > 0 ? metal.WidthUm : MetalTraceStyle.DefaultWidthUm;
+
+            var layerName = metal.Layers?.FirstOrDefault();
+            var layer = layerName == null
+                ? null
+                : process.Layers?.FirstOrDefault(l => l.Name == layerName);
+
+            return new MetalTraceStyle
+            {
+                WidthUm = width,
+                GdsLayer = layer?.Layer ?? MetalTraceStyle.DefaultGdsLayer,
+                GdsDatatype = layer?.Datatype ?? 0,
+            };
+        }
+    }
+}

--- a/CAP-DataAccess/PDKs/cornerstone-sin-pdk.json
+++ b/CAP-DataAccess/PDKs/cornerstone-sin-pdk.json
@@ -3,7 +3,7 @@
   "name": "CornerStone SiN 300nm",
   "description": "CornerStone open-source silicon-nitride (Si3N4, 300 nm) process, generated from gdsfactory's cspdk.sin300 by scripts/generate_cspdk_sin300_pdk.py. A distinct fabrication process from the 220 nm SOI PDKs (single-process rule, #570). gdsfactory backend \u2014 components export via gdsfactory, not Nazca; S-matrices are sampled from cspdk's own sax compact models (#665).",
   "foundry": "CornerStone",
-  "version": "cspdk-1.4.3",
+  "version": "cspdk-1.4.4",
   "defaultWavelengthNm": 1550,
   "backend": "gdsfactory",
   "gdsFactoryRoutingCrossSection": "xs_nc",
@@ -11,6 +11,96 @@
     "name": "CornerStone SiN 300nm",
     "foundry": "CornerStone",
     "coreThicknessNm": 300,
+    "layers": [
+      {
+        "name": "NITRIDE",
+        "layer": 203,
+        "datatype": 0,
+        "description": "Waveguide core (Si3N4)"
+      },
+      {
+        "name": "NITRIDE_ETCH",
+        "layer": 204,
+        "datatype": 0,
+        "description": "Nitride etch region"
+      },
+      {
+        "name": "HEATER",
+        "layer": 39,
+        "datatype": 0,
+        "description": "Heater metal (TiN)"
+      },
+      {
+        "name": "PAD",
+        "layer": 41,
+        "datatype": 0,
+        "description": "Bond-pad / routing metal (Aluminum)"
+      },
+      {
+        "name": "CLAD_OPEN",
+        "layer": 22,
+        "datatype": 0,
+        "description": "Cladding opening"
+      },
+      {
+        "name": "FLOORPLAN",
+        "layer": 99,
+        "datatype": 0,
+        "description": "Chip floorplan / die outline"
+      },
+      {
+        "name": "LBL",
+        "layer": 100,
+        "datatype": 0,
+        "description": "Label"
+      }
+    ],
+    "xsections": [
+      {
+        "name": "xs_nc",
+        "kind": 0,
+        "widthUm": 1.2,
+        "minRadiusUm": 30.0,
+        "recommendedRadiusUm": 30.0,
+        "layers": [
+          "NITRIDE"
+        ],
+        "description": "SiN C-band strip waveguide"
+      },
+      {
+        "name": "xs_no",
+        "kind": 0,
+        "widthUm": 0.95,
+        "minRadiusUm": 30.0,
+        "recommendedRadiusUm": 30.0,
+        "layers": [
+          "NITRIDE"
+        ],
+        "description": "SiN O-band strip waveguide"
+      },
+      {
+        "name": "metal_routing",
+        "kind": 1,
+        "widthUm": 10.0,
+        "minRadiusUm": 0.0,
+        "recommendedRadiusUm": 0.0,
+        "layers": [
+          "PAD"
+        ],
+        "description": "Electrical routing metal"
+      },
+      {
+        "name": "heater_metal",
+        "kind": 1,
+        "widthUm": 4.0,
+        "minRadiusUm": 0.0,
+        "recommendedRadiusUm": 0.0,
+        "layers": [
+          "HEATER"
+        ],
+        "description": "Heater trace metal"
+      }
+    ],
     "materials": [
       {
         "name": "Si3N4",
@@ -758,27 +848,27 @@
       "name": "MZI",
       "category": "Interferometers",
       "gdsFactoryFunction": "cspdk.sin300.mzi",
-      "widthMicrometers": 596.8,
-      "heightMicrometers": 116.1,
+      "widthMicrometers": 616.8,
+      "heightMicrometers": 136.1,
       "nazcaOriginOffsetX": 50.0,
-      "nazcaOriginOffsetY": 55.55,
+      "nazcaOriginOffsetY": 65.55,
       "pins": [
         {
           "name": "o1",
           "offsetXMicrometers": 0.0,
-          "offsetYMicrometers": 55.55,
+          "offsetYMicrometers": 65.55,
           "angleDegrees": 180.0
         },
         {
           "name": "o3",
-          "offsetXMicrometers": 596.8,
-          "offsetYMicrometers": 58.5,
+          "offsetXMicrometers": 616.8,
+          "offsetYMicrometers": 68.5,
           "angleDegrees": 0.0
         },
         {
           "name": "o2",
-          "offsetXMicrometers": 596.8,
-          "offsetYMicrometers": 52.6,
+          "offsetXMicrometers": 616.8,
+          "offsetYMicrometers": 62.6,
           "angleDegrees": 0.0
         }
       ],
@@ -791,14 +881,14 @@
               {
                 "fromPin": "o1",
                 "toPin": "o2",
-                "magnitude": 0.016379,
-                "phaseDegrees": -139.826
+                "magnitude": 0.016378,
+                "phaseDegrees": 128.325
               },
               {
                 "fromPin": "o1",
                 "toPin": "o3",
-                "magnitude": 0.64633,
-                "phaseDegrees": 40.174
+                "magnitude": 0.646322,
+                "phaseDegrees": -51.675
               }
             ]
           },
@@ -808,14 +898,14 @@
               {
                 "fromPin": "o1",
                 "toPin": "o2",
-                "magnitude": 0.437742,
-                "phaseDegrees": -140.34
+                "magnitude": 0.437737,
+                "phaseDegrees": -77.099
               },
               {
                 "fromPin": "o1",
                 "toPin": "o3",
-                "magnitude": 0.694018,
-                "phaseDegrees": 39.66
+                "magnitude": 0.69401,
+                "phaseDegrees": 102.901
               }
             ]
           },
@@ -825,14 +915,14 @@
               {
                 "fromPin": "o1",
                 "toPin": "o2",
-                "magnitude": 0.814306,
-                "phaseDegrees": -112.788
+                "magnitude": 0.814296,
+                "phaseDegrees": 110.865
               },
               {
                 "fromPin": "o1",
                 "toPin": "o3",
-                "magnitude": 0.428775,
-                "phaseDegrees": 67.212
+                "magnitude": 0.42877,
+                "phaseDegrees": -69.135
               }
             ]
           },
@@ -842,14 +932,14 @@
               {
                 "fromPin": "o1",
                 "toPin": "o2",
-                "magnitude": 0.909046,
-                "phaseDegrees": 91.173
+                "magnitude": 0.909035,
+                "phaseDegrees": -143.036
               },
               {
                 "fromPin": "o1",
                 "toPin": "o3",
-                "magnitude": 0.210948,
-                "phaseDegrees": -88.827
+                "magnitude": 0.210946,
+                "phaseDegrees": 36.964
               }
             ]
           },
@@ -859,14 +949,14 @@
               {
                 "fromPin": "o1",
                 "toPin": "o2",
-                "magnitude": 0.920325,
-                "phaseDegrees": -58.25
+                "magnitude": 0.920315,
+                "phaseDegrees": -29.067
               },
               {
                 "fromPin": "o1",
                 "toPin": "o3",
                 "magnitude": 0.023322,
-                "phaseDegrees": -58.25
+                "phaseDegrees": -29.067
               }
             ]
           },
@@ -876,14 +966,14 @@
               {
                 "fromPin": "o1",
                 "toPin": "o2",
-                "magnitude": 0.717937,
-                "phaseDegrees": 22.248
+                "magnitude": 0.717928,
+                "phaseDegrees": -138.115
               },
               {
                 "fromPin": "o1",
                 "toPin": "o3",
-                "magnitude": 0.413376,
-                "phaseDegrees": 22.248
+                "magnitude": 0.413371,
+                "phaseDegrees": -138.115
               }
             ]
           },
@@ -893,14 +983,14 @@
               {
                 "fromPin": "o1",
                 "toPin": "o2",
-                "magnitude": 0.361162,
-                "phaseDegrees": 127.735
+                "magnitude": 0.361158,
+                "phaseDegrees": 142.563
               },
               {
                 "fromPin": "o1",
                 "toPin": "o3",
-                "magnitude": 0.571337,
-                "phaseDegrees": 127.735
+                "magnitude": 0.571331,
+                "phaseDegrees": 142.563
               }
             ]
           }
@@ -1064,20 +1154,20 @@
       "name": "Bend Euler",
       "category": "Waveguides",
       "gdsFactoryFunction": "cspdk.sin300.bend_euler",
-      "widthMicrometers": 25.6,
-      "heightMicrometers": 25.6,
+      "widthMicrometers": 30.6,
+      "heightMicrometers": 30.6,
       "nazcaOriginOffsetX": -0.0,
-      "nazcaOriginOffsetY": 25.0,
+      "nazcaOriginOffsetY": 30.0,
       "pins": [
         {
           "name": "o1",
           "offsetXMicrometers": 0.0,
-          "offsetYMicrometers": 25.0,
+          "offsetYMicrometers": 30.0,
           "angleDegrees": 180.0
         },
         {
           "name": "o2",
-          "offsetXMicrometers": 25.0,
+          "offsetXMicrometers": 30.0,
           "offsetYMicrometers": 0.0,
           "angleDegrees": 270.0
         }

--- a/CAP-DataAccess/PDKs/siepic-ebeam-pdk.json
+++ b/CAP-DataAccess/PDKs/siepic-ebeam-pdk.json
@@ -10,8 +10,79 @@
     "name": "SiEPIC EBeam SOI 220nm",
     "foundry": "Applied Nanotools",
     "coreThicknessNm": 220,
-    "layers": [],
-    "xsections": [],
+    "layers": [
+      {
+        "name": "WG",
+        "layer": 1,
+        "datatype": 0,
+        "description": "Waveguide core (Si)"
+      },
+      {
+        "name": "SLAB150",
+        "layer": 2,
+        "datatype": 0,
+        "description": "150 nm slab (rib waveguide)"
+      },
+      {
+        "name": "M1_HEATER",
+        "layer": 11,
+        "datatype": 0,
+        "description": "Heater metal (TiN)"
+      },
+      {
+        "name": "M2_ROUTER",
+        "layer": 12,
+        "datatype": 0,
+        "description": "Routing metal (Aluminum)"
+      },
+      {
+        "name": "PAD_OPEN",
+        "layer": 13,
+        "datatype": 0,
+        "description": "Bond-pad opening"
+      },
+      {
+        "name": "DEVREC",
+        "layer": 68,
+        "datatype": 0,
+        "description": "Device recognition / bounding box"
+      }
+    ],
+    "xsections": [
+      {
+        "name": "strip",
+        "kind": 0,
+        "widthUm": 0.5,
+        "minRadiusUm": 5,
+        "recommendedRadiusUm": 10,
+        "layers": [
+          "WG"
+        ],
+        "description": "SOI strip waveguide"
+      },
+      {
+        "name": "metal_routing",
+        "kind": 1,
+        "widthUm": 10,
+        "minRadiusUm": 7,
+        "recommendedRadiusUm": 10,
+        "layers": [
+          "M2_ROUTER"
+        ],
+        "description": "Electrical routing metal"
+      },
+      {
+        "name": "heater_metal",
+        "kind": 1,
+        "widthUm": 4,
+        "minRadiusUm": 7,
+        "recommendedRadiusUm": 4,
+        "layers": [
+          "M1_HEATER"
+        ],
+        "description": "Heater trace metal"
+      }
+    ],
     "materials": [
       {
         "name": "Si",

--- a/CAP.Avalonia/Controls/HelpFlyoutButton.axaml
+++ b/CAP.Avalonia/Controls/HelpFlyoutButton.axaml
@@ -1,0 +1,50 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="CAP.Avalonia.Controls.HelpFlyoutButton"
+             x:Name="Root">
+
+    <!-- Reusable "?" help button (#682): lets any panel/window attach its own
+         help content (plain-language sections, an illustrative animation, ...)
+         without hand-rolling a Button + Flyout pair each time. Generalizes the
+         one-off pattern in CAP.Avalonia/Views/Panels/TransientHelpFlyout.axaml.
+         The flyout content fades/slides into place on open; see AnimateEntrance()
+         in the code-behind. -->
+
+    <Button x:Name="HelpButton"
+            Width="22" Height="22" Padding="0"
+            CornerRadius="11"
+            Background="#333338"
+            BorderBrush="#5a5a60"
+            BorderThickness="1"
+            HorizontalContentAlignment="Center"
+            VerticalContentAlignment="Center"
+            ToolTip.Tip="{Binding Title, ElementName=Root, FallbackValue=Help}">
+
+        <Button.Styles>
+            <Style Selector="Button:pointerover /template/ ContentPresenter">
+                <Setter Property="Background" Value="#45454c"/>
+            </Style>
+        </Button.Styles>
+
+        <TextBlock Text="?" FontSize="12" FontWeight="Bold" Foreground="#cfcfd6"/>
+
+        <Button.Flyout>
+            <Flyout Placement="Bottom" ShowMode="Standard">
+                <Border Background="#1a1a1a" BorderBrush="#3d3d3d" BorderThickness="1"
+                        CornerRadius="6" MaxWidth="440" MaxHeight="460">
+                    <ScrollViewer MaxWidth="440" MaxHeight="460">
+                        <StackPanel Margin="14" Spacing="8">
+                            <TextBlock x:Name="TitleText"
+                                       Text="{Binding Title, ElementName=Root}"
+                                       FontWeight="Bold" FontSize="13" Foreground="White"
+                                       TextWrapping="Wrap"
+                                       IsVisible="{Binding Title, ElementName=Root, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                            <ContentPresenter x:Name="ContentHost"
+                                              Content="{Binding HelpContent, ElementName=Root}"/>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Border>
+            </Flyout>
+        </Button.Flyout>
+    </Button>
+</UserControl>

--- a/CAP.Avalonia/Controls/HelpFlyoutButton.axaml.cs
+++ b/CAP.Avalonia/Controls/HelpFlyoutButton.axaml.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media.Transformation;
+
+namespace CAP.Avalonia.Controls;
+
+/// <summary>
+/// Reusable "?" help button: any panel or window drops this in and supplies its own
+/// <see cref="HelpContent"/> (plain-language sections, an illustrative animation, ...)
+/// instead of hand-rolling a Button + Flyout pair. Generalizes the one-off pattern in
+/// <c>CAP.Avalonia/Views/Panels/TransientHelpFlyout.axaml</c>. On open, the flyout content
+/// fades and slides up into place, staggered item-by-item for a "stacking" feel (#682).
+/// </summary>
+public partial class HelpFlyoutButton : UserControl
+{
+    /// <summary>Bold header text shown at the top of the flyout. Hidden when null/empty.</summary>
+    public static readonly StyledProperty<string?> TitleProperty =
+        AvaloniaProperty.Register<HelpFlyoutButton, string?>(nameof(Title));
+
+    /// <summary>Caller-supplied explanatory content (any control tree) shown inside the flyout.</summary>
+    public static readonly StyledProperty<object?> HelpContentProperty =
+        AvaloniaProperty.Register<HelpFlyoutButton, object?>(nameof(HelpContent));
+
+    /// <summary>Delay step between consecutively staggered children, in milliseconds.</summary>
+    private const int StaggerStepMs = 45;
+
+    /// <summary>Caps the number of stagger steps so long content doesn't take forever to reveal.</summary>
+    private const int MaxStaggerSteps = 10;
+
+    /// <summary>Duration of each item's fade + slide-in animation.</summary>
+    private static readonly TimeSpan EntranceDuration = TimeSpan.FromMilliseconds(260);
+
+    /// <summary>Initializes the control and wires the entrance animation to the flyout opening.</summary>
+    public HelpFlyoutButton()
+    {
+        InitializeComponent();
+
+        // The Flyout itself isn't a Control, so it isn't exposed as a generated
+        // x:Name field; reach it via the button that hosts it instead.
+        if (HelpButton.Flyout is FlyoutBase flyout)
+            flyout.Opened += (_, _) => AnimateEntrance();
+    }
+
+    /// <summary>Bold header text shown at the top of the flyout.</summary>
+    public string? Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    /// <summary>Caller-supplied explanatory content shown inside the flyout.</summary>
+    public object? HelpContent
+    {
+        get => GetValue(HelpContentProperty);
+        set => SetValue(HelpContentProperty, value);
+    }
+
+    /// <summary>
+    /// Fades and slides the flyout's content into place. Works for any content: if the
+    /// top-level <see cref="HelpContent"/> is a <see cref="Panel"/> (the common case, a
+    /// StackPanel of sections), each direct child staggers in one after another; otherwise
+    /// the whole content animates as a single block.
+    /// </summary>
+    private void AnimateEntrance()
+    {
+        var targets = GetStaggerTargets();
+        var transitions = CreateEntranceTransitions();
+
+        // Snap every target to the hidden state first, before attaching transitions, so
+        // re-opening the flyout always replays the animation from scratch rather than
+        // animating from wherever the last close left things.
+        foreach (var target in targets)
+        {
+            target.Transitions = null;
+            target.Opacity = 0;
+            target.RenderTransform = TransformOperations.Parse("translateY(14px)");
+        }
+
+        for (int i = 0; i < targets.Count; i++)
+        {
+            var target = targets[i];
+            target.Transitions = transitions;
+            _ = RevealAsync(target, Math.Min(i, MaxStaggerSteps) * StaggerStepMs);
+        }
+    }
+
+    /// <summary>Waits <paramref name="delayMs"/> then transitions one target to its visible state.</summary>
+    private static async Task RevealAsync(Control target, int delayMs)
+    {
+        if (delayMs > 0)
+            await Task.Delay(delayMs);
+
+        target.Opacity = 1;
+        target.RenderTransform = TransformOperations.Identity;
+    }
+
+    /// <summary>Builds the shared opacity + slide transition used by every staggered item.</summary>
+    private static Transitions CreateEntranceTransitions() => new()
+    {
+        new DoubleTransition { Property = Visual.OpacityProperty, Duration = EntranceDuration, Easing = new CubicEaseOut() },
+        new TransformOperationsTransition { Property = Visual.RenderTransformProperty, Duration = EntranceDuration, Easing = new CubicEaseOut() },
+    };
+
+    /// <summary>
+    /// Items to animate: the header (if visible), then either the content panel's own
+    /// direct children (staggered) or the whole content control as one block.
+    /// </summary>
+    private List<Control> GetStaggerTargets()
+    {
+        var targets = new List<Control>();
+
+        if (TitleText.IsVisible)
+            targets.Add(TitleText);
+
+        if (HelpContent is Panel panel)
+            targets.AddRange(panel.Children.OfType<Control>());
+        else if (HelpContent is Control content)
+            targets.Add(content);
+
+        return targets;
+    }
+}

--- a/CAP.Avalonia/Controls/Rendering/WaveguideConnectionRenderer.cs
+++ b/CAP.Avalonia/Controls/Rendering/WaveguideConnectionRenderer.cs
@@ -3,6 +3,7 @@ using Avalonia.Media;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.Visualization;
 using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.Components.PinKinds;
 using CAP_Core.Routing;
 
 namespace CAP.Avalonia.Controls.Rendering;
@@ -46,10 +47,34 @@ public sealed class WaveguideConnectionRenderer : ICanvasRenderer
         DrawConnectionLabel(context, conn, vm);
     }
 
+    /// <summary>Copper/gold marking electrical (metal) connections, matching the electrical
+    /// pin colour in <see cref="PinRenderer"/> (#519/#682).</summary>
+    private static readonly Color ElectricalTraceColor = Color.FromRgb(218, 165, 32);
+
+    /// <summary>Metal traces are drawn markedly thicker than optical waveguides so they read as
+    /// physical metal strips on the canvas, not thin light paths (#682 field feedback).</summary>
+    private const double ElectricalTraceThickness = 5;
+
+    /// <summary>True when both endpoints are electrical pins — i.e. this is a metal trace,
+    /// not an optical waveguide (matches the export classification in the exporters).</summary>
+    private static bool IsElectricalTrace(WaveguideConnectionViewModel conn) =>
+        PinKindHelper.IsElectrical(conn.Connection.StartPin)
+        && PinKindHelper.IsElectrical(conn.Connection.EndPin);
+
     private static Pen CreateWaveguidePen(WaveguideConnectionViewModel conn, DesignCanvasViewModel vm)
     {
         if (conn.IsSelected)
             return new Pen(Brushes.Yellow, 3);
+
+        // Electrical connections are metal traces: a thick copper/gold strip, distinct from
+        // optical waveguides. They carry no optical power flow, so this takes precedence over the
+        // power-flow styling below.
+        if (IsElectricalTrace(conn))
+            return new Pen(new SolidColorBrush(ElectricalTraceColor), ElectricalTraceThickness)
+            {
+                LineCap = PenLineCap.Round,
+                LineJoin = PenLineJoin.Round,
+            };
 
         if (vm.ShowPowerFlow && vm.PowerFlowVisualizer.CurrentResult != null)
         {

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components.Core;
+using CAP_Core.Components.PinKinds;
 using CAP_Core.Export;
 using CAP_DataAccess.Persistence.PIR;
 
@@ -46,16 +47,14 @@ public class GdsFactoryExporter
     }
 
     /// <summary>
-    /// The gdsfactory sizing kwargs that place a routed segment on the metal layer:
-    /// <c>width=…, layer=(…, …)</c>. Used for electrical connections in place of the
-    /// optical waveguide cross-section (issue #682).
+    /// True when a connection between these two pins is a metal (electrical) trace: BOTH pins
+    /// must be electrical (<see cref="PinKindHelper.IsElectrical(PhysicalPin?)"/>); a mixed
+    /// optical+electrical or all-optical connection stays an optical waveguide (issue #686 review
+    /// — the earlier "either pin" predicate would draw a mixed connection wholly on the metal
+    /// layer, silently dropping the optical waveguide).
     /// </summary>
-    private static string MetalKwarg(MetalTraceStyle metal) =>
-        $"width={metal.WidthLiteral}, layer={metal.LayerTuple}";
-
-    /// <summary>True when the pin carries electrical current (a metal contact), not light.</summary>
-    private static bool IsElectrical(PhysicalPin? pin) =>
-        pin is { MatterType: MatterType.Electricity };
+    private static bool IsMetalConnection(PhysicalPin? first, PhysicalPin? second) =>
+        PinKindHelper.IsElectrical(first) && PinKindHelper.IsElectrical(second);
 
     /// <summary>
     /// The waveguide-sizing keyword argument for routed straights/bends. gdsfactory-native
@@ -325,41 +324,50 @@ public class GdsFactoryExporter
             if (conn.StartPin?.ParentComponent?.IsAnalysisTool == true) continue;
             if (conn.EndPin?.ParentComponent?.IsAnalysisTool == true) continue;
 
-            // Electrical connections are metal traces, not optical waveguides — size them with
-            // the metal layer/width instead of the waveguide cross-section (issue #682). The
-            // cross-kind guard (#519) keeps both pins in one domain, so either pin suffices.
-            var kwarg = IsElectrical(conn.StartPin) || IsElectrical(conn.EndPin)
-                ? MetalKwarg(metalStyle)
-                : waveguideKwarg;
+            // Electrical connections are metal traces, not optical waveguides — draw them as a
+            // polygon on the metal layer instead of a routed waveguide cell (issue #682). A
+            // connection is metal only when BOTH pins are electrical; a mixed or all-optical
+            // connection stays a waveguide (issue #686 review).
+            var metal = IsMetalConnection(conn.StartPin, conn.EndPin) ? metalStyle : null;
 
             var segments = conn.GetPathSegments();
             if (segments.Count > 0)
-                GdsFactorySegmentWriter.AppendSegments(sb, segments, conn.StartPin, conn.EndPin, kwarg);
+                GdsFactorySegmentWriter.AppendSegments(sb, segments, conn.StartPin, conn.EndPin, waveguideKwarg, metal);
             else if (conn.StartPin != null && conn.EndPin != null)
-                GdsFactorySegmentWriter.AppendPinToPinFallback(sb, conn.StartPin, conn.EndPin, kwarg);
+                GdsFactorySegmentWriter.AppendPinToPinFallback(sb, conn.StartPin, conn.EndPin, waveguideKwarg, metal);
         }
 
         foreach (var compVm in canvas.Components)
         {
             if (compVm.Component is ComponentGroup group)
-                AppendGroupFrozenPaths(sb, group, waveguideKwarg);
+                AppendGroupFrozenPaths(sb, group, waveguideKwarg, metalStyle);
         }
         sb.AppendLine();
     }
 
-    private static void AppendGroupFrozenPaths(StringBuilder sb, ComponentGroup group, string waveguideKwarg)
+    /// <summary>
+    /// Exports frozen waveguide paths from a ComponentGroup (and nested groups). A frozen path
+    /// between two electrical pins is a metal trace, not a waveguide — mirrors the live
+    /// connection loop above (issue #686 review: this frozen-group path used to always emit a
+    /// waveguide regardless of pin kind, the same gap as the Nazca exporter's frozen-group export).
+    /// </summary>
+    private static void AppendGroupFrozenPaths(
+        StringBuilder sb, ComponentGroup group, string waveguideKwarg, MetalTraceStyle metalStyle)
     {
         foreach (var frozenPath in group.InternalPaths)
         {
             if (frozenPath?.Path?.Segments?.Count > 0)
+            {
+                var metal = IsMetalConnection(frozenPath.StartPin, frozenPath.EndPin) ? metalStyle : null;
                 GdsFactorySegmentWriter.AppendSegments(
-                    sb, frozenPath.Path.Segments, frozenPath.StartPin, frozenPath.EndPin, waveguideKwarg);
+                    sb, frozenPath.Path.Segments, frozenPath.StartPin, frozenPath.EndPin, waveguideKwarg, metal);
+            }
         }
 
         foreach (var child in group.ChildComponents)
         {
             if (child is ComponentGroup nested)
-                AppendGroupFrozenPaths(sb, nested, waveguideKwarg);
+                AppendGroupFrozenPaths(sb, nested, waveguideKwarg, metalStyle);
         }
     }
 

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryExporter.cs
@@ -21,9 +21,13 @@ public class GdsFactoryExporter
     /// <param name="options">Component representation mode (stubs vs. ubcpdk cells).</param>
     /// <param name="overrides">Per-instance overrides; gdsfactory-backend ones are emitted as
     /// component factories. Null skips override handling.</param>
+    /// <param name="metalStyle">Width and GDS layer for electrical (metal) routing traces
+    /// (issue #682); electrical connections are emitted as metal on this layer instead of as
+    /// optical waveguides. Null falls back to <see cref="MetalTraceStyle.Default"/>.</param>
     public string Export(
         DesignCanvasViewModel canvas, GdsFactoryExportOptions options,
-        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides = null)
+        IReadOnlyDictionary<string, NazcaCodeOverride>? overrides = null,
+        MetalTraceStyle? metalStyle = null)
     {
         var sb = new StringBuilder();
         AppendHeader(sb, canvas, options);
@@ -36,10 +40,22 @@ public class GdsFactoryExporter
         foreach (var comp in EnumerateExportableComponents(canvas))
             AppendPlacement(sb, comp, options, overrides, ref refIndex);
         sb.AppendLine();
-        AppendConnections(sb, canvas, RoutingWaveguideKwarg(canvas));
+        AppendConnections(sb, canvas, RoutingWaveguideKwarg(canvas), metalStyle ?? MetalTraceStyle.Default);
         AppendFooter(sb);
         return sb.ToString();
     }
+
+    /// <summary>
+    /// The gdsfactory sizing kwargs that place a routed segment on the metal layer:
+    /// <c>width=…, layer=(…, …)</c>. Used for electrical connections in place of the
+    /// optical waveguide cross-section (issue #682).
+    /// </summary>
+    private static string MetalKwarg(MetalTraceStyle metal) =>
+        $"width={metal.WidthLiteral}, layer={metal.LayerTuple}";
+
+    /// <summary>True when the pin carries electrical current (a metal contact), not light.</summary>
+    private static bool IsElectrical(PhysicalPin? pin) =>
+        pin is { MatterType: MatterType.Electricity };
 
     /// <summary>
     /// The waveguide-sizing keyword argument for routed straights/bends. gdsfactory-native
@@ -299,7 +315,8 @@ public class GdsFactoryExporter
             ? comp.NazcaFunctionParameters
             : string.Empty;
 
-    private static void AppendConnections(StringBuilder sb, DesignCanvasViewModel canvas, string waveguideKwarg)
+    private static void AppendConnections(
+        StringBuilder sb, DesignCanvasViewModel canvas, string waveguideKwarg, MetalTraceStyle metalStyle)
     {
         sb.AppendLine("# Waveguide connections");
         foreach (var connVm in canvas.Connections)
@@ -308,11 +325,18 @@ public class GdsFactoryExporter
             if (conn.StartPin?.ParentComponent?.IsAnalysisTool == true) continue;
             if (conn.EndPin?.ParentComponent?.IsAnalysisTool == true) continue;
 
+            // Electrical connections are metal traces, not optical waveguides — size them with
+            // the metal layer/width instead of the waveguide cross-section (issue #682). The
+            // cross-kind guard (#519) keeps both pins in one domain, so either pin suffices.
+            var kwarg = IsElectrical(conn.StartPin) || IsElectrical(conn.EndPin)
+                ? MetalKwarg(metalStyle)
+                : waveguideKwarg;
+
             var segments = conn.GetPathSegments();
             if (segments.Count > 0)
-                GdsFactorySegmentWriter.AppendSegments(sb, segments, conn.StartPin, conn.EndPin, waveguideKwarg);
+                GdsFactorySegmentWriter.AppendSegments(sb, segments, conn.StartPin, conn.EndPin, kwarg);
             else if (conn.StartPin != null && conn.EndPin != null)
-                GdsFactorySegmentWriter.AppendPinToPinFallback(sb, conn.StartPin, conn.EndPin, waveguideKwarg);
+                GdsFactorySegmentWriter.AppendPinToPinFallback(sb, conn.StartPin, conn.EndPin, kwarg);
         }
 
         foreach (var compVm in canvas.Components)

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactorySegmentWriter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactorySegmentWriter.cs
@@ -15,6 +15,9 @@ namespace CAP.Avalonia.Services.GdsFactoryExport;
 /// </summary>
 public static class GdsFactorySegmentWriter
 {
+    /// <summary>Arc samples used to approximate a bend as a metal ribbon polygon (issue #686 review).</summary>
+    private const int MetalBendArcSampleCount = 16;
+
     /// <summary>
     /// Appends all segments of one routed connection. A single straight segment with
     /// known pins is emitted pin-to-pin (exact endpoints) like the Nazca export.
@@ -26,17 +29,22 @@ public static class GdsFactorySegmentWriter
     /// <param name="waveguideKwarg">The waveguide-sizing keyword argument emitted into every
     /// routed straight/bend — <c>width=WG_WIDTH</c> for Nazca/generic designs, or
     /// <c>cross_section='xs_nc'</c> for a gdsfactory-native PDK whose activated PDK has no
-    /// generic 'strip' cross-section (#570 field-test fix).</param>
+    /// generic 'strip' cross-section (#570 field-test fix). Ignored when <paramref name="metal"/>
+    /// is set.</param>
+    /// <param name="metal">Width/layer of an electrical (metal) trace (issue #682). When set, the
+    /// segment is drawn as a polygon on the metal layer instead of a routed waveguide cell —
+    /// gdsfactory's <c>straight()</c>/<c>bend_circular()</c> factories have no <c>layer=</c>
+    /// kwarg (verified <c>TypeError</c> against the installed gdsfactory, issue #686 review).</param>
     public static void AppendSegments(
         StringBuilder sb, IReadOnlyList<PathSegment> segments,
         PhysicalPin? startPin = null, PhysicalPin? endPin = null,
-        string waveguideKwarg = "width=WG_WIDTH")
+        string waveguideKwarg = "width=WG_WIDTH", MetalTraceStyle? metal = null)
     {
         if (segments.Count == 1 && segments[0] is StraightSegment && startPin != null && endPin != null)
         {
             var (sx, sy) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
             var (ex, ey) = NazcaCoordinateMapper.GetPinNazcaPosition(endPin);
-            AppendStraight(sb, sx, sy, ex, ey, waveguideKwarg);
+            AppendStraightOrMetal(sb, sx, sy, ex, ey, waveguideKwarg, metal);
             return;
         }
 
@@ -47,10 +55,13 @@ public static class GdsFactorySegmentWriter
             {
                 case StraightSegment:
                     var (nex, ney) = NazcaCoordinateMapper.ToNazca(segment.EndPoint.X, segment.EndPoint.Y);
-                    AppendStraight(sb, nsx, nsy, nex, ney, waveguideKwarg);
+                    AppendStraightOrMetal(sb, nsx, nsy, nex, ney, waveguideKwarg, metal);
                     break;
                 case BendSegment bend:
-                    AppendBend(sb, bend, nsx, nsy, waveguideKwarg);
+                    if (metal != null)
+                        AppendMetalPolygon(sb, SampleBendCenterlineNazca(bend), metal);
+                    else
+                        AppendBend(sb, bend, nsx, nsy, waveguideKwarg);
                     break;
                 default:
                     sb.AppendLine($"# Unknown segment type: {segment.GetType().Name}");
@@ -65,12 +76,26 @@ public static class GdsFactorySegmentWriter
     /// </summary>
     public static void AppendPinToPinFallback(
         StringBuilder sb, PhysicalPin startPin, PhysicalPin endPin,
-        string waveguideKwarg = "width=WG_WIDTH")
+        string waveguideKwarg = "width=WG_WIDTH", MetalTraceStyle? metal = null)
     {
         var (sx, sy) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
         var (ex, ey) = NazcaCoordinateMapper.GetPinNazcaPosition(endPin);
         sb.AppendLine("# routeless connection: direct pin-to-pin straight");
-        AppendStraight(sb, sx, sy, ex, ey, waveguideKwarg);
+        AppendStraightOrMetal(sb, sx, sy, ex, ey, waveguideKwarg, metal);
+    }
+
+    /// <summary>
+    /// Emits a routed straight: an optical waveguide via <c>gf.components.straight()</c> when
+    /// <paramref name="metal"/> is null, otherwise a metal-layer rectangle via
+    /// <c>add_polygon</c> (issue #682/#686 review).
+    /// </summary>
+    private static void AppendStraightOrMetal(
+        StringBuilder sb, double sx, double sy, double ex, double ey, string waveguideKwarg, MetalTraceStyle? metal)
+    {
+        if (metal != null)
+            AppendMetalPolygon(sb, new[] { (sx, sy), (ex, ey) }, metal);
+        else
+            AppendStraight(sb, sx, sy, ex, ey, waveguideKwarg);
     }
 
     private static void AppendStraight(
@@ -105,4 +130,81 @@ public static class GdsFactorySegmentWriter
         sb.AppendLine($"_seg.rotate({a})");
         sb.AppendLine($"_seg.move(({px}, {py}))");
     }
+
+    /// <summary>
+    /// Draws a metal trace as a rectangle/ribbon polygon directly on the process metal layer via
+    /// <c>c.add_polygon(points, layer=(L, D))</c> — mirroring how <see cref="GdsFactoryStubWriter"/>
+    /// emits stub rectangles — instead of a routed gdsfactory cell. gdsfactory's
+    /// <c>straight()</c>/<c>bend_circular()</c> factories reject an unknown <c>layer=</c> kwarg
+    /// at run time, so a metal trace cannot reuse them (issue #682/#686 review).
+    /// </summary>
+    private static void AppendMetalPolygon(
+        StringBuilder sb, IReadOnlyList<(double X, double Y)> centerline, MetalTraceStyle metal)
+    {
+        if (centerline.Count < 2)
+            return;
+
+        var ci = CultureInfo.InvariantCulture;
+        var halfWidth = metal.WidthUm / 2.0;
+        var polygon = BuildRibbonPolygon(centerline, halfWidth);
+        var points = string.Join(", ", polygon.Select(p => FormatPoint(p, ci)));
+        sb.AppendLine($"c.add_polygon([{points}], layer={metal.LayerTuple})");
+    }
+
+    /// <summary>
+    /// Offsets a centerline (2+ points) into a closed ribbon polygon of the given half-width:
+    /// the left-side offsets forward, then the right-side offsets reversed.
+    /// </summary>
+    private static IReadOnlyList<(double X, double Y)> BuildRibbonPolygon(
+        IReadOnlyList<(double X, double Y)> centerline, double halfWidth)
+    {
+        var left = new List<(double X, double Y)>();
+        var right = new List<(double X, double Y)>();
+        for (int i = 0; i < centerline.Count - 1; i++)
+        {
+            var (x0, y0) = centerline[i];
+            var (x1, y1) = centerline[i + 1];
+            double dx = x1 - x0;
+            double dy = y1 - y0;
+            double len = Math.Sqrt(dx * dx + dy * dy);
+            if (len <= 0)
+                continue;
+
+            double ox = -dy / len * halfWidth;
+            double oy = dx / len * halfWidth;
+            left.Add((x0 + ox, y0 + oy));
+            left.Add((x1 + ox, y1 + oy));
+            right.Add((x0 - ox, y0 - oy));
+            right.Add((x1 - ox, y1 - oy));
+        }
+
+        right.Reverse();
+        left.AddRange(right);
+        return left;
+    }
+
+    /// <summary>
+    /// Samples a bend's arc (in app coordinates, using the same geometry <see cref="BendSegment"/>
+    /// derives its own start/end points from) into Nazca-space centerline points for the metal
+    /// ribbon polygon (issue #686 review).
+    /// </summary>
+    private static IReadOnlyList<(double X, double Y)> SampleBendCenterlineNazca(BendSegment bend)
+    {
+        var points = new List<(double X, double Y)>(MetalBendArcSampleCount + 1);
+        var sign = Math.Sign(bend.SweepAngleDegrees);
+        for (int i = 0; i <= MetalBendArcSampleCount; i++)
+        {
+            double t = (double)i / MetalBendArcSampleCount;
+            double angleDeg = bend.StartAngleDegrees + t * bend.SweepAngleDegrees;
+            double angleRad = angleDeg * Math.PI / 180.0 - Math.PI / 2.0 * sign;
+            double appX = bend.Center.X + bend.RadiusMicrometers * Math.Cos(angleRad);
+            double appY = bend.Center.Y + bend.RadiusMicrometers * Math.Sin(angleRad);
+            points.Add(NazcaCoordinateMapper.ToNazca(appX, appY));
+        }
+        return points;
+    }
+
+    private static string FormatPoint((double X, double Y) point, CultureInfo ci) =>
+        $"({NazcaCoordinateMapper.NormalizeZero(point.X).ToString("F2", ci)}, " +
+        $"{NazcaCoordinateMapper.NormalizeZero(point.Y).ToString("F2", ci)})";
 }

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryStubWriter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryStubWriter.cs
@@ -64,6 +64,10 @@ public static class GdsFactoryStubWriter
 
         foreach (var pin in comp.PhysicalPins)
         {
+            // Electrical pins are metal contacts, not optical ports — never declare them on the
+            // waveguide layer (issue #682); their wiring is emitted as metal traces instead.
+            if (pin.MatterType == MatterType.Electricity) continue;
+
             var (uox, uoy) = NazcaCoordinateMapper.GetUnrotatedPinOffset(comp, pin);
             var py = NazcaCoordinateMapper.NormalizeZero(anchorY - uoy).ToString("F2", ci);
             var pa = NazcaCoordinateMapper.NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);
@@ -96,6 +100,10 @@ public static class GdsFactoryStubWriter
 
         foreach (var pin in comp.PhysicalPins)
         {
+            // Electrical pins are metal contacts, not optical ports — never declare them on the
+            // waveguide layer (issue #682); their wiring is emitted as metal traces instead.
+            if (pin.MatterType == MatterType.Electricity) continue;
+
             var px = NazcaCoordinateMapper.NormalizeZero(pin.OffsetXMicrometers - ox).ToString("F2", ci);
             var py = NazcaCoordinateMapper.NormalizeZero(oy - pin.OffsetYMicrometers).ToString("F2", ci);
             var pa = NazcaCoordinateMapper.NormalizeZero(-pin.AngleDegrees).ToString("F0", ci);

--- a/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryStubWriter.cs
+++ b/CAP.Avalonia/Services/GdsFactoryExport/GdsFactoryStubWriter.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using CAP_Core.Components.Core;
+using CAP_Core.Components.PinKinds;
 using CAP_Core.Export;
 
 namespace CAP.Avalonia.Services.GdsFactoryExport;
@@ -66,7 +67,7 @@ public static class GdsFactoryStubWriter
         {
             // Electrical pins are metal contacts, not optical ports — never declare them on the
             // waveguide layer (issue #682); their wiring is emitted as metal traces instead.
-            if (pin.MatterType == MatterType.Electricity) continue;
+            if (PinKindHelper.IsElectrical(pin)) continue;
 
             var (uox, uoy) = NazcaCoordinateMapper.GetUnrotatedPinOffset(comp, pin);
             var py = NazcaCoordinateMapper.NormalizeZero(anchorY - uoy).ToString("F2", ci);
@@ -102,7 +103,7 @@ public static class GdsFactoryStubWriter
         {
             // Electrical pins are metal contacts, not optical ports — never declare them on the
             // waveguide layer (issue #682); their wiring is emitted as metal traces instead.
-            if (pin.MatterType == MatterType.Electricity) continue;
+            if (PinKindHelper.IsElectrical(pin)) continue;
 
             var px = NazcaCoordinateMapper.NormalizeZero(pin.OffsetXMicrometers - ox).ToString("F2", ci);
             var py = NazcaCoordinateMapper.NormalizeZero(oy - pin.OffsetYMicrometers).ToString("F2", ci);

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -4,6 +4,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Connections;
+using CAP_Core.Components.PinKinds;
 using CAP_Core.Export;
 using CAP_Core.Routing;
 using CAP_DataAccess.Persistence.PIR;
@@ -459,12 +460,12 @@ public class SimpleNazcaExporter
             if (conn.EndPin?.ParentComponent?.IsAnalysisTool == true) continue;
 
             // Electrical connections are metal traces, not optical waveguides — emit them on
-            // the process metal layer/width instead of the waveguide layer (issue #682). The
-            // cross-kind connection guard (#519) ensures both pins share a domain, so testing
-            // either pin is enough.
-            var metal = IsElectrical(conn.StartPin) || IsElectrical(conn.EndPin)
-                ? metalStyle
-                : null;
+            // the process metal layer/width instead of the waveguide layer (issue #682). A
+            // connection is metal only when BOTH pins are electrical; a mixed optical+electrical
+            // or all-optical connection stays a waveguide (issue #686 review — the earlier
+            // "either pin" predicate would draw a mixed connection wholly on the metal layer,
+            // silently dropping the optical waveguide).
+            var metal = IsMetalConnection(conn.StartPin, conn.EndPin) ? metalStyle : null;
 
             // Issue #561: connections touching raw-code–overridden instances export
             // their REAL routed segments like any other connection — the override
@@ -483,27 +484,34 @@ public class SimpleNazcaExporter
         foreach (var compVm in canvas.Components)
         {
             if (compVm.Component is ComponentGroup group)
-                AppendGroupFrozenPaths(sb, group);
+                AppendGroupFrozenPaths(sb, group, metalStyle);
         }
 
         sb.AppendLine();
     }
 
     /// <summary>
-    /// Exports all frozen waveguide paths from a ComponentGroup (and nested groups) as Nazca segments.
+    /// Exports all frozen waveguide paths from a ComponentGroup (and nested groups) as Nazca
+    /// segments. A frozen path between two electrical pins is a metal trace, not an optical
+    /// waveguide — the same classification the live connection loop above applies (issue #686
+    /// review: this frozen-group path used to call <see cref="AppendSegmentExport"/> without the
+    /// metal style at all, so a frozen electrical route always rendered as a waveguide).
     /// </summary>
-    private static void AppendGroupFrozenPaths(StringBuilder sb, ComponentGroup group)
+    private static void AppendGroupFrozenPaths(StringBuilder sb, ComponentGroup group, MetalTraceStyle metalStyle)
     {
         foreach (var frozenPath in group.InternalPaths)
         {
             if (frozenPath?.Path?.Segments?.Count > 0)
-                AppendSegmentExport(sb, frozenPath.Path.Segments, frozenPath.StartPin, frozenPath.EndPin);
+            {
+                var metal = IsMetalConnection(frozenPath.StartPin, frozenPath.EndPin) ? metalStyle : null;
+                AppendSegmentExport(sb, frozenPath.Path.Segments, frozenPath.StartPin, frozenPath.EndPin, metal);
+            }
         }
 
         foreach (var child in group.ChildComponents)
         {
             if (child is ComponentGroup nestedGroup)
-                AppendGroupFrozenPaths(sb, nestedGroup);
+                AppendGroupFrozenPaths(sb, nestedGroup, metalStyle);
         }
     }
 
@@ -549,9 +557,13 @@ public class SimpleNazcaExporter
     private static string MetalKwargs(MetalTraceStyle? metal) =>
         metal is null ? string.Empty : $", width={metal.WidthLiteral}, layer={metal.LayerTuple}";
 
-    /// <summary>True when the pin carries electrical current (a metal contact), not light.</summary>
-    private static bool IsElectrical(PhysicalPin? pin) =>
-        pin is { MatterType: MatterType.Electricity };
+    /// <summary>
+    /// True when a connection between these two pins is a metal (electrical) trace: BOTH pins
+    /// must be electrical (<see cref="PinKindHelper.IsElectrical(PhysicalPin?)"/>); a mixed
+    /// optical+electrical or all-optical connection stays an optical waveguide (issue #686 review).
+    /// </summary>
+    private static bool IsMetalConnection(PhysicalPin? first, PhysicalPin? second) =>
+        PinKindHelper.IsElectrical(first) && PinKindHelper.IsElectrical(second);
 
     /// <summary>
     /// Formats a path segment (straight or bend) with absolute Nazca positions.

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -33,11 +33,17 @@ public class SimpleNazcaExporter
     /// every placed instance's ACTUAL world pin positions — reported by the same nazca
     /// engine that writes the GDS — to '&lt;script&gt;.pins.json' next to the script.
     /// </param>
+    /// <param name="metalStyle">
+    /// Width and GDS layer for electrical (metal) routing traces (issue #682). Electrical
+    /// connections are emitted as metal on this layer instead of as optical waveguides;
+    /// null falls back to <see cref="MetalTraceStyle.Default"/>.
+    /// </param>
     public string Export(
         DesignCanvasViewModel canvas,
         string? pdkModuleName = null,
         IReadOnlyDictionary<string, NazcaCodeOverride>? overrides = null,
-        bool emitVerification = false)
+        bool emitVerification = false,
+        MetalTraceStyle? metalStyle = null)
     {
         var sb = new StringBuilder();
 
@@ -48,7 +54,7 @@ public class SimpleNazcaExporter
         NazcaOverrideFactory.AppendFactories(sb, rawOverrides);
         AppendPdkComponentStubs(sb, canvas, rawOverrides);
         var componentNames = AppendComponents(sb, canvas, rawOverrides, overrides, emitVerification);
-        AppendConnections(sb, canvas, componentNames, rawOverrides);
+        AppendConnections(sb, canvas, componentNames, rawOverrides, metalStyle ?? MetalTraceStyle.Default);
         AppendFooter(sb);
         if (emitVerification)
             AppendVerificationEpilog(sb);
@@ -435,7 +441,8 @@ public class SimpleNazcaExporter
         StringBuilder sb,
         DesignCanvasViewModel canvas,
         Dictionary<Component, string> componentNames,
-        IReadOnlyDictionary<string, string> rawOverrides)
+        IReadOnlyDictionary<string, string> rawOverrides,
+        MetalTraceStyle metalStyle)
     {
         var hasFrozenPaths = canvas.Components.Any(vm => vm.Component is ComponentGroup);
         if (canvas.Connections.Count == 0 && !hasFrozenPaths)
@@ -451,6 +458,14 @@ public class SimpleNazcaExporter
             if (conn.StartPin?.ParentComponent?.IsAnalysisTool == true) continue;
             if (conn.EndPin?.ParentComponent?.IsAnalysisTool == true) continue;
 
+            // Electrical connections are metal traces, not optical waveguides — emit them on
+            // the process metal layer/width instead of the waveguide layer (issue #682). The
+            // cross-kind connection guard (#519) ensures both pins share a domain, so testing
+            // either pin is enough.
+            var metal = IsElectrical(conn.StartPin) || IsElectrical(conn.EndPin)
+                ? metalStyle
+                : null;
+
             // Issue #561: connections touching raw-code–overridden instances export
             // their REAL routed segments like any other connection — the override
             // cell is bbox-anchored, so app-space segment coordinates line up with
@@ -459,9 +474,9 @@ public class SimpleNazcaExporter
             var segments = conn.GetPathSegments();
 
             if (segments.Count > 0)
-                AppendSegmentExport(sb, segments, conn.StartPin, conn.EndPin);
+                AppendSegmentExport(sb, segments, conn.StartPin, conn.EndPin, metal);
             else
-                AppendFallbackExport(sb, conn, componentNames, rawOverrides);
+                AppendFallbackExport(sb, conn, componentNames, rawOverrides, metal);
         }
 
         // Export frozen waveguide paths from ComponentGroups
@@ -507,13 +522,14 @@ public class SimpleNazcaExporter
     /// <param name="endPin">End pin, used for single-straight pin-to-pin geometry.</param>
     internal static void AppendSegmentExport(
         StringBuilder sb, IReadOnlyList<PathSegment> segments,
-        PhysicalPin? startPin = null, PhysicalPin? endPin = null)
+        PhysicalPin? startPin = null, PhysicalPin? endPin = null,
+        MetalTraceStyle? metal = null)
     {
         // Single straight segment: compute geometry directly from both pin positions
         // so the waveguide hits both pins exactly even if the stored segment drifts.
         if (segments.Count == 1 && segments[0] is StraightSegment && startPin != null && endPin != null)
         {
-            sb.AppendLine(FormatStraightSegmentFromPins(startPin, endPin));
+            sb.AppendLine(FormatStraightSegmentFromPins(startPin, endPin, metal));
             return;
         }
 
@@ -522,9 +538,20 @@ public class SimpleNazcaExporter
             var (nStartX, nStartY) = NazcaCoordinateMapper.ToNazca(segment.StartPoint.X, segment.StartPoint.Y);
             var (nEndX, nEndY) = NazcaCoordinateMapper.ToNazca(segment.EndPoint.X, segment.EndPoint.Y);
 
-            sb.AppendLine(FormatSegmentAbsolute(segment, nStartX, nStartY, nEndX, nEndY));
+            sb.AppendLine(FormatSegmentAbsolute(segment, nStartX, nStartY, nEndX, nEndY, metal));
         }
     }
+
+    /// <summary>
+    /// The trailing <c>width=…, layer=(…, …)</c> kwargs that place a segment on the metal
+    /// routing layer; empty for optical segments (which use the Nazca default layer).
+    /// </summary>
+    private static string MetalKwargs(MetalTraceStyle? metal) =>
+        metal is null ? string.Empty : $", width={metal.WidthLiteral}, layer={metal.LayerTuple}";
+
+    /// <summary>True when the pin carries electrical current (a metal contact), not light.</summary>
+    private static bool IsElectrical(PhysicalPin? pin) =>
+        pin is { MatterType: MatterType.Electricity };
 
     /// <summary>
     /// Formats a path segment (straight or bend) with absolute Nazca positions.
@@ -534,14 +561,14 @@ public class SimpleNazcaExporter
     /// </summary>
     private static string FormatSegmentAbsolute(
         PathSegment segment, double nazcaStartX, double nazcaStartY,
-        double nazcaEndX, double nazcaEndY)
+        double nazcaEndX, double nazcaEndY, MetalTraceStyle? metal = null)
     {
         var ci = CultureInfo.InvariantCulture;
         return segment switch
         {
             StraightSegment => FormatStraightAbsolute(
-                nazcaStartX, nazcaStartY, nazcaEndX, nazcaEndY, ci),
-            BendSegment bend => FormatBendAbsolute(bend, nazcaStartX, nazcaStartY, ci),
+                nazcaStartX, nazcaStartY, nazcaEndX, nazcaEndY, ci, metal),
+            BendSegment bend => FormatBendAbsolute(bend, nazcaStartX, nazcaStartY, ci, metal),
             _ => $"        # Unknown segment type: {segment.GetType().Name}"
         };
     }
@@ -553,7 +580,7 @@ public class SimpleNazcaExporter
     /// </summary>
     private static string FormatStraightAbsolute(
         double nazcaStartX, double nazcaStartY,
-        double nazcaEndX, double nazcaEndY, CultureInfo ci)
+        double nazcaEndX, double nazcaEndY, CultureInfo ci, MetalTraceStyle? metal = null)
     {
         double dx = nazcaEndX - nazcaStartX;
         double dy = nazcaEndY - nazcaStartY;
@@ -564,7 +591,7 @@ public class SimpleNazcaExporter
         var x = NazcaCoordinateMapper.NormalizeZero(nazcaStartX).ToString("F2", ci);
         var y = NazcaCoordinateMapper.NormalizeZero(nazcaStartY).ToString("F2", ci);
         var a = NazcaCoordinateMapper.NormalizeZero(angleDeg).ToString("F2", ci);
-        return $"        nd.strt(length={l}).put({x}, {y}, {a})";
+        return $"        nd.strt(length={l}{MetalKwargs(metal)}).put({x}, {y}, {a})";
     }
 
     /// <summary>
@@ -572,14 +599,14 @@ public class SimpleNazcaExporter
     /// The radius is invariant under Y-flip; the sweep angle and start angle are negated.
     /// </summary>
     private static string FormatBendAbsolute(
-        BendSegment bend, double nazcaX, double nazcaY, CultureInfo ci)
+        BendSegment bend, double nazcaX, double nazcaY, CultureInfo ci, MetalTraceStyle? metal = null)
     {
         var radius = bend.RadiusMicrometers.ToString("F2", ci);
         var sweepAngle = NazcaCoordinateMapper.NormalizeZero(-bend.SweepAngleDegrees).ToString("F2", ci);
         var x = NazcaCoordinateMapper.NormalizeZero(nazcaX).ToString("F2", ci);
         var y = NazcaCoordinateMapper.NormalizeZero(nazcaY).ToString("F2", ci);
         var angle = NazcaCoordinateMapper.NormalizeZero(-bend.StartAngleDegrees).ToString("F2", ci);
-        return $"        nd.bend(radius={radius}, angle={sweepAngle}).put({x}, {y}, {angle})";
+        return $"        nd.bend(radius={radius}, angle={sweepAngle}{MetalKwargs(metal)}).put({x}, {y}, {angle})";
     }
 
     /// <summary>
@@ -587,7 +614,8 @@ public class SimpleNazcaExporter
     /// Computes length and angle from start pin to end pin in Nazca coordinates,
     /// ensuring the waveguide reaches both pins exactly.
     /// </summary>
-    private static string FormatStraightSegmentFromPins(PhysicalPin startPin, PhysicalPin endPin)
+    private static string FormatStraightSegmentFromPins(
+        PhysicalPin startPin, PhysicalPin endPin, MetalTraceStyle? metal = null)
     {
         var ci = CultureInfo.InvariantCulture;
         var (sx, sy) = NazcaCoordinateMapper.GetPinNazcaPosition(startPin);
@@ -603,7 +631,7 @@ public class SimpleNazcaExporter
         var a = NazcaCoordinateMapper.NormalizeZero(angleDeg).ToString("F2", ci);
         var l = length.ToString("F2", ci);
 
-        return $"        nd.strt(length={l}).put({x}, {y}, {a})";
+        return $"        nd.strt(length={l}{MetalKwargs(metal)}).put({x}, {y}, {a})";
     }
 
     /// <summary>
@@ -709,8 +737,17 @@ public class SimpleNazcaExporter
         StringBuilder sb,
         WaveguideConnection conn,
         Dictionary<Component, string> componentNames,
-        IReadOnlyDictionary<string, string> rawOverrides)
+        IReadOnlyDictionary<string, string> rawOverrides,
+        MetalTraceStyle? metal = null)
     {
+        // A routeless electrical connection is a direct metal straight between both pins on the
+        // metal layer — the optical sbend interconnect (ic) would draw it as a waveguide (#682).
+        if (metal != null && conn.StartPin != null && conn.EndPin != null)
+        {
+            sb.AppendLine(FormatStraightSegmentFromPins(conn.StartPin, conn.EndPin, metal));
+            return;
+        }
+
         var startRef = BuildEndpointReference(conn.StartPin, componentNames, rawOverrides);
         var endRef = BuildEndpointReference(conn.EndPin, componentNames, rawOverrides);
 

--- a/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Export/GdsFactoryExportViewModel.cs
@@ -45,6 +45,10 @@ public partial class GdsFactoryExportViewModel : ObservableObject
     /// stored overrides); gdsfactory-backend ones are emitted as factories.</summary>
     public Func<IReadOnlyDictionary<string, CAP_DataAccess.Persistence.PIR.NazcaCodeOverride>>? OverridesProvider { get; set; }
 
+    /// <summary>Supplies the metal trace style for electrical routing (issue #682), resolved
+    /// from the design's active process. Null falls back to <see cref="MetalTraceStyle.Default"/>.</summary>
+    public Func<MetalTraceStyle>? MetalStyleProvider { get; set; }
+
     /// <summary>
     /// Ensures gdsfactory is installed into a managed environment (creating one if needed)
     /// and returns true when it is available afterwards. Wired by the DI layer to the
@@ -147,7 +151,7 @@ public partial class GdsFactoryExportViewModel : ObservableObject
             // back to ubcpdk/stub (surfaced as a mismatch warning).
             await File.WriteAllTextAsync(filePath,
                 _exporter.Export(_canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.UbcPdkCells),
-                    OverridesProvider?.Invoke()));
+                    OverridesProvider?.Invoke(), MetalStyleProvider?.Invoke()));
 
             StatusText = "Running gdsfactory to generate the GDS...";
             var result = await _exportService.ExportToGdsAsync(filePath, generateGds: true);

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -237,6 +237,13 @@ public partial class MainViewModel : ObservableObject
         GdsFactoryExport.OverridesProvider = () => FileOperations.StoredNazcaOverrides;
         // Let a Nazca export that hits gdsfactory-native components hand off to the gdsfactory export.
         FileOperations.RequestGdsFactoryExport = () => GdsFactoryExport.Export();
+        // Electrical connections export as metal traces (#682); resolve the metal layer/width from
+        // the design's active process (its member PDKs' metal cross-section), else a safe default.
+        Func<CAP_Core.Export.MetalTraceStyle> resolveMetalStyle = () =>
+            CAP_DataAccess.Components.ComponentDraftMapper.MetalTraceStyleResolver.Resolve(
+                FileOperations.ActiveProcess, LeftPanel.GetLoadedPdkDrafts());
+        GdsFactoryExport.MetalStyleProvider = resolveMetalStyle;
+        FileOperations.MetalStyleProvider = resolveMetalStyle;
         ExportMenu = new ExportMenuViewModel(new IExportFormat[]
         {
             new NazcaExportFormat(FileOperations.ExportNazcaCommand),

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -155,6 +155,10 @@ public partial class FileOperationsViewModel : ObservableObject
     /// </summary>
     public Func<Task>? RequestGdsFactoryExport { get; set; }
 
+    /// <summary>Supplies the metal trace style for electrical routing (issue #682), resolved
+    /// from the design's active process. Null falls back to <see cref="MetalTraceStyle.Default"/>.</summary>
+    public Func<MetalTraceStyle>? MetalStyleProvider { get; set; }
+
     /// <summary>Initializes a new instance of <see cref="FileOperationsViewModel"/>.</summary>
     public FileOperationsViewModel(
         DesignCanvasViewModel canvas,
@@ -1413,7 +1417,8 @@ public partial class FileOperationsViewModel : ObservableObject
             try
             {
                 // Export Python script
-                var nazcaCode = _nazcaExporter.Export(_canvas, overrides: StoredNazcaOverrides);
+                var nazcaCode = _nazcaExporter.Export(
+                    _canvas, overrides: StoredNazcaOverrides, metalStyle: MetalStyleProvider?.Invoke());
                 await File.WriteAllTextAsync(filePath, nazcaCode);
 
                 // Warn if any instance has a gdsfactory-backend override: the Nazca export

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -73,6 +74,11 @@ public partial class ProcessManagementViewModel
         foreach (var definition in definitions)
             Merge(definition);
 
+        // Only rows merged from the member PDKs' OWN process definitions above are "owned" by
+        // this process — a later ImportFromPdk (reference import) must not be able to sneak
+        // unrelated rows into SaveProcess's output (issue #686 review, Finding 2).
+        MarkAllRowsOwned();
+
         // Merge() may adopt the PDK-declared process name; the dialog reflects the
         // active selection, so its display name always wins.
         ProcessName = active.DisplayName;
@@ -88,8 +94,7 @@ public partial class ProcessManagementViewModel
     private static IReadOnlyList<PdkDraft> MemberDrafts(
         ActiveProcessSelection active, IReadOnlyList<PdkDraft> loadedPdks) =>
         active.MemberPdkNames
-            .Select(name => loadedPdks.FirstOrDefault(
-                d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase)))
+            .Select(name => MetalTraceStyleResolver.FindByName(loadedPdks, name, d => d.Name))
             .Where(d => d != null)
             .Select(d => d!)
             .ToList();
@@ -117,5 +122,7 @@ public partial class ProcessManagementViewModel
         Layers.Clear();
         Xsections.Clear();
         Materials.Clear();
+        _memberDrafts = new List<PdkDraft>();
+        MarkAllRowsOwned();
     }
 }

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
@@ -38,6 +38,7 @@ public partial class ProcessManagementViewModel
     public void ShowActiveProcess(ActiveProcessSelection? active, IReadOnlyList<PdkDraft> loadedPdks)
     {
         ResetState();
+        SetAvailablePresets(loadedPdks);
 
         if (active == null)
         {

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.ActiveProcess.cs
@@ -65,7 +65,11 @@ public partial class ProcessManagementViewModel
             ? string.Join(", ", active.MemberPdkNames)
             : "(none loaded)";
 
-        var definitions = MemberProcessDefinitions(active, loadedPdks);
+        // Keep the member drafts so edits (e.g. a metal cross-section, #682) can be persisted
+        // back to their PDK JSON via SaveProcess.
+        _memberDrafts = MemberDrafts(active, loadedPdks);
+
+        var definitions = _memberDrafts.Select(d => d.Process).Where(p => p != null).Select(p => p!).ToList();
         foreach (var definition in definitions)
             Merge(definition);
 
@@ -81,13 +85,13 @@ public partial class ProcessManagementViewModel
               "showing the fingerprint only; data can be imported or entered below.";
     }
 
-    private static IReadOnlyList<ProcessDefinition> MemberProcessDefinitions(
+    private static IReadOnlyList<PdkDraft> MemberDrafts(
         ActiveProcessSelection active, IReadOnlyList<PdkDraft> loadedPdks) =>
         active.MemberPdkNames
             .Select(name => loadedPdks.FirstOrDefault(
-                d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase))?.Process)
-            .Where(p => p != null)
-            .Select(p => p!)
+                d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase)))
+            .Where(d => d != null)
+            .Select(d => d!)
             .ToList();
 
     private static string FormatFingerprint(ProcessFingerprint? fp)

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
@@ -49,6 +49,22 @@ public partial class ProcessManagementViewModel : ObservableObject
     public static IReadOnlyList<XsectionKind> XsectionKinds { get; } =
         new[] { XsectionKind.Optical, XsectionKind.Metal };
 
+    /// <summary>
+    /// Bundled/loaded PDKs whose fabrication process can be loaded into the editor as a preset
+    /// (issue #570 follow-up): SiEPIC EBeam, CornerStone SiN, Demo, and any other loaded PDK that
+    /// declares a <see cref="ProcessDefinition"/>. Populated by <see cref="SetAvailablePresets"/>,
+    /// which <see cref="ShowActiveProcess"/> calls with every loaded PDK each time the dialog opens.
+    /// </summary>
+    public ObservableCollection<PdkDraft> AvailablePresets { get; } = new();
+
+    /// <summary>
+    /// The preset picked in the "Load preset" dropdown; selecting one loads its process via
+    /// <see cref="OnSelectedPresetChanged"/> (same pattern as <c>PdkOffsetEditorViewModel</c>'s
+    /// installed-PDK picker — a plain property setter, no extra command/behavior wiring needed).
+    /// </summary>
+    [ObservableProperty]
+    private PdkDraft? _selectedPreset;
+
     /// <summary>Resolves a PDK name to its source JSON path so edits can be persisted; wired by the
     /// UI layer to the loaded-PDK registry. Null (e.g. in tests/headless) disables saving.</summary>
     public Func<string, string?>? PdkFilePathResolver { get; set; }
@@ -102,6 +118,36 @@ public partial class ProcessManagementViewModel : ObservableObject
         Replace(Materials, process.Materials);
         MarkAllRowsOwned();
         HasProcess = true;
+    }
+
+    /// <summary>
+    /// Refreshes <see cref="AvailablePresets"/> from the currently loaded PDKs: any PDK that
+    /// declares a <see cref="ProcessDefinition"/> (bundled or user-loaded) can seed the editor.
+    /// Called by <see cref="ShowActiveProcess"/> every time the dialog opens, so the picker
+    /// always reflects the live PDK set instead of a stale snapshot.
+    /// </summary>
+    public void SetAvailablePresets(IReadOnlyList<PdkDraft> loadedPdks)
+    {
+        AvailablePresets.Clear();
+        foreach (var pdk in loadedPdks.Where(p => p.Process != null))
+            AvailablePresets.Add(pdk);
+    }
+
+    /// <summary>
+    /// Loads a bundled/loaded PDK's fabrication process into the editor as a starting point
+    /// (issue #570 follow-up), triggered by picking an entry in the "Load preset" dropdown
+    /// (<see cref="SelectedPreset"/>). The picked PDK's <see cref="ProcessDefinition"/> replaces
+    /// the current editable state via <see cref="Load"/>, so every row is marked owned by this
+    /// preset (issue #686 provenance) and can be edited and saved back to it.
+    /// </summary>
+    partial void OnSelectedPresetChanged(PdkDraft? value)
+    {
+        if (value == null)
+            return;
+
+        Load(value.Process ?? new ProcessDefinition { Name = value.Name });
+        _memberDrafts = new List<PdkDraft> { value };
+        StatusText = $"Loaded '{value.Name}' as a starting process. Adjust as needed, then Save to PDK.";
     }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
@@ -28,6 +28,23 @@ public partial class ProcessManagementViewModel : ObservableObject
     /// <summary>Member PDK drafts of the active process, captured on open, used to persist edits.</summary>
     private IReadOnlyList<PdkDraft> _memberDrafts = new List<PdkDraft>();
 
+    /// <summary>
+    /// Names of the layer/cross-section/material rows that belong to the currently loaded member
+    /// PDK(s), as opposed to rows pulled in later by <see cref="ImportFromPdk"/>'s <see cref="Merge"/>
+    /// from an unrelated reference PDK. <see cref="SaveProcess"/> only ever writes rows in these
+    /// sets, so an ad-hoc reference import can never corrupt the member PDK's own layer stack
+    /// (issue #686 review, Finding 2). Populated by <see cref="Load"/> / <see cref="ShowLockedProcess"/>
+    /// and by the manual Add* commands; a later <see cref="Merge"/> call (the import path) does
+    /// NOT add to these sets.
+    /// </summary>
+    private readonly HashSet<string> _ownLayerNames = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Cross-section names owned by the loaded member PDK(s); see <see cref="_ownLayerNames"/>.</summary>
+    private readonly HashSet<string> _ownXsectionNames = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Material names owned by the loaded member PDK(s); see <see cref="_ownLayerNames"/>.</summary>
+    private readonly HashSet<string> _ownMaterialNames = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>The cross-section kinds offered in the editor (Optical / Metal).</summary>
     public static IReadOnlyList<XsectionKind> XsectionKinds { get; } =
         new[] { XsectionKind.Optical, XsectionKind.Metal };
@@ -83,7 +100,27 @@ public partial class ProcessManagementViewModel : ObservableObject
         Replace(Layers, process.Layers);
         Replace(Xsections, process.Xsections);
         Replace(Materials, process.Materials);
+        MarkAllRowsOwned();
         HasProcess = true;
+    }
+
+    /// <summary>
+    /// Snapshots the names currently in <see cref="Layers"/>/<see cref="Xsections"/>/<see cref="Materials"/>
+    /// as belonging to the process being edited (issue #686 review, Finding 2) — called right after
+    /// the collections are populated from the process's OWN definition(s), before any later
+    /// <see cref="ImportFromPdk"/> reference import can add unrelated rows.
+    /// </summary>
+    private void MarkAllRowsOwned()
+    {
+        _ownLayerNames.Clear();
+        _ownXsectionNames.Clear();
+        _ownMaterialNames.Clear();
+        foreach (var layer in Layers)
+            if (layer.Name != null) _ownLayerNames.Add(layer.Name);
+        foreach (var xs in Xsections)
+            if (xs.Name != null) _ownXsectionNames.Add(xs.Name);
+        foreach (var mat in Materials)
+            if (mat.Name != null) _ownMaterialNames.Add(mat.Name);
     }
 
     /// <summary>Builds a process definition from the current editable state.</summary>
@@ -175,11 +212,21 @@ public partial class ProcessManagementViewModel : ObservableObject
 
     /// <summary>Adds an empty layer row for manual entry.</summary>
     [RelayCommand]
-    private void AddLayer() => Layers.Add(new ProcessLayer { Name = "NEW_LAYER" });
+    private void AddLayer()
+    {
+        var layer = new ProcessLayer { Name = "NEW_LAYER" };
+        Layers.Add(layer);
+        _ownLayerNames.Add(layer.Name);
+    }
 
     /// <summary>Adds an empty cross-section row for manual entry.</summary>
     [RelayCommand]
-    private void AddXsection() => Xsections.Add(new ProcessXsection { Name = "new_xs" });
+    private void AddXsection()
+    {
+        var xsection = new ProcessXsection { Name = "new_xs" };
+        Xsections.Add(xsection);
+        _ownXsectionNames.Add(xsection.Name);
+    }
 
     /// <summary>
     /// Adds a metal cross-section preset for electrical routing (issue #682) plus a matching
@@ -188,17 +235,30 @@ public partial class ProcessManagementViewModel : ObservableObject
     [RelayCommand]
     private void AddMetalXsection()
     {
-        if (Layers.All(l => !l.Name.Contains("METAL", StringComparison.OrdinalIgnoreCase)))
-            Layers.Add(new ProcessLayer { Name = "METAL-1", Layer = 11, Datatype = 0, Description = "Electrical routing metal" });
+        // A legacy/imported row can have a null Name despite the DTO's non-nullable declaration
+        // (e.g. deserialized from JSON that omitted "name") — guard like the resolver does
+        // (issue #686 review, Finding 3) so this command doesn't throw an NRE.
+        if (Layers.All(l => l.Name == null || !l.Name.Contains("METAL", StringComparison.OrdinalIgnoreCase)))
+        {
+            var metalLayer = new ProcessLayer
+            {
+                Name = "METAL-1", Layer = MetalTraceStyle.DefaultGdsLayer, Datatype = 0,
+                Description = "Electrical routing metal",
+            };
+            Layers.Add(metalLayer);
+            _ownLayerNames.Add(metalLayer.Name);
+        }
 
-        Xsections.Add(new ProcessXsection
+        var metalXsection = new ProcessXsection
         {
             Name = "metal",
             Kind = XsectionKind.Metal,
             WidthUm = MetalTraceStyle.DefaultWidthUm,
             Layers = { "METAL-1" },
             Description = "Electrical routing trace",
-        });
+        };
+        Xsections.Add(metalXsection);
+        _ownXsectionNames.Add(metalXsection.Name);
         HasProcess = true;
         StatusText = "Added a metal cross-section for electrical routing. Set its width/layer, then Save.";
     }
@@ -207,7 +267,10 @@ public partial class ProcessManagementViewModel : ObservableObject
     /// Persists the edited process back to its PDK JSON so the export picks up the metal
     /// cross-section (issue #682). Only unambiguous single-member processes are written; the
     /// PDK's fingerprint fields (thickness, materials, angles) are preserved — only the layer
-    /// stack, cross-sections and materials are updated.
+    /// stack, cross-sections and materials are updated, and only the rows that belong to this
+    /// member PDK (<see cref="_ownLayerNames"/> etc.) — an unrelated PDK pulled in via
+    /// <see cref="ImportFromPdk"/> for reference must never be written into this PDK's file
+    /// (issue #686 review, Finding 2).
     /// </summary>
     [RelayCommand]
     private void SaveProcess()
@@ -238,9 +301,9 @@ public partial class ProcessManagementViewModel : ObservableObject
             // user-editable stack/xsections/materials change, and update the in-memory draft so
             // the next export uses the new metal cross-section without a reload.
             var process = draft.Process ?? new ProcessDefinition { Name = ProcessName };
-            process.Layers = Layers.ToList();
-            process.Xsections = Xsections.ToList();
-            process.Materials = Materials.ToList();
+            process.Layers = Layers.Where(l => l.Name != null && _ownLayerNames.Contains(l.Name)).ToList();
+            process.Xsections = Xsections.Where(x => x.Name != null && _ownXsectionNames.Contains(x.Name)).ToList();
+            process.Materials = Materials.Where(m => m.Name != null && _ownMaterialNames.Contains(m.Name)).ToList();
             draft.Process = process;
 
             _pdkSaver.SaveToFile(draft, path);
@@ -254,7 +317,12 @@ public partial class ProcessManagementViewModel : ObservableObject
 
     /// <summary>Adds an empty material row for manual entry.</summary>
     [RelayCommand]
-    private void AddMaterial() => Materials.Add(new ProcessMaterial { Name = "NewMaterial" });
+    private void AddMaterial()
+    {
+        var material = new ProcessMaterial { Name = "NewMaterial" };
+        Materials.Add(material);
+        _ownMaterialNames.Add(material.Name);
+    }
 
     private static void Replace<T>(ObservableCollection<T> target, IEnumerable<T> items)
     {

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
@@ -318,8 +318,16 @@ public partial class ProcessManagementViewModel : ObservableObject
     /// <see cref="ImportFromPdk"/> for reference must never be written into this PDK's file
     /// (issue #686 review, Finding 2).
     /// </summary>
+    /// <summary>
+    /// Optional confirmation gate before writing the process back to a PDK file on disk. The UI
+    /// wires this to a yes/no prompt naming the target file, so a user cannot overwrite a PDK's
+    /// JSON by accident. Receives the file path; returns true to proceed. Null (tests/headless)
+    /// proceeds without prompting.
+    /// </summary>
+    public Func<string, Task<bool>>? ConfirmSaveToPdk { get; set; }
+
     [RelayCommand]
-    private void SaveProcess()
+    private async Task SaveProcess()
     {
         if (_memberDrafts.Count == 0)
         {
@@ -338,6 +346,15 @@ public partial class ProcessManagementViewModel : ObservableObject
         if (string.IsNullOrEmpty(path))
         {
             StatusText = $"Could not locate the PDK file for '{draft.Name}' — save unavailable.";
+            return;
+        }
+
+        // Writing edits back to a PDK's JSON on disk is a deliberate act — confirm first so a
+        // real PDK cannot be overwritten by accident (user field feedback). Only this process's
+        // own rows are written regardless; the prompt makes the file target explicit.
+        if (ConfirmSaveToPdk != null && !await ConfirmSaveToPdk(path))
+        {
+            StatusText = "Save cancelled — the PDK file was not changed.";
             return;
         }
 

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CAP.Avalonia.Services;
+using CAP_Core.Export;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -22,6 +23,18 @@ public partial class ProcessManagementViewModel : ObservableObject
 {
     private readonly IFileDialogService _fileDialog;
     private readonly IReadOnlyList<IProcessImporter> _importers;
+    private readonly PdkJsonSaver _pdkSaver;
+
+    /// <summary>Member PDK drafts of the active process, captured on open, used to persist edits.</summary>
+    private IReadOnlyList<PdkDraft> _memberDrafts = new List<PdkDraft>();
+
+    /// <summary>The cross-section kinds offered in the editor (Optical / Metal).</summary>
+    public static IReadOnlyList<XsectionKind> XsectionKinds { get; } =
+        new[] { XsectionKind.Optical, XsectionKind.Metal };
+
+    /// <summary>Resolves a PDK name to its source JSON path so edits can be persisted; wired by the
+    /// UI layer to the loaded-PDK registry. Null (e.g. in tests/headless) disables saving.</summary>
+    public Func<string, string?>? PdkFilePathResolver { get; set; }
 
     /// <summary>Name of the loaded process.</summary>
     [ObservableProperty]
@@ -55,10 +68,12 @@ public partial class ProcessManagementViewModel : ObservableObject
     }
 
     /// <summary>Initialises the ViewModel with a specific importer set (tests).</summary>
-    public ProcessManagementViewModel(IFileDialogService fileDialog, IReadOnlyList<IProcessImporter> importers)
+    public ProcessManagementViewModel(
+        IFileDialogService fileDialog, IReadOnlyList<IProcessImporter> importers, PdkJsonSaver? pdkSaver = null)
     {
         _fileDialog = fileDialog;
         _importers = importers;
+        _pdkSaver = pdkSaver ?? new PdkJsonSaver();
     }
 
     /// <summary>Populates the editable collections from a process definition.</summary>
@@ -165,6 +180,77 @@ public partial class ProcessManagementViewModel : ObservableObject
     /// <summary>Adds an empty cross-section row for manual entry.</summary>
     [RelayCommand]
     private void AddXsection() => Xsections.Add(new ProcessXsection { Name = "new_xs" });
+
+    /// <summary>
+    /// Adds a metal cross-section preset for electrical routing (issue #682) plus a matching
+    /// METAL layer if the stack has none, so a user can define electrical routing in one click.
+    /// </summary>
+    [RelayCommand]
+    private void AddMetalXsection()
+    {
+        if (Layers.All(l => !l.Name.Contains("METAL", StringComparison.OrdinalIgnoreCase)))
+            Layers.Add(new ProcessLayer { Name = "METAL-1", Layer = 11, Datatype = 0, Description = "Electrical routing metal" });
+
+        Xsections.Add(new ProcessXsection
+        {
+            Name = "metal",
+            Kind = XsectionKind.Metal,
+            WidthUm = MetalTraceStyle.DefaultWidthUm,
+            Layers = { "METAL-1" },
+            Description = "Electrical routing trace",
+        });
+        HasProcess = true;
+        StatusText = "Added a metal cross-section for electrical routing. Set its width/layer, then Save.";
+    }
+
+    /// <summary>
+    /// Persists the edited process back to its PDK JSON so the export picks up the metal
+    /// cross-section (issue #682). Only unambiguous single-member processes are written; the
+    /// PDK's fingerprint fields (thickness, materials, angles) are preserved — only the layer
+    /// stack, cross-sections and materials are updated.
+    /// </summary>
+    [RelayCommand]
+    private void SaveProcess()
+    {
+        if (_memberDrafts.Count == 0)
+        {
+            StatusText = "Nothing to save — this process has no editable member PDK (Playground or import-only).";
+            return;
+        }
+        if (_memberDrafts.Count > 1)
+        {
+            StatusText = "This process merges several PDKs; pick which one owns the edit by saving to that PDK "
+                       + "directly (multi-PDK target selection is not implemented yet).";
+            return;
+        }
+
+        var draft = _memberDrafts[0];
+        var path = PdkFilePathResolver?.Invoke(draft.Name);
+        if (string.IsNullOrEmpty(path))
+        {
+            StatusText = $"Could not locate the PDK file for '{draft.Name}' — save unavailable.";
+            return;
+        }
+
+        try
+        {
+            // Preserve the fingerprint-bearing fields (thickness, foundry, angles); only the
+            // user-editable stack/xsections/materials change, and update the in-memory draft so
+            // the next export uses the new metal cross-section without a reload.
+            var process = draft.Process ?? new ProcessDefinition { Name = ProcessName };
+            process.Layers = Layers.ToList();
+            process.Xsections = Xsections.ToList();
+            process.Materials = Materials.ToList();
+            draft.Process = process;
+
+            _pdkSaver.SaveToFile(draft, path);
+            StatusText = $"Saved to {Path.GetFileName(path)}. Electrical routing now uses this process's metal cross-section.";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Save failed: {ex.Message}";
+        }
+    }
 
     /// <summary>Adds an empty material row for manual entry.</summary>
     [RelayCommand]

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -672,11 +672,7 @@
                                        Margin="2,8,2,0" TextWrapping="Wrap"
                                        ToolTip.Tip="The fabrication process this design is locked to. Chosen at New Design; foreign-process PDKs are locked below."/>
 
-                            <!-- Fabrication process (layer stack, cross-sections, materials) — #570 -->
-                            <Button Content="Fabrication Process…" Command="{Binding OpenProcessManagerCommand}"
-                                    HorizontalAlignment="Stretch" Height="24" Margin="2,6,2,0" FontSize="10"
-                                    Background="#3d4d6d"
-                                    ToolTip.Tip="View and adjust the fabrication process; import it from a foundry PDK"/>
+                            <!-- Fabrication process now opens from the top toolbar icon (#570). -->
                         </StackPanel>
                     </ScrollViewer>
                 </DockPanel>

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -231,6 +231,16 @@
 
                 <Separator Width="1" Background="Gray" Margin="10,5"/>
 
+                <!-- Fabrication process (layer stack, cross-sections, materials) — top-level
+                     shortcut so it doesn't require scrolling the right panel (#682/#570). -->
+                <Button Command="{Binding OpenProcessManagerCommand}"
+                        Width="36" Margin="2" Background="#3d3d3d"
+                        ToolTip.Tip="Fabrication process — layer stack, cross-sections, materials (opens the process manager)">
+                    <TextBlock Text="🧱" FontSize="16" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                </Button>
+
+                <Separator Width="1" Background="Gray" Margin="10,5"/>
+
                 <!-- Settings -->
                 <Button Command="{Binding OpenSettingsWindowCommand}"
                         Width="36" Margin="2" Background="#3d3d3d" ToolTip.Tip="Open Settings (grid snap, updates, Python environment, AI key)">

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -8,6 +8,7 @@ using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Analysis.OnaAnalysis;
 using CAP.Avalonia.ViewModels.ComponentSettings;
 using CAP_Core.Components.Core;
+using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.PdkImport;
@@ -93,8 +94,8 @@ public partial class MainWindow : Window
                     var processVm = new ProcessManagementViewModel(new FileDialogService(this));
                     // Resolve a PDK name to its source JSON so edited metal cross-sections (#682) can be
                     // persisted, using the same loaded-PDK registry the offset editor writes through.
-                    processVm.PdkFilePathResolver = name => vm.LeftPanel.PdkManager.LoadedPdks
-                        .FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase))?.FilePath;
+                    processVm.PdkFilePathResolver = name => MetalTraceStyleResolver
+                        .FindByName(vm.LeftPanel.PdkManager.LoadedPdks, name, p => p.Name)?.FilePath;
                     processVm.ShowActiveProcess(vm.FileOperations.ActiveProcess, vm.LeftPanel.GetLoadedPdkDrafts());
                     var processWindow = new ProcessManagementWindow
                     {

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -97,6 +97,16 @@ public partial class MainWindow : Window
                     processVm.PdkFilePathResolver = name => MetalTraceStyleResolver
                         .FindByName(vm.LeftPanel.PdkManager.LoadedPdks, name, p => p.Name)?.FilePath;
                     processVm.ShowActiveProcess(vm.FileOperations.ActiveProcess, vm.LeftPanel.GetLoadedPdkDrafts());
+                    // Confirm before overwriting a PDK's JSON on disk (user field feedback): naming
+                    // the exact file so a real PDK can't be edited by accident.
+                    processVm.ConfirmSaveToPdk = async path =>
+                    {
+                        var choice = await new MessageBoxService().ShowChoicePromptAsync(
+                            $"This overwrites the PDK file on disk:\n{path}\n\nOnly this process's own "
+                            + "layers and cross-sections are written — imported or preset rows are not. Continue?",
+                            "Save to PDK file?", new[] { "Cancel", "Save" });
+                        return choice == 1;
+                    };
                     var processWindow = new ProcessManagementWindow
                     {
                         DataContext = processVm

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -91,6 +91,10 @@ public partial class MainWindow : Window
                 vm.ShowProcessManagerRequested = () =>
                 {
                     var processVm = new ProcessManagementViewModel(new FileDialogService(this));
+                    // Resolve a PDK name to its source JSON so edited metal cross-sections (#682) can be
+                    // persisted, using the same loaded-PDK registry the offset editor writes through.
+                    processVm.PdkFilePathResolver = name => vm.LeftPanel.PdkManager.LoadedPdks
+                        .FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase))?.FilePath;
                     processVm.ShowActiveProcess(vm.FileOperations.ActiveProcess, vm.LeftPanel.GetLoadedPdkDrafts());
                     var processWindow = new ProcessManagementWindow
                     {

--- a/CAP.Avalonia/Views/ProcessManagementWindow.axaml
+++ b/CAP.Avalonia/Views/ProcessManagementWindow.axaml
@@ -39,6 +39,9 @@
                 <Button Content="New" Command="{Binding NewProcessCommand}"
                         Padding="12,6" Background="#3d3d3d"
                         ToolTip.Tip="Start a blank process (seeded with public SOI material defaults)"/>
+                <Button Content="Save to PDK" Command="{Binding SaveProcessCommand}" IsVisible="{Binding HasProcess}"
+                        Padding="12,6" Background="#2a4a2a"
+                        ToolTip.Tip="Persist the edited layer stack / cross-sections back to this process's PDK JSON (single-PDK processes)"/>
                 <TextBlock Text="Process:" VerticalAlignment="Center" Foreground="#aaa"/>
                 <TextBox Text="{Binding ProcessName}" Width="220" VerticalAlignment="Center"/>
             </StackPanel>
@@ -78,6 +81,8 @@
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <TextBlock Text="Cross-sections (waveguide / metal)" FontWeight="SemiBold" Foreground="#aaaacc" FontSize="13" VerticalAlignment="Center"/>
                     <Button Content="+ Cross-section" Command="{Binding AddXsectionCommand}" FontSize="10" Padding="6,1" Background="#2a4a2a"/>
+                    <Button Content="+ Metal (electrical)" Command="{Binding AddMetalXsectionCommand}" FontSize="10" Padding="6,1" Background="#4a3a2a"
+                            ToolTip.Tip="Adds a metal cross-section (and a METAL layer) used to route electrical connections in the GDS export (#682)"/>
                 </StackPanel>
                 <Grid ColumnDefinitions="2*,1*,1*,1.2*,1.4*,2*">
                     <TextBlock Grid.Column="0" Text="Name" Foreground="#888" FontSize="10"/>
@@ -92,7 +97,10 @@
                         <DataTemplate>
                             <Grid ColumnDefinitions="2*,1*,1*,1.2*,1.4*,2*" Margin="0,1">
                                 <TextBox Grid.Column="0" Text="{Binding Name}" FontSize="11" Margin="0,0,2,0"/>
-                                <TextBlock Grid.Column="1" Text="{Binding Kind}" FontSize="11" VerticalAlignment="Center" Foreground="#ccc"/>
+                                <ComboBox Grid.Column="1" FontSize="11" Margin="0,0,2,0" HorizontalAlignment="Stretch"
+                                          ItemsSource="{x:Static vm:ProcessManagementViewModel.XsectionKinds}"
+                                          SelectedItem="{Binding Kind}"
+                                          ToolTip.Tip="Metal cross-sections route electrical connections (#682); optical route waveguides."/>
                                 <TextBox Grid.Column="2" Text="{Binding WidthUm}" FontSize="11" Margin="0,0,2,0"/>
                                 <TextBox Grid.Column="3" Text="{Binding MinRadiusUm}" FontSize="11" Margin="0,0,2,0"/>
                                 <TextBox Grid.Column="4" Text="{Binding RecommendedRadiusUm}" FontSize="11" Margin="0,0,2,0"/>

--- a/CAP.Avalonia/Views/ProcessManagementWindow.axaml
+++ b/CAP.Avalonia/Views/ProcessManagementWindow.axaml
@@ -171,6 +171,16 @@
                 <Button Content="New" Command="{Binding NewProcessCommand}"
                         Padding="12,6" Background="#3d3d3d"
                         ToolTip.Tip="Start a blank process (seeded with public SOI material defaults)"/>
+                <TextBlock Text="Load preset ▾" VerticalAlignment="Center" Foreground="#aaa" FontSize="11"/>
+                <ComboBox ItemsSource="{Binding AvailablePresets}" SelectedItem="{Binding SelectedPreset}" Width="220"
+                          PlaceholderText="Choose a bundled PDK…"
+                          ToolTip.Tip="Loads a bundled/loaded PDK's fabrication process (layer stack, cross-sections, materials) into the editor as a starting point">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
                 <Button Content="Save to PDK" Command="{Binding SaveProcessCommand}" IsVisible="{Binding HasProcess}"
                         Padding="12,6" Background="#2a4a2a"
                         ToolTip.Tip="Persist the edited layer stack / cross-sections back to this process's PDK JSON (single-PDK processes)"/>

--- a/CAP.Avalonia/Views/ProcessManagementWindow.axaml
+++ b/CAP.Avalonia/Views/ProcessManagementWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:CAP.Avalonia.ViewModels"
+        xmlns:controls="using:CAP.Avalonia.Controls"
         x:Class="CAP.Avalonia.Views.ProcessManagementWindow"
         x:CompileBindings="False"
         Title="Fabrication Process"
@@ -13,7 +14,62 @@
 
         <!-- Header -->
         <StackPanel DockPanel.Dock="Top" Spacing="6" Margin="0,0,0,10">
-            <TextBlock Text="Fabrication Process" FontWeight="SemiBold" FontSize="16" Foreground="LightBlue"/>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Fabrication Process" FontWeight="SemiBold" FontSize="16" Foreground="LightBlue"/>
+                <!-- Plain-language explainer for non-physicists (#682 / #570): what a process,
+                     layers, cross-sections and materials are, and why electrical routing needs
+                     its own metal cross-section. -->
+                <controls:HelpFlyoutButton Title="Fabrication process — what is this?" VerticalAlignment="Center">
+                    <controls:HelpFlyoutButton.HelpContent>
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="What is a fabrication process?" FontWeight="Bold" FontSize="12" Foreground="White"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="LightGray">
+                                It is the foundry's recipe: which material layers get deposited or
+                                etched, in what order, and with what shapes. Your whole chip -
+                                every waveguide and every wire - is built in ONE process. That is
+                                why picking a process up front matters: a design only makes sense,
+                                and can only be manufactured, within the process it was built for.
+                            </TextBlock>
+
+                            <TextBlock Text="Layers" FontWeight="Bold" FontSize="12" Foreground="White" Margin="0,4,0,0"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="LightGray">
+                                A layer is one physical sheet of material in the chip, for example
+                                the waveguide core that guides light, or a metal layer used for
+                                electrical wiring. The "Layer stack" table lists every sheet the
+                                foundry can pattern, each with its own GDS layer/datatype number.
+                            </TextBlock>
+
+                            <TextBlock Text="Cross-sections" FontWeight="Bold" FontSize="12" Foreground="White" Margin="0,4,0,0"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="LightGray">
+                                A cross-section is the width and shape a routed connection gets on
+                                a given layer. An optical waveguide is typically very narrow
+                                (around 0.5 µm) so it only carries one mode of light cleanly; a
+                                metal trace is usually much wider (around 10 µm) so it can carry
+                                current without excessive resistance. The same "wire" behaves very
+                                differently depending on which cross-section routes it.
+                            </TextBlock>
+
+                            <TextBlock Text="Materials" FontWeight="Bold" FontSize="12" Foreground="White" Margin="0,4,0,0"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="LightGray">
+                                Materials describe what each layer is actually made of: silicon or
+                                silicon nitride for waveguides, metal for electrical wiring, and so
+                                on. The material sets how light bends and travels (its refractive
+                                index) or how easily current flows, so getting it right is what
+                                makes the simulation physically meaningful.
+                            </TextBlock>
+
+                            <TextBlock Text="Electrical routing needs its own metal cross-section" FontWeight="Bold" FontSize="12" Foreground="White" Margin="0,4,0,0"/>
+                            <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="LightGray">
+                                Electrical connections (for example to a heater or a modulator)
+                                cannot travel on an optical waveguide - they need a conductive metal
+                                layer instead, routed at a much wider metal cross-section. Use
+                                "+ Metal (electrical)" below to add one; it also adds the METAL
+                                layer that carries it in the GDS export.
+                            </TextBlock>
+                        </StackPanel>
+                    </controls:HelpFlyoutButton.HelpContent>
+                </controls:HelpFlyoutButton>
+            </StackPanel>
             <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="#9999bb"
                        Text="A chip is built in one fabrication process — chosen for this design at startup / File → New Design. Here you inspect and edit what that process is: layer stack and materials (future FDTD input) and design rules (why a fab may reject certain components). Import details from a foundry PDK (uPDK YAML / CSV tables) and adjust as needed."/>
 

--- a/CAP.Avalonia/Views/ProcessManagementWindow.axaml
+++ b/CAP.Avalonia/Views/ProcessManagementWindow.axaml
@@ -22,6 +22,82 @@
                 <controls:HelpFlyoutButton Title="Fabrication process — what is this?" VerticalAlignment="Center">
                     <controls:HelpFlyoutButton.HelpContent>
                         <StackPanel Spacing="8">
+                            <StackPanel.Styles>
+                                <!-- Looping fabrication animation: the chip is built by stacking
+                                     patterned material layers one after another (substrate → core →
+                                     cladding → metal). Each layer fades + rises into place in
+                                     sequence, giving a real-world sense of how fabrication works. -->
+                                <Style Selector="Rectangle.fabLayer">
+                                    <Setter Property="Opacity" Value="0"/>
+                                </Style>
+                                <Style Selector="Rectangle.fab0">
+                                    <Style.Animations>
+                                        <Animation Duration="0:0:5" IterationCount="INFINITE">
+                                            <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="96"/></KeyFrame>
+                                            <KeyFrame Cue="12%"><Setter Property="Opacity" Value="1"/><Setter Property="Canvas.Top" Value="88"/></KeyFrame>
+                                            <KeyFrame Cue="94%"><Setter Property="Opacity" Value="1"/><Setter Property="Canvas.Top" Value="88"/></KeyFrame>
+                                            <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="88"/></KeyFrame>
+                                        </Animation>
+                                    </Style.Animations>
+                                </Style>
+                                <Style Selector="Rectangle.fab1">
+                                    <Style.Animations>
+                                        <Animation Duration="0:0:5" IterationCount="INFINITE">
+                                            <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="82"/></KeyFrame>
+                                            <KeyFrame Cue="22%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="82"/></KeyFrame>
+                                            <KeyFrame Cue="34%"><Setter Property="Opacity" Value="1"/><Setter Property="Canvas.Top" Value="74"/></KeyFrame>
+                                            <KeyFrame Cue="94%"><Setter Property="Opacity" Value="1"/><Setter Property="Canvas.Top" Value="74"/></KeyFrame>
+                                            <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="74"/></KeyFrame>
+                                        </Animation>
+                                    </Style.Animations>
+                                </Style>
+                                <Style Selector="Rectangle.fab2">
+                                    <Style.Animations>
+                                        <Animation Duration="0:0:5" IterationCount="INFINITE">
+                                            <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="68"/></KeyFrame>
+                                            <KeyFrame Cue="44%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="68"/></KeyFrame>
+                                            <KeyFrame Cue="56%"><Setter Property="Opacity" Value="0.55"/><Setter Property="Canvas.Top" Value="60"/></KeyFrame>
+                                            <KeyFrame Cue="94%"><Setter Property="Opacity" Value="0.55"/><Setter Property="Canvas.Top" Value="60"/></KeyFrame>
+                                            <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="60"/></KeyFrame>
+                                        </Animation>
+                                    </Style.Animations>
+                                </Style>
+                                <Style Selector="Rectangle.fab3">
+                                    <Style.Animations>
+                                        <Animation Duration="0:0:5" IterationCount="INFINITE">
+                                            <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="54"/></KeyFrame>
+                                            <KeyFrame Cue="66%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="54"/></KeyFrame>
+                                            <KeyFrame Cue="78%"><Setter Property="Opacity" Value="1"/><Setter Property="Canvas.Top" Value="46"/></KeyFrame>
+                                            <KeyFrame Cue="94%"><Setter Property="Opacity" Value="1"/><Setter Property="Canvas.Top" Value="46"/></KeyFrame>
+                                            <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0"/><Setter Property="Canvas.Top" Value="46"/></KeyFrame>
+                                        </Animation>
+                                    </Style.Animations>
+                                </Style>
+                            </StackPanel.Styles>
+
+                            <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="#cfe0ff">
+                                Here you review the chip's layer stack, add a metal cross-section for
+                                electrical routing, and can import a real foundry PDK. Below is what
+                                each of those settings means and why it matters.
+                            </TextBlock>
+
+                            <!-- Fabrication layer-stack animation (cross-section, builds bottom→top). -->
+                            <Border Background="#151515" BorderBrush="#3d3d3d" BorderThickness="1"
+                                    CornerRadius="4" Padding="4">
+                                <Canvas Width="360" Height="112">
+                                    <TextBlock Canvas.Left="2" Canvas.Top="2" Text="A chip is built layer by layer:"
+                                               FontSize="9" Foreground="Gray"/>
+                                    <Rectangle Classes="fabLayer fab0" Canvas.Left="30" Width="270" Height="14" Fill="#666666"/>
+                                    <Rectangle Classes="fabLayer fab1" Canvas.Left="30" Width="270" Height="12" Fill="#4CAF50"/>
+                                    <Rectangle Classes="fabLayer fab2" Canvas.Left="30" Width="270" Height="14" Fill="#3F51B5"/>
+                                    <Rectangle Classes="fabLayer fab3" Canvas.Left="110" Width="110" Height="12" Fill="#DAA520"/>
+                                    <TextBlock Canvas.Left="306" Canvas.Top="84" Text="substrate" FontSize="8" Foreground="#888"/>
+                                    <TextBlock Canvas.Left="306" Canvas.Top="70" Text="core (light)" FontSize="8" Foreground="#7CCB7C"/>
+                                    <TextBlock Canvas.Left="306" Canvas.Top="56" Text="cladding" FontSize="8" Foreground="#8890D0"/>
+                                    <TextBlock Canvas.Left="306" Canvas.Top="42" Text="metal (wiring)" FontSize="8" Foreground="#DAA520"/>
+                                </Canvas>
+                            </Border>
+
                             <TextBlock Text="What is a fabrication process?" FontWeight="Bold" FontSize="12" Foreground="White"/>
                             <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="LightGray">
                                 It is the foundry's recipe: which material layers get deposited or

--- a/CAP.Avalonia/Views/ProcessManagementWindow.axaml
+++ b/CAP.Avalonia/Views/ProcessManagementWindow.axaml
@@ -181,9 +181,9 @@
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
-                <Button Content="Save to PDK" Command="{Binding SaveProcessCommand}" IsVisible="{Binding HasProcess}"
+                <Button Content="Save to PDK file…" Command="{Binding SaveProcessCommand}" IsVisible="{Binding HasProcess}"
                         Padding="12,6" Background="#2a4a2a"
-                        ToolTip.Tip="Persist the edited layer stack / cross-sections back to this process's PDK JSON (single-PDK processes)"/>
+                        ToolTip.Tip="Write the edited layer stack / cross-sections back into this process's PDK JSON on disk (asks for confirmation; only single-PDK processes; only this process's own rows are written)"/>
                 <TextBlock Text="Process:" VerticalAlignment="Center" Foreground="#aaa"/>
                 <TextBox Text="{Binding ProcessName}" Width="220" VerticalAlignment="Center"/>
             </StackPanel>

--- a/Connect-A-Pic-Core/Components/PinKinds/PinKindHelper.cs
+++ b/Connect-A-Pic-Core/Components/PinKinds/PinKindHelper.cs
@@ -72,6 +72,16 @@ namespace CAP_Core.Components.PinKinds
             => matterType == MatterType.Electricity;
 
         /// <summary>
+        /// True when the pin carries electrical current (a metal contact), not light. Single
+        /// source of the pin-domain check for exporters, which used to re-implement this
+        /// individually (<c>SimpleNazcaExporter</c>, <c>GdsFactoryExporter</c>,
+        /// <c>GdsFactoryStubWriter</c>) and could drift apart (#682/#686 review).
+        /// </summary>
+        /// <param name="pin">The physical pin to check; null is treated as not electrical.</param>
+        public static bool IsElectrical(PhysicalPin? pin)
+            => pin is { MatterType: MatterType.Electricity };
+
+        /// <summary>
         /// User-facing message explaining why two pins of different signal domains cannot be
         /// connected. Single source of the wording, shared by every connect path (both gesture
         /// recognizers and click-to-connect) so the text can't drift between them (#519 review).

--- a/Connect-A-Pic-Core/Export/MetalTraceStyle.cs
+++ b/Connect-A-Pic-Core/Export/MetalTraceStyle.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+
+namespace CAP_Core.Export;
+
+/// <summary>
+/// The geometry an electrical (metal) routing trace is drawn with in a GDS export:
+/// its width and the GDS layer/datatype it lands on. Electrical connections are NOT
+/// optical waveguides — they must not be emitted on the waveguide layer (issue #682).
+/// A fabrication process declares this via a metal cross-section; when none is defined
+/// the exporter falls back to <see cref="Default"/> so the trace is still drawn on a
+/// distinct, clearly-metal layer rather than silently becoming an optical waveguide.
+/// </summary>
+public sealed record MetalTraceStyle
+{
+    /// <summary>Trace width in micrometres.</summary>
+    public double WidthUm { get; init; }
+
+    /// <summary>GDS layer number the metal trace is drawn on.</summary>
+    public int GdsLayer { get; init; }
+
+    /// <summary>GDS datatype of the metal layer.</summary>
+    public int GdsDatatype { get; init; }
+
+    /// <summary>Default metal trace width in µm when the process defines no metal cross-section.</summary>
+    public const double DefaultWidthUm = 2.0;
+
+    /// <summary>
+    /// Default metal GDS layer when the process defines none. Chosen distinct from the
+    /// waveguide layer (1) so a placeholder metal trace is never mistaken for an optical
+    /// one; a real process should override this via its metal cross-section.
+    /// </summary>
+    public const int DefaultGdsLayer = 11;
+
+    /// <summary>
+    /// Fallback style used when the active process declares no metal cross-section:
+    /// a 2 µm trace on layer 11/0. Overridden by a process's metal cross-section.
+    /// </summary>
+    public static MetalTraceStyle Default { get; } = new()
+    {
+        WidthUm = DefaultWidthUm,
+        GdsLayer = DefaultGdsLayer,
+        GdsDatatype = 0,
+    };
+
+    /// <summary>The <c>(layer, datatype)</c> tuple literal used in Nazca/gdsfactory scripts.</summary>
+    public string LayerTuple =>
+        $"({GdsLayer.ToString(CultureInfo.InvariantCulture)}, {GdsDatatype.ToString(CultureInfo.InvariantCulture)})";
+
+    /// <summary>The width formatted for a machine-facing export script (invariant culture).</summary>
+    public string WidthLiteral => WidthUm.ToString("F2", CultureInfo.InvariantCulture);
+}

--- a/Connect-A-Pic-Core/Export/MetalTraceStyle.cs
+++ b/Connect-A-Pic-Core/Export/MetalTraceStyle.cs
@@ -21,8 +21,13 @@ public sealed record MetalTraceStyle
     /// <summary>GDS datatype of the metal layer.</summary>
     public int GdsDatatype { get; init; }
 
-    /// <summary>Default metal trace width in µm when the process defines no metal cross-section.</summary>
-    public const double DefaultWidthUm = 2.0;
+    /// <summary>
+    /// Default metal trace width in µm when the process defines no metal cross-section. 10 µm
+    /// keeps a placeholder trace visually distinct from an optical waveguide (field feedback:
+    /// the earlier 2 µm default looked like a waveguide); a real process overrides this via its
+    /// metal cross-section.
+    /// </summary>
+    public const double DefaultWidthUm = 10.0;
 
     /// <summary>
     /// Default metal GDS layer when the process defines none. Chosen distinct from the
@@ -33,7 +38,7 @@ public sealed record MetalTraceStyle
 
     /// <summary>
     /// Fallback style used when the active process declares no metal cross-section:
-    /// a 2 µm trace on layer 11/0. Overridden by a process's metal cross-section.
+    /// a 10 µm trace on layer 11/0. Overridden by a process's metal cross-section.
     /// </summary>
     public static MetalTraceStyle Default { get; } = new()
     {

--- a/UnitTests/Components/PinKinds/PinKindHelperTests.cs
+++ b/UnitTests/Components/PinKinds/PinKindHelperTests.cs
@@ -123,6 +123,23 @@ namespace UnitTests.Components.PinKinds
             clone.MatterType.ShouldBe(MatterType.Electricity);
         }
 
+        [Fact]
+        public void IsElectrical_PhysicalPin_TrueOnlyForElectricalKind()
+        {
+            // Single source of the pin-domain check the exporters used to re-implement
+            // individually (SimpleNazcaExporter, GdsFactoryExporter, GdsFactoryStubWriter);
+            // now they all route through here (#682/#686 review, Finding 8).
+            PinKindHelper.IsElectrical(CreatePhysicalPin(MatterType.Electricity)).ShouldBeTrue();
+            PinKindHelper.IsElectrical(CreatePhysicalPin(MatterType.Light)).ShouldBeFalse();
+            PinKindHelper.IsElectrical(CreatePhysicalPin(MatterType.None)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsElectrical_NullPin_ReturnsFalse()
+        {
+            PinKindHelper.IsElectrical(null).ShouldBeFalse();
+        }
+
         private static PhysicalPin CreatePhysicalPin(MatterType matterType) => new()
         {
             Name = "p0",

--- a/UnitTests/Components/Process/BundledPdkProcessTests.cs
+++ b/UnitTests/Components/Process/BundledPdkProcessTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using CAP_Core.Components.Process;
 using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using Shouldly;
 using Xunit;
 
@@ -192,5 +193,45 @@ public class BundledPdkProcessTests
         groups.Count.ShouldBe(2);   // SOI (demo+siepic) + SiN (cornerstone)
         groups.ShouldContain(g => g.MemberPdkNames.Contains("CornerStone SiN 300nm")
                                   && g.MemberPdkNames.Count == 1);
+    }
+
+    [Fact]
+    public void SiepicEbeam_DeclaresRealLayerStackAndCrossSections()
+    {
+        // Real ubcpdk layer numbers / cross-section widths+radii (issue #570 process-preset
+        // follow-up) — not the empty stack the PDK shipped with previously.
+        var draft = new PdkLoader().LoadFromFile(Path.Combine(PdkDir, "siepic-ebeam-pdk.json"));
+        var process = draft.Process!;
+
+        process.Layers.ShouldNotBeEmpty();
+        process.Layers.ShouldContain(l => l.Name == "WG" && l.Layer == 1);
+        process.Layers.ShouldContain(l => l.Name == "M2_ROUTER");
+
+        process.Xsections.ShouldNotBeEmpty();
+        var strip = process.Xsections.Single(x => x.Name == "strip");
+        strip.Kind.ShouldBe(XsectionKind.Optical);
+        strip.WidthUm.ShouldBe(0.5);
+
+        process.Xsections.ShouldContain(x => x.Kind == XsectionKind.Metal && x.WidthUm > 0);
+    }
+
+    [Fact]
+    public void CornerStoneSin_DeclaresRealLayerStackAndCrossSections()
+    {
+        // Real cspdk.sin300 layer numbers / cross-section widths+radii, read from the
+        // activated PDK by scripts/generate_cspdk_sin300_pdk.py — not the empty stack the
+        // gdsfactory-backend PDK previously shipped with.
+        var draft = new PdkLoader().LoadFromFile(Path.Combine(PdkDir, "cornerstone-sin-pdk.json"));
+        var process = draft.Process!;
+
+        process.Layers.ShouldNotBeEmpty();
+        process.Layers.ShouldContain(l => l.Name == "NITRIDE" && l.Layer == 203);
+
+        process.Xsections.ShouldNotBeEmpty();
+        var xsNc = process.Xsections.Single(x => x.Name == "xs_nc");
+        xsNc.Kind.ShouldBe(XsectionKind.Optical);
+        xsNc.WidthUm.ShouldBe(1.2);
+
+        process.Xsections.ShouldContain(x => x.Kind == XsectionKind.Metal && x.WidthUm > 0);
     }
 }

--- a/UnitTests/Export/MetalRouting/ElectricalConnectionExportTests.cs
+++ b/UnitTests/Export/MetalRouting/ElectricalConnectionExportTests.cs
@@ -1,0 +1,105 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.GdsFactoryExport;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using CAP_Core.Tiles;
+using Shouldly;
+
+namespace UnitTests.Export.MetalRouting;
+
+/// <summary>
+/// Electrical connections must export as metal traces on the metal layer — never as optical
+/// waveguides (issue #682). Covers both layout emitters (Nazca and gdsfactory).
+/// </summary>
+public class ElectricalConnectionExportTests
+{
+    private static Component MakeComponentWithPin(
+        string id, double x, string pinName, MatterType kind)
+    {
+        var comp = TestComponentFactory.CreateBasicComponent();
+        comp.Identifier = id;
+        comp.NazcaFunctionName = "demo_pdk.heater";
+        comp.PhysicalX = x;
+        comp.PhysicalY = 0;
+        comp.WidthMicrometers = 50;
+        comp.HeightMicrometers = 30;
+        comp.PhysicalPins.Add(new PhysicalPin
+        {
+            Name = pinName,
+            ParentComponent = comp,
+            OffsetXMicrometers = 25,
+            OffsetYMicrometers = 0,
+            AngleDegrees = 270,
+            LogicalPin = new Pin(pinName, 0, kind, RectSide.Up),
+        });
+        return comp;
+    }
+
+    private static DesignCanvasViewModel CanvasWithConnection(MatterType pinKind)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var a = MakeComponentWithPin("A", 0, "p_a", pinKind);
+        var b = MakeComponentWithPin("B", 200, "p_b", pinKind);
+        canvas.Components.Add(new ComponentViewModel(a));
+        canvas.Components.Add(new ComponentViewModel(b));
+        canvas.Connections.Add(new WaveguideConnectionViewModel(new WaveguideConnection
+        {
+            StartPin = a.PhysicalPins.First(p => p.Name == "p_a"),
+            EndPin = b.PhysicalPins.First(p => p.Name == "p_b"),
+        }));
+        return canvas;
+    }
+
+    [Fact]
+    public void NazcaExport_ElectricalConnection_EmitsMetalStraightNotWaveguideInterconnect()
+    {
+        var canvas = CanvasWithConnection(MatterType.Electricity);
+
+        var script = new SimpleNazcaExporter().Export(canvas, metalStyle: MetalTraceStyle.Default);
+
+        // Metal trace: a straight on the metal layer with the metal width.
+        script.ShouldContain("layer=(11, 0)");
+        script.ShouldContain("width=2.00");
+        // NOT drawn as the optical sbend interconnect that all waveguide connections use.
+        script.ShouldNotContain("ic.sbend_p2p");
+    }
+
+    [Fact]
+    public void NazcaExport_OpticalConnection_StaysWaveguide_NoMetalLayer()
+    {
+        var canvas = CanvasWithConnection(MatterType.Light);
+
+        var script = new SimpleNazcaExporter().Export(canvas, metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldNotContain("layer=(11, 0)");
+        script.ShouldContain("ic.sbend_p2p");
+    }
+
+    [Fact]
+    public void GdsFactoryExport_ElectricalConnection_EmitsMetalLayer()
+    {
+        var canvas = CanvasWithConnection(MatterType.Electricity);
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs),
+            metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldContain("layer=(11, 0)");
+        script.ShouldContain("width=2.00");
+    }
+
+    [Fact]
+    public void GdsFactoryExport_OpticalConnection_UsesWaveguideWidth_NoMetalLayer()
+    {
+        var canvas = CanvasWithConnection(MatterType.Light);
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs),
+            metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldNotContain("layer=(11, 0)");
+        script.ShouldContain("width=WG_WIDTH");
+    }
+}

--- a/UnitTests/Export/MetalRouting/ElectricalConnectionExportTests.cs
+++ b/UnitTests/Export/MetalRouting/ElectricalConnectionExportTests.cs
@@ -4,6 +4,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
 using CAP_Core.Export;
+using CAP_Core.Routing;
 using CAP_Core.Tiles;
 using Shouldly;
 
@@ -11,7 +12,8 @@ namespace UnitTests.Export.MetalRouting;
 
 /// <summary>
 /// Electrical connections must export as metal traces on the metal layer — never as optical
-/// waveguides (issue #682). Covers both layout emitters (Nazca and gdsfactory).
+/// waveguides (issue #682). Covers both layout emitters (Nazca and gdsfactory), frozen-group
+/// paths, and the both-pins-electrical classification (issue #686 review, Findings 1/4/5).
 /// </summary>
 public class ElectricalConnectionExportTests
 {
@@ -37,11 +39,11 @@ public class ElectricalConnectionExportTests
         return comp;
     }
 
-    private static DesignCanvasViewModel CanvasWithConnection(MatterType pinKind)
+    private static DesignCanvasViewModel CanvasWithConnection(MatterType startKind, MatterType? endKind = null)
     {
         var canvas = new DesignCanvasViewModel();
-        var a = MakeComponentWithPin("A", 0, "p_a", pinKind);
-        var b = MakeComponentWithPin("B", 200, "p_b", pinKind);
+        var a = MakeComponentWithPin("A", 0, "p_a", startKind);
+        var b = MakeComponentWithPin("B", 200, "p_b", endKind ?? startKind);
         canvas.Components.Add(new ComponentViewModel(a));
         canvas.Components.Add(new ComponentViewModel(b));
         canvas.Connections.Add(new WaveguideConnectionViewModel(new WaveguideConnection
@@ -49,6 +51,39 @@ public class ElectricalConnectionExportTests
             StartPin = a.PhysicalPins.First(p => p.Name == "p_a"),
             EndPin = b.PhysicalPins.First(p => p.Name == "p_b"),
         }));
+        return canvas;
+    }
+
+    /// <summary>
+    /// A ComponentGroup with one frozen internal path between two pins of the given kind — used
+    /// to cover the frozen-group export path separately from the live-connection loop (Finding 1).
+    /// </summary>
+    private static DesignCanvasViewModel CanvasWithFrozenGroupPath(MatterType pinKind)
+    {
+        var group = new ComponentGroup("MetalGroup");
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, 200, 0, 0));
+
+        var startPin = new PhysicalPin
+        {
+            Name = "gp_a",
+            ParentComponent = group,
+            OffsetXMicrometers = 0,
+            OffsetYMicrometers = 0,
+            LogicalPin = new Pin("gp_a", 0, pinKind, RectSide.Right),
+        };
+        var endPin = new PhysicalPin
+        {
+            Name = "gp_b",
+            ParentComponent = group,
+            OffsetXMicrometers = 200,
+            OffsetYMicrometers = 0,
+            LogicalPin = new Pin("gp_b", 0, pinKind, RectSide.Right),
+        };
+        group.InternalPaths.Add(new FrozenWaveguidePath { Path = path, StartPin = startPin, EndPin = endPin });
+
+        var canvas = new DesignCanvasViewModel();
+        canvas.Components.Add(new ComponentViewModel(group));
         return canvas;
     }
 
@@ -61,7 +96,7 @@ public class ElectricalConnectionExportTests
 
         // Metal trace: a straight on the metal layer with the metal width.
         script.ShouldContain("layer=(11, 0)");
-        script.ShouldContain("width=2.00");
+        script.ShouldContain("width=10.00");
         // NOT drawn as the optical sbend interconnect that all waveguide connections use.
         script.ShouldNotContain("ic.sbend_p2p");
     }
@@ -78,16 +113,73 @@ public class ElectricalConnectionExportTests
     }
 
     [Fact]
-    public void GdsFactoryExport_ElectricalConnection_EmitsMetalLayer()
+    public void NazcaExport_MixedOpticalElectricalConnection_StaysWaveguide_NotMetal()
     {
+        // Finding 5: classification must require BOTH pins electrical — a mixed connection
+        // (guarded at connect-time by #519, but the export predicate must not assume that)
+        // must still stay an optical waveguide, not silently become a metal trace.
+        var canvas = CanvasWithConnection(MatterType.Light, MatterType.Electricity);
+
+        var script = new SimpleNazcaExporter().Export(canvas, metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldNotContain("layer=(11, 0)");
+        script.ShouldContain("ic.sbend_p2p");
+    }
+
+    [Fact]
+    public void NazcaExport_FrozenGroupElectricalPath_EmitsMetalLayer()
+    {
+        // Finding 1: a frozen electrical group path used to be exported unconditionally as an
+        // optical waveguide because AppendGroupFrozenPaths never received the metal style.
+        var canvas = CanvasWithFrozenGroupPath(MatterType.Electricity);
+
+        var script = new SimpleNazcaExporter().Export(canvas, metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldContain("layer=(11, 0)");
+        script.ShouldContain("width=10.00");
+    }
+
+    [Fact]
+    public void NazcaExport_FrozenGroupOpticalPath_StaysWaveguide_NoMetalLayer()
+    {
+        var canvas = CanvasWithFrozenGroupPath(MatterType.Light);
+
+        var script = new SimpleNazcaExporter().Export(canvas, metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldNotContain("layer=(11, 0)");
+    }
+
+    [Fact]
+    public void GdsFactoryExport_ElectricalConnection_EmitsMetalPolygonOnMetalLayer_NotStraightWithLayerKwarg()
+    {
+        // Finding 4: gf.components.straight() has no layer= kwarg (verified TypeError against the
+        // installed gdsfactory) — the metal trace must be a polygon on the metal layer instead.
         var canvas = CanvasWithConnection(MatterType.Electricity);
 
         var script = new GdsFactoryExporter().Export(
             canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs),
             metalStyle: MetalTraceStyle.Default);
 
+        script.ShouldContain("c.add_polygon(");
         script.ShouldContain("layer=(11, 0)");
-        script.ShouldContain("width=2.00");
+        script.ShouldNotMatch(@"gf\.components\.straight\([^)]*layer=");
+        script.ShouldNotMatch(@"gf\.components\.bend_circular\([^)]*layer=");
+    }
+
+    [Fact]
+    public void GdsFactoryExport_ElectricalConnection_PolygonSizeReflectsMetalWidth()
+    {
+        var canvas = CanvasWithConnection(MatterType.Electricity);
+        var narrow = new MetalTraceStyle { WidthUm = 2, GdsLayer = 11, GdsDatatype = 0 };
+        var wide = new MetalTraceStyle { WidthUm = 20, GdsLayer = 11, GdsDatatype = 0 };
+
+        var narrowScript = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs), metalStyle: narrow);
+        var wideScript = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs), metalStyle: wide);
+
+        // Different trace widths must produce different polygon coordinates.
+        narrowScript.ShouldNotBe(wideScript);
     }
 
     [Fact]
@@ -101,5 +193,44 @@ public class ElectricalConnectionExportTests
 
         script.ShouldNotContain("layer=(11, 0)");
         script.ShouldContain("width=WG_WIDTH");
+    }
+
+    [Fact]
+    public void GdsFactoryExport_MixedOpticalElectricalConnection_StaysWaveguide_NotMetal()
+    {
+        var canvas = CanvasWithConnection(MatterType.Light, MatterType.Electricity);
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs),
+            metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldNotContain("layer=(11, 0)");
+        script.ShouldContain("width=WG_WIDTH");
+    }
+
+    [Fact]
+    public void GdsFactoryExport_FrozenGroupElectricalPath_EmitsMetalPolygonOnMetalLayer()
+    {
+        // Finding 1 (gdsfactory side): the frozen-group loop had the same gap as Nazca's.
+        var canvas = CanvasWithFrozenGroupPath(MatterType.Electricity);
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs),
+            metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldContain("c.add_polygon(");
+        script.ShouldContain("layer=(11, 0)");
+    }
+
+    [Fact]
+    public void GdsFactoryExport_FrozenGroupOpticalPath_StaysWaveguide_NoMetalLayer()
+    {
+        var canvas = CanvasWithFrozenGroupPath(MatterType.Light);
+
+        var script = new GdsFactoryExporter().Export(
+            canvas, new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs),
+            metalStyle: MetalTraceStyle.Default);
+
+        script.ShouldNotContain("layer=(11, 0)");
     }
 }

--- a/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
+++ b/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
@@ -120,4 +120,33 @@ public class MetalTraceStyleResolverTests
         var playground = ActiveProcessSelection.Playground();
         MetalTraceStyleResolver.Resolve(playground, new List<PdkDraft>()).ShouldBe(MetalTraceStyle.Default);
     }
+
+    /// <summary>
+    /// Finding 7: the by-name PDK/draft lookup was copy-pasted across three call sites
+    /// (this resolver, the Fabrication Process dialog, MainWindow's PDK-path wiring) — now a
+    /// single shared helper all three call.
+    /// </summary>
+    [Fact]
+    public void FindByName_MatchesCaseInsensitively()
+    {
+        var drafts = new[]
+        {
+            new PdkDraft { Name = "FabA" },
+            new PdkDraft { Name = "FabB" },
+        };
+
+        var found = MetalTraceStyleResolver.FindByName(drafts, "fabb", (PdkDraft d) => d.Name);
+
+        found.ShouldNotBeNull();
+        found!.Name.ShouldBe("FabB");
+    }
+
+    [Fact]
+    public void FindByName_NoMatchOrNullItems_ReturnsNull()
+    {
+        var drafts = new[] { new PdkDraft { Name = "FabA" } };
+
+        MetalTraceStyleResolver.FindByName(drafts, "Unknown", (PdkDraft d) => d.Name).ShouldBeNull();
+        MetalTraceStyleResolver.FindByName((List<PdkDraft>?)null, "FabA", (PdkDraft d) => d.Name).ShouldBeNull();
+    }
 }

--- a/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
+++ b/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
@@ -1,0 +1,102 @@
+using CAP_Core.Components.Process;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+
+namespace UnitTests.Export.MetalRouting;
+
+/// <summary>
+/// Tests for <see cref="MetalTraceStyleResolver"/> — mapping a fabrication process's metal
+/// cross-section to the width/layer an electrical trace is drawn with (issue #682).
+/// </summary>
+public class MetalTraceStyleResolverTests
+{
+    [Fact]
+    public void Resolve_NullProcess_ReturnsDefault()
+    {
+        MetalTraceStyleResolver.Resolve((ProcessDefinition?)null).ShouldBe(MetalTraceStyle.Default);
+    }
+
+    [Fact]
+    public void Resolve_ProcessWithoutMetalXsection_ReturnsDefault()
+    {
+        var process = new ProcessDefinition
+        {
+            Xsections = { new ProcessXsection { Name = "wg", Kind = XsectionKind.Optical, WidthUm = 0.45 } },
+        };
+
+        MetalTraceStyleResolver.Resolve(process).ShouldBe(MetalTraceStyle.Default);
+    }
+
+    [Fact]
+    public void Resolve_MetalXsectionWithMatchingLayer_UsesProcessWidthAndLayer()
+    {
+        var process = new ProcessDefinition
+        {
+            Layers = { new ProcessLayer { Name = "METAL-1", Layer = 41, Datatype = 3 } },
+            Xsections =
+            {
+                new ProcessXsection
+                {
+                    Name = "MetalDC", Kind = XsectionKind.Metal, WidthUm = 5.0,
+                    Layers = { "METAL-1" },
+                },
+            },
+        };
+
+        var style = MetalTraceStyleResolver.Resolve(process);
+
+        style.WidthUm.ShouldBe(5.0);
+        style.GdsLayer.ShouldBe(41);
+        style.GdsDatatype.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Resolve_MetalXsectionWithoutResolvableLayer_KeepsWidthButDefaultsLayer()
+    {
+        // A metal xsection that lists no layer (or a name absent from the stack) still sets the
+        // trace width, but the GDS layer falls back to the default so nothing lands on layer 0.
+        var process = new ProcessDefinition
+        {
+            Xsections = { new ProcessXsection { Name = "M", Kind = XsectionKind.Metal, WidthUm = 3.5 } },
+        };
+
+        var style = MetalTraceStyleResolver.Resolve(process);
+
+        style.WidthUm.ShouldBe(3.5);
+        style.GdsLayer.ShouldBe(MetalTraceStyle.DefaultGdsLayer);
+    }
+
+    [Fact]
+    public void Resolve_ActiveProcess_MatchesMemberPdkDraftsByName()
+    {
+        var draft = new PdkDraft
+        {
+            Name = "MyFab",
+            Process = new ProcessDefinition
+            {
+                Layers = { new ProcessLayer { Name = "M1", Layer = 12, Datatype = 0 } },
+                Xsections =
+                {
+                    new ProcessXsection { Name = "metal", Kind = XsectionKind.Metal, WidthUm = 4.0, Layers = { "M1" } },
+                },
+            },
+        };
+        var active = new ActiveProcessSelection("MyFab", null, new[] { "MyFab" }, IsPlayground: false);
+
+        var style = MetalTraceStyleResolver.Resolve(active, new[] { draft });
+
+        style.WidthUm.ShouldBe(4.0);
+        style.GdsLayer.ShouldBe(12);
+    }
+
+    [Fact]
+    public void Resolve_PlaygroundOrNoSelection_ReturnsDefault()
+    {
+        MetalTraceStyleResolver.Resolve(null, new List<PdkDraft>()).ShouldBe(MetalTraceStyle.Default);
+
+        var playground = ActiveProcessSelection.Playground();
+        MetalTraceStyleResolver.Resolve(playground, new List<PdkDraft>()).ShouldBe(MetalTraceStyle.Default);
+    }
+}

--- a/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
+++ b/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
@@ -69,6 +69,27 @@ public class MetalTraceStyleResolverTests
     }
 
     [Fact]
+    public void Resolve_MetalXsectionWithoutLinkedLayer_FallsBackToMetalNamedLayer()
+    {
+        // A user may add a metal xsection and a "METAL-1" layer without wiring them together;
+        // the resolver still finds the metal-named layer for the trace.
+        var process = new ProcessDefinition
+        {
+            Layers =
+            {
+                new ProcessLayer { Name = "WAVEGUIDE", Layer = 1, Datatype = 0 },
+                new ProcessLayer { Name = "METAL-1", Layer = 41, Datatype = 0 },
+            },
+            Xsections = { new ProcessXsection { Name = "M", Kind = XsectionKind.Metal, WidthUm = 6.0 } },
+        };
+
+        var style = MetalTraceStyleResolver.Resolve(process);
+
+        style.GdsLayer.ShouldBe(41);
+        style.WidthUm.ShouldBe(6.0);
+    }
+
+    [Fact]
     public void Resolve_ActiveProcess_MatchesMemberPdkDraftsByName()
     {
         var draft = new PdkDraft

--- a/UnitTests/Export/MetalRouting/ProcessManagementMetalPersistenceTests.cs
+++ b/UnitTests/Export/MetalRouting/ProcessManagementMetalPersistenceTests.cs
@@ -1,6 +1,7 @@
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels;
 using CAP_Core.Components.Process;
+using CAP_Core.Export;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using Moq;
@@ -53,12 +54,27 @@ public class ProcessManagementMetalPersistenceTests
             reloaded.Process.ShouldNotBeNull();
             reloaded.Process!.CoreThicknessNm.ShouldBe(220);
             reloaded.Process.Xsections.ShouldContain(x => x.Kind == XsectionKind.Metal);
-            reloaded.Process.Layers.ShouldContain(l => l.Name.Contains("METAL"));
+            var metalLayer = reloaded.Process.Layers.FirstOrDefault(l => l.Name.Contains("METAL"));
+            metalLayer.ShouldNotBeNull();
+            metalLayer!.Layer.ShouldBe(MetalTraceStyle.DefaultGdsLayer);   // named constant, not a magic 11 (Finding 6)
         }
         finally
         {
             Directory.Delete(dir, recursive: true);
         }
+    }
+
+    [Fact]
+    public void AddMetalXsection_LayerWithNullName_DoesNotThrow()
+    {
+        // A legacy/imported row can have a null Name despite the DTO's non-nullable declaration
+        // (e.g. deserialized from JSON that omitted "name") — must not NRE (issue #686, Finding 3).
+        var vm = new ProcessManagementViewModel(Mock.Of<IFileDialogService>());
+        vm.Layers.Add(new ProcessLayer { Name = null! });
+
+        Should.NotThrow(() => vm.AddMetalXsectionCommand.Execute(null));
+
+        vm.Layers.ShouldContain(l => l.Name != null && l.Name.Contains("METAL"));
     }
 
     [Fact]
@@ -77,5 +93,57 @@ public class ProcessManagementMetalPersistenceTests
         vm.SaveProcessCommand.Execute(null);
 
         vm.StatusText.ShouldContain("several PDKs");
+    }
+
+    [Fact]
+    public void SaveProcess_AfterImportingAnUnrelatedReferencePdk_DoesNotWriteForeignRows()
+    {
+        // Reproduces issue #686 Finding 2: opening "Import from PDK" while a single-member
+        // process is loaded pulls a foreign PDK's rows into the SAME editable collections via
+        // Merge(); Save must persist only the rows that belong to the loaded member PDK.
+        var dir = Path.Combine(Path.GetTempPath(), "lunima_metal_scope_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "fab.json");
+
+        try
+        {
+            var draft = new PdkDraft
+            {
+                Name = "MyFab",
+                Process = new ProcessDefinition
+                {
+                    Name = "MyFab",
+                    CoreThicknessNm = 220,
+                    Layers = { new ProcessLayer { Name = "OWN_LAYER", Layer = 5 } },
+                    Xsections = { new ProcessXsection { Name = "own_xs", WidthUm = 0.5 } },
+                },
+            };
+            new PdkJsonSaver().SaveToFile(draft, path);
+
+            var active = new ActiveProcessSelection("MyFab", null, new[] { "MyFab" }, IsPlayground: false);
+            var vm = VmSavingTo(path, "MyFab");
+            vm.ShowActiveProcess(active, new[] { draft });
+
+            // Simulate "Import from PDK" pulling in an unrelated reference PDK for comparison.
+            vm.Merge(new ProcessDefinition
+            {
+                Name = "SomeOtherFab",
+                Layers = { new ProcessLayer { Name = "FOREIGN_LAYER", Layer = 99 } },
+                Xsections = { new ProcessXsection { Name = "foreign_xs", WidthUm = 9 } },
+            });
+
+            vm.SaveProcessCommand.Execute(null);
+
+            var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+            reloaded.Process.ShouldNotBeNull();
+            reloaded.Process!.Layers.ShouldContain(l => l.Name == "OWN_LAYER");
+            reloaded.Process.Layers.ShouldNotContain(l => l.Name == "FOREIGN_LAYER");
+            reloaded.Process.Xsections.ShouldContain(x => x.Name == "own_xs");
+            reloaded.Process.Xsections.ShouldNotContain(x => x.Name == "foreign_xs");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
     }
 }

--- a/UnitTests/Export/MetalRouting/ProcessManagementMetalPersistenceTests.cs
+++ b/UnitTests/Export/MetalRouting/ProcessManagementMetalPersistenceTests.cs
@@ -1,0 +1,81 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+
+namespace UnitTests.Export.MetalRouting;
+
+/// <summary>
+/// The Fabrication Process dialog can define a metal cross-section and persist it back to the
+/// PDK JSON so the export uses it (issue #682) — without dropping the process's fingerprint
+/// fields (core thickness etc.).
+/// </summary>
+public class ProcessManagementMetalPersistenceTests
+{
+    private static ProcessManagementViewModel VmSavingTo(string path, string pdkName)
+    {
+        var vm = new ProcessManagementViewModel(Mock.Of<IFileDialogService>())
+        {
+            PdkFilePathResolver = name => name == pdkName ? path : null,
+        };
+        return vm;
+    }
+
+    [Fact]
+    public void AddMetalXsection_ThenSave_PersistsMetalAndPreservesThickness()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "lunima_metal_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "fab.json");
+
+        try
+        {
+            // A single-member process with a fingerprint-bearing thickness that must survive the save.
+            var draft = new PdkDraft
+            {
+                Name = "MyFab",
+                Process = new ProcessDefinition { Name = "MyFab", CoreThicknessNm = 220 },
+            };
+            new PdkJsonSaver().SaveToFile(draft, path);
+
+            var active = new ActiveProcessSelection("MyFab", null, new[] { "MyFab" }, IsPlayground: false);
+            var vm = VmSavingTo(path, "MyFab");
+            vm.ShowActiveProcess(active, new[] { draft });
+
+            vm.AddMetalXsectionCommand.Execute(null);
+            vm.SaveProcessCommand.Execute(null);
+
+            // Reload from disk: metal xsection persisted, thickness preserved.
+            var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+            reloaded.Process.ShouldNotBeNull();
+            reloaded.Process!.CoreThicknessNm.ShouldBe(220);
+            reloaded.Process.Xsections.ShouldContain(x => x.Kind == XsectionKind.Metal);
+            reloaded.Process.Layers.ShouldContain(l => l.Name.Contains("METAL"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveProcess_MultiMemberProcess_DoesNotWriteAndExplains()
+    {
+        var active = new ActiveProcessSelection(
+            "Merged", null, new[] { "PdkA", "PdkB" }, IsPlayground: false);
+        var drafts = new[]
+        {
+            new PdkDraft { Name = "PdkA", Process = new ProcessDefinition { Name = "A" } },
+            new PdkDraft { Name = "PdkB", Process = new ProcessDefinition { Name = "B" } },
+        };
+        var vm = new ProcessManagementViewModel(Mock.Of<IFileDialogService>());
+        vm.ShowActiveProcess(active, drafts);
+
+        vm.SaveProcessCommand.Execute(null);
+
+        vm.StatusText.ShouldContain("several PDKs");
+    }
+}

--- a/UnitTests/ViewModels/ProcessManagementViewModelTests.cs
+++ b/UnitTests/ViewModels/ProcessManagementViewModelTests.cs
@@ -100,4 +100,42 @@ public class ProcessManagementViewModelTests
 
         vm.HasProcess.ShouldBeFalse();
     }
+
+    [Fact]
+    public void SetAvailablePresets_OnlyListsPdksWithAProcessBlock()
+    {
+        var vm = new ProcessManagementViewModel(Mock.Of<IFileDialogService>());
+        var withProcess = new PdkDraft { Name = "SiEPIC EBeam PDK", Process = new ProcessDefinition { Name = "SOI-220" } };
+        var withoutProcess = new PdkDraft { Name = "Analysis Tools", Process = null };
+
+        vm.SetAvailablePresets(new[] { withProcess, withoutProcess });
+
+        vm.AvailablePresets.ShouldContain(withProcess);
+        vm.AvailablePresets.ShouldNotContain(withoutProcess);
+    }
+
+    [Fact]
+    public void SelectingAPreset_LoadsItsProcessIntoTheEditor()
+    {
+        var vm = new ProcessManagementViewModel(Mock.Of<IFileDialogService>());
+        var preset = new PdkDraft
+        {
+            Name = "CornerStone SiN 300nm",
+            Process = new ProcessDefinition
+            {
+                Name = "CornerStone SiN 300nm",
+                Layers = { new ProcessLayer { Name = "NITRIDE", Layer = 203 } },
+                Xsections = { new ProcessXsection { Name = "xs_nc", Kind = XsectionKind.Optical, WidthUm = 1.2 } },
+            },
+        };
+        vm.SetAvailablePresets(new[] { preset });
+
+        vm.SelectedPreset = preset;
+
+        vm.HasProcess.ShouldBeTrue();
+        vm.ProcessName.ShouldBe("CornerStone SiN 300nm");
+        vm.Layers.ShouldContain(l => l.Name == "NITRIDE");
+        vm.Xsections.ShouldContain(x => x.Name == "xs_nc");
+        vm.StatusText.ShouldContain("CornerStone SiN 300nm");
+    }
 }

--- a/scripts/generate_cspdk_sin300_pdk.py
+++ b/scripts/generate_cspdk_sin300_pdk.py
@@ -52,6 +52,31 @@ CIRCUIT_MODEL_COMPONENTS = {"mzi"}
 # so a pass-through would be a wrong model — it gets its real sax model above (#665).
 PASS_THROUGH_COMPONENTS = {"straight", "taper", "bend_euler", "bend_s", "wire_corner"}
 
+# Curated subset of cspdk.sin300's LayerMapCornerstone (issue #570 follow-up): the physical
+# fabrication layers relevant to a placed/routed design. Excludes label/error-marker layers
+# (LABEL_SETTINGS/LABEL_INSTANCE duplicate LBL; routing_error_marker is a diagnostic, not a
+# fabrication layer). Numbers are read from LAYER at generation time — never hand-typed here.
+PROCESS_LAYER_NAMES = ["NITRIDE", "NITRIDE_ETCH", "HEATER", "PAD", "CLAD_OPEN", "FLOORPLAN", "LBL"]
+LAYER_DESCRIPTIONS = {
+    "NITRIDE": "Waveguide core (Si3N4)",
+    "NITRIDE_ETCH": "Nitride etch region",
+    "HEATER": "Heater metal (TiN)",
+    "PAD": "Bond-pad / routing metal (Aluminum)",
+    "CLAD_OPEN": "Cladding opening",
+    "FLOORPLAN": "Chip floorplan / die outline",
+    "LBL": "Label",
+}
+
+# Routing cross-sections cspdk.sin300 actually defines (xs_nc/xs_no optical, metal_routing/
+# heater_metal electrical — see cspdk.sin300.tech). kind 0 = Optical, 1 = Metal (ProcessDefinition.
+# XsectionKind's default int serialization — no JsonStringEnumConverter is registered).
+XSECTION_SPECS = [
+    ("xs_nc", 0, "NITRIDE", "SiN C-band strip waveguide"),
+    ("xs_no", 0, "NITRIDE", "SiN O-band strip waveguide"),
+    ("metal_routing", 1, "PAD", "Electrical routing metal"),
+    ("heater_metal", 1, "HEATER", "Heater trace metal"),
+]
+
 
 def _num(v):
     """kdb.DBox left/right/top/bottom are float properties; width()/height() are methods;
@@ -265,6 +290,40 @@ def build_smatrix(pdk, name, pins):
     return None
 
 
+def build_layers(sin):
+    """Real GDS layer/datatype numbers read from cspdk.sin300's LayerMapCornerstone — never
+    hand-typed, so a cspdk layer renumbering is caught by re-running this generator."""
+    layer = sin.LAYER
+    return [
+        {
+            "name": name,
+            "layer": int(getattr(layer, name)[0]),
+            "datatype": int(getattr(layer, name)[1]),
+            "description": LAYER_DESCRIPTIONS[name],
+        }
+        for name in PROCESS_LAYER_NAMES
+    ]
+
+
+def build_xsections():
+    """Real cross-section width/bend-radius numbers from cspdk.sin300's activated PDK
+    (gf.get_cross_section), not invented — see XSECTION_SPECS."""
+    import gdsfactory as gf
+    xsections = []
+    for name, kind, layer_name, description in XSECTION_SPECS:
+        xs = gf.get_cross_section(name)
+        xsections.append({
+            "name": name,
+            "kind": kind,
+            "widthUm": round(float(xs.width), 3),
+            "minRadiusUm": round(float(xs.radius_min or 0), 3),
+            "recommendedRadiusUm": round(float(xs.radius or 0), 3),
+            "layers": [layer_name],
+            "description": description,
+        })
+    return xsections
+
+
 def main():
     import cspdk.sin300 as sin
     pdk = sin.PDK
@@ -306,6 +365,8 @@ def main():
             "name": "CornerStone SiN 300nm",
             "foundry": "CornerStone",
             "coreThicknessNm": 300,
+            "layers": build_layers(sin),
+            "xsections": build_xsections(),
             "materials": [
                 {"name": "Si3N4", "role": "core"},
                 {"name": "SiO2", "role": "cladding"},


### PR DESCRIPTION
Closes the first slice of #682. Follow-up to the electrical pin domain (#519/#623).

## Problem

Connecting two electrical pins and exporting to GDS still drew an **optical waveguide** on the waveguide layer — both export paths (Nazca and gdsfactory) emitted every connection as a waveguide regardless of pin kind. Reported from the running app: *"beim gds export erzeugt er immer noch waveguides bei der verbindung von einem elektrischen pin zum anderen."*

## What this does

Electrical (metal) connections now export as **metal traces on a metal layer**, never as optical waveguides.

**Core**
- `MetalTraceStyle` (`CAP_Core.Export`): width + GDS layer/datatype a metal trace uses, with a safe `Default` (2 µm, layer 11) distinct from the waveguide layer.
- `MetalTraceStyleResolver` (`CAP-DataAccess`): resolves the style from the active process's metal cross-section (`XsectionKind.Metal`) + its layer stack; matches a metal-named layer if the xsection lists none; falls back to `Default`. Overload resolves from the design's `ActiveProcessSelection` + loaded PDK drafts.

**Exporters**
- `SimpleNazcaExporter` and `GdsFactoryExporter`: per connection, electrical links emit metal geometry (`nd.strt/bend` with `width`+`layer`; gdsfactory `width`+`layer` kwarg) instead of the optical waveguide. Optical links are unchanged.
- `GdsFactoryStubWriter`: electrical pins are no longer declared as optical `add_port`s.
- Wiring: `MainViewModel` resolves the metal style from the active process and feeds both exporters via a `MetalStyleProvider` (mirrors the existing `OverridesProvider`).

**Fabrication Process settings (define the metal layer)**
- Cross-section **Kind is editable** (Optical / Metal) instead of read-only.
- **"+ Metal (electrical)"** adds a metal cross-section preset + a METAL layer in one click.
- **"Save to PDK"** persists the edited stack/cross-sections/materials back to the process's PDK JSON, **preserving the fingerprint fields** (core thickness, foundry, angles) and updating the in-memory draft so the next export uses it immediately.

## Tests

- Resolver: process/layer mapping, metal-named-layer fallback, active-process match, default fallbacks.
- Both exporters: electrical → metal layer/width, optical unchanged.
- Settings persistence: metal xsection round-trips to JSON with thickness preserved.

Full suite green (3088 passed, 0 failed, 14 skipped) locally.

## Known limitations / follow-ups (rest of #682)

- **Save is single-member only**: a process merged from several PDKs can't yet pick which PDK owns the edit (the button explains this). Multi-PDK target selection is TODO.
- **No waveguide-crossing bridges yet**: metal traces are drawn on their own layer, but the process-dependent bridge-vs-cross policy (some fabs need air-bridges, others route on a higher metal layer) is still open (#682).
- **No probe/bond-pad component** yet (#682).
- `XsectionKind` serialises as an int in the JSON (`"kind": 1`); round-trips correctly, could be prettified to `"Metal"` later.
- Metal geometry follows the routed segments (bends included); Manhattan-only metal routing is a later refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
