### PR TITLE
Self-update (Linux): relaunch guard can now actually roll back (#616 leftover)

### DIFF
--- a/CAP.Avalonia/Services/Update/UpdaterScripts.cs
+++ b/CAP.Avalonia/Services/Update/UpdaterScripts.cs
@@ -181,7 +181,17 @@ public static class UpdaterScripts
         done < <(cd "$NEWDIR" && find . -mindepth 1 -maxdepth 1 -print0)
         chmod +x "$TARGET/$EXE_NAME" 2>/dev/null || true
 
-        ( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & ) || rollback "relaunch failed"
+        # Relaunch the new binary and verify it comes up before the backup is deleted.
+        # A backgrounded subshell always exits 0, so the previous `( … & ) || rollback`
+        # guard could never fire — probe the spawned PID instead. Still running after a
+        # second (the normal GUI case) or exited cleanly counts as up; a failed exec or
+        # early crash (missing libs, wrong arch, truncated binary) rolls back.
+        "$TARGET/$EXE_NAME" >/dev/null 2>&1 &
+        NEW_PID=$!
+        sleep 1
+        if ! kill -0 "$NEW_PID" 2>/dev/null; then
+          wait "$NEW_PID" || rollback "relaunch failed"
+        fi
         rm -rf "$BACKUP"
         cleanup_stage
         rm -f "$ARCHIVE" 2>/dev/null || true

--- a/UnitTests/Update/LinuxUpdaterExecutionTests.cs
+++ b/UnitTests/Update/LinuxUpdaterExecutionTests.cs
@@ -64,6 +64,50 @@ public class LinuxUpdaterExecutionTests
     }
 
     [Fact]
+    public void BuildLinux_Run_CrashingNewBinary_RollsBackToTheOldFiles()
+    {
+        if (OperatingSystem.IsWindows()) return;   // no bash
+
+        var sandbox = Path.Combine(Path.GetTempPath(), $"lunima-upd-rb-{Guid.NewGuid():N}");
+        var target = Path.Combine(sandbox, "install");
+        Directory.CreateDirectory(target);
+        try
+        {
+            const string exeName = "Lunima";
+            File.WriteAllText(Path.Combine(target, exeName), "#!/bin/sh\nexit 0\n");   // old, working
+            File.WriteAllText(Path.Combine(target, "libSkiaSharp.so"), "OLD-LIB");
+            File.WriteAllText(Path.Combine(target, "my_notes.txt"), "PRECIOUS USER DATA");
+            MakeExecutable(Path.Combine(target, exeName));
+
+            // New release whose binary crashes on start (truncated download, wrong arch, …).
+            var stage = Path.Combine(sandbox, "release");
+            Directory.CreateDirectory(stage);
+            File.WriteAllText(Path.Combine(stage, exeName), "#!/bin/sh\nexit 1\n");
+            File.WriteAllText(Path.Combine(stage, "libSkiaSharp.so"), "NEW-LIB");
+            var archive = Path.Combine(sandbox, "lunima.tar.gz");
+            Run("tar", $"-czf \"{archive}\" -C \"{stage}\" .", sandbox);
+
+            var location = new InstallLocation(target, Path.Combine(target, exeName), DeadPid());
+            var script = UpdaterScripts.BuildLinux(location, archive);
+            var scriptPath = Path.Combine(sandbox, "update.sh");
+            File.WriteAllText(scriptPath, script);
+            MakeExecutable(scriptPath);
+
+            Run("bash", $"\"{scriptPath}\"", sandbox);
+
+            // The crash-on-start binary must be rolled back to the old, working files…
+            File.ReadAllText(Path.Combine(target, exeName)).ShouldNotContain("exit 1");
+            File.ReadAllText(Path.Combine(target, "libSkiaSharp.so")).ShouldBe("OLD-LIB");
+            // …and the unrelated user file stays untouched either way.
+            File.ReadAllText(Path.Combine(target, "my_notes.txt")).ShouldBe("PRECIOUS USER DATA");
+        }
+        finally
+        {
+            try { Directory.Delete(sandbox, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
     public void BuildLinux_Run_MkdirBackupFailure_AbortsWithoutReportingSuccess()
     {
         if (OperatingSystem.IsWindows()) return;   // no bash

--- a/UnitTests/Update/UpdaterScriptsTests.cs
+++ b/UnitTests/Update/UpdaterScriptsTests.cs
@@ -67,6 +67,22 @@ public class UpdaterScriptsTests
     }
 
     [Fact]
+    public void BuildLinux_RelaunchGuard_ProbesTheSpawnedPidBeforeDeletingTheBackup()
+    {
+        var target = new InstallLocation("/opt/lunima", "/opt/lunima/Lunima", 55);
+
+        var script = UpdaterScripts.BuildLinux(target, "/tmp/lunima.tar.gz");
+
+        // A backgrounded subshell always exits 0, so `( … & ) || rollback` could never
+        // fire — the guard must probe the spawned PID instead, and only then delete
+        // the backup (a non-starting binary rolls back to the known-good files).
+        script.ShouldContain("NEW_PID=$!");
+        script.ShouldContain("if ! kill -0 \"$NEW_PID\" 2>/dev/null; then");
+        script.ShouldContain("wait \"$NEW_PID\" || rollback \"relaunch failed\"");
+        script.ShouldNotContain("( \"$TARGET/$EXE_NAME\" >/dev/null 2>&1 & ) ||");
+    }
+
+    [Fact]
     public void BuildWindows_WaitsForExitRunsMsiexecAndRelaunches()
     {
         var target = new InstallLocation(


### PR DESCRIPTION
Mini-hotfix for the last open finding from the #616 review ([correction comment](https://github.com/aignermax/Lunima/pull/616#issuecomment-4927810567)):

`( "$TARGET/$EXE_NAME" >/dev/null 2>&1 & ) || rollback "relaunch failed"` — a backgrounded subshell always exits 0, so the `||` branch was unreachable. A new binary that failed to start was reported as `update OK` and the known-good backup deleted.

**Fix:** spawn the binary, probe its PID after a second — still running (normal GUI case) or exited cleanly counts as up; a failed exec / early crash triggers `rollback`, which restores the backed-up files and relaunches the old binary.

**Tests:** template assertion (`UpdaterScriptsTests`) + a real execution test that installs a crash-on-start binary and asserts the old files come back (`LinuxUpdaterExecutionTests`). Full Update suite green (184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sg1cSdNtqNKL2fULFH42V9