### PR TITLE
Bring-your-own-Component v1: eigene gdsfactory-Komponente → eigenes PDK (FDTD-S-Matrix, prozess-gebunden)

### DIFF
--- a/CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs
+++ b/CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP_DataAccess.Components.AddCustomComponent;
+
+/// <summary>
+/// Persists user-authored components into a writable, per-process user PDK file under
+/// the user's local app-data directory. Never touches the bundled foundry PDK JSONs
+/// (those live under <c>CAP-DataAccess/PDKs</c> and are read-only at runtime).
+/// One PDK file per fabrication process, because the S-matrix and layout are
+/// process-specific (issue #570).
+/// </summary>
+public sealed class UserPdkStore
+{
+    private readonly string _root;
+    private readonly PdkJsonSaver _saver;
+    private readonly PdkLoader _loader;
+
+    /// <summary>Creates a store rooted at an explicit directory (used by tests).</summary>
+    public UserPdkStore(string userPdkRootDirectory, PdkJsonSaver saver, PdkLoader loader)
+    {
+        _root = userPdkRootDirectory;
+        _saver = saver;
+        _loader = loader;
+    }
+
+    /// <summary>
+    /// Creates the store used at runtime, rooted at
+    /// <c>%LOCALAPPDATA%/Lunima/user-pdks</c> (per-user, per-machine; never inside the
+    /// installed application directory so it survives reinstalls/updates).
+    /// </summary>
+    public static UserPdkStore CreateDefault() => new(
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Lunima", "user-pdks"),
+        new PdkJsonSaver(),
+        new PdkLoader());
+
+    /// <summary>The user-PDK file path for a fabrication process. Does not create the file.</summary>
+    public string ResolvePath(ProcessDefinition process) =>
+        Path.Combine(_root, Slug(process.Name) + ".json");
+
+    /// <summary>True when a component of that name is already stored for the process.</summary>
+    public bool ComponentExists(ProcessDefinition process, string componentName)
+    {
+        var path = ResolvePath(process);
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        var pdk = _loader.LoadFromFileForEditing(path);
+        return pdk.Components.Exists(c => string.Equals(c.Name, componentName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Adds or replaces (by name, case-insensitive) the component in the process's user PDK,
+    /// creating the PDK file on first use. Returns the file path written to.
+    /// </summary>
+    public string Save(ProcessDefinition process, PdkComponentDraft component, string backend, string? routingCrossSection)
+    {
+        var path = ResolvePath(process);
+        Directory.CreateDirectory(_root);
+
+        var pdk = File.Exists(path)
+            ? _loader.LoadFromFileForEditing(path)
+            : NewPdk(process, backend, routingCrossSection);
+
+        pdk.Components.RemoveAll(c => string.Equals(c.Name, component.Name, StringComparison.OrdinalIgnoreCase));
+        pdk.Components.Add(component);
+
+        _saver.SaveToFile(pdk, path);
+        return path;
+    }
+
+    private static PdkDraft NewPdk(ProcessDefinition process, string backend, string? routingCrossSection) => new()
+    {
+        Name = $"My {process.Name} Components",
+        Foundry = process.Foundry,
+        Backend = backend,
+        Process = process,
+        GdsFactoryRoutingCrossSection = routingCrossSection,
+        Components = new()
+    };
+
+    /// <summary>
+    /// Converts a process display name into a filesystem- and culture-invariant slug
+    /// (lowercase, non-alphanumeric runs collapsed to a single hyphen).
+    /// </summary>
+    private static string Slug(string name)
+    {
+        var lower = (name ?? string.Empty).ToLower(CultureInfo.InvariantCulture);
+        var slug = Regex.Replace(lower, "[^a-z0-9]+", "-").Trim('-');
+        return slug.Length == 0 ? "custom" : slug;
+    }
+}

--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -36,6 +36,7 @@ public partial class App : Application
         services.AddFdtdFeature();
         services.AddModeSolverFeature();
         services.AddNotificationFeature();
+        services.AddAddCustomComponentFeature();
 
         services.AddSingleton<MainViewModel>();
     }

--- a/CAP.Avalonia/DI/AddCustomComponentFeature.cs
+++ b/CAP.Avalonia/DI/AddCustomComponentFeature.cs
@@ -1,0 +1,32 @@
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>
+/// Registers the "add custom component → user PDK" feature (issue #656): the per-process
+/// <see cref="UserPdkStore"/>, the <see cref="ComponentGeometryExtractor"/> that renders a
+/// component reference's geometry via the Nazca and gdsfactory preview services already
+/// registered for the per-instance override feature (issue #637, see
+/// <see cref="PdkOffsetFeatureExtensions.AddPdkOffsetFeature"/>), and the
+/// <see cref="AddCustomComponentDependencies"/> bundle <c>LeftPanelViewModel</c> consumes.
+/// </summary>
+internal static class AddCustomComponentFeature
+{
+    /// <summary>Adds the feature's services and its <see cref="AddCustomComponentDependencies"/> bundle.</summary>
+    public static IServiceCollection AddAddCustomComponentFeature(this IServiceCollection services)
+    {
+        services.AddSingleton(_ => UserPdkStore.CreateDefault());
+        services.AddSingleton(sp => new ComponentGeometryExtractor(
+            new ComponentPreviewRendererAdapter(sp.GetRequiredService<NazcaComponentPreviewService>()),
+            new ComponentPreviewRendererAdapter(sp.GetRequiredService<GdsFactoryComponentPreviewService>())));
+        services.AddSingleton(sp => new AddCustomComponentDependencies(
+            sp.GetRequiredService<ComponentGeometryExtractor>(),
+            sp.GetRequiredService<IFdtdSMatrixService>(),
+            sp.GetRequiredService<UserPdkStore>()));
+        return services;
+    }
+}

--- a/CAP.Avalonia/Services/AddCustomComponent/AddCustomComponentDependencies.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/AddCustomComponentDependencies.cs
@@ -1,0 +1,11 @@
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Bundles the "add custom component → user PDK" feature's optional collaborators (issue
+/// #656) so <c>LeftPanelViewModel</c> takes one constructor parameter instead of three.
+/// </summary>
+public sealed record AddCustomComponentDependencies(
+    ComponentGeometryExtractor Extractor, IFdtdSMatrixService? Fdtd, UserPdkStore UserPdkStore);

--- a/CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs
@@ -1,0 +1,93 @@
+using CAP.Avalonia.ViewModels.ComponentSettings.InstanceOverride;
+using CAP_Core.Export;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Rendering seam consumed by <see cref="ComponentGeometryExtractor"/>. Mirrors the two
+/// preview entry points of <see cref="NazcaComponentPreviewService"/>
+/// (<see cref="NazcaComponentPreviewService.RenderAsync"/> and
+/// <see cref="NazcaComponentPreviewService.RenderRawCodeAsync"/>). Exists because
+/// <see cref="GdsFactoryComponentPreviewService"/> is <c>sealed</c>, so Moq cannot generate
+/// a mocking proxy for it directly — this interface gives the extractor a mockable
+/// dependency instead.
+/// </summary>
+public interface IComponentPreviewRenderer
+{
+    /// <summary>Renders a component from a module/function reference ("module mode").</summary>
+    Task<NazcaPreviewResult> RenderAsync(string? module, string function, string? parameters, CancellationToken ct = default);
+
+    /// <summary>Renders a component from raw Python cell code ("raw-code mode").</summary>
+    Task<NazcaPreviewResult> RenderRawCodeAsync(string code, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Thin <see cref="IComponentPreviewRenderer"/> adapter over a concrete
+/// <see cref="NazcaComponentPreviewService"/> (or its <see cref="GdsFactoryComponentPreviewService"/>
+/// subtype). Carries no state of its own — it only forwards to the wrapped service.
+/// </summary>
+public sealed class ComponentPreviewRendererAdapter : IComponentPreviewRenderer
+{
+    private readonly NazcaComponentPreviewService _service;
+
+    /// <summary>Wraps the given preview service.</summary>
+    public ComponentPreviewRendererAdapter(NazcaComponentPreviewService service)
+    {
+        _service = service;
+    }
+
+    /// <inheritdoc/>
+    public Task<NazcaPreviewResult> RenderAsync(string? module, string function, string? parameters, CancellationToken ct = default)
+        => _service.RenderAsync(module, function, parameters, ct);
+
+    /// <inheritdoc/>
+    public Task<NazcaPreviewResult> RenderRawCodeAsync(string code, CancellationToken ct = default)
+        => _service.RenderRawCodeAsync(code, ct);
+}
+
+/// <summary>Result of rendering a geometry reference: bounding-box size + extracted pins.</summary>
+/// <param name="Success">Whether the render succeeded.</param>
+/// <param name="Error">Error description when <see cref="Success"/> is false.</param>
+/// <param name="WidthUm">Bounding-box width in micrometers.</param>
+/// <param name="HeightUm">Bounding-box height in micrometers.</param>
+/// <param name="Pins">Extracted physical pins, empty when <see cref="Success"/> is false.</param>
+/// <param name="Raw">The underlying preview result, for callers that need polygons/source too.</param>
+public sealed record GeometryExtractResult(
+    bool Success, string? Error, double WidthUm, double HeightUm,
+    IReadOnlyList<OverridePinData> Pins, NazcaPreviewResult Raw);
+
+/// <summary>
+/// Renders a <see cref="GeometryReference"/> to geometry via the appropriate preview
+/// renderer (nazca in module mode, gdsfactory via a raw-code wrapper) and extracts the
+/// bounding-box size and physical pins — the same extraction the per-instance override
+/// "Apply" performs (see <see cref="OverridePinMapper.BuildOverridePins"/>).
+/// </summary>
+public sealed class ComponentGeometryExtractor
+{
+    private readonly IComponentPreviewRenderer _nazca;
+    private readonly IComponentPreviewRenderer _gdsFactory;
+
+    /// <summary>Creates the extractor from the two backend-specific preview renderers.</summary>
+    public ComponentGeometryExtractor(IComponentPreviewRenderer nazcaPreview, IComponentPreviewRenderer gdsFactoryPreview)
+    {
+        _nazca = nazcaPreview;
+        _gdsFactory = gdsFactoryPreview;
+    }
+
+    /// <summary>Renders the reference and extracts size + pins. On render failure, Success is false.</summary>
+    public async Task<GeometryExtractResult> ExtractAsync(GeometryReference reference, CancellationToken ct = default)
+    {
+        NazcaPreviewResult preview = reference.Backend == GeometryBackend.GdsFactory
+            ? await _gdsFactory.RenderRawCodeAsync(reference.ToGdsFactoryRawCode(), ct)
+            : await _nazca.RenderAsync(reference.Module, reference.Function, reference.Parameters, ct);
+
+        if (!preview.Success)
+            return new GeometryExtractResult(false, preview.Error, 0, 0, Array.Empty<OverridePinData>(), preview);
+
+        double width = preview.XMax - preview.XMin;
+        double height = preview.YMax - preview.YMin;
+        var pins = OverridePinMapper.BuildOverridePins(preview);
+        return new GeometryExtractResult(true, null, width, height, pins, preview);
+    }
+}

--- a/CAP.Avalonia/Services/AddCustomComponent/CustomComponentDraftFactory.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/CustomComponentDraftFactory.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Assembles the <see cref="PdkComponentDraft"/> saved by <c>NewComponentViewModel</c> from a
+/// rendered geometry reference plus its extracted size/pins and an (already-decided) S-matrix.
+/// Pure mapping — it invents no physics; the caller passes the S-matrix it resolved (black box
+/// or FDTD), so this factory never fabricates one.
+/// </summary>
+public static class CustomComponentDraftFactory
+{
+    /// <summary>
+    /// Builds the draft for <paramref name="name"/> from the rendered <paramref name="preview"/>,
+    /// routing the qualified function to the gdsfactory or nazca field per the reference's backend
+    /// and attaching <paramref name="sMatrix"/> (null = black box) verbatim.
+    /// </summary>
+    public static PdkComponentDraft Build(
+        string name, GeometryReference reference, GeometryExtractResult preview, PdkSMatrixDraft? sMatrix)
+    {
+        var draft = new PdkComponentDraft
+        {
+            Name = name,
+            WidthMicrometers = preview.WidthUm,
+            HeightMicrometers = preview.HeightUm,
+            Pins = MapPins(preview.Pins),
+            SMatrix = sMatrix,
+        };
+        if (reference.Backend == GeometryBackend.GdsFactory)
+            draft.GdsFactoryFunction = reference.QualifiedFunction;
+        else
+            draft.NazcaFunction = reference.QualifiedFunction;
+        return draft;
+    }
+
+    /// <summary>
+    /// Maps extracted preview pins to PDK physical-pin drafts. Only name/offset/angle are
+    /// derivable from geometry extraction — logical-pin linkage and pin kind have no source
+    /// here and are left at their defaults.
+    /// </summary>
+    private static List<PhysicalPinDraft> MapPins(IReadOnlyList<OverridePinData> pins) =>
+        pins.Select(p => new PhysicalPinDraft
+        {
+            Name = p.Name,
+            OffsetXMicrometers = p.OffsetXMicrometers,
+            OffsetYMicrometers = p.OffsetYMicrometers,
+            AngleDegrees = p.AngleDegrees,
+        }).ToList();
+}

--- a/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.ObjectModel;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Registers a user-authored component's saved <see cref="PdkComponentDraft"/> into the
+/// component library (issue #656): converts it to a <see cref="ComponentTemplate"/>, adds it
+/// (and, if new, its category), and — the first time this PDK file is seen — registers it
+/// with the PDK manager and the user's persisted PDK path list. Stateless by design (a static
+/// method over its inputs) so <c>LeftPanelViewModel.RegisterSavedCustomComponent</c> stays a
+/// thin, always-available pass-through — this logic needs none of the "add custom component"
+/// feature's optional collaborators (geometry extractor, FDTD, user-PDK store).
+/// </summary>
+public static class CustomComponentLibraryRegistrar
+{
+    /// <summary>Mirrors <c>LeftPanelViewModel.LoadPdkFromJsonFileAsync</c>'s registration pattern for a single component.</summary>
+    public static void Register(
+        PdkComponentDraft draft, string pdkName, string filePath,
+        ObservableCollection<ComponentTemplate> allTemplates,
+        ObservableCollection<string> categories,
+        PdkManagerViewModel pdkManager,
+        UserPreferencesService preferencesService,
+        Action filterComponents)
+    {
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, pdkName, null);
+        allTemplates.Add(template);
+        if (!categories.Contains(template.Category))
+            categories.Add(template.Category);
+
+        if (!pdkManager.IsPdkLoaded(filePath))
+        {
+            pdkManager.RegisterPdk(pdkName, filePath, false, 1);
+            preferencesService.AddUserPdkPath(filePath);
+        }
+
+        filterComponents();
+    }
+}

--- a/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using CAP.Avalonia.ViewModels.Library;
+using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 
 namespace CAP.Avalonia.Services.AddCustomComponent;
@@ -8,11 +11,14 @@ namespace CAP.Avalonia.Services.AddCustomComponent;
 /// <summary>
 /// Registers a user-authored component's saved <see cref="PdkComponentDraft"/> into the
 /// component library (issue #656): converts it to a <see cref="ComponentTemplate"/>, adds it
-/// (and, if new, its category), and — the first time this PDK file is seen — registers it
-/// with the PDK manager and the user's persisted PDK path list. Stateless by design (a static
-/// method over its inputs) so <c>LeftPanelViewModel.RegisterSavedCustomComponent</c> stays a
-/// thin, always-available pass-through — this logic needs none of the "add custom component"
-/// feature's optional collaborators (geometry extractor, FDTD, user-PDK store).
+/// (and, if new, its category), and — the first time this PDK file is seen — takes the whole
+/// user-PDK draft into the loaded set exactly like a normal PDK load (so its process
+/// fingerprint participates in single-process grouping and the active-process lock can govern
+/// its visibility, issue #570), registers it with the PDK manager, and records its path.
+/// Stateless by design (a static method over its inputs) so
+/// <c>LeftPanelViewModel.RegisterSavedCustomComponent</c> stays a thin, always-available
+/// pass-through — this logic needs none of the "add custom component" feature's optional
+/// collaborators (geometry extractor, FDTD, user-PDK store).
 /// </summary>
 public static class CustomComponentLibraryRegistrar
 {
@@ -23,6 +29,9 @@ public static class CustomComponentLibraryRegistrar
         ObservableCollection<string> categories,
         PdkManagerViewModel pdkManager,
         UserPreferencesService preferencesService,
+        PdkLoader pdkLoader,
+        List<PdkDraft> loadedPdkDrafts,
+        Action reapplyActiveProcess,
         Action filterComponents)
     {
         var template = PdkTemplateConverter.ConvertToTemplate(draft, pdkName, null);
@@ -32,10 +41,20 @@ public static class CustomComponentLibraryRegistrar
 
         if (!pdkManager.IsPdkLoaded(filePath))
         {
+            // Take the user PDK into the loaded set like a normal load (#570). Use the
+            // edit-tolerant loader — the same one UserPdkStore reads its own files with —
+            // so a freshly-saved user PDK (which may lack a Nazca origin offset) still loads.
+            if (File.Exists(filePath))
+                loadedPdkDrafts.Add(pdkLoader.LoadFromFileForEditing(filePath));
             pdkManager.RegisterPdk(pdkName, filePath, false, 1);
             preferencesService.AddUserPdkPath(filePath);
         }
 
+        // A component saved for a NON-active process must not escape the active process lock;
+        // one saved for the active process must appear immediately. Re-applying the lock (a
+        // no-op in Playground / no selection) enforces both, then the explicit re-filter covers
+        // the unlocked case (issue #570).
+        reapplyActiveProcess();
         filterComponents();
     }
 }

--- a/CAP.Avalonia/Services/AddCustomComponent/FdtdSMatrixToDraftConverter.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/FdtdSMatrixToDraftConverter.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Converts an FDTD-computed <see cref="ComponentSMatrixData"/> into the PDK draft's
+/// <see cref="PdkSMatrixDraft"/>, and provides the two honest no-FDTD fallbacks: a
+/// black-box (no simulation model) and a lossless two-port pass-through for pure
+/// routing components. Never fabricates S-parameter values — every number in the
+/// resulting draft is either copied verbatim from the FDTD result (converted from
+/// rectangular to polar form, which is pure math, not physics) or is the exact
+/// lossless identity (magnitude 1, phase 0).
+/// </summary>
+public static class FdtdSMatrixToDraftConverter
+{
+    /// <summary>
+    /// Builds a multi-wavelength <see cref="PdkSMatrixDraft"/> from a raw FDTD
+    /// <see cref="ComponentSMatrixData"/> result. Every row-major (Real, Imag) entry of
+    /// every wavelength is converted to a polar-form <see cref="SMatrixConnection"/>
+    /// between the corresponding ports, with no filtering or interpretation of the
+    /// FDTD values. Returns null when <paramref name="data"/> has no wavelength
+    /// entries, since a draft without any S-matrix content is meaningless.
+    /// </summary>
+    /// <param name="data">The FDTD-computed S-matrix data, keyed by wavelength in nm.</param>
+    public static PdkSMatrixDraft? FromFdtd(ComponentSMatrixData data)
+    {
+        if (data.Wavelengths == null || data.Wavelengths.Count == 0)
+            return null;
+
+        var entries = new List<WavelengthSMatrixEntry>();
+        foreach (var pair in data.Wavelengths)
+        {
+            int wavelengthNm = int.Parse(pair.Key, CultureInfo.InvariantCulture);
+            entries.Add(new WavelengthSMatrixEntry
+            {
+                WavelengthNm = wavelengthNm,
+                Connections = ToConnections(pair.Value)
+            });
+        }
+
+        return new PdkSMatrixDraft
+        {
+            WavelengthNm = entries[0].WavelengthNm,
+            WavelengthData = entries
+        };
+    }
+
+    /// <summary>No FDTD model available — the component stays a black box (no S-matrix draft).</summary>
+    public static PdkSMatrixDraft? BlackBox() => null;
+
+    /// <summary>
+    /// The honest lossless two-port pass-through: unit transmission magnitude and zero
+    /// phase in both directions. Used only for pure 2-port routing components where the
+    /// ideal is physically exact (not assumed), so a full FDTD run would add no information.
+    /// </summary>
+    /// <param name="inPin">Name of the first port.</param>
+    /// <param name="outPin">Name of the second port.</param>
+    /// <param name="wavelengthNm">Wavelength in nm this ideal applies at.</param>
+    public static PdkSMatrixDraft LosslessTwoPort(string inPin, string outPin, int wavelengthNm) => new()
+    {
+        WavelengthNm = wavelengthNm,
+        Connections = new()
+        {
+            new SMatrixConnection { FromPin = inPin, ToPin = outPin, Magnitude = 1.0, PhaseDegrees = 0.0 },
+            new SMatrixConnection { FromPin = outPin, ToPin = inPin, Magnitude = 1.0, PhaseDegrees = 0.0 },
+        }
+    };
+
+    /// <summary>
+    /// Converts a single row-major (Real, Imag) S-matrix into port-to-port polar-form
+    /// connections. Row index is the output port, column index is the input port
+    /// (standard S-parameter convention S[out, in]). Port names come from
+    /// <see cref="SMatrixWavelengthEntry.PortNames"/>; when absent, ports are named by
+    /// their zero-based matrix index.
+    /// </summary>
+    private static List<SMatrixConnection> ToConnections(SMatrixWavelengthEntry matrix)
+    {
+        var portNames = matrix.PortNames ?? IndexPortNames(matrix.Rows);
+        var connections = new List<SMatrixConnection>(matrix.Real.Count);
+
+        for (int row = 0; row < matrix.Rows; row++)
+        {
+            for (int col = 0; col < matrix.Cols; col++)
+            {
+                int index = row * matrix.Cols + col;
+                double real = matrix.Real[index];
+                double imag = matrix.Imag[index];
+
+                connections.Add(new SMatrixConnection
+                {
+                    FromPin = portNames[col],
+                    ToPin = portNames[row],
+                    Magnitude = Math.Sqrt(real * real + imag * imag),
+                    PhaseDegrees = Math.Atan2(imag, real) * (180.0 / Math.PI)
+                });
+            }
+        }
+
+        return connections;
+    }
+
+    /// <summary>Fallback port names ("0", "1", ...) used when the FDTD result has no port names.</summary>
+    private static List<string> IndexPortNames(int portCount)
+    {
+        var names = new List<string>(portCount);
+        for (int i = 0; i < portCount; i++)
+            names.Add(i.ToString(CultureInfo.InvariantCulture));
+        return names;
+    }
+}

--- a/CAP.Avalonia/Services/AddCustomComponent/FdtdSMatrixToDraftConverter.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/FdtdSMatrixToDraftConverter.cs
@@ -26,6 +26,17 @@ public static class FdtdSMatrixToDraftConverter
     /// entries, since a draft without any S-matrix content is meaningless.
     /// </summary>
     /// <param name="data">The FDTD-computed S-matrix data, keyed by wavelength in nm.</param>
+    /// <remarks>
+    /// The directed (out, in) entries produced here are faithful to the FDTD result, but the
+    /// draft consumer (<c>PdkTemplateConverter.CreateSMatrixFromPdk</c>) <b>symmetrizes</b>
+    /// connections: for each connection it writes the same value to both the forward
+    /// <c>(from → to)</c> and the reverse <c>(to → from)</c> transfer. As a result,
+    /// <b>non-reciprocal devices (e.g. isolators, circulators) are currently NOT represented
+    /// correctly</b> — the distinct directed <c>(out, in)</c> and <c>(in, out)</c> values
+    /// collapse onto a single value at load time. Fixing this requires a change on the
+    /// consumer side and is deliberately out of scope for this converter; the integration
+    /// task must account for it before relying on directionality.
+    /// </remarks>
     public static PdkSMatrixDraft? FromFdtd(ComponentSMatrixData data)
     {
         if (data.Wavelengths == null || data.Wavelengths.Count == 0)
@@ -79,7 +90,21 @@ public static class FdtdSMatrixToDraftConverter
     /// </summary>
     private static List<SMatrixConnection> ToConnections(SMatrixWavelengthEntry matrix)
     {
-        var portNames = matrix.PortNames ?? IndexPortNames(matrix.Rows);
+        int expected = matrix.Rows * matrix.Cols;
+        if (matrix.Real.Count != expected || matrix.Imag.Count != expected)
+            throw new ArgumentException(
+                $"S-matrix data is inconsistent: Rows={matrix.Rows}, Cols={matrix.Cols} " +
+                $"require {expected} entries, but Real has {matrix.Real.Count} and " +
+                $"Imag has {matrix.Imag.Count}.", nameof(matrix));
+
+        int portCount = Math.Max(matrix.Rows, matrix.Cols);
+        if (matrix.PortNames != null && matrix.PortNames.Count < portCount)
+            throw new ArgumentException(
+                $"S-matrix data is inconsistent: PortNames has {matrix.PortNames.Count} " +
+                $"entries but at least {portCount} are required for a {matrix.Rows}x{matrix.Cols} matrix.",
+                nameof(matrix));
+
+        var portNames = matrix.PortNames ?? IndexPortNames(portCount);
         var connections = new List<SMatrixConnection>(matrix.Real.Count);
 
         for (int row = 0; row < matrix.Rows; row++)

--- a/CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs
@@ -30,6 +30,15 @@ public sealed record GeometryReference(GeometryBackend Backend, string? Module, 
     /// Wraps the reference in a raw-code snippet the gdsfactory preview script understands:
     /// it imports the module and assigns the built cell to a variable named <c>component</c>.
     /// </summary>
+    /// <remarks>
+    /// When <see cref="Module"/> is set, the emitted code is
+    /// <c>import &lt;Module&gt;\ncomponent = &lt;Module&gt;.&lt;Function&gt;(&lt;Parameters&gt;)</c>.
+    /// When <see cref="Module"/> is null/empty only <c>import gdsfactory as gf</c> is emitted,
+    /// so <see cref="Function"/> MUST then be gf-qualified (e.g. "gf.components.straight");
+    /// a bare name like "straight" would produce <c>component = straight()</c> with no import
+    /// that resolves it, raising a Python <c>NameError</c>. A later UI task enforces/derives
+    /// this qualification — here the contract is only documented, not validated.
+    /// </remarks>
     public string ToGdsFactoryRawCode()
     {
         var import = string.IsNullOrWhiteSpace(Module) ? "import gdsfactory as gf" : $"import {Module}";

--- a/CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs
@@ -1,0 +1,38 @@
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>Which geometry engine renders/exports a custom component.</summary>
+public enum GeometryBackend
+{
+    /// <summary>Nazca PDK cell, rendered in module/function mode.</summary>
+    Nazca,
+
+    /// <summary>gdsfactory PCell, rendered via a raw-code import wrapper.</summary>
+    GdsFactory,
+}
+
+/// <summary>
+/// A reference to a component-producing function in a Python module, e.g.
+/// module "cspdk.sin300", function "coupler". <see cref="Parameters"/> is an optional
+/// Python kwargs fragment (e.g. "length=10"). Renders in one of two ways depending on
+/// <see cref="Backend"/>: nazca via module/function dispatch, gdsfactory via a raw-code
+/// import-and-call wrapper (see <see cref="ToGdsFactoryRawCode"/>).
+/// </summary>
+/// <param name="Backend">Which geometry engine builds this component.</param>
+/// <param name="Module">Python module path, e.g. "cspdk.sin300". Null/empty for gdsfactory's default import.</param>
+/// <param name="Function">Cell-producing function name, e.g. "coupler".</param>
+/// <param name="Parameters">Optional Python kwargs fragment passed to the function call.</param>
+public sealed record GeometryReference(GeometryBackend Backend, string? Module, string Function, string? Parameters)
+{
+    /// <summary>The fully-qualified call, e.g. "cspdk.sin300.coupler" or "coupler".</summary>
+    public string QualifiedFunction => string.IsNullOrWhiteSpace(Module) ? Function : $"{Module}.{Function}";
+
+    /// <summary>
+    /// Wraps the reference in a raw-code snippet the gdsfactory preview script understands:
+    /// it imports the module and assigns the built cell to a variable named <c>component</c>.
+    /// </summary>
+    public string ToGdsFactoryRawCode()
+    {
+        var import = string.IsNullOrWhiteSpace(Module) ? "import gdsfactory as gf" : $"import {Module}";
+        return $"{import}\ncomponent = {QualifiedFunction}({Parameters ?? string.Empty})";
+    }
+}

--- a/CAP.Avalonia/Services/AddCustomComponent/NewComponentWindowLauncher.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/NewComponentWindowLauncher.cs
@@ -39,7 +39,10 @@ public static class NewComponentWindowLauncher
         if (vm.SavedDraft is null || vm.SelectedProcess is null) return;
 
         var filePath = userPdkStore.ResolvePath(vm.SelectedProcess);
-        var pdk = pdkLoader.LoadFromFile(filePath);
+        // Edit-tolerant load (matches CustomComponentLibraryRegistrar): a freshly-saved user
+        // PDK may lack a Nazca origin offset, which the strict LoadFromFile would reject —
+        // that rejection would silently skip registration while the UI still says "Saved".
+        var pdk = pdkLoader.LoadFromFileForEditing(filePath);
         register(vm.SavedDraft, pdk.Name, filePath);
     }
 }

--- a/CAP.Avalonia/Services/AddCustomComponent/NewComponentWindowLauncher.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/NewComponentWindowLauncher.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Builds the <see cref="NewComponentViewModel"/> offered by the "New Component" window
+/// (issue #656) and wires its <see cref="NewComponentViewModel.Saved"/> event: on save, reads
+/// the saved process's user-PDK file back (so the registered PDK name always matches what
+/// <see cref="UserPdkStore"/> wrote to disk) and hands the draft to <paramref name="register"/>
+/// in <see cref="BuildViewModel"/>. Extracted out of <c>LeftPanelViewModel.OpenNewComponent</c>
+/// to keep that command thin.
+/// </summary>
+public static class NewComponentWindowLauncher
+{
+    /// <summary>
+    /// Creates the view model, offering every currently loaded PDK's fabrication process as a
+    /// save target (a process-less/tool PDK has nowhere physically meaningful to save into).
+    /// </summary>
+    public static NewComponentViewModel BuildViewModel(
+        AddCustomComponentDependencies deps, PdkLoader pdkLoader, IReadOnlyList<PdkDraft> loadedPdks,
+        Action<PdkComponentDraft, string, string> register)
+    {
+        var processes = loadedPdks.Where(d => d.Process != null).Select(d => d.Process!).ToList();
+        var vm = new NewComponentViewModel(deps.Extractor, deps.Fdtd, deps.UserPdkStore, processes);
+        vm.Saved += (_, _) => OnSaved(vm, deps.UserPdkStore, pdkLoader, register);
+        return vm;
+    }
+
+    private static void OnSaved(
+        NewComponentViewModel vm, UserPdkStore userPdkStore, PdkLoader pdkLoader,
+        Action<PdkComponentDraft, string, string> register)
+    {
+        if (vm.SavedDraft is null || vm.SelectedProcess is null) return;
+
+        var filePath = userPdkStore.ResolvePath(vm.SelectedProcess);
+        var pdk = pdkLoader.LoadFromFile(filePath);
+        register(vm.SavedDraft, pdk.Name, filePath);
+    }
+}

--- a/CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs
+++ b/CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs
@@ -51,11 +51,40 @@ public class ComponentFdtdRequestFactory
 
         var componentPinNames = component.PhysicalPins?.Select(p => p.Name).ToList() ?? new List<string>();
 
+        return BuildFromPreview(preview, componentPinNames, _siliconLayer, _portWidthUm);
+    }
+
+    /// <summary>
+    /// Builds a complete <see cref="FdtdSMatrixRequest"/> directly from an already
+    /// rendered <see cref="NazcaPreviewResult"/>, without re-rendering. Used by flows
+    /// that already hold a preview render (e.g. the custom-PDK "own component" editor)
+    /// so they don't pay for a second Nazca render just to get an FDTD request.
+    /// Polygons are filtered to <paramref name="siliconLayer"/> (falling back to all
+    /// layers when none match) and ports are index-matched to <paramref name="portNames"/>
+    /// (falling back to the preview's own pin names on a count mismatch) — the same
+    /// mapping <see cref="BuildAsync"/> applies.
+    /// </summary>
+    /// <param name="preview">Rendered geometry/pins to build the request from.</param>
+    /// <param name="portNames">
+    /// Port names to assign, index-matched to <paramref name="preview"/>'s pins
+    /// (e.g. the component's own pin names, so the S-matrix is keyed as expected).
+    /// </param>
+    /// <param name="siliconLayer">GDS layer carrying the optical waveguide.</param>
+    /// <param name="portWidthUm">Port (waveguide) width in µm.</param>
+    public static FdtdSMatrixRequest BuildFromPreview(
+        NazcaPreviewResult preview,
+        IReadOnlyList<string> portNames,
+        int siliconLayer = DefaultSiliconLayer,
+        double portWidthUm = DefaultPortWidthUm)
+    {
+        ArgumentNullException.ThrowIfNull(preview);
+        ArgumentNullException.ThrowIfNull(portNames);
+
         return new FdtdSMatrixRequest
         {
-            Polygons = BuildPolygons(preview.Polygons, _siliconLayer),
-            Ports = BuildPorts(preview.Pins, componentPinNames, _portWidthUm),
-            LayerNumber = _siliconLayer,
+            Polygons = BuildPolygons(preview.Polygons, siliconLayer),
+            Ports = BuildPorts(preview.Pins, portNames, portWidthUm),
+            LayerNumber = siliconLayer,
             Is3D = false, // 2D for a quick recompute; a 3D/accuracy toggle can come later
         };
     }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -150,9 +150,10 @@ public partial class NewComponentViewModel : ObservableObject
     /// missing any of these reports why via <see cref="StatusText"/> and leaves
     /// <see cref="SavedDraft"/> null. A name collision is reported via <see cref="StatusText"/>
     /// unless <see cref="ConfirmOverwrite"/> confirms the overwrite. On success the S-matrix is
-    /// either the last FDTD result or a black box when none was computed — never fabricated —
-    /// and any diagnostic already in <see cref="StatusText"/> (e.g. an FDTD failure explaining
-    /// why the save is a black box) is left in place rather than overwritten.
+    /// either the last FDTD result or a black box when none was computed — never fabricated. A
+    /// black-box save preserves any pending diagnostic in <see cref="StatusText"/> (e.g. an FDTD
+    /// failure explaining why the save is a black box) and prefixes it with a save confirmation,
+    /// so the user always gets confirmation without losing the reason there is no model.
     /// </summary>
     [RelayCommand]
     private async Task Save()
@@ -175,24 +176,24 @@ public partial class NewComponentViewModel : ObservableObject
             return;
         }
 
-        var process = SelectedProcess;
-        if (_store.ComponentExists(process, name))
-        {
-            if (ConfirmOverwrite is null)
-            {
-                StatusText = $"'{name}' already exists in {process.Name}.";
-                return;
-            }
-            if (!await ConfirmOverwrite(name, process.Name))
-            {
-                StatusText = "Save cancelled.";
-                return;
-            }
-        }
-
         IsBusy = true;
         try
         {
+            var process = SelectedProcess;
+            if (_store.ComponentExists(process, name))
+            {
+                if (ConfirmOverwrite is null)
+                {
+                    StatusText = $"'{name}' already exists in {process.Name}.";
+                    return;
+                }
+                if (!await ConfirmOverwrite(name, process.Name))
+                {
+                    StatusText = "Save cancelled.";
+                    return;
+                }
+            }
+
             var reference = new GeometryReference(SelectedBackend, Module, Function, Parameters);
             var draft = new PdkComponentDraft
             {
@@ -214,6 +215,9 @@ public partial class NewComponentViewModel : ObservableObject
 
             SavedDraft = draft;
             SavedProcessName = process.Name;
+            StatusText = _computedModel is null
+                ? $"Saved as black box. {StatusText}".Trim()
+                : "Saved with FDTD S-matrix.";
             Saved?.Invoke(this, EventArgs.Empty);
         }
         finally

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -42,6 +42,9 @@ public partial class NewComponentViewModel : ObservableObject
     /// <summary>Fabrication processes available for the "save to" selection.</summary>
     public IReadOnlyList<ProcessDefinition> Processes { get; }
 
+    /// <summary>The two geometry backends selectable in the UI.</summary>
+    public static IReadOnlyList<GeometryBackend> AvailableBackends { get; } = Enum.GetValues<GeometryBackend>();
+
     /// <summary>The draft last written by <see cref="Save"/>, or null before a successful save.</summary>
     public PdkComponentDraft? SavedDraft { get; private set; }
 
@@ -70,6 +73,14 @@ public partial class NewComponentViewModel : ObservableObject
         _store = store;
         Processes = processes;
     }
+
+    // A change to any input the preview was rendered from invalidates HasPreview — otherwise
+    // a saved draft could be built from a preview that no longer matches the current
+    // Module/Function/Parameters/Backend (drift between the last render and what gets saved).
+    partial void OnSelectedBackendChanged(GeometryBackend value) => HasPreview = false;
+    partial void OnModuleChanged(string? value) => HasPreview = false;
+    partial void OnFunctionChanged(string value) => HasPreview = false;
+    partial void OnParametersChanged(string? value) => HasPreview = false;
 
     /// <summary>Renders the configured geometry reference and extracts its size and pins.</summary>
     [RelayCommand]

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CAP_DataAccess.Persistence.PIR;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>
+/// Orchestrates adding a user-authored component to a fabrication process's user PDK:
+/// renders its geometry (nazca or gdsfactory), optionally recomputes its S-matrix via the
+/// FDTD solver, and saves the result as a <see cref="PdkComponentDraft"/>. Never invents
+/// physics — a missing solver, an unavailable backend, or a failed solve always saves the
+/// component as a black box (no S-matrix), never a fabricated one.
+/// </summary>
+public partial class NewComponentViewModel : ObservableObject
+{
+    private readonly ComponentGeometryExtractor _extractor;
+    private readonly IFdtdSMatrixService? _fdtd;
+    private readonly UserPdkStore _store;
+
+    private GeometryExtractResult? _lastPreview;
+    private ComponentSMatrixData? _computedModel;
+
+    [ObservableProperty] private string _componentName = string.Empty;
+    [ObservableProperty] private GeometryBackend _selectedBackend = GeometryBackend.GdsFactory;
+    [ObservableProperty] private string? _module;
+    [ObservableProperty] private string _function = string.Empty;
+    [ObservableProperty] private string? _parameters;
+    [ObservableProperty] private ProcessDefinition? _selectedProcess;
+    [ObservableProperty] private string _statusText = string.Empty;
+    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] private bool _hasPreview;
+
+    /// <summary>Fabrication processes available for the "save to" selection.</summary>
+    public IReadOnlyList<ProcessDefinition> Processes { get; }
+
+    /// <summary>The draft last written by <see cref="Save"/>, or null before a successful save.</summary>
+    public PdkComponentDraft? SavedDraft { get; private set; }
+
+    /// <summary>The process name <see cref="SavedDraft"/> was saved under.</summary>
+    public string? SavedProcessName { get; private set; }
+
+    /// <summary>Raised after a successful save, so a listener (e.g. the left panel) can refresh.</summary>
+    public event EventHandler? Saved;
+
+    /// <summary>
+    /// Optional confirmation hook invoked with (componentName, processName) when a save would
+    /// overwrite an existing component; returning true proceeds with the overwrite. When null,
+    /// a collision is reported via <see cref="StatusText"/> and the save is aborted.
+    /// </summary>
+    public Func<string, string, Task<bool>>? ConfirmOverwrite { get; set; }
+
+    /// <summary>Initializes the view model with its collaborators and the available processes.</summary>
+    public NewComponentViewModel(
+        ComponentGeometryExtractor extractor,
+        IFdtdSMatrixService? fdtd,
+        UserPdkStore store,
+        IReadOnlyList<ProcessDefinition> processes)
+    {
+        _extractor = extractor;
+        _fdtd = fdtd;
+        _store = store;
+        Processes = processes;
+    }
+
+    /// <summary>Renders the configured geometry reference and extracts its size and pins.</summary>
+    [RelayCommand]
+    private async Task RunPreview()
+    {
+        if (IsBusy) return;
+        IsBusy = true;
+        try
+        {
+            var reference = new GeometryReference(SelectedBackend, Module, Function, Parameters);
+            var result = await _extractor.ExtractAsync(reference);
+            _lastPreview = result;
+            HasPreview = result.Success;
+            StatusText = result.Success
+                ? $"Preview rendered: {result.WidthUm:0.###} x {result.HeightUm:0.###} um, {result.Pins.Count} pins."
+                : result.Error ?? "Preview render failed.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Recomputes the S-matrix from the rendered geometry via the FDTD solver. Any failure —
+    /// no solver configured, an unavailable backend, or a failed solve — clears the pending
+    /// model and reports the reason via <see cref="StatusText"/>; a black-box save is the
+    /// only fallback, never a fabricated matrix.
+    /// </summary>
+    [RelayCommand]
+    private async Task ComputeSMatrix()
+    {
+        if (IsBusy) return;
+        if (_lastPreview is not { Success: true } preview || SelectedProcess is null)
+        {
+            StatusText = "Render a preview and select a process before computing the S-matrix.";
+            return;
+        }
+        if (_fdtd is null)
+        {
+            StatusText = "FDTD solver is not configured.";
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            var availability = await _fdtd.CheckAvailabilityAsync();
+            if (!availability.IsAvailable)
+            {
+                _computedModel = null;
+                StatusText = availability.Message;
+                return;
+            }
+
+            var portNames = preview.Pins.Select(p => p.Name).ToList();
+            var request = ComponentFdtdRequestFactory.BuildFromPreview(preview.Raw, portNames);
+            var result = await _fdtd.SolveAsync(request);
+            if (!result.Success)
+            {
+                _computedModel = null;
+                StatusText = result.Error ?? "FDTD solve failed.";
+                return;
+            }
+
+            _computedModel = FdtdSMatrixConverter.ToComponentSMatrixData(result, "FDTD Meep");
+            StatusText = "S-matrix computed.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Saves the current component as a <see cref="PdkComponentDraft"/> into the selected
+    /// process's user PDK. Requires a name, a rendered preview, and a selected process —
+    /// missing any of these reports why via <see cref="StatusText"/> and leaves
+    /// <see cref="SavedDraft"/> null. A name collision is reported via <see cref="StatusText"/>
+    /// unless <see cref="ConfirmOverwrite"/> confirms the overwrite. On success the S-matrix is
+    /// either the last FDTD result or a black box when none was computed — never fabricated —
+    /// and any diagnostic already in <see cref="StatusText"/> (e.g. an FDTD failure explaining
+    /// why the save is a black box) is left in place rather than overwritten.
+    /// </summary>
+    [RelayCommand]
+    private async Task Save()
+    {
+        if (IsBusy) return;
+        var name = ComponentName?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            StatusText = "Enter a component name before saving.";
+            return;
+        }
+        if (_lastPreview is not { Success: true } preview)
+        {
+            StatusText = "Render a preview before saving.";
+            return;
+        }
+        if (SelectedProcess is null)
+        {
+            StatusText = "Select a fabrication process before saving.";
+            return;
+        }
+
+        var process = SelectedProcess;
+        if (_store.ComponentExists(process, name))
+        {
+            if (ConfirmOverwrite is null)
+            {
+                StatusText = $"'{name}' already exists in {process.Name}.";
+                return;
+            }
+            if (!await ConfirmOverwrite(name, process.Name))
+            {
+                StatusText = "Save cancelled.";
+                return;
+            }
+        }
+
+        IsBusy = true;
+        try
+        {
+            var reference = new GeometryReference(SelectedBackend, Module, Function, Parameters);
+            var draft = new PdkComponentDraft
+            {
+                Name = name,
+                WidthMicrometers = preview.WidthUm,
+                HeightMicrometers = preview.HeightUm,
+                Pins = MapPins(preview.Pins),
+                SMatrix = _computedModel is null
+                    ? FdtdSMatrixToDraftConverter.BlackBox()
+                    : FdtdSMatrixToDraftConverter.FromFdtd(_computedModel),
+            };
+            if (SelectedBackend == GeometryBackend.GdsFactory)
+                draft.GdsFactoryFunction = reference.QualifiedFunction;
+            else
+                draft.NazcaFunction = reference.QualifiedFunction;
+
+            var backend = SelectedBackend == GeometryBackend.GdsFactory ? "gdsfactory" : "nazca";
+            _store.Save(process, draft, backend, null);
+
+            SavedDraft = draft;
+            SavedProcessName = process.Name;
+            Saved?.Invoke(this, EventArgs.Empty);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Maps extracted preview pins to PDK physical-pin drafts. Only name/offset/angle are
+    /// derivable from geometry extraction — logical-pin linkage and pin kind have no source
+    /// here and are left at their defaults.
+    /// </summary>
+    private static List<PhysicalPinDraft> MapPins(IReadOnlyList<OverridePinData> pins) =>
+        pins.Select(p => new PhysicalPinDraft
+        {
+            Name = p.Name,
+            OffsetXMicrometers = p.OffsetXMicrometers,
+            OffsetYMicrometers = p.OffsetYMicrometers,
+            AngleDegrees = p.AngleDegrees,
+        }).ToList();
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -42,8 +42,14 @@ public partial class NewComponentViewModel : ObservableObject
     /// <summary>Fabrication processes available for the "save to" selection.</summary>
     public IReadOnlyList<ProcessDefinition> Processes { get; }
 
-    /// <summary>The two geometry backends selectable in the UI.</summary>
-    public static IReadOnlyList<GeometryBackend> AvailableBackends { get; } = Enum.GetValues<GeometryBackend>();
+    /// <summary>
+    /// Geometry backends selectable in the UI. v1 offers gdsfactory only: a nazca custom
+    /// component saved without a derived <c>NazcaOriginOffset</c> has no clean export/sim path,
+    /// so nazca custom components are deferred to v2 (needs NazcaOriginOffset derivation). The
+    /// <see cref="GeometryBackend"/> enum and the extractor's nazca branch stay for tests/v2.
+    /// </summary>
+    public static IReadOnlyList<GeometryBackend> AvailableBackends { get; } =
+        new[] { GeometryBackend.GdsFactory };
 
     /// <summary>The draft last written by <see cref="Save"/>, or null before a successful save.</summary>
     public PdkComponentDraft? SavedDraft { get; private set; }
@@ -220,20 +226,10 @@ public partial class NewComponentViewModel : ObservableObject
             }
 
             var reference = new GeometryReference(SelectedBackend, Module, Function, Parameters);
-            var draft = new PdkComponentDraft
-            {
-                Name = name,
-                WidthMicrometers = preview.WidthUm,
-                HeightMicrometers = preview.HeightUm,
-                Pins = MapPins(preview.Pins),
-                SMatrix = _computedModel is null
-                    ? FdtdSMatrixToDraftConverter.BlackBox()
-                    : FdtdSMatrixToDraftConverter.FromFdtd(_computedModel),
-            };
-            if (SelectedBackend == GeometryBackend.GdsFactory)
-                draft.GdsFactoryFunction = reference.QualifiedFunction;
-            else
-                draft.NazcaFunction = reference.QualifiedFunction;
+            var sMatrix = _computedModel is null
+                ? FdtdSMatrixToDraftConverter.BlackBox()
+                : FdtdSMatrixToDraftConverter.FromFdtd(_computedModel);
+            var draft = CustomComponentDraftFactory.Build(name, reference, preview, sMatrix);
 
             var backend = SelectedBackend == GeometryBackend.GdsFactory ? "gdsfactory" : "nazca";
             _store.Save(process, draft, backend, null);
@@ -250,18 +246,4 @@ public partial class NewComponentViewModel : ObservableObject
             IsBusy = false;
         }
     }
-
-    /// <summary>
-    /// Maps extracted preview pins to PDK physical-pin drafts. Only name/offset/angle are
-    /// derivable from geometry extraction — logical-pin linkage and pin kind have no source
-    /// here and are left at their defaults.
-    /// </summary>
-    private static List<PhysicalPinDraft> MapPins(IReadOnlyList<OverridePinData> pins) =>
-        pins.Select(p => new PhysicalPinDraft
-        {
-            Name = p.Name,
-            OffsetXMicrometers = p.OffsetXMicrometers,
-            OffsetYMicrometers = p.OffsetYMicrometers,
-            AngleDegrees = p.AngleDegrees,
-        }).ToList();
 }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -74,13 +74,27 @@ public partial class NewComponentViewModel : ObservableObject
         Processes = processes;
     }
 
-    // A change to any input the preview was rendered from invalidates HasPreview — otherwise
-    // a saved draft could be built from a preview that no longer matches the current
+    // A change to any input the preview was rendered from invalidates the preview — otherwise
+    // a saved draft could be built from a rendered preview that no longer matches the current
     // Module/Function/Parameters/Backend (drift between the last render and what gets saved).
-    partial void OnSelectedBackendChanged(GeometryBackend value) => HasPreview = false;
-    partial void OnModuleChanged(string? value) => HasPreview = false;
-    partial void OnFunctionChanged(string value) => HasPreview = false;
-    partial void OnParametersChanged(string? value) => HasPreview = false;
+    // Clearing _lastPreview is the load-bearing part: Save gates on that field, so a stale
+    // preview cannot be saved; HasPreview (which drives the Save button's enablement) tracks it.
+    partial void OnSelectedBackendChanged(GeometryBackend value) => InvalidatePreview();
+    partial void OnModuleChanged(string? value) => InvalidatePreview();
+    partial void OnFunctionChanged(string value) => InvalidatePreview();
+    partial void OnParametersChanged(string? value) => InvalidatePreview();
+
+    private void InvalidatePreview()
+    {
+        _lastPreview = null;
+        HasPreview = false;
+    }
+
+    /// <summary>Save is only possible once a matching preview has been rendered and no work is in flight.</summary>
+    private bool CanSave => HasPreview && !IsBusy;
+
+    partial void OnHasPreviewChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
+    partial void OnIsBusyChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
 
     /// <summary>Renders the configured geometry reference and extracts its size and pins.</summary>
     [RelayCommand]
@@ -166,7 +180,7 @@ public partial class NewComponentViewModel : ObservableObject
     /// failure explaining why the save is a black box) and prefixes it with a save confirmation,
     /// so the user always gets confirmation without losing the reason there is no model.
     /// </summary>
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanSave))]
     private async Task Save()
     {
         if (IsBusy) return;

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -7,6 +7,7 @@ using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.AddCustomComponent;
 using CAP_Core.Components.Creation;
 using CAP_Core.Components;
 using CAP_Core.Components.Process;
@@ -26,6 +27,7 @@ public partial class LeftPanelViewModel : ObservableObject
     private readonly PdkLoader _pdkLoader;
     private readonly UserPreferencesService _preferencesService;
     private readonly ErrorConsoleService? _errorConsole;
+    private readonly AddCustomComponentDependencies? _addCustomComponentDeps;
 
     /// <summary>
     /// Every PDK loaded into the library so far (bundled + user-imported), kept so
@@ -115,6 +117,8 @@ public partial class LeftPanelViewModel : ObservableObject
     /// </summary>
     public Func<string, Task<string?>>? ShowImportWizardAsync { get; set; }
 
+    /// <summary>Shows the "New Component" window (non-modal; set by MainWindow.axaml.cs).</summary>
+    public Func<CAP.Avalonia.ViewModels.Components.AddCustomComponent.NewComponentViewModel, Task>? ShowNewComponentWindowAsync { get; set; }
     /// <summary>Initializes a new instance of <see cref="LeftPanelViewModel"/>.</summary>
     public LeftPanelViewModel(
         DesignCanvasViewModel canvas,
@@ -124,12 +128,14 @@ public partial class LeftPanelViewModel : ObservableObject
         HierarchyPanelViewModel hierarchyPanel,
         PdkManagerViewModel pdkManager,
         ComponentLibraryViewModel componentLibrary,
-        ErrorConsoleService? errorConsole = null)
+        ErrorConsoleService? errorConsole = null,
+        AddCustomComponentDependencies? addCustomComponentDeps = null)
     {
         _canvas = canvas;
         _pdkLoader = pdkLoader;
         _preferencesService = preferencesService;
         _errorConsole = errorConsole;
+        _addCustomComponentDeps = addCustomComponentDeps;
 
         HierarchyPanel = hierarchyPanel;
         PdkManager = pdkManager;
@@ -410,6 +416,17 @@ public partial class LeftPanelViewModel : ObservableObject
         => PdkTemplateConverter.ConvertToTemplate(
             pdkComp, pdkName, nazcaModuleName, gdsFactoryRoutingCrossSection);
 
+    /// <summary>Opens the "New Component" window (issue #656); see <see cref="NewComponentWindowLauncher"/>.</summary>
+    [RelayCommand]
+    private async Task OpenNewComponent()
+    {
+        if (ShowNewComponentWindowAsync is null || _addCustomComponentDeps is null) return;
+
+        await ShowNewComponentWindowAsync(NewComponentWindowLauncher.BuildViewModel(_addCustomComponentDeps, _pdkLoader, GetLoadedPdkDrafts(), RegisterSavedCustomComponent));
+    }
+    /// <summary>Registers a saved custom component into the library; see <see cref="CustomComponentLibraryRegistrar"/>.</summary>
+    public void RegisterSavedCustomComponent(PdkComponentDraft draft, string pdkName, string filePath) =>
+        CustomComponentLibraryRegistrar.Register(draft, pdkName, filePath, AllTemplates, Categories, PdkManager, _preferencesService, FilterComponents);
     /// <summary>
     /// Process fingerprints of all loaded PDKs, for single-process grouping (#570).
     /// Excludes process-agnostic tool PDKs (e.g. "Analysis Tools") — they are not a

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -426,7 +426,7 @@ public partial class LeftPanelViewModel : ObservableObject
     }
     /// <summary>Registers a saved custom component into the library; see <see cref="CustomComponentLibraryRegistrar"/>.</summary>
     public void RegisterSavedCustomComponent(PdkComponentDraft draft, string pdkName, string filePath) =>
-        CustomComponentLibraryRegistrar.Register(draft, pdkName, filePath, AllTemplates, Categories, PdkManager, _preferencesService, FilterComponents);
+        CustomComponentLibraryRegistrar.Register(draft, pdkName, filePath, AllTemplates, Categories, PdkManager, _preferencesService, _pdkLoader, _loadedPdkDrafts, ReapplyActiveProcessAfterPdkChange, FilterComponents);
     /// <summary>
     /// Process fingerprints of all loaded PDKs, for single-process grouping (#570).
     /// Excludes process-agnostic tool PDKs (e.g. "Analysis Tools") — they are not a

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -556,8 +556,13 @@
 
                 <!-- Component Library -->
                 <DockPanel Grid.Row="4">
-                    <TextBlock DockPanel.Dock="Top" Text="Component Library"
-                               FontWeight="Bold" Margin="10,6,10,4" Foreground="White"/>
+                    <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="10,6,10,4">
+                        <TextBlock Grid.Column="0" Text="Component Library"
+                                   FontWeight="Bold" Foreground="White" VerticalAlignment="Center"/>
+                        <Button Grid.Column="1" Content="+" Command="{Binding LeftPanel.OpenNewComponentCommand}"
+                                Padding="8,0" FontWeight="Bold" Background="#2a4a2a"
+                                ToolTip.Tip="Neue Komponente…"/>
+                    </Grid>
                     <TextBox DockPanel.Dock="Top" Watermark="Search components..."
                              Text="{Binding LeftPanel.SearchText}"
                              Margin="10,0,10,6" FontSize="11"

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -74,6 +74,16 @@ public partial class MainWindow : Window
                     };
                 }
 
+                // Wire up the "New Component" window (issue #656) — non-modal, like the
+                // Fabrication Process and ONA Analyzer tool windows, so the user can keep
+                // iterating on the design while it stays open.
+                vm.LeftPanel.ShowNewComponentWindowAsync = newComponentVm =>
+                {
+                    var window = new NewComponentWindow { DataContext = newComponentVm };
+                    window.Show(this);
+                    return System.Threading.Tasks.Task.CompletedTask;
+                };
+
                 // Wire up PDK Offset Editor window
                 vm.ShowPdkOffsetEditorRequested = () =>
                 {

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -1,0 +1,85 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:CAP.Avalonia.ViewModels.Components.AddCustomComponent"
+        xmlns:dto="using:CAP_DataAccess.Components.ComponentDraftMapper.DTOs"
+        x:Class="CAP.Avalonia.Views.NewComponentWindow"
+        x:DataType="vm:NewComponentViewModel"
+        Title="New Component"
+        Width="480" Height="620"
+        MinWidth="420" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
+        Background="#1e1e1e"
+        Foreground="White">
+
+    <DockPanel Margin="16" LastChildFill="True">
+
+        <!-- Buttons — always visible at the bottom -->
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                    HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
+            <Button Content="Preview" Command="{Binding RunPreviewCommand}"
+                    Width="90" Background="#3d4d6d"
+                    ToolTip.Tip="Renders the geometry reference below and extracts its size and pins"/>
+            <Button Content="Compute S-Matrix" Command="{Binding ComputeSMatrixCommand}"
+                    Width="140" Background="#3d4d6d"
+                    ToolTip.Tip="Recomputes the S-matrix from the rendered geometry via the FDTD solver (optional)"/>
+            <Button Content="Save" Command="{Binding SaveCommand}"
+                    Width="80" Background="#2a4a2a"
+                    ToolTip.Tip="Saves the component into the selected fabrication process's user PDK"/>
+        </StackPanel>
+
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="10">
+
+                <TextBlock Text="New Component" FontSize="15" FontWeight="SemiBold" Foreground="LightBlue"/>
+                <TextBlock TextWrapping="Wrap" Foreground="Gray" FontSize="10"
+                           Text="Renders a component's geometry from a Python module/function reference, optionally recomputes its S-matrix via FDTD, and saves it into a fabrication process's own user PDK. A save with no computed S-matrix is stored as a black box, never a fabricated one."/>
+
+                <Separator Background="#3d3d3d"/>
+
+                <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,8,Auto,8,Auto,8,Auto,8,Auto">
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Name:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding ComponentName}"
+                             Background="#2d2d2d" Foreground="White"/>
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Backend:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <ComboBox Grid.Row="2" Grid.Column="2"
+                              ItemsSource="{x:Static vm:NewComponentViewModel.AvailableBackends}"
+                              SelectedItem="{Binding SelectedBackend}"
+                              Background="#2d2d2d" Foreground="White" HorizontalAlignment="Stretch"/>
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Module:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="4" Grid.Column="2" Text="{Binding Module}"
+                             Watermark="e.g. cspdk.sin300" Background="#2d2d2d" Foreground="White"/>
+
+                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Function:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="6" Grid.Column="2" Text="{Binding Function}"
+                             Watermark="e.g. coupler" Background="#2d2d2d" Foreground="White"/>
+
+                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Parameters:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="8" Grid.Column="2" Text="{Binding Parameters}"
+                             Watermark="e.g. length=10" Background="#2d2d2d" Foreground="White"/>
+                </Grid>
+
+                <Separator Background="#3d3d3d"/>
+
+                <TextBlock Text="Save to fabrication process" Foreground="#aaaaaa" FontSize="11" FontWeight="SemiBold"/>
+                <ComboBox ItemsSource="{Binding Processes}" SelectedItem="{Binding SelectedProcess}"
+                          Background="#2d2d2d" Foreground="White" HorizontalAlignment="Stretch">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="dto:ProcessDefinition">
+                            <TextBlock Text="{Binding Name}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                <TextBlock TextWrapping="Wrap" FontSize="10" Foreground="#777799"
+                           Text="Only fabrication processes from currently loaded PDKs are listed — import or configure one via the Fabrication Process window if none appear."/>
+
+                <Separator Background="#3d3d3d"/>
+
+                <ProgressBar IsIndeterminate="True" IsVisible="{Binding IsBusy}" Height="4" Background="#2d2d2d"/>
+                <TextBlock Text="{Binding StatusText}" Foreground="#dddddd" FontSize="11" TextWrapping="Wrap"/>
+
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml.cs
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+
+namespace CAP.Avalonia.Views;
+
+/// <summary>
+/// Window for authoring a new PDK component: render its geometry, optionally recompute its
+/// S-matrix via FDTD, and save it into a fabrication process's user PDK. DataContext must be a
+/// <see cref="CAP.Avalonia.ViewModels.Components.AddCustomComponent.NewComponentViewModel"/>.
+/// </summary>
+public partial class NewComponentWindow : Window
+{
+    /// <summary>Initializes the window.</summary>
+    public NewComponentWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/UnitTests/Architecture/AddCustomComponentSliceTests.cs
+++ b/UnitTests/Architecture/AddCustomComponentSliceTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Architecture;
+
+/// <summary>
+/// Enforces the "user PDK, never the bundled foundry PDK" invariant from issue #570/#655:
+/// <see cref="UserPdkStore"/> must always resolve into the caller-supplied writable root,
+/// never into the bundled <c>CAP-DataAccess/PDKs</c> folder that ships read-only foundry data.
+/// </summary>
+public class AddCustomComponentSliceTests
+{
+    [Fact]
+    public void UserPdk_path_is_never_inside_the_bundled_pdk_folder()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "lunima-arch-" + Guid.NewGuid().ToString("N"));
+        var store = new UserPdkStore(root, new PdkJsonSaver(), new PdkLoader());
+        var path = store.ResolvePath(new ProcessDefinition { Name = "CornerStone SiN" });
+
+        path.Replace('\\', '/').ShouldNotContain("/PDKs/");
+        path.ShouldStartWith(root);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/ComponentGeometryExtractorTests.cs
+++ b/UnitTests/Components/AddCustomComponent/ComponentGeometryExtractorTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="ComponentGeometryExtractor"/>: gdsfactory references render via the
+/// raw-code wrapper, nazca references render via module/function dispatch, and a failed
+/// render surfaces the error without pins.
+/// </summary>
+public class ComponentGeometryExtractorTests
+{
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 12, YMax = 3,
+        Polygons = new List<NazcaPreviewPolygon>(),
+        Pins = new List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 1.5, Angle = 180 },
+            new() { Name = "o2", X = 12, Y = 1.5, Angle = 0 },
+        }
+    };
+
+    [Fact]
+    public async Task GdsFactory_reference_renders_via_raw_code_wrapper()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.Is<string>(s => s.Contains("cspdk.sin300.coupler")), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var result = await extractor.ExtractAsync(
+            new GeometryReference(GeometryBackend.GdsFactory, "cspdk.sin300", "coupler", null));
+
+        result.Success.ShouldBeTrue();
+        result.WidthUm.ShouldBe(12);
+        result.HeightUm.ShouldBe(3);
+        result.Pins.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Nazca_reference_renders_via_module_function()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        nazca.Setup(n => n.RenderAsync("mymod", "mycell", null, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var result = await extractor.ExtractAsync(
+            new GeometryReference(GeometryBackend.Nazca, "mymod", "mycell", null));
+
+        result.Success.ShouldBeTrue();
+        result.Pins.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Failed_render_surfaces_error_and_no_pins()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(new NazcaPreviewResult { Success = false, Error = "boom" });
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var result = await extractor.ExtractAsync(
+            new GeometryReference(GeometryBackend.GdsFactory, "m", "f", null));
+
+        result.Success.ShouldBeFalse();
+        result.Error.ShouldBe("boom");
+        result.Pins.Count.ShouldBe(0);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/CustomComponentDraftFactoryTests.cs
+++ b/UnitTests/Components/AddCustomComponent/CustomComponentDraftFactoryTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="CustomComponentDraftFactory"/>: the pure draft/pin assembly extracted out of
+/// <see cref="CAP.Avalonia.ViewModels.Components.AddCustomComponent.NewComponentViewModel"/> to
+/// keep that view model under the 250-line new-file cap.
+/// </summary>
+public class CustomComponentDraftFactoryTests
+{
+    private static GeometryExtractResult Preview() => new(
+        Success: true, Error: null, WidthUm: 10, HeightUm: 2,
+        Pins: new List<OverridePinData>
+        {
+            new() { Name = "o1", OffsetXMicrometers = 0, OffsetYMicrometers = 1, AngleDegrees = 180 },
+            new() { Name = "o2", OffsetXMicrometers = 10, OffsetYMicrometers = 1, AngleDegrees = 0 },
+        },
+        Raw: new NazcaPreviewResult { Success = true, XMin = 0, YMin = 0, XMax = 10, YMax = 2 });
+
+    [Fact]
+    public void Build_gdsfactory_maps_size_pins_and_routes_function_to_gdsfactory_field()
+    {
+        var reference = new GeometryReference(GeometryBackend.GdsFactory, "cspdk.sin300", "coupler", null);
+
+        var draft = CustomComponentDraftFactory.Build("My Coupler", reference, Preview(), sMatrix: null);
+
+        draft.Name.ShouldBe("My Coupler");
+        draft.WidthMicrometers.ShouldBe(10);
+        draft.HeightMicrometers.ShouldBe(2);
+        draft.GdsFactoryFunction.ShouldBe("cspdk.sin300.coupler");
+        draft.NazcaFunction.ShouldBeNull();
+        draft.SMatrix.ShouldBeNull();                     // null in => black box, never fabricated
+        draft.Pins.Count.ShouldBe(2);
+        draft.Pins[0].Name.ShouldBe("o1");
+        draft.Pins[0].AngleDegrees.ShouldBe(180);
+    }
+
+    [Fact]
+    public void Build_nazca_routes_function_to_the_nazca_field_and_keeps_the_sMatrix()
+    {
+        var reference = new GeometryReference(GeometryBackend.Nazca, "demo", "mmi", null);
+        var sMatrix = new PdkSMatrixDraft { WavelengthNm = 1550 };
+
+        var draft = CustomComponentDraftFactory.Build("MMI", reference, Preview(), sMatrix);
+
+        draft.NazcaFunction.ShouldBe("demo.mmi");
+        draft.GdsFactoryFunction.ShouldBeNull();
+        draft.SMatrix.ShouldBe(sMatrix);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/FdtdSMatrixToDraftConverterTests.cs
+++ b/UnitTests/Components/AddCustomComponent/FdtdSMatrixToDraftConverterTests.cs
@@ -62,6 +62,26 @@ public class FdtdSMatrixToDraftConverterTests
     }
 
     [Fact]
+    public void FromFdtd_throws_ArgumentException_on_length_mismatch()
+    {
+        var data = new ComponentSMatrixData
+        {
+            Wavelengths = new()
+            {
+                ["1550"] = new SMatrixWavelengthEntry
+                {
+                    Rows = 2, Cols = 2,
+                    Real = new() { 0, 1, 1 }, // 3 entries, but 2x2 needs 4
+                    Imag = new() { 0, 0, 0, 0 },
+                    PortNames = new() { "o1", "o2" }
+                }
+            }
+        };
+
+        Should.Throw<System.ArgumentException>(() => FdtdSMatrixToDraftConverter.FromFdtd(data));
+    }
+
+    [Fact]
     public void FromFdtd_returns_null_when_no_wavelengths()
     {
         var data = new ComponentSMatrixData { Wavelengths = new() };

--- a/UnitTests/Components/AddCustomComponent/FdtdSMatrixToDraftConverterTests.cs
+++ b/UnitTests/Components/AddCustomComponent/FdtdSMatrixToDraftConverterTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Verifies <see cref="FdtdSMatrixToDraftConverter"/> maps real FDTD results honestly,
+/// never fabricates values, and produces the exact lossless two-port identity.
+/// </summary>
+public class FdtdSMatrixToDraftConverterTests
+{
+    [Fact]
+    public void FromFdtd_maps_each_wavelength_entry()
+    {
+        var data = new ComponentSMatrixData
+        {
+            SourceNote = "FDTD Meep 2D",
+            Wavelengths = new()
+            {
+                ["1550"] = new SMatrixWavelengthEntry
+                {
+                    Rows = 2, Cols = 2,
+                    Real = new() { 0, 1, 1, 0 },
+                    Imag = new() { 0, 0, 0, 0 },
+                    PortNames = new() { "o1", "o2" }
+                }
+            }
+        };
+
+        var draft = FdtdSMatrixToDraftConverter.FromFdtd(data);
+
+        draft.ShouldNotBeNull();
+        draft!.WavelengthData!.Count.ShouldBe(1);
+        draft.WavelengthData[0].WavelengthNm.ShouldBe(1550);
+    }
+
+    [Fact]
+    public void FromFdtd_converts_rectangular_values_to_magnitude_and_phase()
+    {
+        var data = new ComponentSMatrixData
+        {
+            Wavelengths = new()
+            {
+                ["1550"] = new SMatrixWavelengthEntry
+                {
+                    Rows = 2, Cols = 2,
+                    Real = new() { 0, 1, 1, 0 },
+                    Imag = new() { 0, 0, 0, 0 },
+                    PortNames = new() { "o1", "o2" }
+                }
+            }
+        };
+
+        var draft = FdtdSMatrixToDraftConverter.FromFdtd(data);
+
+        var connections = draft!.WavelengthData![0].Connections;
+        connections.ShouldContain(c => c.FromPin == "o2" && c.ToPin == "o1" && c.Magnitude == 1.0 && c.PhaseDegrees == 0.0);
+        connections.ShouldContain(c => c.FromPin == "o1" && c.ToPin == "o2" && c.Magnitude == 1.0 && c.PhaseDegrees == 0.0);
+    }
+
+    [Fact]
+    public void FromFdtd_returns_null_when_no_wavelengths()
+    {
+        var data = new ComponentSMatrixData { Wavelengths = new() };
+        FdtdSMatrixToDraftConverter.FromFdtd(data).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BlackBox_is_null_so_the_component_has_no_model()
+    {
+        FdtdSMatrixToDraftConverter.BlackBox().ShouldBeNull();
+    }
+
+    [Fact]
+    public void LosslessTwoPort_is_unit_magnitude_both_directions()
+    {
+        var draft = FdtdSMatrixToDraftConverter.LosslessTwoPort("o1", "o2", 1550);
+        draft.Connections.Count.ShouldBe(2);
+        draft.Connections.ShouldContain(c => c.FromPin == "o1" && c.ToPin == "o2" && c.Magnitude == 1.0);
+        draft.Connections.ShouldContain(c => c.FromPin == "o2" && c.ToPin == "o1" && c.Magnitude == 1.0);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/GeometryReferenceTests.cs
+++ b/UnitTests/Components/AddCustomComponent/GeometryReferenceTests.cs
@@ -1,0 +1,64 @@
+using CAP.Avalonia.Services.AddCustomComponent;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="GeometryReference.ToGdsFactoryRawCode"/> and
+/// <see cref="GeometryReference.QualifiedFunction"/> — the exact raw-code string emitted
+/// for the module/no-module and with/without-parameters cases.
+/// </summary>
+public class GeometryReferenceTests
+{
+    [Fact]
+    public void ToGdsFactoryRawCode_with_module_and_params_emits_import_and_kwargs()
+    {
+        var reference = new GeometryReference(GeometryBackend.GdsFactory, "cspdk.sin300", "coupler", "length=10");
+
+        var code = reference.ToGdsFactoryRawCode();
+
+        code.ShouldBe("import cspdk.sin300\ncomponent = cspdk.sin300.coupler(length=10)");
+        code.ShouldContain("import cspdk.sin300");
+        code.ShouldContain("component = cspdk.sin300.coupler(length=10)");
+    }
+
+    [Fact]
+    public void ToGdsFactoryRawCode_with_module_and_null_params_emits_empty_parentheses()
+    {
+        var reference = new GeometryReference(GeometryBackend.GdsFactory, "cspdk.sin300", "coupler", null);
+
+        var code = reference.ToGdsFactoryRawCode();
+
+        code.ShouldBe("import cspdk.sin300\ncomponent = cspdk.sin300.coupler()");
+        code.ShouldContain("component = cspdk.sin300.coupler()");
+    }
+
+    [Fact]
+    public void ToGdsFactoryRawCode_with_empty_module_imports_gdsfactory_and_uses_qualified_function()
+    {
+        var reference = new GeometryReference(GeometryBackend.GdsFactory, null, "gf.components.straight", null);
+
+        var code = reference.ToGdsFactoryRawCode();
+
+        code.ShouldBe("import gdsfactory as gf\ncomponent = gf.components.straight()");
+        code.ShouldContain("import gdsfactory as gf");
+        code.ShouldContain("component = gf.components.straight()");
+    }
+
+    [Fact]
+    public void QualifiedFunction_prefixes_module_when_set()
+    {
+        var reference = new GeometryReference(GeometryBackend.GdsFactory, "cspdk.sin300", "coupler", null);
+
+        reference.QualifiedFunction.ShouldBe("cspdk.sin300.coupler");
+    }
+
+    [Fact]
+    public void QualifiedFunction_is_bare_function_when_module_empty()
+    {
+        var reference = new GeometryReference(GeometryBackend.GdsFactory, null, "gf.components.straight", null);
+
+        reference.QualifiedFunction.ShouldBe("gf.components.straight");
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/LeftPanelNewComponentTests.cs
+++ b/UnitTests/Components/AddCustomComponent/LeftPanelNewComponentTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Linq;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Hierarchy;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP.Avalonia.Services;
+using CAP_Core.Components.Creation;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="LeftPanelViewModel.RegisterSavedCustomComponent"/>: the headless-testable
+/// half of the "add custom component" flow (the window itself cannot be opened in a unit test).
+/// </summary>
+public class LeftPanelNewComponentTests
+{
+    /// <summary>Builds a <see cref="LeftPanelViewModel"/> the same way <c>LeftPanelViewModelTests</c> does.</summary>
+    private static LeftPanelViewModel CreateLeftPanelViewModel()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var libraryManager = new GroupLibraryManager();
+        var pdkLoader = new PdkLoader();
+        var preferencesPath = Path.Combine(Path.GetTempPath(), $"test-preferences-{Guid.NewGuid()}.json");
+        var preferencesService = new UserPreferencesService(preferencesPath);
+
+        return new LeftPanelViewModel(
+            canvas, libraryManager, pdkLoader, preferencesService,
+            new HierarchyPanelViewModel(canvas),
+            new PdkManagerViewModel(),
+            new ComponentLibraryViewModel(libraryManager));
+    }
+
+    [Fact]
+    public void RegisterSavedCustomComponent_adds_template_to_the_library()
+    {
+        var vm = CreateLeftPanelViewModel();
+        int before = vm.AllTemplates.Count;
+
+        var draft = new PdkComponentDraft
+        {
+            Name = "My Coupler", Category = "Custom",
+            GdsFactoryFunction = "cspdk.sin300.coupler",
+            WidthMicrometers = 10, HeightMicrometers = 2
+        };
+        vm.RegisterSavedCustomComponent(draft, "My CornerStone Components", "C:/tmp/x.json");
+
+        vm.AllTemplates.Count.ShouldBe(before + 1);
+        vm.AllTemplates.ShouldContain(t => t.Name == "My Coupler");
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/LeftPanelNewComponentTests.cs
+++ b/UnitTests/Components/AddCustomComponent/LeftPanelNewComponentTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CAP.Avalonia.ViewModels.Canvas;
@@ -7,6 +8,8 @@ using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP.Avalonia.Services;
 using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.AddCustomComponent;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using Shouldly;
@@ -18,8 +21,10 @@ namespace UnitTests.Components.AddCustomComponent;
 /// Covers <see cref="LeftPanelViewModel.RegisterSavedCustomComponent"/>: the headless-testable
 /// half of the "add custom component" flow (the window itself cannot be opened in a unit test).
 /// </summary>
-public class LeftPanelNewComponentTests
+public class LeftPanelNewComponentTests : IDisposable
 {
+    private readonly List<string> _tempDirs = new();
+
     /// <summary>Builds a <see cref="LeftPanelViewModel"/> the same way <c>LeftPanelViewModelTests</c> does.</summary>
     private static LeftPanelViewModel CreateLeftPanelViewModel()
     {
@@ -34,6 +39,43 @@ public class LeftPanelNewComponentTests
             new HierarchyPanelViewModel(canvas),
             new PdkManagerViewModel(),
             new ComponentLibraryViewModel(libraryManager));
+    }
+
+    private static PdkComponentDraft SampleDraft() => new()
+    {
+        Name = "My Coupler", Category = "Custom",
+        GdsFactoryFunction = "cspdk.sin300.coupler",
+        WidthMicrometers = 10, HeightMicrometers = 2,
+        Pins = new List<PhysicalPinDraft>
+        {
+            new() { Name = "o1", OffsetXMicrometers = 0, OffsetYMicrometers = 1, AngleDegrees = 180 },
+            new() { Name = "o2", OffsetXMicrometers = 10, OffsetYMicrometers = 1, AngleDegrees = 0 },
+        }
+    };
+
+    /// <summary>
+    /// Writes a real user-PDK file for <paramref name="processName"/> containing the sample
+    /// component (exactly as <see cref="UserPdkStore"/> does at runtime) and returns its
+    /// on-disk path plus the PDK display name the store assigned it.
+    /// </summary>
+    private (string filePath, string pdkName, PdkComponentDraft draft) SaveUserPdk(string processName)
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"lunima-lp-nc-{Guid.NewGuid():N}");
+        _tempDirs.Add(root);
+        var store = new UserPdkStore(root, new PdkJsonSaver(), new PdkLoader());
+        var process = new ProcessDefinition { Name = processName };
+        var draft = SampleDraft();
+        var path = store.Save(process, draft, "gdsfactory", null);
+        var pdkName = new PdkLoader().LoadFromFileForEditing(path).Name;
+        return (path, pdkName, draft);
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs.Where(Directory.Exists))
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
     }
 
     [Fact]
@@ -52,5 +94,42 @@ public class LeftPanelNewComponentTests
 
         vm.AllTemplates.Count.ShouldBe(before + 1);
         vm.AllTemplates.ShouldContain(t => t.Name == "My Coupler");
+    }
+
+    [Fact]
+    public void RegisterSavedCustomComponent_forNonActiveProcess_isHiddenWhileProcessLocked()
+    {
+        var vm = CreateLeftPanelViewModel();
+        var (filePath, pdkName, draft) = SaveUserPdk("OtherProc");
+
+        // A different process is active and locked — its member set does NOT include the
+        // user PDK we are about to save.
+        vm.ApplyActiveProcess(new ActiveProcessSelection(
+            DisplayName: "Active Process", Fingerprint: null,
+            MemberPdkNames: new List<string> { "Some Foundry PDK" }, IsPlayground: false));
+
+        vm.RegisterSavedCustomComponent(draft, pdkName, filePath);
+
+        // Added to the catalog, but the active-process lock must keep it out of the visible list
+        // (issue #570): a component saved for a non-active process cannot leak into the library.
+        vm.AllTemplates.ShouldContain(t => t.Name == "My Coupler");
+        vm.FilteredTemplates.ShouldNotContain(t => t.Name == "My Coupler");
+    }
+
+    [Fact]
+    public void RegisterSavedCustomComponent_forActiveProcess_appearsImmediately()
+    {
+        var vm = CreateLeftPanelViewModel();
+        var (filePath, pdkName, draft) = SaveUserPdk("ActiveProc");
+
+        // The active process's member set includes this user PDK, so its component must show up
+        // right away — no manual re-enable needed.
+        vm.ApplyActiveProcess(new ActiveProcessSelection(
+            DisplayName: "Active Process", Fingerprint: null,
+            MemberPdkNames: new List<string> { pdkName }, IsPlayground: false));
+
+        vm.RegisterSavedCustomComponent(draft, pdkName, filePath);
+
+        vm.FilteredTemplates.ShouldContain(t => t.Name == "My Coupler");
     }
 }

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
@@ -121,5 +121,14 @@ public class NewComponentViewModelTests : IDisposable
         vm.SavedDraft.ShouldBeNull();
     }
 
+    [Fact]
+    public void Only_GdsFactory_backend_is_selectable_in_v1()
+    {
+        // v1 scope: nazca custom components need NazcaOriginOffset derivation (v2), so the UI
+        // must offer gdsfactory only. The enum + extractor's nazca branch remain for tests/v2.
+        NewComponentViewModel.AvailableBackends.ShouldHaveSingleItem();
+        NewComponentViewModel.AvailableBackends[0].ShouldBe(GeometryBackend.GdsFactory);
+    }
+
     public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
 }

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
@@ -100,5 +100,26 @@ public class NewComponentViewModelTests : IDisposable
         vm.SavedDraft.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task Changing_the_geometry_after_preview_invalidates_it_and_blocks_save()
+    {
+        var (vm, _) = Build(withFdtd: false);
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        vm.HasPreview.ShouldBeTrue();
+        vm.SaveCommand.CanExecute(null).ShouldBeTrue();
+
+        // Edit the function reference without re-previewing: the rendered geometry no longer
+        // matches what would be saved, so Save must become impossible (drift guard, #656 review).
+        vm.Function = "mmi1x2";
+
+        vm.HasPreview.ShouldBeFalse();
+        vm.SaveCommand.CanExecute(null).ShouldBeFalse();
+
+        // Even if the command body is invoked directly (bypassing CanExecute), the cleared
+        // preview makes Save bail out — no mixed-geometry draft is ever persisted.
+        await vm.SaveCommand.ExecuteAsync(null);
+        vm.SavedDraft.ShouldBeNull();
+    }
+
     public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
 }

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="NewComponentViewModel"/>: geometry preview + optional FDTD S-matrix
+/// recompute + save into a process's user PDK, with a hard rule that a missing or failed
+/// FDTD run always saves as a black box, never a fabricated S-matrix.
+/// </summary>
+public class NewComponentViewModelTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-nc-vm-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 10, YMax = 2,
+        Polygons = new List<NazcaPreviewPolygon> { new() { Layer = 1, Vertices = new List<(double, double)> { (0, 0), (10, 0), (10, 2), (0, 2) } } },
+        Pins = new List<NazcaPreviewPin> { new() { Name = "o1", X = 0, Y = 1, Angle = 180 }, new() { Name = "o2", X = 10, Y = 1, Angle = 0 } }
+    };
+
+    private (NewComponentViewModel vm, Mock<IFdtdSMatrixService> fdtd) Build(bool withFdtd = true)
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var fdtd = new Mock<IFdtdSMatrixService>();
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var vm = new NewComponentViewModel(extractor, withFdtd ? fdtd.Object : null, store,
+            new List<ProcessDefinition> { new() { Name = "P" } });
+        vm.ComponentName = "My Comp";
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+        vm.Module = "cspdk.sin300"; vm.Function = "coupler";
+        vm.SelectedProcess = vm.Processes[0];
+        return (vm, fdtd);
+    }
+
+    [Fact]
+    public async Task Save_without_fdtd_writes_a_black_box_component()
+    {
+        var (vm, _) = Build(withFdtd: false);
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.SavedDraft.ShouldNotBeNull();
+        vm.SavedDraft!.SMatrix.ShouldBeNull();      // black box, no invented physics
+        vm.SavedDraft.Pins.Count.ShouldBe(2);
+        vm.SavedDraft.GdsFactoryFunction.ShouldBe("cspdk.sin300.coupler");
+    }
+
+    [Fact]
+    public async Task ComputeSMatrix_failure_does_not_produce_a_model()
+    {
+        var (vm, fdtd) = Build();
+        fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FdtdAvailability.Available(""));
+        fdtd.Setup(f => f.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FdtdSMatrixResult.Fail("solver blew up"));
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.ComputeSMatrixCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.StatusText.ShouldContain("solver blew up");
+        vm.SavedDraft!.SMatrix.ShouldBeNull();       // failed FDTD => still no model, never fake
+    }
+
+    [Fact]
+    public async Task Save_requires_a_name()
+    {
+        var (vm, _) = Build(withFdtd: false);
+        vm.ComponentName = "   ";
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+        vm.SavedDraft.ShouldBeNull();
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
@@ -80,6 +80,17 @@ public class NewComponentViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task Save_without_fdtd_reports_a_confirmation()
+    {
+        var (vm, _) = Build(withFdtd: false);
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.SavedDraft.ShouldNotBeNull();
+        vm.StatusText.ShouldContain("Saved");   // black-box save still confirms
+    }
+
+    [Fact]
     public async Task Save_requires_a_name()
     {
         var (vm, _) = Build(withFdtd: false);

--- a/UnitTests/Components/AddCustomComponent/PreviewFdtdRequestTests.cs
+++ b/UnitTests/Components/AddCustomComponent/PreviewFdtdRequestTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Verifies <see cref="ComponentFdtdRequestFactory.BuildFromPreview"/> builds a
+/// complete FDTD request straight from a <see cref="NazcaPreviewResult"/>, without
+/// re-rendering — the flow used by the "own component" custom-PDK path, which
+/// already has a preview render in hand.
+/// </summary>
+public class PreviewFdtdRequestTests
+{
+    private static NazcaPreviewResult TwoPortPreview() => new()
+    {
+        Success = true,
+        XMin = 0, YMin = 0, XMax = 10, YMax = 2,
+        Polygons = new List<NazcaPreviewPolygon>
+        {
+            new() { Layer = 1, Vertices = new List<(double X, double Y)> { (0, 0), (10, 0), (10, 2), (0, 2) } },
+        },
+        Pins = new List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 1, Angle = 180 },
+            new() { Name = "o2", X = 10, Y = 1, Angle = 0 },
+        },
+    };
+
+    [Fact]
+    public void BuildFromPreview_keeps_layer1_polygons_and_named_ports()
+    {
+        var req = ComponentFdtdRequestFactory.BuildFromPreview(TwoPortPreview(), new[] { "o1", "o2" });
+
+        req.Polygons.Count.ShouldBe(1);
+        req.Ports.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void BuildFromPreview_maps_port_names_positions_and_orientation()
+    {
+        var req = ComponentFdtdRequestFactory.BuildFromPreview(TwoPortPreview(), new[] { "o1", "o2" });
+
+        req.Ports[0].Name.ShouldBe("o1");
+        req.Ports[0].X.ShouldBe(0);
+        req.Ports[0].Y.ShouldBe(1);
+        req.Ports[0].Orientation.ShouldBe(180);
+        req.Ports[1].Name.ShouldBe("o2");
+        req.Ports[1].X.ShouldBe(10);
+    }
+
+    [Fact]
+    public void BuildFromPreview_sets_layer_number_and_uses_2D()
+    {
+        var req = ComponentFdtdRequestFactory.BuildFromPreview(TwoPortPreview(), new[] { "o1", "o2" }, siliconLayer: 1);
+
+        req.LayerNumber.ShouldBe(1);
+        req.Is3D.ShouldBeFalse();
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/UserPdkStoreTests.cs
+++ b/UnitTests/Components/AddCustomComponent/UserPdkStoreTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Verifies <see cref="UserPdkStore"/>: user-authored components are persisted into a
+/// per-process, per-user file under a writable root — never into the bundled foundry
+/// PDK JSONs — with save-then-reload roundtripping and replace-not-duplicate semantics.
+/// </summary>
+public class UserPdkStoreTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-userpdk-" + Guid.NewGuid().ToString("N"));
+
+    private UserPdkStore CreateStore() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    private static ProcessDefinition Process(string name) => new() { Name = name };
+
+    // Width/height and two pins are required: PdkLoader.LoadFromFileForEditing still
+    // structurally validates components (name/dimensions/pins) even though it tolerates
+    // a missing NazcaOriginOffset. GdsFactoryFunction marks this as a gdsfactory-backend
+    // component, exempt from the Nazca-only origin-offset requirement.
+    private static PdkComponentDraft Comp(string name) => new()
+    {
+        Name = name,
+        GdsFactoryFunction = "cspdk.sin300.coupler",
+        WidthMicrometers = 10,
+        HeightMicrometers = 5,
+        Pins = new List<PhysicalPinDraft>
+        {
+            new() { Name = "in0", OffsetXMicrometers = 0, OffsetYMicrometers = 2.5, AngleDegrees = 180 },
+            new() { Name = "out0", OffsetXMicrometers = 10, OffsetYMicrometers = 2.5, AngleDegrees = 0 }
+        }
+    };
+
+    [Fact]
+    public void ResolvePath_is_under_user_root_and_slugified()
+    {
+        var store = CreateStore();
+        var path = store.ResolvePath(Process("CornerStone SiN 300"));
+
+        path.ShouldStartWith(_root);
+        Path.GetFileName(path).ShouldBe("cornerstone-sin-300.json");
+    }
+
+    [Fact]
+    public void Save_creates_file_and_roundtrips_the_component()
+    {
+        var store = CreateStore();
+        var path = store.Save(Process("CornerStone SiN 300"), Comp("My Coupler"), backend: "gdsfactory", routingCrossSection: "xs_nc");
+
+        File.Exists(path).ShouldBeTrue();
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+        reloaded.Components.ShouldContain(c => c.Name == "My Coupler");
+        reloaded.Process!.Name.ShouldBe("CornerStone SiN 300");
+        reloaded.Backend.ShouldBe("gdsfactory");
+    }
+
+    [Fact]
+    public void Save_twice_same_name_replaces_not_duplicates()
+    {
+        var store = CreateStore();
+        store.Save(Process("P"), Comp("X"), "gdsfactory", null);
+        var path = store.Save(Process("P"), Comp("X"), "gdsfactory", null);
+
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+        reloaded.Components.FindAll(c => c.Name == "X").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ComponentExists_reflects_saved_state()
+    {
+        var store = CreateStore();
+        store.ComponentExists(Process("P"), "X").ShouldBeFalse();
+        store.Save(Process("P"), Comp("X"), "gdsfactory", null);
+        store.ComponentExists(Process("P"), "X").ShouldBeTrue();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, true);
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-07-09-add-custom-component-pdk.md
+++ b/docs/superpowers/plans/2026-07-09-add-custom-component-pdk.md
@@ -1,0 +1,1008 @@
+# Bring-your-own-Component → eigenes PDK (v1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ein „+ Neue Komponente"-Fenster in der PDK-Library, mit dem Nutzer eine eigene Komponente über eine gdsfactory-/nazca-Funktionsreferenz anlegen, ihre S-Matrix mit dem vorhandenen FDTD/Meep-Solver berechnen (oder als Blackbox/2-Port-Ideal speichern) und in ein automatisch angelegtes User-PDK pro Prozess ablegen.
+
+**Architecture:** Neuer Vertical Slice `AddCustomComponent`. Reine Persistenz (`UserPdkStore`) liegt in CAP-DataAccess; UI-koordinierende Services (`ComponentGeometryExtractor`, `FdtdSMatrixToDraftConverter`) und das ViewModel/Fenster in CAP.Avalonia. Wiederverwendet die bestehende FDTD-Pipeline (`IFdtdSMatrixService`, `FdtdSMatrixConverter`), die Preview-Services (`NazcaComponentPreviewService`, `GdsFactoryComponentPreviewService`), `OverridePinMapper`, `PdkJsonSaver`/`PdkLoader`, `PdkTemplateConverter` und die `LeftPanelViewModel`-Library.
+
+**Tech Stack:** C# / .NET 10 / Avalonia 11 / CommunityToolkit.Mvvm; xUnit + Shouldly + Moq; Python-Subprozess-Preview + Docker-Meep-FDTD (beide bereits vorhanden).
+
+## Global Constraints
+
+- Keine erfundene Physik: S-Matrix nur aus FDTD-Meep (real), Blackbox (leer), oder verlustfreiem 2-Port-Ideal. Nie erfundene Werte; FDTD-Fehler → nichts speichern.
+- Cross-Platform-Parität: Pfade via `Path.Combine` + `Environment.GetFolderPath(SpecialFolder.LocalApplicationData)`; keine Drive-Letter/`\`-Literale. Kein direkter `Process.Start` (nur die vorhandenen Abstraktionen). Maschinennahe Strings (Slug, JSON) mit `CultureInfo.InvariantCulture`.
+- Gebündelte Foundry-JSONs (`CAP-DataAccess/PDKs/*.json`) werden NIE geschrieben. User-PDKs liegen ausschließlich unter `%LOCALAPPDATA%/Lunima/user-pdks/`.
+- Max. 250 Zeilen pro NEUER Datei. XML-Doku auf public members. `[ObservableProperty]`/`[RelayCommand]` im ViewModel. Neuer Service in DI via Feature-Extension in `CAP.Avalonia/DI/`, aufgerufen aus `App.axaml.cs`.
+- Tests deterministisch; plattform-spezifische Pfad-Assertions mit `OperatingSystem.IsX()` guarden (Linux-CI grün). Preview-/FDTD-Subprozesse in Unit-Tests immer mocken.
+- Vertical-Slice-Import-Regeln (CLAUDE.md): der Slice importiert nur eigene Namespaces, den Shared-Kernel und Framework-Namespaces.
+
+## File Structure
+
+- `CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs` — Auflösung des User-PDK-Pfads pro Prozess; Laden-oder-Anlegen, Komponente hinzufügen/ersetzen, Speichern.
+- `CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs` — Wertobjekt (Backend, Modul, Funktion, Parameter) + Erzeugung des gdsfactory-Rawcode-Wrappers.
+- `CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs` — rendert eine Referenz über den passenden Preview-Service → bbox + Pins + rohes `NazcaPreviewResult`.
+- `CAP.Avalonia/Services/AddCustomComponent/FdtdSMatrixToDraftConverter.cs` — `ComponentSMatrixData` → `PdkSMatrixDraft`; Blackbox → null; 2-Port-Ideal → verlustfreies Pass-through.
+- `CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs` (MODIFY) — die private Polygon-/Port-Baulogik in eine statische `BuildFromPreview(...)` herauslösen, damit der neue Flow denselben Code nutzt.
+- `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs` — Orchestrierung (Name/Backend/Referenz/Prozess/Preview/FDTD/Speichern).
+- `CAP.Avalonia/Views/NewComponentWindow.axaml` (+ `.axaml.cs`) — das Fenster.
+- `CAP.Avalonia/DI/AddCustomComponentFeature.cs` — DI-Extension.
+- `CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs` (MODIFY) — `[RelayCommand] OpenNewComponent` + Registrierung des gespeicherten Drafts in `AllTemplates`.
+- `CAP.Avalonia/Views/MainWindow.axaml` (MODIFY) — „+"-Button an der Komponenten-Library.
+- `CAP.Avalonia/App.axaml.cs` (MODIFY) — `services.AddAddCustomComponentFeature();`
+- Tests unter `UnitTests/Components/AddCustomComponent/` und `UnitTests/Architecture/`.
+
+---
+
+### Task 1: `UserPdkStore` (Persistenz pro Prozess)
+
+**Files:**
+- Create: `CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs`
+- Test: `UnitTests/Components/AddCustomComponent/UserPdkStoreTests.cs`
+
+**Interfaces:**
+- Consumes: `PdkJsonSaver.SaveToFile(PdkDraft pdk, string filePath) : void`; `PdkLoader.LoadFromFileForEditing(string) : PdkDraft`; DTOs `PdkDraft` (Props: `Name`, `Foundry`, `Backend`, `Process`, `GdsFactoryRoutingCrossSection`, `Components`), `PdkComponentDraft` (Prop `Name`), `ProcessDefinition` (Prop `Name`).
+- Produces:
+  - `UserPdkStore(string userPdkRootDirectory, PdkJsonSaver saver, PdkLoader loader)`
+  - `static UserPdkStore CreateDefault()` — root = `%LOCALAPPDATA%/Lunima/user-pdks`
+  - `string ResolvePath(ProcessDefinition process) : string`
+  - `bool ComponentExists(ProcessDefinition process, string componentName) : bool`
+  - `string Save(ProcessDefinition process, PdkComponentDraft component, string backend, string? routingCrossSection) : string` — legt an/lädt, ersetzt-oder-fügt-hinzu (Name-Match, Ordinal-IgnoreCase), speichert, gibt den Pfad zurück.
+
+- [ ] **Step 1: Read the real signatures**
+
+Lies vor dem Schreiben:
+- `CAP-DataAccess/Components/ComponentDraftMapper/PdkJsonSaver.cs` (Methode `SaveToFile`).
+- `CAP-DataAccess/Components/ComponentDraftMapper/PdkLoader.cs` (`LoadFromFileForEditing`, ctor — ist er parameterlos?).
+- `CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs` (exakte Property-Namen von `PdkDraft`, `PdkComponentDraft`, `ProcessDefinition`).
+Verwende die tatsächlichen Namen; unten stehende sind aus der Inventur, aber verifiziere sie.
+
+- [ ] **Step 2: Write the failing tests**
+
+```csharp
+using System;
+using System.IO;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class UserPdkStoreTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-userpdk-" + Guid.NewGuid().ToString("N"));
+    private UserPdkStore CreateStore() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    private static ProcessDefinition Process(string name) => new() { Name = name };
+    private static PdkComponentDraft Comp(string name) => new() { Name = name, GdsFactoryFunction = "cspdk.sin300.coupler" };
+
+    [Fact]
+    public void ResolvePath_is_under_user_root_and_slugified()
+    {
+        var store = CreateStore();
+        var path = store.ResolvePath(Process("CornerStone SiN 300"));
+        path.ShouldStartWith(_root);
+        Path.GetFileName(path).ShouldBe("cornerstone-sin-300.json");
+    }
+
+    [Fact]
+    public void Save_creates_file_and_roundtrips_the_component()
+    {
+        var store = CreateStore();
+        var path = store.Save(Process("CornerStone SiN 300"), Comp("My Coupler"), backend: "gdsfactory", routingCrossSection: "xs_nc");
+
+        File.Exists(path).ShouldBeTrue();
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+        reloaded.Components.ShouldContain(c => c.Name == "My Coupler");
+        reloaded.Process!.Name.ShouldBe("CornerStone SiN 300");
+        reloaded.Backend.ShouldBe("gdsfactory");
+    }
+
+    [Fact]
+    public void Save_twice_same_name_replaces_not_duplicates()
+    {
+        var store = CreateStore();
+        store.Save(Process("P"), Comp("X"), "gdsfactory", null);
+        var path = store.Save(Process("P"), Comp("X"), "gdsfactory", null);
+
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+        reloaded.Components.FindAll(c => c.Name == "X").Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ComponentExists_reflects_saved_state()
+    {
+        var store = CreateStore();
+        store.ComponentExists(Process("P"), "X").ShouldBeFalse();
+        store.Save(Process("P"), Comp("X"), "gdsfactory", null);
+        store.ComponentExists(Process("P"), "X").ShouldBeTrue();
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" UserPdkStore`
+Expected: FAIL (Typ `UserPdkStore` existiert nicht).
+
+- [ ] **Step 4: Implement `UserPdkStore`**
+
+```csharp
+using System.Globalization;
+using System.Text.RegularExpressions;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP_DataAccess.Components.AddCustomComponent;
+
+/// <summary>
+/// Persists user-authored components into a writable, per-process user PDK file under
+/// the user's local app-data directory. Never touches the bundled foundry PDK JSONs.
+/// One PDK file per fabrication process (the S-matrix is process-specific, #570).
+/// </summary>
+public sealed class UserPdkStore
+{
+    private readonly string _root;
+    private readonly PdkJsonSaver _saver;
+    private readonly PdkLoader _loader;
+
+    /// <summary>Creates a store rooted at an explicit directory (used by tests).</summary>
+    public UserPdkStore(string userPdkRootDirectory, PdkJsonSaver saver, PdkLoader loader)
+    {
+        _root = userPdkRootDirectory;
+        _saver = saver;
+        _loader = loader;
+    }
+
+    /// <summary>Creates a store rooted at %LOCALAPPDATA%/Lunima/user-pdks.</summary>
+    public static UserPdkStore CreateDefault() => new(
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Lunima", "user-pdks"),
+        new PdkJsonSaver(), new PdkLoader());
+
+    /// <summary>The user-PDK file path for a process (creates no file).</summary>
+    public string ResolvePath(ProcessDefinition process) =>
+        Path.Combine(_root, Slug(process.Name) + ".json");
+
+    /// <summary>True when a component of that name is already stored for the process.</summary>
+    public bool ComponentExists(ProcessDefinition process, string componentName)
+    {
+        var path = ResolvePath(process);
+        if (!File.Exists(path)) return false;
+        var pdk = _loader.LoadFromFileForEditing(path);
+        return pdk.Components.Exists(c => string.Equals(c.Name, componentName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Adds or replaces (by name, case-insensitive) the component in the process's user PDK,
+    /// creating the PDK file on first use. Returns the file path written.
+    /// </summary>
+    public string Save(ProcessDefinition process, PdkComponentDraft component, string backend, string? routingCrossSection)
+    {
+        var path = ResolvePath(process);
+        Directory.CreateDirectory(_root);
+
+        var pdk = File.Exists(path) ? _loader.LoadFromFileForEditing(path) : NewPdk(process, backend, routingCrossSection);
+        pdk.Components.RemoveAll(c => string.Equals(c.Name, component.Name, StringComparison.OrdinalIgnoreCase));
+        pdk.Components.Add(component);
+
+        _saver.SaveToFile(pdk, path);
+        return path;
+    }
+
+    private static PdkDraft NewPdk(ProcessDefinition process, string backend, string? routingCrossSection) => new()
+    {
+        Name = $"My {process.Name} Components",
+        Foundry = process.Foundry,
+        Backend = backend,
+        Process = process,
+        GdsFactoryRoutingCrossSection = routingCrossSection,
+        Components = new()
+    };
+
+    private static string Slug(string name)
+    {
+        var lower = (name ?? string.Empty).ToLower(CultureInfo.InvariantCulture);
+        var slug = Regex.Replace(lower, "[^a-z0-9]+", "-").Trim('-');
+        return slug.Length == 0 ? "custom" : slug;
+    }
+}
+```
+
+Falls `PdkLoader` keinen parameterlosen ctor hat, passe die Tests + `CreateDefault` an den echten ctor an (Step 1 hat ihn ermittelt). Falls `ProcessDefinition.Foundry` nicht existiert, lasse `Foundry` weg.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" UserPdkStore`
+Expected: PASS (4/4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs UnitTests/Components/AddCustomComponent/UserPdkStoreTests.cs
+git commit -m "(+) UserPdkStore: per-process, writable user PDK persistence (never touches foundry JSONs)"
+```
+
+---
+
+### Task 2: `FdtdSMatrixToDraftConverter` (ehrliche S-Matrix → Draft)
+
+**Files:**
+- Create: `CAP.Avalonia/Services/AddCustomComponent/FdtdSMatrixToDraftConverter.cs`
+- Test: `UnitTests/Components/AddCustomComponent/FdtdSMatrixToDraftConverterTests.cs`
+
+**Interfaces:**
+- Consumes: `ComponentSMatrixData` (`Dictionary<string,SMatrixWavelengthEntry> Wavelengths`, `string? SourceNote`), `SMatrixWavelengthEntry` (`int Rows`, `int Cols`, `List<double> Real`, `List<double> Imag`, `List<string>? PortNames`). Ziel-DTO `PdkSMatrixDraft` (`int WavelengthNm`, `List<SMatrixConnection> Connections`, `List<WavelengthSMatrixEntry>? WavelengthData`) und `WavelengthSMatrixEntry`.
+- Produces:
+  - `static PdkSMatrixDraft? FromFdtd(ComponentSMatrixData data)` — null bei leeren Wavelengths.
+  - `static PdkSMatrixDraft? BlackBox()` — gibt `null` zurück (kein Modell → Draft-Feld `SMatrix` bleibt null).
+  - `static PdkSMatrixDraft LosslessTwoPort(string inPin, string outPin, int wavelengthNm)` — Betrag 1, Phase 0 in beide Richtungen.
+
+- [ ] **Step 1: Read the real signatures**
+
+Lies `CAP-DataAccess/Persistence/PIR/ComponentSMatrixData.cs`, `CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs` (Typen `PdkSMatrixDraft`, `SMatrixConnection`, `WavelengthSMatrixEntry`). Bestätige die exakte Form von `WavelengthSMatrixEntry` (Feldnamen für Wellenlänge/Real/Imag/Ports) und `SMatrixConnection` (`FromPin`, `ToPin`, `Magnitude`, `PhaseDegrees`).
+
+- [ ] **Step 2: Write the failing tests**
+
+```csharp
+using System.Collections.Generic;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class FdtdSMatrixToDraftConverterTests
+{
+    [Fact]
+    public void FromFdtd_maps_each_wavelength_entry()
+    {
+        var data = new ComponentSMatrixData
+        {
+            SourceNote = "FDTD Meep 2D",
+            Wavelengths = new()
+            {
+                ["1550"] = new SMatrixWavelengthEntry
+                {
+                    Rows = 2, Cols = 2,
+                    Real = new() { 0, 1, 1, 0 },
+                    Imag = new() { 0, 0, 0, 0 },
+                    PortNames = new() { "o1", "o2" }
+                }
+            }
+        };
+
+        var draft = FdtdSMatrixToDraftConverter.FromFdtd(data);
+
+        draft.ShouldNotBeNull();
+        draft!.WavelengthData!.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void FromFdtd_returns_null_when_no_wavelengths()
+    {
+        var data = new ComponentSMatrixData { Wavelengths = new() };
+        FdtdSMatrixToDraftConverter.FromFdtd(data).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BlackBox_is_null_so_the_component_has_no_model()
+    {
+        FdtdSMatrixToDraftConverter.BlackBox().ShouldBeNull();
+    }
+
+    [Fact]
+    public void LosslessTwoPort_is_unit_magnitude_both_directions()
+    {
+        var draft = FdtdSMatrixToDraftConverter.LosslessTwoPort("o1", "o2", 1550);
+        draft.Connections.Count.ShouldBe(2);
+        draft.Connections.ShouldContain(c => c.FromPin == "o1" && c.ToPin == "o2" && c.Magnitude == 1.0);
+        draft.Connections.ShouldContain(c => c.FromPin == "o2" && c.ToPin == "o1" && c.Magnitude == 1.0);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" FdtdSMatrixToDraftConverter`
+Expected: FAIL (Typ existiert nicht).
+
+- [ ] **Step 4: Implement the converter**
+
+Mappe jeden `ComponentSMatrixData.Wavelengths`-Eintrag (Key = nm-String) auf einen `WavelengthSMatrixEntry` des Drafts. Übertrage `Rows/Cols/Real/Imag/PortNames` 1:1 in die Feldnamen, die Step 1 ermittelt hat. Beispiel-Skelett (Feldnamen ggf. anpassen):
+
+```csharp
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CAP_DataAccess.Persistence.PIR;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Converts an FDTD-computed <see cref="ComponentSMatrixData"/> into the PDK draft's
+/// <see cref="PdkSMatrixDraft"/>, and provides the two honest no-FDTD fallbacks:
+/// a black-box (no model) and a lossless two-port pass-through. Never fabricates values.
+/// </summary>
+public static class FdtdSMatrixToDraftConverter
+{
+    /// <summary>Multi-wavelength draft from FDTD output; null if there is no data.</summary>
+    public static PdkSMatrixDraft? FromFdtd(ComponentSMatrixData data)
+    {
+        if (data.Wavelengths == null || data.Wavelengths.Count == 0)
+            return null;
+
+        var entries = new List<WavelengthSMatrixEntry>();
+        foreach (var kv in data.Wavelengths)
+        {
+            int nm = int.Parse(kv.Key, CultureInfo.InvariantCulture);
+            entries.Add(new WavelengthSMatrixEntry
+            {
+                // Map to the real field names verified in Step 1:
+                WavelengthNm = nm,
+                Rows = kv.Value.Rows,
+                Cols = kv.Value.Cols,
+                Real = kv.Value.Real,
+                Imag = kv.Value.Imag,
+                PortNames = kv.Value.PortNames
+            });
+        }
+
+        int firstNm = entries[0].WavelengthNm;
+        return new PdkSMatrixDraft { WavelengthNm = firstNm, WavelengthData = entries };
+    }
+
+    /// <summary>No simulation model — the draft's SMatrix stays null (black box).</summary>
+    public static PdkSMatrixDraft? BlackBox() => null;
+
+    /// <summary>The honest lossless two-port pass-through (routing components).</summary>
+    public static PdkSMatrixDraft LosslessTwoPort(string inPin, string outPin, int wavelengthNm) => new()
+    {
+        WavelengthNm = wavelengthNm,
+        Connections = new()
+        {
+            new SMatrixConnection { FromPin = inPin, ToPin = outPin, Magnitude = 1.0, PhaseDegrees = 0.0 },
+            new SMatrixConnection { FromPin = outPin, ToPin = inPin, Magnitude = 1.0, PhaseDegrees = 0.0 },
+        }
+    };
+}
+```
+
+Falls `WavelengthSMatrixEntry` andere Feldnamen hat (z.B. `Wavelength` in µm statt `WavelengthNm`), passe Mapping + Test an die echten Namen an.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" FdtdSMatrixToDraftConverter`
+Expected: PASS (4/4).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CAP.Avalonia/Services/AddCustomComponent/FdtdSMatrixToDraftConverter.cs UnitTests/Components/AddCustomComponent/FdtdSMatrixToDraftConverterTests.cs
+git commit -m "(+) FdtdSMatrixToDraftConverter: FDTD result / black-box / lossless-2-port -> PdkSMatrixDraft"
+```
+
+---
+
+### Task 3: FDTD-Request aus einem Preview-Ergebnis (DRY-Refactor)
+
+**Files:**
+- Modify: `CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs`
+- Test: `UnitTests/Components/AddCustomComponent/PreviewFdtdRequestTests.cs`
+
+**Interfaces:**
+- Consumes: `NazcaPreviewResult` (`IReadOnlyList<NazcaPreviewPolygon> Polygons` mit `int Layer` + `Vertices`; `IReadOnlyList<NazcaPreviewPin> Pins` mit `Name`), `FdtdSMatrixRequest`, `FdtdPolygon`, `FdtdPort`.
+- Produces (neue statische Methode auf `ComponentFdtdRequestFactory`):
+  - `public static FdtdSMatrixRequest BuildFromPreview(NazcaPreviewResult preview, IReadOnlyList<string> portNames, int siliconLayer = 1, double portWidthUm = 0.5)`
+
+**Rationale:** `ComponentFdtdRequestFactory.BuildAsync` besitzt private `BuildPolygons`/`BuildPorts`. Der neue Flow hat bereits ein `NazcaPreviewResult` (aus dem Preview-Render) und darf nicht doppelt rendern. Wir heben die Polygon-/Port-Erzeugung in eine statische, wiederverwendbare Methode und lassen `BuildAsync` sie aufrufen (DRY).
+
+- [ ] **Step 1: Read the current factory**
+
+Lies `CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs` vollständig — insbesondere `BuildPolygons` (Layer-Filter auf `siliconLayer`) und `BuildPorts` (Index-Matching Pin-Namen). Lies `CAP_Core/Solvers/Fdtd/FdtdSMatrixRequest.cs` für die exakte Form von `FdtdPolygon`/`FdtdPort`.
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class PreviewFdtdRequestTests
+{
+    private static NazcaPreviewResult TwoPortPreview() => new()
+    {
+        Success = true,
+        XMin = 0, YMin = 0, XMax = 10, YMax = 2,
+        Polygons = new List<NazcaPreviewPolygon>
+        {
+            new() { Layer = 1, Vertices = new List<(double X, double Y)> { (0,0),(10,0),(10,2),(0,2) } }
+        },
+        Pins = new List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 1, Angle = 180 },
+            new() { Name = "o2", X = 10, Y = 1, Angle = 0 },
+        }
+    };
+
+    [Fact]
+    public void BuildFromPreview_keeps_layer1_polygons_and_named_ports()
+    {
+        var req = ComponentFdtdRequestFactory.BuildFromPreview(TwoPortPreview(), new[] { "o1", "o2" });
+        req.Polygons.Count.ShouldBe(1);
+        req.Ports.Count.ShouldBe(2);
+    }
+}
+```
+
+Passe die Konstruktion von `NazcaPreviewResult`/`NazcaPreviewPolygon`/`NazcaPreviewPin` an deren echte (evtl. `init`-only) Member an (aus Step 1).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" PreviewFdtdRequest`
+Expected: FAIL (`BuildFromPreview` existiert nicht).
+
+- [ ] **Step 4: Refactor — extract `BuildFromPreview`**
+
+Verschiebe die Logik aus den privaten `BuildPolygons`/`BuildPorts` in eine neue statische `BuildFromPreview(NazcaPreviewResult preview, IReadOnlyList<string> portNames, int siliconLayer = 1, double portWidthUm = 0.5)`, die einen vollständigen `FdtdSMatrixRequest` zurückgibt (Polygone gefiltert auf `siliconLayer`, Ports index-gematcht auf `portNames`, `LayerNumber = siliconLayer`, `Is3D = false`, restliche Defaults wie bisher). Lasse die bestehende `BuildAsync` diese Methode aufrufen (mit `component.PhysicalPins.Select(p => p.Name)` als `portNames`), sodass sich das bisherige Verhalten nicht ändert. XML-Doku auf die neue public-Methode.
+
+- [ ] **Step 5: Run the focused test AND the existing factory tests**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" PreviewFdtdRequest`
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" ComponentFdtdRequestFactory`
+Expected: beide PASS (bestehendes Verhalten unverändert).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CAP.Avalonia/Services/Solvers/ComponentFdtdRequestFactory.cs UnitTests/Components/AddCustomComponent/PreviewFdtdRequestTests.cs
+git commit -m "(~) ComponentFdtdRequestFactory: extract reusable BuildFromPreview(NazcaPreviewResult, portNames)"
+```
+
+---
+
+### Task 4: `GeometryReference` + `ComponentGeometryExtractor`
+
+**Files:**
+- Create: `CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs`
+- Create: `CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs`
+- Test: `UnitTests/Components/AddCustomComponent/ComponentGeometryExtractorTests.cs`
+
+**Interfaces:**
+- Consumes: `NazcaComponentPreviewService.RenderAsync(string? module, string func, string? parameters, CancellationToken) : Task<NazcaPreviewResult>` und `.RenderRawCodeAsync(string code, CancellationToken) : Task<NazcaPreviewResult>`; `GdsFactoryComponentPreviewService` (Subtyp, für gdsfactory); `OverridePinMapper.BuildOverridePins(NazcaPreviewResult) : List<OverridePinData>`; `NazcaPreviewResult` (`Success`, `Error`, `XMin/YMin/XMax/YMax`, `Pins`).
+- Produces:
+  - `enum GeometryBackend { Nazca, GdsFactory }`
+  - `record GeometryReference(GeometryBackend Backend, string? Module, string Function, string? Parameters)` mit `string ToGdsFactoryRawCode()`.
+  - `record GeometryExtractResult(bool Success, string? Error, double WidthUm, double HeightUm, IReadOnlyList<OverridePinData> Pins, NazcaPreviewResult Raw)`
+  - `ComponentGeometryExtractor(NazcaComponentPreviewService nazcaPreview, GdsFactoryComponentPreviewService gdsFactoryPreview)`
+  - `Task<GeometryExtractResult> ExtractAsync(GeometryReference reference, CancellationToken ct = default)`
+
+- [ ] **Step 1: Read the real signatures**
+
+Lies `Connect-A-Pic-Core/Export/NazcaComponentPreviewService.cs` (`RenderAsync`, `RenderRawCodeAsync`, `NazcaPreviewResult`-Member) und `CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/OverridePinMapper.cs` (`BuildOverridePins`, `OverridePinData`-Member). Prüfe, ob `RenderAsync`/`RenderRawCodeAsync` `virtual` sind (für Moq) — laut Inventur ja (`public virtual`).
+
+- [ ] **Step 2: Write `GeometryReference` first (pure, unit-testable)**
+
+Erzeuge `GeometryReference.cs`:
+
+```csharp
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>Which geometry engine renders/exports a custom component.</summary>
+public enum GeometryBackend { Nazca, GdsFactory }
+
+/// <summary>
+/// A reference to a component-producing function in a Python module, e.g.
+/// module "cspdk.sin300", function "coupler". Parameters is an optional Python
+/// kwargs fragment (e.g. "length=10"). Renders in one of two ways depending on backend.
+/// </summary>
+public sealed record GeometryReference(GeometryBackend Backend, string? Module, string Function, string? Parameters)
+{
+    /// <summary>The fully-qualified call, e.g. "cspdk.sin300.coupler" or "coupler".</summary>
+    public string QualifiedFunction => string.IsNullOrWhiteSpace(Module) ? Function : $"{Module}.{Function}";
+
+    /// <summary>
+    /// Wraps the reference in a raw-code snippet the gdsfactory preview script understands:
+    /// it imports the module and assigns the built cell to a variable named `component`.
+    /// </summary>
+    public string ToGdsFactoryRawCode()
+    {
+        var import = string.IsNullOrWhiteSpace(Module) ? "import gdsfactory as gf" : $"import {Module}";
+        return $"{import}\ncomponent = {QualifiedFunction}({Parameters ?? string.Empty})";
+    }
+}
+```
+
+- [ ] **Step 3: Write the failing extractor tests**
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class ComponentGeometryExtractorTests
+{
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 12, YMax = 3,
+        Polygons = new System.Collections.Generic.List<NazcaPreviewPolygon>(),
+        Pins = new System.Collections.Generic.List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 1.5, Angle = 180 },
+            new() { Name = "o2", X = 12, Y = 1.5, Angle = 0 },
+        }
+    };
+
+    private static (Mock<NazcaComponentPreviewService> nazca, Mock<GdsFactoryComponentPreviewService> gds) Mocks()
+    {
+        // Both preview services take (pythonExecutable, scriptPath, timeout?, launchFactory?); Moq needs ctor args.
+        var nazca = new Mock<NazcaComponentPreviewService>("python", "render_component_preview.py", null, null) { CallBase = false };
+        var gds = new Mock<GdsFactoryComponentPreviewService>("python", "render_gdsfactory_preview.py", null, null) { CallBase = false };
+        return (nazca, gds);
+    }
+
+    [Fact]
+    public async Task GdsFactory_reference_renders_via_raw_code_wrapper()
+    {
+        var (nazca, gds) = Mocks();
+        gds.Setup(g => g.RenderRawCodeAsync(It.Is<string>(s => s.Contains("cspdk.sin300.coupler")), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var result = await extractor.ExtractAsync(
+            new GeometryReference(GeometryBackend.GdsFactory, "cspdk.sin300", "coupler", null));
+
+        result.Success.ShouldBeTrue();
+        result.WidthUm.ShouldBe(12);
+        result.HeightUm.ShouldBe(3);
+        result.Pins.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Nazca_reference_renders_via_module_function()
+    {
+        var (nazca, gds) = Mocks();
+        nazca.Setup(n => n.RenderAsync("mymod", "mycell", null, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var result = await extractor.ExtractAsync(
+            new GeometryReference(GeometryBackend.Nazca, "mymod", "mycell", null));
+
+        result.Success.ShouldBeTrue();
+        result.Pins.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task Failed_render_surfaces_error_and_no_pins()
+    {
+        var (nazca, gds) = Mocks();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(new NazcaPreviewResult { Success = false, Error = "boom" });
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var result = await extractor.ExtractAsync(
+            new GeometryReference(GeometryBackend.GdsFactory, "m", "f", null));
+
+        result.Success.ShouldBeFalse();
+        result.Error.ShouldBe("boom");
+    }
+}
+```
+
+Falls `NazcaComponentPreviewService`/`GdsFactoryComponentPreviewService` von Moq nicht mockbar sind (nicht-virtuelle Methoden oder `sealed`): `GdsFactoryComponentPreviewService` IST `sealed` — führe stattdessen ein schmales Interface `IComponentPreviewRenderer` mit `RenderAsync`/`RenderRawCodeAsync` ein, implementiert als dünner Adapter über die zwei Services, und injiziere zwei `IComponentPreviewRenderer` in den Extractor. Passe die Tests entsprechend an (Mock<IComponentPreviewRenderer>). Bevorzuge diesen Interface-Weg, wenn Moq an den konkreten Typen scheitert.
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" ComponentGeometryExtractor`
+Expected: FAIL.
+
+- [ ] **Step 5: Implement `ComponentGeometryExtractor`**
+
+```csharp
+using CAP.Avalonia.ViewModels.ComponentSettings.InstanceOverride;
+using CAP_Core.Export;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>Result of rendering a geometry reference: bounding-box size + extracted pins.</summary>
+public sealed record GeometryExtractResult(
+    bool Success, string? Error, double WidthUm, double HeightUm,
+    IReadOnlyList<OverridePinData> Pins, NazcaPreviewResult Raw);
+
+/// <summary>
+/// Renders a <see cref="GeometryReference"/> to geometry via the appropriate preview service
+/// (nazca in module mode, gdsfactory via a raw-code wrapper) and extracts the bounding-box
+/// size and physical pins — the same extraction the per-instance override "Apply" performs.
+/// </summary>
+public sealed class ComponentGeometryExtractor
+{
+    private readonly NazcaComponentPreviewService _nazca;
+    private readonly GdsFactoryComponentPreviewService _gdsFactory;
+
+    /// <summary>Creates the extractor from the two shared preview services.</summary>
+    public ComponentGeometryExtractor(NazcaComponentPreviewService nazcaPreview, GdsFactoryComponentPreviewService gdsFactoryPreview)
+    {
+        _nazca = nazcaPreview;
+        _gdsFactory = gdsFactoryPreview;
+    }
+
+    /// <summary>Renders the reference and extracts size + pins. On render failure, Success is false.</summary>
+    public async Task<GeometryExtractResult> ExtractAsync(GeometryReference reference, CancellationToken ct = default)
+    {
+        NazcaPreviewResult preview = reference.Backend == GeometryBackend.GdsFactory
+            ? await _gdsFactory.RenderRawCodeAsync(reference.ToGdsFactoryRawCode(), ct)
+            : await _nazca.RenderAsync(reference.Module, reference.Function, reference.Parameters, ct);
+
+        if (!preview.Success)
+            return new GeometryExtractResult(false, preview.Error, 0, 0, System.Array.Empty<OverridePinData>(), preview);
+
+        double width = preview.XMax - preview.XMin;
+        double height = preview.YMax - preview.YMin;
+        var pins = OverridePinMapper.BuildOverridePins(preview);
+        return new GeometryExtractResult(true, null, width, height, pins, preview);
+    }
+}
+```
+
+Wenn du in Step 3 den Interface-Weg gewählt hast, injiziere `IComponentPreviewRenderer nazca, IComponentPreviewRenderer gdsFactory` statt der konkreten Typen.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" ComponentGeometryExtractor`
+Expected: PASS (3/3).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs UnitTests/Components/AddCustomComponent/ComponentGeometryExtractorTests.cs
+git commit -m "(+) ComponentGeometryExtractor: render a gdsfactory/nazca function reference -> bbox + pins"
+```
+
+---
+
+### Task 5: `NewComponentViewModel` (Orchestrierung)
+
+**Files:**
+- Create: `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs`
+- Test: `UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `ComponentGeometryExtractor.ExtractAsync`; `IFdtdSMatrixService.CheckAvailabilityAsync`/`SolveAsync`; `ComponentFdtdRequestFactory.BuildFromPreview` (Task 3); `FdtdSMatrixConverter.ToComponentSMatrixData` (static); `FdtdSMatrixToDraftConverter` (Task 2); `UserPdkStore.Save`/`ComponentExists` (Task 1); DTOs `PdkComponentDraft`, `ProcessDefinition`, `PhysicalPinDraft`; `OverridePinData`.
+- Produces:
+  - `NewComponentViewModel(ComponentGeometryExtractor extractor, IFdtdSMatrixService? fdtd, UserPdkStore store, IReadOnlyList<ProcessDefinition> processes)`
+  - `[ObservableProperty]` : `ComponentName`, `SelectedBackend` (GeometryBackend), `Module`, `Function`, `Parameters`, `SelectedProcess` (ProcessDefinition?), `StatusText`, `IsBusy`, `HasPreview`.
+  - `[RelayCommand] RunPreview`, `[RelayCommand] ComputeSMatrix`, `[RelayCommand] Save`.
+  - `PdkComponentDraft? SavedDraft { get; }`, `string? SavedProcessName { get; }`, `event EventHandler? Saved;` — damit die LeftPanel-Integration (Task 6) das Ergebnis registriert. `Func<string, string, Task<bool>>? ConfirmOverwrite` für Kollisionsdialog.
+
+**Design notes (verhalten):**
+- `RunPreview`: ruft `ExtractAsync`; bei Erfolg setzt `HasPreview=true`, merkt sich `GeometryExtractResult`.
+- `ComputeSMatrix`: nur wenn `HasPreview` und `SelectedProcess != null`. Prüft `fdtd.CheckAvailabilityAsync`; baut `BuildFromPreview(raw, pins.Select(p=>p.Name))`; `SolveAsync`; bei `!Success` → `StatusText = Fehler`, KEINE S-Matrix (kein Save-taugliches Modell). Bei Erfolg → `ComponentSMatrixData` via `ToComponentSMatrixData`, gemerkt als `_computedModel`.
+- `Save`: erfordert Name + Prozess + Preview. Baut `PdkComponentDraft` (Name, `GdsFactoryFunction`=QualifiedFunction wenn gdsfactory, sonst `NazcaFunction`; `WidthMicrometers`/`HeightMicrometers`; `Pins` aus `OverridePinData` → `PhysicalPinDraft`; `SMatrix` = `_computedModel==null ? BlackBox() : FromFdtd(_computedModel)`). Kollision via `ConfirmOverwrite`. Ruft `store.Save(...)`, setzt `SavedDraft`/`SavedProcessName`, feuert `Saved`.
+
+- [ ] **Step 1: Read the real signatures**
+
+Lies `CAP.Avalonia/Services/Solvers/FdtdSMatrixConverter.cs`, `CAP_Core/Solvers/Fdtd/IFdtdSMatrixService.cs` + `FdtdAvailability`, und `OverridePinMapper.cs` (`OverridePinData`-Member: `Name`, Offsets, Angle, `LogicalPinNumber`, `PinKind`?). Lies `PhysicalPinDraft.cs` für die Mapping-Zielfelder.
+
+- [ ] **Step 2: Write the failing tests**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class NewComponentViewModelTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-nc-vm-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 10, YMax = 2,
+        Polygons = new List<NazcaPreviewPolygon> { new() { Layer = 1, Vertices = new List<(double,double)> { (0,0),(10,0),(10,2),(0,2) } } },
+        Pins = new List<NazcaPreviewPin> { new() { Name = "o1", X = 0, Y = 1, Angle = 180 }, new() { Name = "o2", X = 10, Y = 1, Angle = 0 } }
+    };
+
+    private (NewComponentViewModel vm, Mock<IFdtdSMatrixService> fdtd) Build(bool withFdtd = true)
+    {
+        var nazca = new Mock<NazcaComponentPreviewService>("python", "s.py", null, null);
+        var gds = new Mock<GdsFactoryComponentPreviewService>("python", "g.py", null, null);
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var fdtd = new Mock<IFdtdSMatrixService>();
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var vm = new NewComponentViewModel(extractor, withFdtd ? fdtd.Object : null, store,
+            new List<ProcessDefinition> { new() { Name = "P" } });
+        vm.ComponentName = "My Comp";
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+        vm.Module = "cspdk.sin300"; vm.Function = "coupler";
+        vm.SelectedProcess = vm.Processes[0];
+        return (vm, fdtd);
+    }
+
+    [Fact]
+    public async Task Save_without_fdtd_writes_a_black_box_component()
+    {
+        var (vm, _) = Build(withFdtd: false);
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.SavedDraft.ShouldNotBeNull();
+        vm.SavedDraft!.SMatrix.ShouldBeNull();      // black box, no invented physics
+        vm.SavedDraft.Pins.Count.ShouldBe(2);
+        vm.SavedDraft.GdsFactoryFunction.ShouldBe("cspdk.sin300.coupler");
+    }
+
+    [Fact]
+    public async Task ComputeSMatrix_failure_does_not_produce_a_model()
+    {
+        var (vm, fdtd) = Build();
+        fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FdtdAvailability(true, ""));
+        fdtd.Setup(f => f.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FdtdSMatrixResult.Fail("solver blew up"));
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.ComputeSMatrixCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.StatusText.ShouldContain("solver blew up");
+        vm.SavedDraft!.SMatrix.ShouldBeNull();       // failed FDTD => still no model, never fake
+    }
+
+    [Fact]
+    public async Task Save_requires_a_name()
+    {
+        var (vm, _) = Build(withFdtd: false);
+        vm.ComponentName = "   ";
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+        vm.SavedDraft.ShouldBeNull();
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}
+```
+
+Passe `FdtdAvailability`-Konstruktion an die echte Form an (Step 1). Wenn Moq an den Preview-Service-Typen scheitert, verwende das in Task 4 eingeführte `IComponentPreviewRenderer` und baue den Extractor darüber.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" NewComponentViewModel`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement `NewComponentViewModel`**
+
+Implementiere das ViewModel gemäß den Design-Notes. Halte es unter 250 Zeilen (lagere das Pin-Mapping `OverridePinData` → `PhysicalPinDraft` in eine private statische Hilfsmethode aus). Kernpunkte:
+- `Processes` als `IReadOnlyList<ProcessDefinition>` exponieren (Dropdown-Backing).
+- `RunPreview`/`ComputeSMatrix`/`Save` als `async` `[RelayCommand]`; `IsBusy` schützt vor Reentrancy.
+- `ComputeSMatrix` NUR wenn `_lastPreview?.Success == true && SelectedProcess != null`.
+- FDTD-Fehler: `StatusText` = `result.Error`, `_computedModel = null` — NIE eine Fake-Matrix.
+- `Save`: früh raus bei leerem Namen/keinem Preview/keinem Prozess (setzt `StatusText`, lässt `SavedDraft` null).
+- Kollision: wenn `store.ComponentExists(process, name)` und `ConfirmOverwrite` gesetzt → nur speichern, wenn bestätigt.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" NewComponentViewModel`
+Expected: PASS (3/3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
+git commit -m "(+) NewComponentViewModel: orchestrate name/geometry/process/FDTD/save for a custom component"
+```
+
+---
+
+### Task 6: UI-Fenster, DI-Extension und LeftPanel-Integration
+
+**Files:**
+- Create: `CAP.Avalonia/Views/NewComponentWindow.axaml` (+ `.axaml.cs`)
+- Create: `CAP.Avalonia/DI/AddCustomComponentFeature.cs`
+- Modify: `CAP.Avalonia/App.axaml.cs` (Aufruf der Feature-Extension)
+- Modify: `CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs` (`[RelayCommand] OpenNewComponent` + Registrierung)
+- Modify: `CAP.Avalonia/Views/MainWindow.axaml` („+"-Button an der Komponenten-Library)
+- Test: `UnitTests/Components/AddCustomComponent/LeftPanelNewComponentTests.cs`
+
+**Interfaces:**
+- Consumes: `NewComponentViewModel` (Task 5, `SavedDraft`, `SavedProcessName`, `Saved`-Event); `PdkTemplateConverter.ConvertToTemplate(PdkComponentDraft, string pdkName, string? nazcaModule, string? gdsFactoryRoutingXs = null) : ComponentTemplate`; `PdkManagerViewModel.RegisterPdk(string, string?, bool, int)`; `UserPreferencesService.AddUserPdkPath(string)`; `LeftPanelViewModel.AllTemplates`/`Categories`/`FilterComponents()`.
+- Produces: `LeftPanelViewModel.RegisterSavedCustomComponent(PdkComponentDraft draft, string pdkName, string filePath)` — konvertiert Draft → Template, fügt zu `AllTemplates` + Kategorie hinzu, ruft `RegisterPdk` + `AddUserPdkPath`, `FilterComponents()`. (Öffentlich, damit testbar ohne Fenster.)
+
+- [ ] **Step 1: Read the integration points**
+
+Lies `LeftPanelViewModel.cs` Z324-411 (`LoadPdk`, `LoadPdkFromJsonFileAsync`, `ConvertPdkComponentToTemplate`) — spiegle exakt dieses Registrier-Muster. Lies eine bestehende DI-Extension (`CAP.Avalonia/DI/FdtdFeatureExtensions.cs`) und wie `App.axaml.cs` sie aufruft. Lies `MainWindow.axaml` an der Stelle der Komponenten-Library, um den „+"-Button zu platzieren.
+
+- [ ] **Step 2: Write the failing test (LeftPanel-Registrierung, ohne Fenster)**
+
+```csharp
+using System.Linq;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class LeftPanelNewComponentTests
+{
+    [Fact]
+    public void RegisterSavedCustomComponent_adds_template_to_the_library()
+    {
+        var vm = LeftPanelViewModelTestFactory.Create();  // reuse existing test construction helper
+        int before = vm.AllTemplates.Count;
+
+        var draft = new PdkComponentDraft
+        {
+            Name = "My Coupler", Category = "Custom",
+            GdsFactoryFunction = "cspdk.sin300.coupler",
+            WidthMicrometers = 10, HeightMicrometers = 2
+        };
+        vm.RegisterSavedCustomComponent(draft, "My CornerStone Components", "C:/tmp/x.json");
+
+        vm.AllTemplates.Count.ShouldBe(before + 1);
+        vm.AllTemplates.ShouldContain(t => t.Name == "My Coupler");
+    }
+}
+```
+
+Wenn es keinen Konstruktions-Helper für `LeftPanelViewModel` gibt, sieh in bestehenden `LeftPanelViewModel`-Tests nach, wie das VM dort gebaut wird, und repliziere das inline (KEINEN produktiven Test-only-Helper hinzufügen).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" LeftPanelNewComponent`
+Expected: FAIL (`RegisterSavedCustomComponent` existiert nicht).
+
+- [ ] **Step 4: Implement `RegisterSavedCustomComponent` in `LeftPanelViewModel`**
+
+Spiegle `LoadPdkFromJsonFileAsync`: `var template = ConvertPdkComponentToTemplate(draft, pdkName, null);` → `AllTemplates.Add(template);` → Kategorie hinzufügen falls neu → `PdkManager.RegisterPdk(pdkName, filePath, false, 1)` (oder Anzahl aktualisieren, wenn bereits registriert — nutze `PdkManager.IsPdkLoaded(filePath)` um doppelte Registrierung zu vermeiden) → `_preferencesService.AddUserPdkPath(filePath)` → `FilterComponents()`. XML-Doku.
+
+- [ ] **Step 5: Add `[RelayCommand] OpenNewComponent` in `LeftPanelViewModel`**
+
+Öffnet `NewComponentWindow` mit einem `NewComponentViewModel` (Prozessliste via `GetLoadedPdkProcessEntries()`/`GetLoadedPdkDrafts()` gefiltert auf `Process != null`). Abonniert `Saved` und ruft `RegisterSavedCustomComponent(vm.SavedDraft!, ...)`. Da das Öffnen eines Fensters nicht headless-testbar ist, halte die Command-Methode dünn und delegiere die testbare Logik an `RegisterSavedCustomComponent` (in Step 4 getestet). Die Fenster-Instanziierung erfolgt über einen injizierten Dialog-Öffner oder `Func<NewComponentViewModel, Task>` (analog zu `ConfirmSaveToPdk`-Muster), damit die Command-Methode selbst frei von direkter View-Kopplung bleibt.
+
+- [ ] **Step 6: Create `NewComponentWindow.axaml` (+ code-behind)**
+
+Minimales Avalonia-Fenster mit `x:DataType="vm:NewComponentViewModel"`, compiled bindings: TextBox `ComponentName`; ComboBox Backend (Nazca/GdsFactory); TextBoxes `Module`/`Function`/`Parameters`; ComboBox `Processes`/`SelectedProcess`; Buttons `RunPreviewCommand`, `ComputeSMatrixCommand`, `SaveCommand`; `StatusText`-TextBlock; `IsBusy`-Indikator. Folge dem Layout-Stil von `ProcessManagementWindow.axaml`. Code-behind nur `InitializeComponent()`.
+
+- [ ] **Step 7: Create the DI extension and wire it**
+
+`CAP.Avalonia/DI/AddCustomComponentFeature.cs`:
+
+```csharp
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_DataAccess.Components.AddCustomComponent;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CAP.Avalonia.DI;
+
+/// <summary>DI registrations for the "add custom component → user PDK" feature.</summary>
+internal static class AddCustomComponentFeature
+{
+    /// <summary>Registers the user-PDK store and the geometry extractor.</summary>
+    public static IServiceCollection AddAddCustomComponentFeature(this IServiceCollection services)
+    {
+        services.AddSingleton(_ => UserPdkStore.CreateDefault());
+        services.AddSingleton<ComponentGeometryExtractor>();
+        return services;
+    }
+}
+```
+
+`ComponentGeometryExtractor` braucht `NazcaComponentPreviewService` + `GdsFactoryComponentPreviewService` aus DI — prüfe, dass beide registriert sind (sie werden fürs Override-Feature registriert); falls nicht als beide Typen verfügbar, registriere sie in dieser Extension analog zur Preview-Registrierung des Override-Features. In `App.axaml.cs` neben `AddFdtdFeature()`: `services.AddAddCustomComponentFeature();`
+
+- [ ] **Step 8: Add the "+" button to `MainWindow.axaml`**
+
+An der Komponenten-Library (dort wo `FilteredTemplates` gelistet werden) ein kompakter Button mit Tooltip „Neue Komponente…" gebunden an `OpenNewComponentCommand` des `LeftPanelViewModel`. Folge dem vorhandenen Button-Stil des linken Panels.
+
+- [ ] **Step 9: Build + run the focused test**
+
+Run: `dotnet build -clp:ErrorsOnly`
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" LeftPanelNewComponent`
+Expected: Build 0 Fehler; Test PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add CAP.Avalonia/Views/NewComponentWindow.axaml CAP.Avalonia/Views/NewComponentWindow.axaml.cs CAP.Avalonia/DI/AddCustomComponentFeature.cs CAP.Avalonia/App.axaml.cs CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs CAP.Avalonia/Views/MainWindow.axaml UnitTests/Components/AddCustomComponent/LeftPanelNewComponentTests.cs
+git commit -m "(+) New Component window + '+' library button, DI wiring and LeftPanel registration"
+```
+
+---
+
+### Task 7: Architektur-Test für den Slice
+
+**Files:**
+- Modify: `UnitTests/Architecture/VerticalSliceConventionTests.cs` (Feature in die enumerierte Liste aufnehmen, falls das Muster das verlangt) ODER Create: `UnitTests/Architecture/AddCustomComponentSliceTests.cs`
+- Test: derselbe.
+
+**Interfaces:**
+- Consumes: die bestehende Architektur-Test-Infrastruktur.
+- Produces: eine Assertion, dass die `AddCustomComponent`-Namespaces nur erlaubte Namespaces importieren, und dass `UserPdkStore.ResolvePath` nie einen Pfad unter `CAP-DataAccess/PDKs` liefert.
+
+- [ ] **Step 1: Read the existing architecture test**
+
+Lies `UnitTests/Architecture/VerticalSliceConventionTests.cs` und `CrossPlatformProcessLaunchTests.cs`, um Stil/Mechanik zu übernehmen.
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+using System;
+using System.IO;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Architecture;
+
+public class AddCustomComponentSliceTests
+{
+    [Fact]
+    public void UserPdk_path_is_never_inside_the_bundled_pdk_folder()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "lunima-arch-" + Guid.NewGuid().ToString("N"));
+        var store = new UserPdkStore(root, new PdkJsonSaver(), new PdkLoader());
+        var path = store.ResolvePath(new ProcessDefinition { Name = "CornerStone SiN" });
+
+        path.Replace('\\', '/').ShouldNotContain("/PDKs/");
+        path.ShouldStartWith(root);
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails, implement if needed, run to verify it passes**
+
+Run: `$env:PYTHONUTF8='1'; py "$env:USERPROFILE\.cap-tools\smart_test.py" AddCustomComponentSlice`
+(Der Test sollte nach Task 1 direkt grün sein — wenn ja, ist das die Verifikation; wenn die Vertical-Slice-Konvention eine Enumeration verlangt, ergänze den Slice dort und stelle grün.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add UnitTests/Architecture/AddCustomComponentSliceTests.cs
+git commit -m "(+) Architecture test: user PDK never lands in the bundled PDK folder"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- „+"-Fenster in Library → Task 6. Name/Prozess/Geometrie/FDTD/Save-Flow → Task 5. User-PDK pro Prozess, nie Foundry → Task 1 + Task 7. Ehrliche S-Matrix (FDTD/Blackbox/2-Port) → Task 2 + Task 5. Funktions-Referenz-Render (gdsfactory Rawcode-Wrapper, nazca module-mode) → Task 4. FDTD aus Preview → Task 3. DI/Registrierung → Task 6. Cross-Platform-Pfade/Kultur → Task 1. Alle Spec-Abschnitte abgedeckt.
+- Rawcode-Authoring ist explizit v2 (Spec) → keine Tasks, korrekt.
+
+**Placeholder scan:** Keine TBD/„handle edge cases" ohne Code. Alle Code-Steps enthalten echten Code oder eine präzise Read-then-mirror-Anweisung mit exakter Datei/Signatur.
+
+**Type consistency:** `GeometryReference`/`GeometryBackend` (Task 4) konsistent in Task 5 genutzt. `GeometryExtractResult.Raw`/`Pins`/`WidthUm`/`HeightUm` (Task 4) → Task 5 Save/Compute. `BuildFromPreview` (Task 3) → Task 5 Compute. `FdtdSMatrixToDraftConverter.FromFdtd/BlackBox/LosslessTwoPort` (Task 2) → Task 5 Save. `UserPdkStore.Save/ComponentExists/ResolvePath` (Task 1) → Task 5/6/7. `RegisterSavedCustomComponent` (Task 6) konsistent mit `NewComponentViewModel.SavedDraft` (Task 5).
+
+**Bekannte Verifikationspunkte (in den Steps als „Read the real signatures" markiert):** exakte Feldnamen von `WavelengthSMatrixEntry`, `FdtdAvailability`, `PhysicalPinDraft`, `OverridePinData`, `PdkLoader`-ctor, und Moq-Fähigkeit der Preview-Services (Fallback: `IComponentPreviewRenderer`). Diese sind bewusst dem Implementierer überlassen, weil sie 1 Read entfernt sind und exakt benannt wurden.

--- a/docs/superpowers/specs/2026-07-09-add-custom-component-pdk-design.md
+++ b/docs/superpowers/specs/2026-07-09-add-custom-component-pdk-design.md
@@ -1,0 +1,140 @@
+# Bring-your-own-Component → eigenes PDK — Design
+
+**Datum:** 2026-07-09
+**Status:** Freigegeben (Brainstorm), bereit für Implementierungsplan
+
+## Ziel
+
+Ein UI-Pfad, mit dem Nutzer eigene photonische Komponenten (Geometrie via gdsfactory
+oder nazca) anlegen, ihre S-Matrix mit dem vorhandenen Meep/Docker-FDTD-Solver berechnen
+und in ein eigenes, wiederverwendbares PDK speichern — gebunden an einen gewählten
+Fabrikationsprozess. So definiert der Nutzer schrittweise sein eigenes PDK.
+
+## Motivation
+
+Nutzer haben gefragt, wie sie eigene Komponenten via gdsfactory einfügen können. Heute gibt
+es nur zwei Pfade: (1) Import einer **ganzen** PDK-Datei (.json / .py über den Import-Wizard),
+oder (2) einen per-Instanz-Override (#637), der nur eine bereits platzierte Instanz umschreibt
+und nichts zur Library hinzufügt. Es fehlt der glatte „eigene Komponente → wiederverwendbare
+Library"-Pfad. Personas: **Priya** (import own PDK first-class) und **Mirko** (gdsfactory /
+offene Formate).
+
+## Harte Randbedingung: keine erfundene Physik
+
+Die S-Matrix einer eigenen Komponente stammt **ausschließlich** aus einer dieser Quellen:
+
+- **(a) FDTD-Meep** auf der echten Geometrie + echtem Prozess-Materialstack → echte Physik.
+- **(b) Blackbox** — leere S-Matrix, klar als „kein Simulationsmodell" gelabelt (wie die
+  bestehende `HasNoSimulationModel`-Warnung), wenn der Nutzer das Rechnen überspringt.
+- **(c) Verlustfreies Ideal** (honest pass-through) nur für reine 2-Port-Routing-Bauteile.
+
+**Nie erfundene Werte.** Schlägt FDTD fehl, wird der rohe Solver-Fehler gezeigt und **nichts**
+gespeichert — keine Fake-S-Matrix als Fallback.
+
+## Architektur
+
+Vertical Slice `AddCustomComponent`, wiederverwendet die bestehende FDTD-Pipeline und den
+Geometrie-Editor des Override-Pfads.
+
+```
+Connect-A-Pic-Core/Components/AddCustomComponent/
+  UserPdkStore.cs               — legt/aktualisiert eine beschreibbare User-PDK-Datei pro Prozess
+  ComponentGeometryExtractor.cs — Render→bbox+pins (herausgelöst aus der Override-Apply-Logik)
+CAP.Avalonia/ViewModels/Components/AddCustomComponent/
+  NewComponentViewModel.cs      — orchestriert Name/Prozess/Geometrie/FDTD/Speichern
+CAP.Avalonia/Views/
+  NewComponentWindow.axaml(.cs)
+CAP.Avalonia/DI/
+  AddCustomComponentFeature.cs  — DI-Extension, aufgerufen aus App.axaml.cs
+UnitTests/Components/AddCustomComponent/
+```
+
+Wiederverwendete bestehende Bausteine (nicht neu bauen):
+- `IFdtdSMatrixService` / `DockerFdtdSMatrixService` — `CheckAvailabilityAsync`, `SolveAsync`.
+- `ComponentFdtdRequestFactory` (`Func<Component, CancellationToken, Task<FdtdSMatrixRequest?>>`).
+- `FdtdSMatrixConverter.ToComponentSMatrixData(...)`.
+- Der Geometrie-Code-Editor + Live-Render aus dem #637-Override
+  (`InstanceNazcaCodeEditorViewModel` inkl. Backend-Toggle nazca|gdsfactory).
+- `PdkManager.RegisterPdk(...)`, der PDK-JSON-Writer (`PdkJsonSaver`/`_pdkSaver.SaveToFile`),
+  `UserPreferencesService.AddUserPdkPath(...)`.
+- DTOs `PdkDraft` / `PdkComponentDraft` / `PdkSMatrixDraft`
+  (`CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs`).
+
+## Nutzer-Flow
+
+Ein `+`-Button in der Component-Library-Panel (links, an `ComponentLibraryViewModel` /
+`LeftPanelViewModel`) öffnet das **„Neue Komponente"-Fenster**:
+
+1. **Name** eingeben.
+2. **Prozess** aus Dropdown wählen (bundled + vorhandene User-Prozesse). Bestimmt den
+   Materialstack für FDTD und das Ziel-User-PDK.
+3. **Geometrie** definieren — Code-Editor + „Run Preview" (gdsfactory oder nazca via Toggle);
+   Bounding-Box + physische Pins werden aus dem Render extrahiert.
+4. **S-Matrix berechnen** — „Mit FDTD (Meep) rechnen" nutzt die vorhandene Pipeline gegen den
+   gewählten Prozess. Oder überspringen → Blackbox.
+5. **Speichern** → schreibt einen `PdkComponentDraft` ins User-PDK des Prozesses, registriert es,
+   Komponente erscheint sofort in der Library.
+
+Wiederöffnen des Fensters für eine User-PDK-Komponente erlaubt Editieren (Geometrie/Name ändern
+→ neu extrahieren → neu rechnen → speichern). Foundry-Komponenten bleiben read-only.
+
+## Datenfluss
+
+```
+Name + Geometrie-Code + Prozess
+  → ComponentGeometryExtractor (Subprozess-Render) → bbox + Pins
+  → transiente Component (Geometrie + Pins, Prozess-gebunden)
+  → [optional] ComponentFdtdRequestFactory → IFdtdSMatrixService.SolveAsync
+       → FdtdSMatrixResult → FdtdSMatrixConverter → PdkSMatrixDraft
+  → PdkComponentDraft (name, backend-Funktion/Rawcode, dims, pins, sMatrix|leer)
+  → UserPdkStore.AddOrUpdate(process, draft) → schreibt user-pdks/<slug>.json
+  → PdkManager.RegisterPdk + AddUserPdkPath → Library aktualisiert
+```
+
+## User-PDK-Persistenz & Prozess-Bindung (#570)
+
+- Erstes „+" pro Prozess legt `%LOCALAPPDATA%/Lunima/user-pdks/<prozess-slug>.json` an
+  (plattformneutral via `Environment.GetFolderPath(SpecialFolder.LocalApplicationData)` +
+  `Path.Combine`; slug locale-invariant erzeugt). Auf macOS/Linux das jeweilige
+  App-Data-Verzeichnis.
+- Als beschreibbares User-PDK registriert (`AddUserPdkPath`). Die **gebündelten Foundry-JSONs
+  werden nie geschrieben** — das entschärft die „Save-to-PDK-gefährlich"-Sorge.
+- Ein PDK = ein Prozess (S-Matrix ist prozess-spezifisch, konsistent mit #570). Weitere
+  Komponenten desselben Prozesses landen in derselben Datei.
+
+## Fehlerbehandlung
+
+- **Docker fehlt/nicht bereit** → bestehende `CheckAvailabilityAsync`-Meldung; Komponente lässt
+  sich trotzdem als Blackbox speichern, Rechnen später.
+- **FDTD-Fehler** → roher Solver-Fehler (bestehendes Verhalten), keine Fake-S-Matrix.
+- **Geometrie-Render schlägt fehl** → Speichern blockiert mit Meldung.
+- **Namenskollision** im Ziel-User-PDK → Überschreiben/Umbenennen abfragen.
+- **Prozess unvollständig** (kein Materialstack/Layer) → FDTD nicht möglich; warnen und
+  Blackbox-Speichern anbieten.
+- Alle maschinennahen Strings (Slug, JSON) mit `CultureInfo.InvariantCulture`.
+
+## Testing
+
+- `UserPdkStore`: Datei-Anlage/-Naming pro Prozess; `PdkComponentDraft`-Round-trip (save→load
+  via `PdkLoader`); Foundry-JSONs werden **nie** geschrieben (Pfad-Assertion).
+- `ComponentGeometryExtractor`: gdsfactory-/nazca-Snippet → bbox + Pins (Subprozess/Preview
+  gemockt). Deckt denselben Extract wie der Override-`Apply`.
+- FDTD-Request-Bau aus eingegebener Geometrie + Prozess (`IFdtdSMatrixService` gemockt).
+- `NewComponentViewModel`: Namensvalidierung; „Prozess nötig für Compute"; Blackbox-Speicherpfad;
+  Kollisionsbehandlung; keine Speicherung bei FDTD-Fehler.
+- Architektur-Test: der Slice hält die Vertical-Slice-Import-Regeln ein.
+- Plattform-abhängige Pfad-Assertions mit `OperatingSystem.IsX()` guarden (Linux-CI grün).
+
+## Cross-Platform-Parität
+
+- Pfade via `Path.Combine` + `Environment.SpecialFolder`, keine Drive-Letter-Annahmen.
+- Kein direkter `Process.Start` — der Render/Solver läuft über die bestehenden Abstraktionen
+  (`ProcessLaunchFactory` / Subprocess-Runner der FDTD-Pipeline).
+- Datei-Öffnen/Reveal (falls „im Ordner zeigen" angeboten wird) über `IUrlLauncher`.
+
+## Out of Scope (YAGNI)
+
+- User-PDKs teilen/publizieren → Photonic-Registry (#655/#656).
+- Netlist-View/Export → separates Issue #687.
+- Round-trip-Import einzelner Komponenten aus fremden Formaten.
+- KI-gestützte PDK-Transformation → #620.

--- a/docs/superpowers/specs/2026-07-09-add-custom-component-pdk-design.md
+++ b/docs/superpowers/specs/2026-07-09-add-custom-component-pdk-design.md
@@ -37,9 +37,11 @@ Vertical Slice `AddCustomComponent`, wiederverwendet die bestehende FDTD-Pipelin
 Geometrie-Editor des Override-Pfads.
 
 ```
-Connect-A-Pic-Core/Components/AddCustomComponent/
+CAP-DataAccess/Components/AddCustomComponent/
   UserPdkStore.cs               — legt/aktualisiert eine beschreibbare User-PDK-Datei pro Prozess
-  ComponentGeometryExtractor.cs — Render→bbox+pins (herausgelöst aus der Override-Apply-Logik)
+CAP.Avalonia/Services/AddCustomComponent/
+  ComponentGeometryExtractor.cs — Render(module,function)→bbox+pins (reuse OverridePinMapper)
+  FdtdSMatrixToDraftConverter.cs— ComponentSMatrixData → PdkSMatrixDraft (+ Blackbox/2-Port-Ideal)
 CAP.Avalonia/ViewModels/Components/AddCustomComponent/
   NewComponentViewModel.cs      — orchestriert Name/Prozess/Geometrie/FDTD/Speichern
 CAP.Avalonia/Views/
@@ -48,6 +50,10 @@ CAP.Avalonia/DI/
   AddCustomComponentFeature.cs  — DI-Extension, aufgerufen aus App.axaml.cs
 UnitTests/Components/AddCustomComponent/
 ```
+
+`UserPdkStore` liegt in CAP-DataAccess (reine Persistenz); die Services, die UI-Preview- und
+FDTD-Bausteine koordinieren, liegen in CAP.Avalonia (dort leben die Preview-Services und
+`OverridePinMapper`).
 
 Wiederverwendete bestehende Bausteine (nicht neu bauen):
 - `IFdtdSMatrixService` / `DockerFdtdSMatrixService` — `CheckAvailabilityAsync`, `SolveAsync`.
@@ -60,36 +66,62 @@ Wiederverwendete bestehende Bausteine (nicht neu bauen):
 - DTOs `PdkDraft` / `PdkComponentDraft` / `PdkSMatrixDraft`
   (`CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs`).
 
-## Nutzer-Flow
+## Zuschnitt: Geometrie-Quelle (v1 vs. v2)
 
-Ein `+`-Button in der Component-Library-Panel (links, an `ComponentLibraryViewModel` /
-`LeftPanelViewModel`) öffnet das **„Neue Komponente"-Fenster**:
+**v1 = Funktions-Referenz.** Die Geometrie wird als gdsfactory-/nazca-**Funktionsreferenz**
+angegeben (`module.function` + optionale Parameter, z.B. `cspdk.sin300.mmi2x2`, `ubcpdk.*`
+oder eine Funktion aus einem eigenen installierten Modul). Dieser Pfad ist end-to-end erprobt
+(Render, Platzieren, Export) — genau wie die gebündelten cspdk-Komponenten — und braucht **kein**
+neues Export-/Render-Plumbing. Das löst direkt „CornerStone hat nur 12 Komponenten": jede
+Funktion aus cspdk/ubcpdk/eigenem Modul wird hinzufügbar.
+
+**v2 (Folge-Projekt, hier nur skizziert): Rawcode-Authoring.** Beliebigen gdsfactory-/nazca-Code
+einfügen (wie im #637-Override). Erfordert (a) ein Rawcode-Feld auf `PdkComponentDraft`,
+(b) Seeding eines per-Instanz-`NazcaCodeOverride` aus dem gespeicherten Code beim Platzieren
+(wiederverwendet die bewährte Rawcode-Render-/Export-Pipeline, #559), (c) Export-Verifikation.
+Wegen des Export-Risikos bewusst aus v1 herausgehalten.
+
+## Nutzer-Flow (v1)
+
+Ein `+`-Button an der PDK-Komponenten-Library (links, an `LeftPanelViewModel`, wo `AllTemplates`
+lebt — **nicht** `ComponentLibraryViewModel`, das verwaltet Gruppen) öffnet das
+**„Neue Komponente"-Fenster**:
 
 1. **Name** eingeben.
-2. **Prozess** aus Dropdown wählen (bundled + vorhandene User-Prozesse). Bestimmt den
-   Materialstack für FDTD und das Ziel-User-PDK.
-3. **Geometrie** definieren — Code-Editor + „Run Preview" (gdsfactory oder nazca via Toggle);
-   Bounding-Box + physische Pins werden aus dem Render extrahiert.
-4. **S-Matrix berechnen** — „Mit FDTD (Meep) rechnen" nutzt die vorhandene Pipeline gegen den
-   gewählten Prozess. Oder überspringen → Blackbox.
-5. **Speichern** → schreibt einen `PdkComponentDraft` ins User-PDK des Prozesses, registriert es,
+2. **Prozess** aus Dropdown wählen (bundled + vorhandene User-Prozesse). Bestimmt das Ziel-User-PDK
+   und (soweit die FDTD-Request-Contract es zulässt) Port-Breite/Wellenlängenbereich.
+3. **Geometrie** als Funktionsreferenz angeben (Backend-Toggle gdsfactory/nazca, Modul.Funktion,
+   optionale Parameter) + „Run Preview"; Bounding-Box + physische Pins werden aus dem Render
+   extrahiert.
+4. **S-Matrix berechnen** — „Mit FDTD (Meep) rechnen" nutzt die vorhandene
+   `IFdtdSMatrixService`-Pipeline. Oder überspringen → Blackbox.
+5. **Speichern** → schreibt einen `PdkComponentDraft` (mit `gdsFactoryFunction`/`nazcaFunction`,
+   extrahierten Maßen/Pins, `sMatrix`|leer) ins User-PDK des Prozesses, registriert es,
    Komponente erscheint sofort in der Library.
 
-Wiederöffnen des Fensters für eine User-PDK-Komponente erlaubt Editieren (Geometrie/Name ändern
-→ neu extrahieren → neu rechnen → speichern). Foundry-Komponenten bleiben read-only.
+Wiederöffnen des Fensters für eine User-PDK-Komponente erlaubt Editieren (Referenz/Parameter/Name
+ändern → neu rendern → neu rechnen → speichern). Foundry-Komponenten bleiben read-only.
 
 ## Datenfluss
 
 ```
-Name + Geometrie-Code + Prozess
-  → ComponentGeometryExtractor (Subprozess-Render) → bbox + Pins
-  → transiente Component (Geometrie + Pins, Prozess-gebunden)
-  → [optional] ComponentFdtdRequestFactory → IFdtdSMatrixService.SolveAsync
-       → FdtdSMatrixResult → FdtdSMatrixConverter → PdkSMatrixDraft
-  → PdkComponentDraft (name, backend-Funktion/Rawcode, dims, pins, sMatrix|leer)
-  → UserPdkStore.AddOrUpdate(process, draft) → schreibt user-pdks/<slug>.json
-  → PdkManager.RegisterPdk + AddUserPdkPath → Library aktualisiert
+Name + Funktionsreferenz (module.function[+params]) + Backend + Prozess
+  → ComponentGeometryExtractor: preview.RenderAsync(module, function, params)
+       → NazcaPreviewResult → bbox (XMax-XMin, YMax-YMin) + Pins (OverridePinMapper.BuildOverridePins)
+  → [optional] transiente Component (NazcaModuleName/NazcaFunctionName + PhysicalPins gesetzt)
+       → ComponentFdtdRequestFactory.BuildAsync → IFdtdSMatrixService.SolveAsync
+       → FdtdSMatrixResult → FdtdSMatrixConverter.ToComponentSMatrixData
+       → FdtdSMatrixToDraftConverter → PdkSMatrixDraft (WavelengthData)
+  → PdkComponentDraft (name, gdsFactoryFunction|nazcaFunction, params, dims, pins, sMatrix|leer)
+  → UserPdkStore.AddOrUpdate(process, draft) → schreibt user-pdks/<slug>.json (PdkJsonSaver)
+  → PdkManagerViewModel.RegisterPdk + AddUserPdkPath
+  → LeftPanelViewModel: PdkTemplateConverter.ConvertToTemplate → AllTemplates → Library aktualisiert
 ```
+
+**FDTD-Backend-Hinweis:** Die FDTD-Request-Factory rendert über den DI-`NazcaComponentPreviewService`.
+Ob gdsfactory-Geometrie damit gerendert wird, hängt von der DI-Registrierung ab; falls der
+FDTD-Pfad für gdsfactory-Backends nicht rendert, ist die contained Fix, der Factory den
+gdsfactory-Preview-Service zu geben (kleiner, lokaler Eingriff, in der Umsetzung zu verifizieren).
 
 ## User-PDK-Persistenz & Prozess-Bindung (#570)
 
@@ -117,11 +149,12 @@ Name + Geometrie-Code + Prozess
 
 - `UserPdkStore`: Datei-Anlage/-Naming pro Prozess; `PdkComponentDraft`-Round-trip (save→load
   via `PdkLoader`); Foundry-JSONs werden **nie** geschrieben (Pfad-Assertion).
-- `ComponentGeometryExtractor`: gdsfactory-/nazca-Snippet → bbox + Pins (Subprozess/Preview
-  gemockt). Deckt denselben Extract wie der Override-`Apply`.
-- FDTD-Request-Bau aus eingegebener Geometrie + Prozess (`IFdtdSMatrixService` gemockt).
+- `ComponentGeometryExtractor`: Funktionsreferenz → bbox + Pins (Preview-Service gemockt).
+  Deckt denselben Extract wie der Override-`Apply` (bbox-Größe + `OverridePinMapper`).
+- `FdtdSMatrixToDraftConverter`: `ComponentSMatrixData` → `PdkSMatrixDraft` (WavelengthData korrekt,
+  Portnamen erhalten); Blackbox → leere `sMatrix`; 2-Port-Ideal → verlustfreies Pass-through.
 - `NewComponentViewModel`: Namensvalidierung; „Prozess nötig für Compute"; Blackbox-Speicherpfad;
-  Kollisionsbehandlung; keine Speicherung bei FDTD-Fehler.
+  Kollisionsbehandlung; keine Speicherung bei FDTD-Fehler (`IFdtdSMatrixService` gemockt).
 - Architektur-Test: der Slice hält die Vertical-Slice-Import-Regeln ein.
 - Plattform-abhängige Pfad-Assertions mit `OperatingSystem.IsX()` guarden (Linux-CI grün).
 


### PR DESCRIPTION
## Was & Warum

Ein UI-Pfad, damit Nutzer eigene Komponenten anlegen können — die häufig gestellte Frage „wie füge ich eigene Komponenten via gdsfactory ein?" und ein Gegenmittel zu „CornerStone hat nur 12 Komponenten". Personas **Priya** (import own PDK first-class) und **Mirko** (gdsfactory/offene Formate).

Ein **„+ Neue Komponente"-Button** an der PDK-Library öffnet ein Fenster: Name eingeben → Prozess wählen → Geometrie als **gdsfactory-Funktionsreferenz** (`module.function` + optionale Parameter) angeben und rendern → optional **S-Matrix via vorhandenem FDTD/Meep-Solver** berechnen → in ein **automatisch angelegtes User-PDK pro Prozess** speichern. Weitere Komponenten wachsen ins selbe PDK → so entsteht ein eigenes PDK.

Spec: `docs/superpowers/specs/2026-07-09-add-custom-component-pdk-design.md`
Plan: `docs/superpowers/plans/2026-07-09-add-custom-component-pdk.md`

## Harte Randbedingung: keine erfundene Physik ✅

Die S-Matrix einer eigenen Komponente kommt **ausschließlich** aus echtem FDTD-Meep, oder ist **Blackbox** (leer/kein Sim-Modell), oder verlustfreies **2-Port-Ideal**. Bei FDTD-Fehler wird **nichts** gespeichert — nie eine Fake-Matrix. Der ehrliche Pfad ist über den gesamten Flow (ViewModel → Converter → Draft) verifiziert.

## Sicherheit & Konsistenz

- **Gebündelte Foundry-JSONs werden nie geschrieben** — User-PDKs liegen nur unter `%LOCALAPPDATA%/Lunima/user-pdks/` (Architektur-Test erzwingt das).
- **#570 (ein Design = ein Prozess):** eine für einen nicht-aktiven Prozess gespeicherte Komponente ist bei aktivem Prozess-Lock nicht sichtbar (Tests belegen das).
- Cross-Platform: `Path.Combine`+`SpecialFolder`, `InvariantCulture`, kein direkter `Process.Start`, compiled bindings.

## Umfang v1

- **gdsfactory-only** (der nazca-Backend-Toggle ist bewusst deaktiviert — nazca-Custom-Komponenten brauchen eine Offset-Ableitung → v2, #701).
- Wiederverwendet die bestehende FDTD-Pipeline, die Preview-Services und `OverridePinMapper`; kein neues Export-Plumbing.

## Tests

Entstanden mit TDD (subagent-getrieben, Review nach jedem Task + finaler Whole-Branch-Review). Feature-Tests grün: AddCustomComponent 33/33, NewComponentViewModel 6/6, LeftPanelNewComponent 3/3, Architecture 24/24. Build inkl. XAML: 0 Fehler.

> Hinweis: Die volle lokale Suite bricht sporadisch mit dem bekannten Test-Host-Crash-Flake ab (#685, 0 Failures, zufällige Abbruchpunkte); die Feature-Tests laufen isoliert sauber durch.

## Bekannte Limitierungen / Follow-ups

- **#700** — User-PDKs überleben aktuell keinen App-Neustart (`GetUserPdkPaths` wird nie aufgerufen; vorbestehende Lücke, betrifft auch .json/.py-Import). Wichtig, damit „eigenes PDK aufbauen" persistent ist.
- **#701** — v2: nazca-Custom-Komponenten, Rawcode-Authoring, verlustfreies 2-Port-Ideal im UI.
- Der **echte Fenster-E2E-Flow + FDTD-Docker-Solve** ist nur zur Laufzeit verifizierbar (headless nicht getestet) — Smoke-Test empfohlen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)