### PR TITLE
CornerStone coupler_straight: real cspdk S-matrix, no silent all-zero black box (#712)

### DIFF
--- a/CAP-DataAccess/PDKs/cornerstone-sin-pdk.json
+++ b/CAP-DataAccess/PDKs/cornerstone-sin-pdk.json
@@ -389,7 +389,215 @@
           "offsetYMicrometers": 0.6,
           "angleDegrees": 0.0
         }
-      ]
+      ],
+      "sMatrix": {
+        "wavelengthNm": 1550,
+        "wavelengthData": [
+          {
+            "wavelengthNm": 1500,
+            "connections": [
+              {
+                "fromPin": "o1",
+                "toPin": "o3",
+                "magnitude": 0.568584,
+                "phaseDegrees": 0.0
+              },
+              {
+                "fromPin": "o1",
+                "toPin": "o4",
+                "magnitude": 0.568584,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o3",
+                "magnitude": 0.568584,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o4",
+                "magnitude": 0.568584,
+                "phaseDegrees": 0.0
+              }
+            ]
+          },
+          {
+            "wavelengthNm": 1520,
+            "connections": [
+              {
+                "fromPin": "o1",
+                "toPin": "o3",
+                "magnitude": 0.64054,
+                "phaseDegrees": 0.0
+              },
+              {
+                "fromPin": "o1",
+                "toPin": "o4",
+                "magnitude": 0.64054,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o3",
+                "magnitude": 0.64054,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o4",
+                "magnitude": 0.64054,
+                "phaseDegrees": 0.0
+              }
+            ]
+          },
+          {
+            "wavelengthNm": 1540,
+            "connections": [
+              {
+                "fromPin": "o1",
+                "toPin": "o3",
+                "magnitude": 0.678361,
+                "phaseDegrees": 0.0
+              },
+              {
+                "fromPin": "o1",
+                "toPin": "o4",
+                "magnitude": 0.678361,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o3",
+                "magnitude": 0.678361,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o4",
+                "magnitude": 0.678361,
+                "phaseDegrees": 0.0
+              }
+            ]
+          },
+          {
+            "wavelengthNm": 1550,
+            "connections": [
+              {
+                "fromPin": "o1",
+                "toPin": "o3",
+                "magnitude": 0.683101,
+                "phaseDegrees": 0.0
+              },
+              {
+                "fromPin": "o1",
+                "toPin": "o4",
+                "magnitude": 0.683101,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o3",
+                "magnitude": 0.683101,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o4",
+                "magnitude": 0.683101,
+                "phaseDegrees": 0.0
+              }
+            ]
+          },
+          {
+            "wavelengthNm": 1560,
+            "connections": [
+              {
+                "fromPin": "o1",
+                "toPin": "o3",
+                "magnitude": 0.678481,
+                "phaseDegrees": 0.0
+              },
+              {
+                "fromPin": "o1",
+                "toPin": "o4",
+                "magnitude": 0.678481,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o3",
+                "magnitude": 0.678481,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o4",
+                "magnitude": 0.678481,
+                "phaseDegrees": 0.0
+              }
+            ]
+          },
+          {
+            "wavelengthNm": 1580,
+            "connections": [
+              {
+                "fromPin": "o1",
+                "toPin": "o3",
+                "magnitude": 0.643618,
+                "phaseDegrees": 0.0
+              },
+              {
+                "fromPin": "o1",
+                "toPin": "o4",
+                "magnitude": 0.643618,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o3",
+                "magnitude": 0.643618,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o4",
+                "magnitude": 0.643618,
+                "phaseDegrees": 0.0
+              }
+            ]
+          },
+          {
+            "wavelengthNm": 1600,
+            "connections": [
+              {
+                "fromPin": "o1",
+                "toPin": "o3",
+                "magnitude": 0.581359,
+                "phaseDegrees": 0.0
+              },
+              {
+                "fromPin": "o1",
+                "toPin": "o4",
+                "magnitude": 0.581359,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o3",
+                "magnitude": 0.581359,
+                "phaseDegrees": 90.0
+              },
+              {
+                "fromPin": "o2",
+                "toPin": "o4",
+                "magnitude": 0.581359,
+                "phaseDegrees": 0.0
+              }
+            ]
+          }
+        ]
+      }
     },
     {
       "name": "Mmi2x2",

--- a/Connect-A-Pic-Core/Analysis/OnaAnalysis/WavelengthSweeper.cs
+++ b/Connect-A-Pic-Core/Analysis/OnaAnalysis/WavelengthSweeper.cs
@@ -99,7 +99,13 @@ namespace CAP_Core.Analysis.OnaAnalysis
                 // loader, which would spuriously trigger this warning.
                 if (component.IsAnalysisTool) continue;
 
-                string key = component.NazcaFunctionName ?? component.Identifier;
+                // gdsfactory-backend components have no real Nazca function — their
+                // NazcaFunctionName is a synthesized "nazca_<name>" placeholder, which made
+                // warnings mislabel e.g. 'cspdk.sin300.coupler_straight' as
+                // 'nazca_coupler_straight' (#712). Prefer the real gdsfactory factory name.
+                string key = component.GdsFactoryFunction
+                    ?? component.NazcaFunctionName
+                    ?? component.Identifier;
                 var definedWavelengths = component.WaveLengthToSMatrixMap.Keys;
 
                 if (definedWavelengths.Count == 1)

--- a/UnitTests/Analysis/OnaAnalysis/WavelengthSweeperTests.cs
+++ b/UnitTests/Analysis/OnaAnalysis/WavelengthSweeperTests.cs
@@ -164,4 +164,25 @@ public class WavelengthSweeperTests
         await Should.ThrowAsync<OperationCanceledException>(
             () => sweeper.RunSweepAsync(config, grid, cts.Token));
     }
+
+    [Fact]
+    public async Task RunSweepAsync_GdsFactoryComponent_WarningNamesTheGdsFactoryFunction()
+    {
+        // gdsfactory-backend components carry a synthesized "nazca_<name>" placeholder as
+        // NazcaFunctionName; coverage warnings used it as the label, reporting e.g.
+        // 'nazca_coupler_straight' for a cspdk.sin300.coupler_straight (#712). The
+        // warning must name the real gdsfactory factory instead.
+        var grid = CreateMinimalGridManager();
+        var component = TestComponentFactory.CreateStraightWaveGuide(); // map: 980/1310/1550
+        component.GdsFactoryFunction = "cspdk.sin300.coupler_straight";
+        grid.ComponentMover.PlaceComponent(0, 0, component);
+
+        var sweeper = new WavelengthSweeper(CreateMockBuilder().Object, CreateMockPortManager().Object);
+        var config = new WavelengthSweepConfiguration(1500, 1600, 3); // extrapolates above 1550
+
+        var result = await sweeper.RunSweepAsync(config, grid);
+
+        result.Warnings.ShouldContain(w => w.Contains("cspdk.sin300.coupler_straight"));
+        result.Warnings.ShouldAllBe(w => !w.Contains(component.NazcaFunctionName));
+    }
 }

--- a/UnitTests/Analysis/OnaAnalysis/WavelengthSweeperTests.cs
+++ b/UnitTests/Analysis/OnaAnalysis/WavelengthSweeperTests.cs
@@ -175,6 +175,7 @@ public class WavelengthSweeperTests
         var grid = CreateMinimalGridManager();
         var component = TestComponentFactory.CreateStraightWaveGuide(); // map: 980/1310/1550
         component.GdsFactoryFunction = "cspdk.sin300.coupler_straight";
+        component.NazcaFunctionName = "nazca_coupler_straight"; // the synthesized placeholder #712 mislabeled with
         grid.ComponentMover.PlaceComponent(0, 0, component);
 
         var sweeper = new WavelengthSweeper(CreateMockBuilder().Object, CreateMockPortManager().Object);

--- a/UnitTests/Components/Process/BundledPdkProcessTests.cs
+++ b/UnitTests/Components/Process/BundledPdkProcessTests.cs
@@ -85,6 +85,7 @@ public class BundledPdkProcessTests
     [InlineData("cspdk.sin300.grating_coupler_rectangular")]
     [InlineData("cspdk.sin300.grating_coupler_elliptical")]
     [InlineData("cspdk.sin300.coupler")]
+    [InlineData("cspdk.sin300.coupler_straight")]
     [InlineData("cspdk.sin300.mzi")]
     public void CornerStoneSin_GratingsCouplerAndMzi_CarryRealMultiWavelengthSMatrices(
         string gdsFactoryFunction)
@@ -100,6 +101,56 @@ public class BundledPdkProcessTests
         var at1550 = comp.SMatrix.WavelengthData.Single(w => w.WavelengthNm == 1550);
         at1550.Connections.ShouldNotBeEmpty();
         at1550.Connections.ShouldAllBe(c => c.Magnitude > 0 && c.Magnitude <= 1);
+    }
+
+    [Fact]
+    public void CornerStoneSin_EveryComponent_CarriesAnSMatrix()
+    {
+        // A PDK component without an sMatrix silently loads as an all-zero
+        // (perfect-absorber) S-matrix: PdkTemplateConverter falls back to
+        // CreateSMatrixFromPdk(pins, null). coupler_straight shipped that way,
+        // so no light reached the ONA and every output sat at the −120 dB floor (#712).
+        var draft = new PdkLoader().LoadFromFile(Path.Combine(PdkDir, "cornerstone-sin-pdk.json"));
+
+        draft.Components.ShouldAllBe(c => c.SMatrix != null);
+    }
+
+    [Fact]
+    public void CornerStoneSin_MultiWavelengthSMatrices_CoverTheCBandSweepRange()
+    {
+        // The generator samples at 1500–1600 nm; every sampled component must bracket
+        // that band so an ONA sweep over the C-band never extrapolates (#712).
+        var draft = new PdkLoader().LoadFromFile(Path.Combine(PdkDir, "cornerstone-sin-pdk.json"));
+
+        foreach (var comp in draft.Components.Where(c => c.SMatrix?.WavelengthData is { Count: > 0 }))
+        {
+            var wavelengths = comp.SMatrix!.WavelengthData!.Select(w => w.WavelengthNm).ToList();
+            wavelengths.Min().ShouldBeLessThanOrEqualTo(1500, comp.Name);
+            wavelengths.Max().ShouldBeGreaterThanOrEqualTo(1600, comp.Name);
+        }
+    }
+
+    [Fact]
+    public void CornerStoneSin_CouplerStraight_PlacedComponent_UsesCspdkSMatrixOver1500To1600()
+    {
+        // Regression for #712: a placed CornerStone coupler_straight used to get the
+        // synthetic {980, 1310, 1550} wavelength triple wrapping an all-zero S-matrix
+        // (ComponentTemplates single-matrix fallback), i.e. silent perfect-absorber
+        // physics labelled 'nazca_coupler_straight'. It must carry its real cspdk
+        // model: 1500–1600 nm keys with a transmitting 50/50 coupling section.
+        var draft = new PdkLoader().LoadFromFile(Path.Combine(PdkDir, "cornerstone-sin-pdk.json"));
+        var comp = draft.Components.Single(
+            c => c.GdsFactoryFunction == "cspdk.sin300.coupler_straight");
+
+        var template = CAP.Avalonia.Services.PdkTemplateConverter.ConvertToTemplate(
+            comp, draft.Name, draft.NazcaModuleName, draft.GdsFactoryRoutingCrossSection);
+        var placed = CAP.Avalonia.ViewModels.Library.ComponentTemplates
+            .CreateFromTemplate(template, 0, 0);
+
+        placed.WaveLengthToSMatrixMap.Keys.Min().ShouldBe(1500);
+        placed.WaveLengthToSMatrixMap.Keys.Max().ShouldBe(1600);
+        placed.WaveLengthToSMatrixMap[1550].GetNonNullValues().Values
+            .ShouldContain(v => v.Magnitude > 0.5);   // light gets through, not absorbed
     }
 
     [Fact]

--- a/scripts/generate_cspdk_sin300_pdk.py
+++ b/scripts/generate_cspdk_sin300_pdk.py
@@ -5,12 +5,13 @@ gdsfactory's open-source `cspdk` library — issue #570 follow-up / gdsfactory-b
 This is the PDK's *updater*: the CornerStone process is a Python library (cspdk); when it
 changes, re-run this to regenerate the Lunima PDK JSON. No hand-editing, no fabricated data.
 
-Environment (cspdk >= 1.4.3 — 1.4.2's `coupler` cell raises on a `bend_s` kwarg; sax ~0.17
-matches cspdk's model kwargs; installed --no-deps to avoid the unused gplugins/gdstk chain):
+Environment (cspdk >= 1.4.4 — 1.4.2's `coupler` cell raises on a `bend_s` kwarg, 1.4.3
+lacks the CLAD_OPEN layer; sax ~0.17 matches cspdk's model kwargs; installed --no-deps to
+avoid the unused gplugins/gdstk chain):
 
     uv venv .cspdk --python 3.12
     uv pip install --python .cspdk "gdsfactory==9.43.0" "sax~=0.17.0"
-    uv pip install --python .cspdk --no-deps "cspdk==1.4.3"
+    uv pip install --python .cspdk --no-deps "cspdk==1.4.4"
     .cspdk/Scripts/python scripts/generate_cspdk_sin300_pdk.py CAP-DataAccess/PDKs/cornerstone-sin-pdk.json
 
 Emits a `backend: "gdsfactory"` PDK: each component carries its gdsfactory factory name
@@ -45,6 +46,16 @@ SAX_MODEL_COMPONENTS = {"mmi1x2", "mmi2x2", "coupler",
 # real layout netlist. (cspdk.sin300's mzi has no heater — passive arms only.)
 CIRCUIT_MODEL_COMPONENTS = {"mzi"}
 
+# Cells whose own cspdk model deliberately raises NotImplementedError ("we should not need
+# this model") but which are placeable and must not ship as an all-zero black box that
+# absorbs all light (#712). `coupler_straight` is the parallel coupling section of the
+# directional coupler — the region where all the coupling physically happens. cspdk models
+# the coupling as a lumped `coupler` (fixed 50/50 + loss_dB, geometry-independent) and
+# leaves the sub-cells unmodeled, so the parent `coupler` model IS cspdk's own physics for
+# this section — not fabricated data. Port names are identical on both cells (o1/o2 west,
+# o3/o4 east), which _eval_model_smatrix verifies by name identity like any sax model.
+MODEL_SUBSTITUTES = {"coupler_straight": "coupler"}
+
 # Passive routing components that faithfully pass light (or current) straight through — a
 # lossless pass-through S-matrix is the honest ideal. Their cspdk sax model wrappers raise
 # on the `loss` kwarg (see _mzi_circuit), so we synthesize the transfer rather than evaluate
@@ -68,13 +79,13 @@ LAYER_DESCRIPTIONS = {
 }
 
 # Routing cross-sections cspdk.sin300 actually defines (xs_nc/xs_no optical, metal_routing/
-# heater_metal electrical — see cspdk.sin300.tech). kind 0 = Optical, 1 = Metal (ProcessDefinition.
-# XsectionKind's default int serialization — no JsonStringEnumConverter is registered).
+# heater_metal electrical — see cspdk.sin300.tech). Kind uses the enum NAME ("Optical" /
+# "Metal"): ProcessDefinition.Xsection.Kind carries JsonStringEnumConverter<XsectionKind>.
 XSECTION_SPECS = [
-    ("xs_nc", 0, "NITRIDE", "SiN C-band strip waveguide"),
-    ("xs_no", 0, "NITRIDE", "SiN O-band strip waveguide"),
-    ("metal_routing", 1, "PAD", "Electrical routing metal"),
-    ("heater_metal", 1, "HEATER", "Heater trace metal"),
+    ("xs_nc", "Optical", "NITRIDE", "SiN C-band strip waveguide"),
+    ("xs_no", "Optical", "NITRIDE", "SiN O-band strip waveguide"),
+    ("metal_routing", "Metal", "PAD", "Electrical routing metal"),
+    ("heater_metal", "Metal", "HEATER", "Heater trace metal"),
 ]
 
 
@@ -264,14 +275,16 @@ def build_smatrix(pdk, name, pins):
 
     - SAX_MODEL_COMPONENTS: the cspdk sax model, sampled at WAVELENGTHS_NM.
     - CIRCUIT_MODEL_COMPONENTS: a sax.circuit composition of the cell's netlist.
+    - MODEL_SUBSTITUTES: a documented stand-in cspdk model (see the map's comment, #712).
     - 2-port passives (1 in, 1 out): a lossless pass-through (their cspdk models raise).
     - otherwise None (unverified port mapping / erroring components stay black-box).
     """
-    if name in SAX_MODEL_COMPONENTS or name in CIRCUIT_MODEL_COMPONENTS:
+    if name in SAX_MODEL_COMPONENTS or name in CIRCUIT_MODEL_COMPONENTS \
+            or name in MODEL_SUBSTITUTES:
         try:
             sax, models = _sax_models()
             model = (_mzi_circuit(pdk, sax, models) if name in CIRCUIT_MODEL_COMPONENTS
-                     else getattr(models, name))
+                     else getattr(models, MODEL_SUBSTITUTES.get(name, name)))
             return _eval_model_smatrix(model, pins)
         except Exception as e:  # noqa: BLE001 — black-box on any model failure
             print(f"{name}: sax model failed ({e}) — black-box", file=sys.stderr)


### PR DESCRIPTION
Closes #712

## Root cause (Modell-Mismatch: teilweise ja)

There is **no runtime Nazca/demofab model fallback** — the truth is worse: the component silently simulated as a **perfect absorber**.

1. **No sMatrix in the PDK JSON** — `cspdk`'s own `coupler_straight` sax model deliberately raises `NotImplementedError` ("we should not need this model"), so `scripts/generate_cspdk_sin300_pdk.py::build_smatrix` emitted `Coupler Straight` black-box: `cornerstone-sin-pdk.json` had no `sMatrix` for it.
2. **All-zero fallback** — `CAP.Avalonia/Services/PdkTemplateConverter.cs:99` then builds `CreateSMatrixFromPdk(pins, null)` → an S-matrix with **zero transfers** (all light absorbed → every ONA output at the −120 dB floor).
3. **980–1550 range** — `CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs:75-80` duplicates that single matrix at the synthetic `{1550, 1310, 980}` triple → the "defined only between 980–1550 nm" warning.
4. **`nazca_coupler_straight` name** — `ComponentTemplates.cs:99-100` synthesizes `nazca_<name>` when a template has no real Nazca function, and `WavelengthSweeper.cs:102` used `NazcaFunctionName` as the warning label — mislabeling a gdsfactory-native cspdk component.

## Fix

- **Generator** (`scripts/generate_cspdk_sin300_pdk.py`): new documented `MODEL_SUBSTITUTES = {"coupler_straight": "coupler"}`. The straight section is where all the coupling physically happens, and cspdk models the coupling as a lumped, geometry-independent `coupler` (50/50 + loss_dB) with unmodeled sub-cells — so the parent model **is cspdk's own physics** for this cell, not fabricated data. Ports verified by name identity (o1/o2 west → o3/o4 east on both cells) like every other sax model. Also: `XsectionKind` now emitted as enum names (current `JsonStringEnumConverter` convention) and cspdk pinned to 1.4.4 (matches the shipped JSON; 1.4.3 lacks `CLAD_OPEN`).
- **Regenerated `cornerstone-sin-pdk.json`** with gdsfactory 9.43.0 / sax 0.17.0 / cspdk 1.4.4 — pure addition: `coupler_straight` gains a 1500–1600 nm S-matrix (|s| ≈ 0.683 per path at 1550 = 50/50 with cspdk's 0.3 dB loss, 0°/90° phases); all other components byte-identical.
- **`WavelengthSweeper.cs`**: coverage warnings now label components by `GdsFactoryFunction ?? NazcaFunctionName ?? Identifier`, so cspdk components are reported under their real name.

## Regression tests

- `BundledPdkProcessTests`: every CornerStone component carries an sMatrix (no silent black box); all multi-wavelength matrices bracket 1500–1600 nm; a **placed** `coupler_straight` (template → `CreateFromTemplate`) has `WaveLengthToSMatrixMap` keys 1500…1600 and a transmitting matrix at 1550; `coupler_straight` added to the multi-wavelength theory.
- `WavelengthSweeperTests`: sweep warning names the gdsfactory factory, never the synthesized `nazca_` placeholder.

Note: the second field-test warning (all outputs at −120 dB) was partly ONA wiring, but with the previous all-zero matrix no wiring could have produced light through this component.

## Test plan
- [x] `dotnet build` — 0 errors / 0 warnings
- [x] Full suite: 3444 passed, 0 failed (18 skipped)
- [ ] CI `🔍 xUnit Tests` green
- [ ] Field re-test: ONA sweep 1500–1600 nm over CornerStone `coupler_straight` shows transmission and no 980–1550/`nazca_` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)