### PR TITLE
Eigene Komponente per Rawcode: Code einfügen / aus .py laden im 'Neue Komponente'-Fenster

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs
@@ -221,6 +221,23 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper.DTOs
         /// </summary>
         [JsonPropertyName("compactModelParameters")]
         public Dictionary<string, double>? CompactModelParameters { get; set; }
+
+        /// <summary>
+        /// Optional raw source code authored by the user for this component
+        /// (e.g. a gdsfactory or Nazca script that builds the cell). When set,
+        /// this is the component's authoritative geometry/export source instead
+        /// of <see cref="NazcaFunction"/>/<see cref="GdsFactoryFunction"/>. Null
+        /// for PDK components defined through the normal function-reference path.
+        /// </summary>
+        [JsonPropertyName("rawCode")]
+        public string? RawCode { get; set; }
+
+        /// <summary>
+        /// Backend the <see cref="RawCode"/> targets: <c>"nazca"</c> or
+        /// <c>"gdsfactory"</c>. Null when <see cref="RawCode"/> is not set.
+        /// </summary>
+        [JsonPropertyName("rawCodeBackend")]
+        public string? RawCodeBackend { get; set; }
     }
 
     /// <summary>

--- a/CAP-DataAccess/Components/ComponentDraftMapper/PdkLoader.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/PdkLoader.cs
@@ -127,10 +127,16 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             // gdsfactory PDK still needs its offset.
             bool isGdsFactoryComponent = !string.IsNullOrWhiteSpace(comp.GdsFactoryFunction);
 
+            // A component authored via raw code (issue #702 rawcode authoring) owns its
+            // own geometry/export path instead of referencing a PDK function, so it is
+            // exempt from the function-reference requirements below just like a
+            // gdsfactory-native or analysis-tool component.
+            bool hasRawCode = !string.IsNullOrWhiteSpace(comp.RawCode);
+
             // Every non-analysis component must be exportable by *some* backend: a
             // gdsfactory PDK component with neither a gdsFactoryFunction nor a nazcaFunction
             // would silently export as an empty/misplaced cell.
-            if (pdkIsGdsFactory && !isAnalysisTool && !isGdsFactoryComponent
+            if (pdkIsGdsFactory && !isAnalysisTool && !isGdsFactoryComponent && !hasRawCode
                 && string.IsNullOrWhiteSpace(comp.NazcaFunction))
             {
                 errors.Add($"[{pdkName}/{compLabel}] gdsfactory-backend component must declare a gdsFactoryFunction (or a nazcaFunction)");
@@ -161,8 +167,10 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             // waveguides. The Offset Editor bypasses this check (it exists
             // precisely to fix PDKs in this state). Analysis tools are also
             // exempt because they are never exported; gdsfactory-native components are
-            // exempt because they export via gdsfactory, not Nazca (#570).
-            if (requireNazcaOffset && !isAnalysisTool && !isGdsFactoryComponent)
+            // exempt because they export via gdsfactory, not Nazca (#570); raw-code
+            // components are exempt because they are placed/exported via their own
+            // script, not the Nazca put()-with-offset convention (#702).
+            if (requireNazcaOffset && !isAnalysisTool && !isGdsFactoryComponent && !hasRawCode)
             {
                 if (comp.NazcaOriginOffsetX == null)
                 {

--- a/CAP.Avalonia/Commands/PlaceComponentCommand.cs
+++ b/CAP.Avalonia/Commands/PlaceComponentCommand.cs
@@ -2,6 +2,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
 using CAP_Core.Components;
 using CAP_Core.Components.Core;
+using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.Commands;
 
@@ -17,20 +18,24 @@ public class PlaceComponentCommand : IUndoableCommand
     private readonly double _x;
     private readonly double _y;
     private readonly bool _isValid;
+    private readonly IDictionary<string, NazcaCodeOverride>? _overrideStore;
     private ComponentViewModel? _createdViewModel;
+    private bool _seededRawCodeOverride;
 
     private PlaceComponentCommand(
         DesignCanvasViewModel canvas,
         ComponentTemplate template,
         double x,
         double y,
-        bool isValid)
+        bool isValid,
+        IDictionary<string, NazcaCodeOverride>? overrideStore)
     {
         _canvas = canvas;
         _template = template;
         _x = x;
         _y = y;
         _isValid = isValid;
+        _overrideStore = overrideStore;
 
         if (isValid)
         {
@@ -41,11 +46,23 @@ public class PlaceComponentCommand : IUndoableCommand
     /// <summary>
     /// Tries to create a placement command. Returns null if no valid position exists.
     /// </summary>
+    /// <param name="canvas">Canvas the component is placed onto.</param>
+    /// <param name="template">PDK template to instantiate.</param>
+    /// <param name="x">Requested X position (µm); may be nudged by placement search.</param>
+    /// <param name="y">Requested Y position (µm); may be nudged by placement search.</param>
+    /// <param name="overrideStore">
+    /// Optional per-instance raw-code override store (e.g.
+    /// <c>FileOperationsViewModel.StoredNazcaOverrides</c>). When <paramref name="template"/>
+    /// carries <see cref="ComponentTemplate.RawCode"/>, <see cref="Execute"/> seeds a matching
+    /// <see cref="NazcaCodeOverride"/> entry for the placed instance so raw-code preview and
+    /// export — which read the override map — work without any export-path changes.
+    /// </param>
     public static PlaceComponentCommand? TryCreate(
         DesignCanvasViewModel canvas,
         ComponentTemplate template,
         double x,
-        double y)
+        double y,
+        IDictionary<string, NazcaCodeOverride>? overrideStore = null)
     {
         var validPosition = canvas.FindValidPlacement(x, y, template.WidthMicrometers, template.HeightMicrometers);
 
@@ -54,7 +71,7 @@ public class PlaceComponentCommand : IUndoableCommand
             return null; // No space available
         }
 
-        return new PlaceComponentCommand(canvas, template, validPosition.Value.x, validPosition.Value.y, true);
+        return new PlaceComponentCommand(canvas, template, validPosition.Value.x, validPosition.Value.y, true, overrideStore);
     }
 
     public string Description => $"Place {_template.Name}";
@@ -71,7 +88,31 @@ public class PlaceComponentCommand : IUndoableCommand
                 // Component not in canvas, add it
                 _createdViewModel = _canvas.AddComponent(_component, _template.Name, _template.PdkSource);
             }
+
+            SeedRawCodeOverride();
         }
+    }
+
+    /// <summary>
+    /// Seeds a per-instance <see cref="NazcaCodeOverride"/> for the placed component when
+    /// <see cref="_template"/> is a raw-code component. No-ops when there is no override
+    /// store, the template has no raw code, or the store already has an entry for this
+    /// instance's identifier (e.g. restored from a .lun file on load) — an existing entry
+    /// is never overwritten. Runs on every <see cref="Execute"/>, not just the first, so a
+    /// redo after <see cref="Undo"/> (which removes the entry this command seeded) restores it.
+    /// </summary>
+    private void SeedRawCodeOverride()
+    {
+        if (_overrideStore == null || _component == null) return;
+        if (string.IsNullOrEmpty(_template.RawCode)) return;
+        if (_overrideStore.ContainsKey(_component.Identifier)) return;
+
+        _overrideStore[_component.Identifier] = new NazcaCodeOverride
+        {
+            RawCode = _template.RawCode,
+            Backend = _template.RawCodeBackend == "gdsfactory" ? OverrideBackend.GdsFactory : OverrideBackend.Nazca
+        };
+        _seededRawCodeOverride = true;
     }
 
     public void Undo()
@@ -86,6 +127,14 @@ public class PlaceComponentCommand : IUndoableCommand
                 _canvas.RemoveComponent(viewModel);
             }
             _createdViewModel = null;
+
+            // Undo symmetry: only remove the override entry if THIS command seeded it —
+            // never touch a pre-existing entry (e.g. loaded from a .lun file).
+            if (_seededRawCodeOverride && _overrideStore != null)
+            {
+                _overrideStore.Remove(_component.Identifier);
+                _seededRawCodeOverride = false;
+            }
         }
     }
 }

--- a/CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs
@@ -78,9 +78,7 @@ public sealed class ComponentGeometryExtractor
     /// <summary>Renders the reference and extracts size + pins. On render failure, Success is false.</summary>
     public async Task<GeometryExtractResult> ExtractAsync(GeometryReference reference, CancellationToken ct = default)
     {
-        NazcaPreviewResult preview = reference.Backend == GeometryBackend.GdsFactory
-            ? await _gdsFactory.RenderRawCodeAsync(reference.ToGdsFactoryRawCode(), ct)
-            : await _nazca.RenderAsync(reference.Module, reference.Function, reference.Parameters, ct);
+        NazcaPreviewResult preview = await RenderAsync(reference, ct);
 
         if (!preview.Success)
             return new GeometryExtractResult(false, preview.Error, 0, 0, Array.Empty<OverridePinData>(), preview);
@@ -89,5 +87,23 @@ public sealed class ComponentGeometryExtractor
         double height = preview.YMax - preview.YMin;
         var pins = OverridePinMapper.BuildOverridePins(preview);
         return new GeometryExtractResult(true, null, width, height, pins, preview);
+    }
+
+    /// <summary>
+    /// Picks the backend-appropriate renderer and, when <see cref="GeometryReference.RawSourceCode"/>
+    /// is set, dispatches its verbatim contents to that renderer's raw-code entry point instead of
+    /// the module/function ("v1") path. Rawcode mode never synthesizes an import/wrapper — the
+    /// pasted code is expected to define <c>component</c> itself.
+    /// </summary>
+    private Task<NazcaPreviewResult> RenderAsync(GeometryReference reference, CancellationToken ct)
+    {
+        IComponentPreviewRenderer renderer = reference.Backend == GeometryBackend.GdsFactory ? _gdsFactory : _nazca;
+
+        if (reference.RawSourceCode is not null)
+            return renderer.RenderRawCodeAsync(reference.RawSourceCode, ct);
+
+        return reference.Backend == GeometryBackend.GdsFactory
+            ? _gdsFactory.RenderRawCodeAsync(reference.ToGdsFactoryRawCode(), ct)
+            : _nazca.RenderAsync(reference.Module, reference.Function, reference.Parameters, ct);
     }
 }

--- a/CAP.Avalonia/Services/AddCustomComponent/CustomComponentDraftFactory.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/CustomComponentDraftFactory.cs
@@ -15,11 +15,15 @@ public static class CustomComponentDraftFactory
 {
     /// <summary>
     /// Builds the draft for <paramref name="name"/> from the rendered <paramref name="preview"/>,
-    /// routing the qualified function to the gdsfactory or nazca field per the reference's backend
-    /// and attaching <paramref name="sMatrix"/> (null = black box) verbatim.
+    /// attaching <paramref name="sMatrix"/> (null = black box) verbatim. When
+    /// <paramref name="rawCode"/> is set, it (plus <paramref name="rawCodeBackend"/>) becomes the
+    /// draft's authoritative source and <c>GdsFactoryFunction</c>/<c>NazcaFunction</c> are left
+    /// unset; otherwise the qualified function is routed to the gdsfactory or nazca field per the
+    /// reference's backend, as in the module/function reference path.
     /// </summary>
     public static PdkComponentDraft Build(
-        string name, GeometryReference reference, GeometryExtractResult preview, PdkSMatrixDraft? sMatrix)
+        string name, GeometryReference reference, GeometryExtractResult preview, PdkSMatrixDraft? sMatrix,
+        string? rawCode = null, string? rawCodeBackend = null)
     {
         var draft = new PdkComponentDraft
         {
@@ -29,7 +33,12 @@ public static class CustomComponentDraftFactory
             Pins = MapPins(preview.Pins),
             SMatrix = sMatrix,
         };
-        if (reference.Backend == GeometryBackend.GdsFactory)
+        if (rawCode is not null)
+        {
+            draft.RawCode = rawCode;
+            draft.RawCodeBackend = rawCodeBackend;
+        }
+        else if (reference.Backend == GeometryBackend.GdsFactory)
             draft.GdsFactoryFunction = reference.QualifiedFunction;
         else
             draft.NazcaFunction = reference.QualifiedFunction;

--- a/CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs
@@ -23,8 +23,28 @@ public enum GeometryBackend
 /// <param name="Parameters">Optional Python kwargs fragment passed to the function call.</param>
 public sealed record GeometryReference(GeometryBackend Backend, string? Module, string Function, string? Parameters)
 {
+    /// <summary>
+    /// Verbatim Python cell code to render directly ("raw-code mode"). When set, this takes
+    /// precedence over <see cref="Module"/>/<see cref="Function"/>/<see cref="Parameters"/>:
+    /// <see cref="ComponentGeometryExtractor"/> passes it as-is to the backend-appropriate
+    /// renderer's <c>RenderRawCodeAsync</c> — no import/wrapper synthesis, the user's code
+    /// must define <c>component</c> itself. Named <c>RawSourceCode</c> rather than
+    /// <c>RawCode</c> because the static factory below is named <see cref="RawCode"/>; a
+    /// property and a method cannot share one identifier in C# (CS0102).
+    /// </summary>
+    public string? RawSourceCode { get; init; }
+
     /// <summary>The fully-qualified call, e.g. "cspdk.sin300.coupler" or "coupler".</summary>
     public string QualifiedFunction => string.IsNullOrWhiteSpace(Module) ? Function : $"{Module}.{Function}";
+
+    /// <summary>
+    /// Creates a raw-code geometry reference: <paramref name="code"/> is rendered verbatim by
+    /// the <paramref name="backend"/>-appropriate renderer, bypassing module/function dispatch.
+    /// </summary>
+    /// <param name="backend">Which renderer (nazca or gdsfactory) executes <paramref name="code"/>.</param>
+    /// <param name="code">Verbatim Python cell code; must assign a variable named <c>component</c>.</param>
+    public static GeometryReference RawCode(GeometryBackend backend, string code) =>
+        new(backend, null, string.Empty, null) { RawSourceCode = code };
 
     /// <summary>
     /// Wraps the reference in a raw-code snippet the gdsfactory preview script understands:

--- a/CAP.Avalonia/Services/AiGridService.cs
+++ b/CAP.Avalonia/Services/AiGridService.cs
@@ -6,6 +6,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Process;
+using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.Services;
 
@@ -35,6 +36,14 @@ public class AiGridService : IAiGridService
     /// path checks the group's children instead of the group's null source (#653).
     /// </summary>
     public Func<Component, string?>? ResolveComponentPdkSource { get; set; }
+
+    /// <summary>
+    /// Per-instance raw-code override store the AI placement path seeds into (issue
+    /// rawcode authoring), mirroring the manual-placement wiring on
+    /// <c>CanvasInteractionViewModel.NazcaOverrideStore</c>. Wired by <c>MainViewModel</c>
+    /// to <c>FileOperations.StoredNazcaOverrides</c>.
+    /// </summary>
+    public IDictionary<string, NazcaCodeOverride>? NazcaOverrideStore { get; set; }
 
     private (bool IsAllowed, string? BlockReason) CheckProcess(string? pdkSource) =>
         SingleProcessPolicy.CheckPlacement(
@@ -126,7 +135,7 @@ public class AiGridService : IAiGridService
         var centeredX = x - template.WidthMicrometers / 2;
         var centeredY = y - template.HeightMicrometers / 2;
 
-        var cmd = PlaceComponentCommand.TryCreate(_canvas, template, centeredX, centeredY);
+        var cmd = PlaceComponentCommand.TryCreate(_canvas, template, centeredX, centeredY, NazcaOverrideStore);
         if (cmd == null)
             return $"Cannot place '{componentType}' — no valid position found near ({x:F0}, {y:F0})µm. Try a different position.";
 

--- a/CAP.Avalonia/Services/PdkTemplateConverter.cs
+++ b/CAP.Avalonia/Services/PdkTemplateConverter.cs
@@ -60,6 +60,8 @@ public static class PdkTemplateConverter
             NazcaModuleName = nazcaModuleName,
             NazcaOriginOffsetX = nazcaOriginOffsetX,
             NazcaOriginOffsetY = nazcaOriginOffsetY,
+            RawCode = pdkComp.RawCode,
+            RawCodeBackend = pdkComp.RawCodeBackend,
         };
 
         if (pdkComp.SMatrix?.WavelengthData is { Count: > 0 } wlData)

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentInputMode.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentInputMode.cs
@@ -1,0 +1,11 @@
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>Which authoring mode <see cref="NewComponentViewModel"/> currently uses.</summary>
+public enum NewComponentInputMode
+{
+    /// <summary>Module/function reference dispatch (v1 default).</summary>
+    Reference,
+
+    /// <summary>User-pasted or file-loaded raw Python code, rendered verbatim.</summary>
+    OwnCode,
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.Services.Solvers;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Persistence.PIR;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>
+/// Save + FDTD-recompute path for <see cref="NewComponentViewModel"/> (split out purely to keep
+/// each file under the project's line-count limit; still one partial class, one responsibility).
+/// </summary>
+public partial class NewComponentViewModel
+{
+    private ComponentSMatrixData? _computedModel;
+
+    /// <summary>Save is only possible once a matching preview has been rendered and no work is in flight.</summary>
+    private bool CanSave => HasPreview && !IsBusy;
+
+    partial void OnHasPreviewChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
+    partial void OnIsBusyChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
+
+    /// <summary>
+    /// Recomputes the S-matrix from the rendered geometry via the FDTD solver. Any failure —
+    /// no solver configured, an unavailable backend, or a failed solve — clears the pending
+    /// model and reports the reason via <see cref="NewComponentViewModel.StatusText"/>; a
+    /// black-box save is the only fallback, never a fabricated matrix.
+    /// </summary>
+    [RelayCommand]
+    private async Task ComputeSMatrix()
+    {
+        if (IsBusy) return;
+        if (_lastPreview is not { Success: true } preview || SelectedProcess is null)
+        {
+            StatusText = "Render a preview and select a process before computing the S-matrix.";
+            return;
+        }
+        if (_fdtd is null)
+        {
+            StatusText = "FDTD solver is not configured.";
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            var availability = await _fdtd.CheckAvailabilityAsync();
+            if (!availability.IsAvailable)
+            {
+                _computedModel = null;
+                StatusText = availability.Message;
+                return;
+            }
+
+            var portNames = preview.Pins.Select(p => p.Name).ToList();
+            var request = ComponentFdtdRequestFactory.BuildFromPreview(preview.Raw, portNames);
+            var result = await _fdtd.SolveAsync(request);
+            if (!result.Success)
+            {
+                _computedModel = null;
+                StatusText = result.Error ?? "FDTD solve failed.";
+                return;
+            }
+
+            _computedModel = FdtdSMatrixConverter.ToComponentSMatrixData(result, "FDTD Meep");
+            StatusText = "S-matrix computed.";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Saves the current component as a PDK component draft into the selected process's user
+    /// PDK. Requires a name, a rendered preview, and a selected process — missing any of these
+    /// reports why via <see cref="NewComponentViewModel.StatusText"/> and leaves
+    /// <see cref="NewComponentViewModel.SavedDraft"/> null. A name collision is reported unless
+    /// <see cref="NewComponentViewModel.ConfirmOverwrite"/> confirms it. The S-matrix is either
+    /// the last FDTD result or a black box when none was computed — never fabricated. In
+    /// own-code mode the draft's raw code/backend are set instead of a module/function
+    /// reference. A black-box save preserves any pending diagnostic and prefixes it with a save
+    /// confirmation.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanSave))]
+    private async Task Save()
+    {
+        if (IsBusy) return;
+        var name = ComponentName?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            StatusText = "Enter a component name before saving.";
+            return;
+        }
+        if (_lastPreview is not { Success: true } preview)
+        {
+            StatusText = "Render a preview before saving.";
+            return;
+        }
+        if (SelectedProcess is null)
+        {
+            StatusText = "Select a fabrication process before saving.";
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            var process = SelectedProcess;
+            if (_store.ComponentExists(process, name))
+            {
+                if (ConfirmOverwrite is null)
+                {
+                    StatusText = $"'{name}' already exists in {process.Name}.";
+                    return;
+                }
+                if (!await ConfirmOverwrite(name, process.Name))
+                {
+                    StatusText = "Save cancelled.";
+                    return;
+                }
+            }
+
+            var reference = BuildReference();
+            var sMatrix = _computedModel is null
+                ? FdtdSMatrixToDraftConverter.BlackBox()
+                : FdtdSMatrixToDraftConverter.FromFdtd(_computedModel);
+            var backend = SelectedBackend == GeometryBackend.GdsFactory ? "gdsfactory" : "nazca";
+            var draft = InputMode == NewComponentInputMode.OwnCode
+                ? CustomComponentDraftFactory.Build(name, reference, preview, sMatrix, Code, backend)
+                : CustomComponentDraftFactory.Build(name, reference, preview, sMatrix);
+
+            _store.Save(process, draft, backend, null);
+
+            SavedDraft = draft;
+            SavedProcessName = process.Name;
+            StatusText = _computedModel is null
+                ? $"Saved as black box. {StatusText}".Trim()
+                : "Saved with FDTD S-matrix.";
+            Saved?.Invoke(this, EventArgs.Empty);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using CAP.Avalonia.Services.AddCustomComponent;
 using CAP.Avalonia.Services.Solvers;
@@ -18,7 +17,8 @@ namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
 /// renders its geometry (nazca or gdsfactory), optionally recomputes its S-matrix via the
 /// FDTD solver, and saves the result as a <see cref="PdkComponentDraft"/>. Never invents
 /// physics — a missing solver, an unavailable backend, or a failed solve always saves the
-/// component as a black box (no S-matrix), never a fabricated one.
+/// component as a black box (no S-matrix), never a fabricated one. The save/FDTD-compute path
+/// lives in the <c>NewComponentViewModel.Save.cs</c> partial (kept a separate file for size).
 /// </summary>
 public partial class NewComponentViewModel : ObservableObject
 {
@@ -27,7 +27,6 @@ public partial class NewComponentViewModel : ObservableObject
     private readonly UserPdkStore _store;
 
     private GeometryExtractResult? _lastPreview;
-    private ComponentSMatrixData? _computedModel;
 
     [ObservableProperty] private string _componentName = string.Empty;
     [ObservableProperty] private GeometryBackend _selectedBackend = GeometryBackend.GdsFactory;
@@ -38,20 +37,29 @@ public partial class NewComponentViewModel : ObservableObject
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private bool _hasPreview;
+    [ObservableProperty] private NewComponentInputMode _inputMode = NewComponentInputMode.Reference;
+    [ObservableProperty] private string _code = string.Empty;
 
     /// <summary>Fabrication processes available for the "save to" selection.</summary>
     public IReadOnlyList<ProcessDefinition> Processes { get; }
 
     /// <summary>
-    /// Geometry backends selectable in the UI. v1 offers gdsfactory only: a nazca custom
-    /// component saved without a derived <c>NazcaOriginOffset</c> has no clean export/sim path,
-    /// so nazca custom components are deferred to v2 (needs NazcaOriginOffset derivation). The
-    /// <see cref="GeometryBackend"/> enum and the extractor's nazca branch stay for tests/v2.
+    /// Geometry backends selectable for <see cref="InputMode"/>: reference mode offers
+    /// gdsfactory only (a nazca custom component needs a derived NazcaOriginOffset, v2);
+    /// own-code mode offers both, since raw code exports via the per-instance override path.
     /// </summary>
-    public static IReadOnlyList<GeometryBackend> AvailableBackends { get; } =
-        new[] { GeometryBackend.GdsFactory };
+    public IReadOnlyList<GeometryBackend> AvailableBackends =>
+        InputMode == NewComponentInputMode.OwnCode
+            ? new[] { GeometryBackend.GdsFactory, GeometryBackend.Nazca }
+            : new[] { GeometryBackend.GdsFactory };
 
-    /// <summary>The draft last written by <see cref="Save"/>, or null before a successful save.</summary>
+    /// <summary>
+    /// File-picker hook for <see cref="LoadCodeFromFile"/>: returns a ".py" file's already-read
+    /// contents, or null if cancelled. Null keeps the command a no-op — no direct file dialog.
+    /// </summary>
+    public Func<Task<string?>>? PickPyFile { get; set; }
+
+    /// <summary>The draft last written by <c>Save</c>, or null before a successful save.</summary>
     public PdkComponentDraft? SavedDraft { get; private set; }
 
     /// <summary>The process name <see cref="SavedDraft"/> was saved under.</summary>
@@ -82,13 +90,19 @@ public partial class NewComponentViewModel : ObservableObject
 
     // A change to any input the preview was rendered from invalidates the preview — otherwise
     // a saved draft could be built from a rendered preview that no longer matches the current
-    // Module/Function/Parameters/Backend (drift between the last render and what gets saved).
-    // Clearing _lastPreview is the load-bearing part: Save gates on that field, so a stale
-    // preview cannot be saved; HasPreview (which drives the Save button's enablement) tracks it.
+    // inputs. Clearing _lastPreview is the load-bearing part: Save gates on that field, so a
+    // stale preview cannot be saved; HasPreview (Save button's enablement) tracks it.
     partial void OnSelectedBackendChanged(GeometryBackend value) => InvalidatePreview();
     partial void OnModuleChanged(string? value) => InvalidatePreview();
     partial void OnFunctionChanged(string value) => InvalidatePreview();
     partial void OnParametersChanged(string? value) => InvalidatePreview();
+    partial void OnCodeChanged(string value) => InvalidatePreview();
+
+    partial void OnInputModeChanged(NewComponentInputMode value)
+    {
+        OnPropertyChanged(nameof(AvailableBackends));
+        InvalidatePreview();
+    }
 
     private void InvalidatePreview()
     {
@@ -96,11 +110,20 @@ public partial class NewComponentViewModel : ObservableObject
         HasPreview = false;
     }
 
-    /// <summary>Save is only possible once a matching preview has been rendered and no work is in flight.</summary>
-    private bool CanSave => HasPreview && !IsBusy;
+    /// <summary>Raw code in own-code mode, else the module/function/parameters reference.</summary>
+    private GeometryReference BuildReference() =>
+        InputMode == NewComponentInputMode.OwnCode
+            ? GeometryReference.RawCode(SelectedBackend, Code)
+            : new GeometryReference(SelectedBackend, Module, Function, Parameters);
 
-    partial void OnHasPreviewChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
-    partial void OnIsBusyChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
+    /// <summary>Loads Python source into <see cref="Code"/> via the injected <see cref="PickPyFile"/> hook.</summary>
+    [RelayCommand]
+    private async Task LoadCodeFromFile()
+    {
+        if (PickPyFile is null) return;
+        var content = await PickPyFile();
+        if (content is not null) Code = content;
+    }
 
     /// <summary>Renders the configured geometry reference and extracts its size and pins.</summary>
     [RelayCommand]
@@ -110,136 +133,13 @@ public partial class NewComponentViewModel : ObservableObject
         IsBusy = true;
         try
         {
-            var reference = new GeometryReference(SelectedBackend, Module, Function, Parameters);
+            var reference = BuildReference();
             var result = await _extractor.ExtractAsync(reference);
             _lastPreview = result;
             HasPreview = result.Success;
             StatusText = result.Success
                 ? $"Preview rendered: {result.WidthUm:0.###} x {result.HeightUm:0.###} um, {result.Pins.Count} pins."
                 : result.Error ?? "Preview render failed.";
-        }
-        finally
-        {
-            IsBusy = false;
-        }
-    }
-
-    /// <summary>
-    /// Recomputes the S-matrix from the rendered geometry via the FDTD solver. Any failure —
-    /// no solver configured, an unavailable backend, or a failed solve — clears the pending
-    /// model and reports the reason via <see cref="StatusText"/>; a black-box save is the
-    /// only fallback, never a fabricated matrix.
-    /// </summary>
-    [RelayCommand]
-    private async Task ComputeSMatrix()
-    {
-        if (IsBusy) return;
-        if (_lastPreview is not { Success: true } preview || SelectedProcess is null)
-        {
-            StatusText = "Render a preview and select a process before computing the S-matrix.";
-            return;
-        }
-        if (_fdtd is null)
-        {
-            StatusText = "FDTD solver is not configured.";
-            return;
-        }
-
-        IsBusy = true;
-        try
-        {
-            var availability = await _fdtd.CheckAvailabilityAsync();
-            if (!availability.IsAvailable)
-            {
-                _computedModel = null;
-                StatusText = availability.Message;
-                return;
-            }
-
-            var portNames = preview.Pins.Select(p => p.Name).ToList();
-            var request = ComponentFdtdRequestFactory.BuildFromPreview(preview.Raw, portNames);
-            var result = await _fdtd.SolveAsync(request);
-            if (!result.Success)
-            {
-                _computedModel = null;
-                StatusText = result.Error ?? "FDTD solve failed.";
-                return;
-            }
-
-            _computedModel = FdtdSMatrixConverter.ToComponentSMatrixData(result, "FDTD Meep");
-            StatusText = "S-matrix computed.";
-        }
-        finally
-        {
-            IsBusy = false;
-        }
-    }
-
-    /// <summary>
-    /// Saves the current component as a <see cref="PdkComponentDraft"/> into the selected
-    /// process's user PDK. Requires a name, a rendered preview, and a selected process —
-    /// missing any of these reports why via <see cref="StatusText"/> and leaves
-    /// <see cref="SavedDraft"/> null. A name collision is reported via <see cref="StatusText"/>
-    /// unless <see cref="ConfirmOverwrite"/> confirms the overwrite. On success the S-matrix is
-    /// either the last FDTD result or a black box when none was computed — never fabricated. A
-    /// black-box save preserves any pending diagnostic in <see cref="StatusText"/> (e.g. an FDTD
-    /// failure explaining why the save is a black box) and prefixes it with a save confirmation,
-    /// so the user always gets confirmation without losing the reason there is no model.
-    /// </summary>
-    [RelayCommand(CanExecute = nameof(CanSave))]
-    private async Task Save()
-    {
-        if (IsBusy) return;
-        var name = ComponentName?.Trim();
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            StatusText = "Enter a component name before saving.";
-            return;
-        }
-        if (_lastPreview is not { Success: true } preview)
-        {
-            StatusText = "Render a preview before saving.";
-            return;
-        }
-        if (SelectedProcess is null)
-        {
-            StatusText = "Select a fabrication process before saving.";
-            return;
-        }
-
-        IsBusy = true;
-        try
-        {
-            var process = SelectedProcess;
-            if (_store.ComponentExists(process, name))
-            {
-                if (ConfirmOverwrite is null)
-                {
-                    StatusText = $"'{name}' already exists in {process.Name}.";
-                    return;
-                }
-                if (!await ConfirmOverwrite(name, process.Name))
-                {
-                    StatusText = "Save cancelled.";
-                    return;
-                }
-            }
-
-            var reference = new GeometryReference(SelectedBackend, Module, Function, Parameters);
-            var sMatrix = _computedModel is null
-                ? FdtdSMatrixToDraftConverter.BlackBox()
-                : FdtdSMatrixToDraftConverter.FromFdtd(_computedModel);
-            var draft = CustomComponentDraftFactory.Build(name, reference, preview, sMatrix);
-
-            var backend = SelectedBackend == GeometryBackend.GdsFactory ? "gdsfactory" : "nazca";
-            _store.Save(process, draft, backend, null);
-
-            SavedDraft = draft;
-            SavedProcessName = process.Name;
-            StatusText = _computedModel is null
-                ? $"Saved as black box. {StatusText}".Trim()
-                : "Saved with FDTD S-matrix.";
-            Saved?.Invoke(this, EventArgs.Empty);
         }
         finally
         {

--- a/CAP.Avalonia/ViewModels/Converters/EnumToBooleanConverter.cs
+++ b/CAP.Avalonia/ViewModels/Converters/EnumToBooleanConverter.cs
@@ -13,9 +13,6 @@ namespace CAP.Avalonia.ViewModels.Converters;
 /// </summary>
 public sealed class EnumToBooleanConverter : IValueConverter
 {
-    /// <summary>Shared instance for use as a static XAML resource.</summary>
-    public static readonly EnumToBooleanConverter Instance = new();
-
     /// <summary>True when <paramref name="value"/>'s enum member name equals <paramref name="parameter"/>.</summary>
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {

--- a/CAP.Avalonia/ViewModels/Converters/EnumToBooleanConverter.cs
+++ b/CAP.Avalonia/ViewModels/Converters/EnumToBooleanConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace CAP.Avalonia.ViewModels.Converters;
+
+/// <summary>
+/// Binds a group of <c>RadioButton</c>s directly to a single enum-valued property: each
+/// button's <c>IsChecked</c> compares the bound enum against the button's own
+/// <c>ConverterParameter</c> (the enum member name, e.g. "OwnCode"). Avoids adding one bool
+/// flag property per option to the view model just to drive radio-button selection.
+/// </summary>
+public sealed class EnumToBooleanConverter : IValueConverter
+{
+    /// <summary>Shared instance for use as a static XAML resource.</summary>
+    public static readonly EnumToBooleanConverter Instance = new();
+
+    /// <summary>True when <paramref name="value"/>'s enum member name equals <paramref name="parameter"/>.</summary>
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is null || parameter is null) return false;
+        return string.Equals(value.ToString(), parameter.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// When a RadioButton becomes checked, parses <paramref name="parameter"/> back into the
+    /// source enum type. A RadioButton becoming unchecked (as its group's partner gets checked)
+    /// yields <see cref="BindingOperations.DoNothing"/> so it never overwrites the value the
+    /// partner is about to set.
+    /// </summary>
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not true || parameter is null) return BindingOperations.DoNothing;
+        return Enum.Parse(targetType, parameter.ToString()!);
+    }
+}

--- a/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
@@ -203,6 +203,20 @@ public partial class ComponentTemplate : ObservableObject
     /// under the activated gdsfactory PDK (#570 field-test fix).
     /// </summary>
     public string? GdsFactoryRoutingCrossSection { get; set; }
+
+    /// <summary>
+    /// Optional raw source code authored by the user for this component
+    /// (e.g. a gdsfactory or Nazca script that builds the cell). Carried over
+    /// from <see cref="CAP_DataAccess.Components.ComponentDraftMapper.DTOs.PdkComponentDraft.RawCode"/>.
+    /// Null for components defined through the normal function-reference path.
+    /// </summary>
+    public string? RawCode { get; set; }
+
+    /// <summary>
+    /// Backend the <see cref="RawCode"/> targets: <c>"nazca"</c> or
+    /// <c>"gdsfactory"</c>. Null when <see cref="RawCode"/> is not set.
+    /// </summary>
+    public string? RawCodeBackend { get; set; }
 }
 
 public class PinDefinition

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -299,11 +299,18 @@ public partial class MainViewModel : ObservableObject
         CanvasInteraction.GetProcessAgnosticPdkNames = getAgnosticPdkNames;
         CanvasInteraction.ResolveComponentPdkSource = resolvePdkSource;
         _canvas.Clipboard.PdkSourceResolver = resolvePdkSource;
+
+        // Raw-code placement seeding: manual and AI placement both write into the same
+        // per-instance override store paste-propagation already uses (see
+        // OnComponentsPasted below), so a placed raw-code template's preview/export
+        // override exists without any export-path changes.
+        CanvasInteraction.NazcaOverrideStore = FileOperations.StoredNazcaOverrides;
         if (aiGridService is Services.AiGridService aiGrid)
         {
             aiGrid.GetActiveProcess = getActiveProcess;
             aiGrid.GetProcessAgnosticPdkNames = getAgnosticPdkNames;
             aiGrid.ResolveComponentPdkSource = resolvePdkSource;
+            aiGrid.NazcaOverrideStore = FileOperations.StoredNazcaOverrides;
         }
 
         // Let the export guard open the Settings window (e.g. on the Python-Environments

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -10,6 +10,7 @@ using CAP.Avalonia.Commands;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.Services;
+using CAP_DataAccess.Persistence.PIR;
 
 namespace CAP.Avalonia.ViewModels.Panels;
 
@@ -92,6 +93,14 @@ public partial class CanvasInteractionViewModel : ObservableObject
     /// Wired by <c>MainViewModel</c> to propagate <c>StoredNazcaOverrides</c>.
     /// </summary>
     public Action<IReadOnlyDictionary<string, string>>? OnComponentsPasted { get; set; }
+
+    /// <summary>
+    /// Per-instance raw-code override store manual placement seeds into (issue rawcode
+    /// authoring). Wired by <c>MainViewModel</c> to <c>FileOperations.StoredNazcaOverrides</c>
+    /// so placing a raw-code template creates the override the raw-code preview/export path
+    /// reads, without any export-path changes. Null in tests that don't need placement seeding.
+    /// </summary>
+    public IDictionary<string, NazcaCodeOverride>? NazcaOverrideStore { get; set; }
 
     /// <summary>
     /// Callback invoked when the user probes an element in Probe mode (issue #691):
@@ -358,7 +367,7 @@ public partial class CanvasInteractionViewModel : ObservableObject
         double centeredX = x - SelectedTemplate.WidthMicrometers / 2;
         double centeredY = y - SelectedTemplate.HeightMicrometers / 2;
 
-        var cmd = PlaceComponentCommand.TryCreate(_canvas, SelectedTemplate, centeredX, centeredY);
+        var cmd = PlaceComponentCommand.TryCreate(_canvas, SelectedTemplate, centeredX, centeredY, NazcaOverrideStore);
         if (cmd == null)
         {
             UpdateStatus?.Invoke("No space available on chip for this component");

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -17,6 +17,7 @@ using CAP.Avalonia.Views.Dialogs;
 using CAP.Avalonia.Views.PdkImport;
 using CAP.Avalonia.ViewModels.Solvers;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 
 namespace CAP.Avalonia.Views;
@@ -80,6 +81,15 @@ public partial class MainWindow : Window
                 // iterating on the design while it stays open.
                 vm.LeftPanel.ShowNewComponentWindowAsync = newComponentVm =>
                 {
+                    // Own-code mode's "Load from .py…" button (#custom-component-rawcode): the
+                    // view model only knows the file's already-read contents (PickPyFile's
+                    // contract), never a path, so it can't own a FileDialogService itself.
+                    newComponentVm.PickPyFile = async () =>
+                    {
+                        var path = await new FileDialogService(this).ShowOpenFileDialogAsync(
+                            "Load Python file", "Python Files (*.py)|*.py|All Files (*.*)|*.*");
+                        return path is null ? null : await File.ReadAllTextAsync(path);
+                    };
                     var window = new NewComponentWindow { DataContext = newComponentVm };
                     window.Show(this);
                     return System.Threading.Tasks.Task.CompletedTask;

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -49,9 +49,9 @@
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="Input:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
                     <StackPanel Grid.Row="2" Grid.Column="2" Orientation="Horizontal" Spacing="14">
                         <RadioButton Content="Function reference" GroupName="InputMode" Foreground="White"
-                                     IsChecked="{Binding InputMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Reference}"/>
+                                     IsChecked="{Binding InputMode, Mode=TwoWay, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Reference}"/>
                         <RadioButton Content="Own code" GroupName="InputMode" Foreground="White"
-                                     IsChecked="{Binding InputMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=OwnCode}"/>
+                                     IsChecked="{Binding InputMode, Mode=TwoWay, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=OwnCode}"/>
                     </StackPanel>
 
                     <TextBlock Grid.Row="4" Grid.Column="0" Text="Backend:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -43,7 +43,7 @@
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="Backend:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
                     <ComboBox Grid.Row="2" Grid.Column="2"
-                              ItemsSource="{x:Static vm:NewComponentViewModel.AvailableBackends}"
+                              ItemsSource="{Binding AvailableBackends}"
                               SelectedItem="{Binding SelectedBackend}"
                               Background="#2d2d2d" Foreground="White" HorizontalAlignment="Stretch"/>
 

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -2,14 +2,19 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:CAP.Avalonia.ViewModels.Components.AddCustomComponent"
         xmlns:dto="using:CAP_DataAccess.Components.ComponentDraftMapper.DTOs"
+        xmlns:conv="using:CAP.Avalonia.ViewModels.Converters"
         x:Class="CAP.Avalonia.Views.NewComponentWindow"
         x:DataType="vm:NewComponentViewModel"
         Title="New Component"
-        Width="480" Height="620"
+        Width="480" Height="660"
         MinWidth="420" MinHeight="520"
         WindowStartupLocation="CenterOwner"
         Background="#1e1e1e"
         Foreground="White">
+
+    <Window.Resources>
+        <conv:EnumToBooleanConverter x:Key="EnumToBooleanConverter"/>
+    </Window.Resources>
 
     <DockPanel Margin="16" LastChildFill="True">
 
@@ -36,29 +41,61 @@
 
                 <Separator Background="#3d3d3d"/>
 
-                <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,8,Auto,8,Auto,8,Auto,8,Auto">
+                <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,8,Auto,8,Auto">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Name:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
                     <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding ComponentName}"
                              Background="#2d2d2d" Foreground="White"/>
 
-                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Backend:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
-                    <ComboBox Grid.Row="2" Grid.Column="2"
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Input:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <StackPanel Grid.Row="2" Grid.Column="2" Orientation="Horizontal" Spacing="14">
+                        <RadioButton Content="Function reference" GroupName="InputMode" Foreground="White"
+                                     IsChecked="{Binding InputMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Reference}"/>
+                        <RadioButton Content="Own code" GroupName="InputMode" Foreground="White"
+                                     IsChecked="{Binding InputMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=OwnCode}"/>
+                    </StackPanel>
+
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Backend:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <ComboBox Grid.Row="4" Grid.Column="2"
                               ItemsSource="{Binding AvailableBackends}"
                               SelectedItem="{Binding SelectedBackend}"
                               Background="#2d2d2d" Foreground="White" HorizontalAlignment="Stretch"/>
+                </Grid>
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Module:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="4" Grid.Column="2" Text="{Binding Module}"
+                <!-- Reference mode: module/function/parameters dispatch -->
+                <Grid ColumnDefinitions="*,8,*" RowDefinitions="Auto,8,Auto,8,Auto"
+                      IsVisible="{Binding InputMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Reference}">
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Module:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="0" Grid.Column="2" Text="{Binding Module}"
                              Watermark="e.g. cspdk.sin300" Background="#2d2d2d" Foreground="White"/>
 
-                    <TextBlock Grid.Row="6" Grid.Column="0" Text="Function:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="6" Grid.Column="2" Text="{Binding Function}"
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Function:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="2" Grid.Column="2" Text="{Binding Function}"
                              Watermark="e.g. coupler" Background="#2d2d2d" Foreground="White"/>
 
-                    <TextBlock Grid.Row="8" Grid.Column="0" Text="Parameters:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
-                    <TextBox Grid.Row="8" Grid.Column="2" Text="{Binding Parameters}"
+                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Parameters:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                    <TextBox Grid.Row="4" Grid.Column="2" Text="{Binding Parameters}"
                              Watermark="e.g. length=10" Background="#2d2d2d" Foreground="White"/>
                 </Grid>
+
+                <!-- Own-code mode: pasted or file-loaded raw Python, rendered verbatim -->
+                <StackPanel Spacing="6"
+                            IsVisible="{Binding InputMode, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=OwnCode}">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Grid.Column="0" Text="Python code:" Foreground="Gray" FontSize="11" VerticalAlignment="Center"/>
+                        <Button Grid.Column="1" Content="Load from .py…" Command="{Binding LoadCodeFromFileCommand}"
+                                Background="#3d4d6d" FontSize="11"
+                                ToolTip.Tip="Reads a .py file's contents into the editor below"/>
+                    </Grid>
+                    <TextBox Text="{Binding Code}"
+                             AcceptsReturn="True" AcceptsTab="True"
+                             TextWrapping="NoWrap"
+                             FontFamily="Consolas, Cascadia Mono, Courier New, monospace" FontSize="11"
+                             Height="180"
+                             Background="#151515" Foreground="#dddddd"
+                             VerticalContentAlignment="Top"
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                </StackPanel>
 
                 <Separator Background="#3d3d3d"/>
 

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelRawCodeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelRawCodeTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="NewComponentViewModel"/>'s own-code mode: pasting/loading raw Python
+/// source instead of a module/function reference, previewing it via
+/// <see cref="GeometryReference.RawCode"/>, and saving it as a raw-code draft (never a
+/// fabricated module/function reference).
+/// </summary>
+public class NewComponentViewModelRawCodeTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-nc-vm-raw-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 8, YMax = 1.5,
+        Pins = new List<NazcaPreviewPin> { new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 }, new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 } }
+    };
+
+    private NewComponentViewModel Build()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var vm = new NewComponentViewModel(extractor, fdtd: null, store,
+            new List<ProcessDefinition> { new() { Name = "P" } });
+        vm.ComponentName = "My Raw Comp";
+        vm.SelectedProcess = vm.Processes[0];
+        return vm;
+    }
+
+    [Fact]
+    public async Task OwnCodeMode_preview_and_save_writes_a_raw_code_draft()
+    {
+        var vm = Build();
+        vm.InputMode = NewComponentInputMode.OwnCode;
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+        vm.Code = "import gdsfactory as gf\ncomponent = gf.components.mmi1x2()";
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        vm.HasPreview.ShouldBeTrue();
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.SavedDraft.ShouldNotBeNull();
+        vm.SavedDraft!.RawCode.ShouldContain("gf.components.mmi1x2");
+        vm.SavedDraft.RawCodeBackend.ShouldBe("gdsfactory");
+        vm.SavedDraft.GdsFactoryFunction.ShouldBeNull();
+        vm.SavedDraft.NazcaFunction.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task LoadCodeFromFile_fills_Code_from_the_injected_picker()
+    {
+        var vm = Build();
+        vm.InputMode = NewComponentInputMode.OwnCode;
+        vm.PickPyFile = () => Task.FromResult<string?>("component = gf.components.straight()");
+
+        await vm.LoadCodeFromFileCommand.ExecuteAsync(null);
+
+        vm.Code.ShouldBe("component = gf.components.straight()");
+    }
+
+    [Fact]
+    public async Task LoadCodeFromFile_is_a_noop_when_the_picker_returns_null()
+    {
+        var vm = Build();
+        vm.Code = "unchanged";
+        vm.PickPyFile = () => Task.FromResult<string?>(null);
+
+        await vm.LoadCodeFromFileCommand.ExecuteAsync(null);
+
+        vm.Code.ShouldBe("unchanged");
+    }
+
+    [Fact]
+    public void AvailableBackends_offers_both_backends_in_own_code_mode_and_only_gdsfactory_in_reference_mode()
+    {
+        var vm = Build();
+
+        vm.AvailableBackends.ShouldHaveSingleItem();
+        vm.AvailableBackends[0].ShouldBe(GeometryBackend.GdsFactory);
+
+        vm.InputMode = NewComponentInputMode.OwnCode;
+
+        vm.AvailableBackends.Count.ShouldBe(2);
+        vm.AvailableBackends.ShouldContain(GeometryBackend.GdsFactory);
+        vm.AvailableBackends.ShouldContain(GeometryBackend.Nazca);
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
@@ -122,12 +122,15 @@ public class NewComponentViewModelTests : IDisposable
     }
 
     [Fact]
-    public void Only_GdsFactory_backend_is_selectable_in_v1()
+    public void Only_GdsFactory_backend_is_selectable_in_reference_mode()
     {
-        // v1 scope: nazca custom components need NazcaOriginOffset derivation (v2), so the UI
-        // must offer gdsfactory only. The enum + extractor's nazca branch remain for tests/v2.
-        NewComponentViewModel.AvailableBackends.ShouldHaveSingleItem();
-        NewComponentViewModel.AvailableBackends[0].ShouldBe(GeometryBackend.GdsFactory);
+        // Reference mode: nazca custom components need NazcaOriginOffset derivation (v2), so
+        // the UI must offer gdsfactory only. The enum + extractor's nazca branch remain for
+        // tests/v2. Own-code mode's own AvailableBackends behavior is covered separately
+        // (NewComponentViewModelRawCodeTests).
+        var (vm, _) = Build(withFdtd: false);
+        vm.AvailableBackends.ShouldHaveSingleItem();
+        vm.AvailableBackends[0].ShouldBe(GeometryBackend.GdsFactory);
     }
 
     public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }

--- a/UnitTests/Components/AddCustomComponent/RawCodeEndToEndTests.cs
+++ b/UnitTests/Components/AddCustomComponent/RawCodeEndToEndTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Integration test for the rawcode authoring chain (issue #702 follow-up): a
+/// raw-code component definition survives the full Draft -> Template -> Placement
+/// pipeline, from the PDK JSON persistence round-trip through template conversion
+/// to the per-instance <see cref="NazcaCodeOverride"/> seeded at placement time.
+/// All building blocks (RC-Tasks 1-3) already exist; this test wires them together
+/// end-to-end and asserts one thing per stage.
+/// </summary>
+public class RawCodeEndToEndTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-rawcode-e2e-" + Guid.NewGuid().ToString("N"));
+
+    private static PdkComponentDraft BuildDraft() => new()
+    {
+        Name = "My Cell",
+        WidthMicrometers = 10,
+        HeightMicrometers = 2,
+        RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()",
+        RawCodeBackend = "gdsfactory",
+        Pins = new List<PhysicalPinDraft>
+        {
+            new() { Name = "o1", OffsetXMicrometers = 0, OffsetYMicrometers = 1, AngleDegrees = 180 },
+            new() { Name = "o2", OffsetXMicrometers = 10, OffsetYMicrometers = 1, AngleDegrees = 0 }
+        }
+    };
+
+    [Fact]
+    public void RawCode_component_survives_draft_to_template_to_placement_override()
+    {
+        var draft = BuildDraft();
+
+        // Stage 1: Save via UserPdkStore into a temp root, then reload via PdkLoader.
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var path = store.Save(new ProcessDefinition { Name = "My P" }, draft, "gdsfactory", null);
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+        var reloadedComponent = reloaded.Components.Single(c => c.Name == "My Cell");
+        reloadedComponent.RawCode.ShouldContain("gf.components.straight");
+
+        // Stage 2: Convert the reloaded draft to a ComponentTemplate.
+        var template = PdkTemplateConverter.ConvertToTemplate(reloadedComponent, "My P", null);
+        template.RawCode.ShouldContain("gf.components.straight");
+
+        // Stage 3: Place the template and verify the placement seeds a per-instance
+        // raw-code override in the override store.
+        var canvas = new DesignCanvasViewModel();
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+        var command = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrides);
+        command.ShouldNotBeNull();
+        command!.Execute();
+
+        var seededOverride = overrides.Values.Single();
+        seededOverride.RawCode.ShouldContain("gf.components.straight");
+        seededOverride.Backend.ShouldBe(OverrideBackend.GdsFactory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, true);
+        }
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/RawCodeExtractionTests.cs
+++ b/UnitTests/Components/AddCustomComponent/RawCodeExtractionTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="ComponentGeometryExtractor"/>'s raw-code mode
+/// (<see cref="GeometryReference.RawCode"/>): pasted code is rendered verbatim by the
+/// backend-appropriate renderer, with no import/wrapper synthesis, and a failed render
+/// surfaces the error without pins — same contract as v1's module/function path.
+/// </summary>
+public class RawCodeExtractionTests
+{
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 8, YMax = 1.5,
+        Pins = new List<NazcaPreviewPin>
+        { new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 }, new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 } }
+    };
+
+    [Fact]
+    public async Task RawCode_gdsfactory_renders_code_verbatim()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync("component = gf.components.mmi1x2()", It.IsAny<CancellationToken>()))
+           .ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var res = await extractor.ExtractAsync(GeometryReference.RawCode(GeometryBackend.GdsFactory, "component = gf.components.mmi1x2()"));
+
+        res.Success.ShouldBeTrue();
+        res.WidthUm.ShouldBe(8);
+        res.Pins.Count.ShouldBe(2);
+        gds.Verify(g => g.RenderRawCodeAsync("component = gf.components.mmi1x2()", It.IsAny<CancellationToken>()), Times.Once);
+        gds.Verify(g => g.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RawCode_nazca_renders_code_verbatim()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        nazca.Setup(n => n.RenderRawCodeAsync("component = nd.Cell()", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var res = await extractor.ExtractAsync(GeometryReference.RawCode(GeometryBackend.Nazca, "component = nd.Cell()"));
+
+        res.Success.ShouldBeTrue();
+        res.Pins.Count.ShouldBe(2);
+        nazca.Verify(n => n.RenderRawCodeAsync("component = nd.Cell()", It.IsAny<CancellationToken>()), Times.Once);
+        nazca.Verify(n => n.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RawCode_render_failure_surfaces_error_and_no_pins()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(new NazcaPreviewResult { Success = false, Error = "boom" });
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var res = await extractor.ExtractAsync(GeometryReference.RawCode(GeometryBackend.GdsFactory, "component = broken()"));
+
+        res.Success.ShouldBeFalse();
+        res.Error.ShouldBe("boom");
+        res.Pins.Count.ShouldBe(0);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/RawCodePersistenceTests.cs
+++ b/UnitTests/Components/AddCustomComponent/RawCodePersistenceTests.cs
@@ -1,0 +1,57 @@
+using CAP.Avalonia.Services;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Verifies that a raw-code component definition (issue #702 follow-up: rawcode
+/// authoring) survives the PDK JSON save/load round-trip and is carried over
+/// onto the <see cref="CAP.Avalonia.ViewModels.Library.ComponentTemplate"/>
+/// produced by <see cref="PdkTemplateConverter.ConvertToTemplate"/>.
+/// </summary>
+public class RawCodePersistenceTests
+{
+    [Fact]
+    public void PdkComponentDraft_roundtrips_rawcode_through_saver_and_loader()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lunima-rawcode-" + System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var path = System.IO.Path.Combine(dir, "p.json");
+        var pdk = new PdkDraft
+        {
+            Name = "My P", Backend = "gdsfactory", Components = new()
+            {
+                new PdkComponentDraft
+                {
+                    Name = "My Cell", WidthMicrometers = 10, HeightMicrometers = 2,
+                    RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()",
+                    RawCodeBackend = "gdsfactory",
+                    Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+                }
+            }
+        };
+        new PdkJsonSaver().SaveToFile(pdk, path);
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+        var c = reloaded.Components[0];
+        c.RawCode.ShouldContain("gf.components.straight");
+        c.RawCodeBackend.ShouldBe("gdsfactory");
+        System.IO.Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public void ConvertToTemplate_carries_rawcode_onto_the_template()
+    {
+        var draft = new PdkComponentDraft
+        {
+            Name = "My Cell", WidthMicrometers = 10, HeightMicrometers = 2,
+            RawCode = "component = gf.components.straight()", RawCodeBackend = "gdsfactory",
+            Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+        };
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, "My P", null);
+        template.RawCode.ShouldBe("component = gf.components.straight()");
+        template.RawCodeBackend.ShouldBe("gdsfactory");
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/RawCodePlacementSeedingTests.cs
+++ b/UnitTests/Components/AddCustomComponent/RawCodePlacementSeedingTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.Linq;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.LightCalculation;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Verifies that placing a raw-code component template (rawcode authoring, Task 2)
+/// seeds a per-instance <see cref="NazcaCodeOverride"/> in the placement-time override
+/// store, so the raw-code preview and export — which read the override map — work
+/// without any export-path changes. Also pins the undo/redo symmetry of that seeding.
+/// </summary>
+public class RawCodePlacementSeedingTests
+{
+    private static ComponentTemplate BuildTemplate(string name, string? rawCode, string? backend)
+    {
+        return new ComponentTemplate
+        {
+            Name = name,
+            Category = "Test",
+            PdkSource = "test-pdk",
+            WidthMicrometers = 10,
+            HeightMicrometers = 2,
+            PinDefinitions = new[]
+            {
+                new PinDefinition("o1", 0, 1, 180),
+                new PinDefinition("o2", 10, 1, 0)
+            },
+            CreateSMatrix = pins =>
+            {
+                var allIds = pins.SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+                return new SMatrix(allIds, new List<(System.Guid, double)>());
+            },
+            RawCode = rawCode,
+            RawCodeBackend = backend,
+        };
+    }
+
+    [Fact]
+    public void Placing_a_gdsfactory_rawcode_template_seeds_a_per_instance_override()
+    {
+        var template = BuildTemplate(
+            "MyGfCell",
+            rawCode: "import gdsfactory as gf\ncomponent = gf.components.straight()",
+            backend: "gdsfactory");
+        var canvas = new DesignCanvasViewModel();
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+
+        var cmd = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrides);
+        cmd.ShouldNotBeNull();
+        cmd!.Execute();
+
+        overrides.Count.ShouldBe(1);
+        var ovr = overrides.Values.First();
+        ovr.RawCode.ShouldContain("gf.components.straight");
+        ovr.Backend.ShouldBe(OverrideBackend.GdsFactory);
+    }
+
+    [Fact]
+    public void Placing_a_nazca_rawcode_template_seeds_an_override_with_nazca_backend()
+    {
+        var template = BuildTemplate(
+            "MyNazcaCell",
+            rawCode: "import nazca as nd\ncell = nd.Cell('x')",
+            backend: "nazca");
+        var canvas = new DesignCanvasViewModel();
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+
+        var cmd = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrides);
+        cmd!.Execute();
+
+        overrides.Count.ShouldBe(1);
+        overrides.Values.First().Backend.ShouldBe(OverrideBackend.Nazca);
+    }
+
+    [Fact]
+    public void Undo_removes_the_seeded_override()
+    {
+        var template = BuildTemplate("MyGfCell", "component = gf.components.straight()", "gdsfactory");
+        var canvas = new DesignCanvasViewModel();
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+
+        var cmd = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrides);
+        cmd!.Execute();
+        overrides.Count.ShouldBe(1);
+
+        cmd.Undo();
+
+        overrides.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Redo_after_undo_reseeds_the_override()
+    {
+        var template = BuildTemplate("MyGfCell", "component = gf.components.straight()", "gdsfactory");
+        var canvas = new DesignCanvasViewModel();
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+
+        var cmd = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrides);
+        cmd!.Execute();
+        cmd.Undo();
+        cmd.Execute();
+
+        overrides.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Placing_a_non_rawcode_template_seeds_nothing()
+    {
+        var template = BuildTemplate("PlainCell", rawCode: null, backend: null);
+        var canvas = new DesignCanvasViewModel();
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+
+        var cmd = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrides);
+        cmd!.Execute();
+
+        overrides.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Preexisting_override_entry_is_not_overwritten_and_undo_leaves_it_alone()
+    {
+        var template = BuildTemplate("MyGfCell", "component = gf.components.straight()", "gdsfactory");
+        var canvas = new DesignCanvasViewModel();
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+
+        var cmd = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrides);
+        cmd!.Execute();
+        var identifier = overrides.Keys.Single();
+
+        // Undo removes the entry this command seeded, then something else (e.g. a
+        // project load) populates the same identifier before this command's Execute
+        // runs again — simulating a pre-existing entry the command never created.
+        cmd.Undo();
+        var existing = new NazcaCodeOverride { RawCode = "keep-me", Backend = OverrideBackend.Nazca };
+        overrides[identifier] = existing;
+
+        cmd.Execute();
+        overrides[identifier].ShouldBeSameAs(existing);
+
+        // Undo must not remove an entry this command didn't create.
+        cmd.Undo();
+        overrides[identifier].ShouldBeSameAs(existing);
+    }
+
+    [Fact]
+    public void No_override_store_does_not_throw()
+    {
+        var template = BuildTemplate("MyGfCell", "component = gf.components.straight()", "gdsfactory");
+        var canvas = new DesignCanvasViewModel();
+
+        var cmd = PlaceComponentCommand.TryCreate(canvas, template, 0, 0, overrideStore: null);
+        cmd!.Execute();
+        cmd.Undo();
+    }
+}

--- a/docs/superpowers/plans/2026-07-10-custom-component-rawcode.md
+++ b/docs/superpowers/plans/2026-07-10-custom-component-rawcode.md
@@ -1,0 +1,317 @@
+# Eigene Komponente per Rawcode (Editor + .py-Datei) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Das „Neue Komponente"-Fenster (v1, PR #702) um einen Modus „Eigener Code" erweitern: gdsfactory-/nazca-Code in einen Editor einfügen (oder aus einer `.py`-Datei laden), live rendern, S-Matrix via FDTD berechnen, und als wiederverwendbare Komponente ins eigene PDK speichern.
+
+**Architecture:** Rawcode-Export ist bei beiden Exportern (`SimpleNazcaExporter`, `GdsFactoryExporter`) rein über die per-Instanz-Override-Map (`Identifier → NazcaCodeOverride.RawCode`+`Backend`, im .lun) getrieben. Deshalb: die PDK-Komponente speichert ihren Rawcode; beim **Platzieren** wird ein `NazcaCodeOverride` für den Instanz-Identifier geseedet → Preview UND Export laufen über den bewährten #637/#559-Pfad, **ohne Export-Umbau**. Render/Extraktion (`RenderRawCodeAsync`) und FDTD-Request (`ComponentFdtdRequestFactory.BuildFromPreview`) werden aus v1 wiederverwendet.
+
+**Tech Stack:** C#/.NET 10/Avalonia 11/CommunityToolkit.Mvvm; xUnit + Shouldly + Moq. Baut auf PR #702 (`*/AddCustomComponent/`) und dem #637-Override (`NazcaCodeOverride`, `NazcaComponentPreviewService.RenderRawCodeAsync`, `OverridePinMapper`).
+
+## Global Constraints
+
+- Keine erfundene Physik: S-Matrix nur aus echtem FDTD / Blackbox / verlustfreiem 2-Port-Ideal; FDTD-Fehler → nichts speichern.
+- Kein Export-Umbau: Rawcode fließt ausschließlich über `NazcaCodeOverride.RawCode`+`Backend`, den beide Exporter schon lesen. Nicht die Exporter anfassen.
+- Foundry-JSONs bleiben unangetastet; User-PDKs nur unter `%LOCALAPPDATA%/Lunima/user-pdks/`.
+- Cross-Platform: `Path.Combine`, kein direkter `Process.Start`, `x:DataType` in AXAML, `InvariantCulture` für maschinennahe Strings.
+- Max. 250 Zeilen pro NEUER Datei; bestehende ≤500 (hartes Limit). `LeftPanelViewModel.cs` liegt bereits bei 500 — NICHT weiter anfassen.
+- XML-Doku auf public members. Nur feature-bezogene Dateien ändern.
+
+## File Structure
+
+- `CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs` (MODIFY) — `PdkComponentDraft.RawCode` + `RawCodeBackend`.
+- `CAP.Avalonia/Services/PdkTemplateConverter.cs` (MODIFY) — Rawcode-Felder in die `ComponentTemplate` durchreichen.
+- `CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs` (MODIFY) — `ComponentTemplate.RawCode`/`RawCodeBackend`.
+- `CAP.Avalonia/Commands/PlaceComponentCommand.cs` (MODIFY) — beim Platzieren einer Rawcode-Komponente den Override seeden.
+- `CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs` (MODIFY) — Rawcode-Variante.
+- `CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs` (MODIFY) — Rawcode direkt rendern.
+- `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs` (MODIFY) — Modus „Eigener Code": Code + LoadFromFile; Draft mit RawCode bauen.
+- `CAP.Avalonia/Services/AddCustomComponent/CustomComponentDraftFactory.cs` (MODIFY) — RawCode/Backend in den Draft schreiben.
+- `CAP.Avalonia/Views/NewComponentWindow.axaml` (MODIFY) — Modus-Umschalter + Code-Editor + „aus .py laden".
+- Tests unter `UnitTests/Components/AddCustomComponent/`.
+
+---
+
+### Task 1: Rawcode-Persistenz + Template-Durchreichung
+
+**Files:**
+- Modify: `CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PdkDraft.cs`
+- Modify: `CAP.Avalonia/Services/PdkTemplateConverter.cs`
+- Modify: `CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs`
+- Test: `UnitTests/Components/AddCustomComponent/RawCodePersistenceTests.cs`
+
+**Interfaces:**
+- Produces: `PdkComponentDraft.RawCode` (`string?`, JSON `rawCode`), `PdkComponentDraft.RawCodeBackend` (`string?`, JSON `rawCodeBackend`, "nazca"|"gdsfactory"); `ComponentTemplate.RawCode` (`string?`), `ComponentTemplate.RawCodeBackend` (`string?`); `PdkTemplateConverter.ConvertToTemplate` überträgt beide.
+
+- [ ] **Step 1: Read** `DTOs/PdkDraft.cs` (`PdkComponentDraft`), `PdkTemplateConverter.ConvertToTemplate`, und `ComponentTemplates.cs` (`ComponentTemplate`-Klasse ab Z135). Nutze das vorhandene Property-Muster (JSON-Attribut-Stil).
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+using CAP.Avalonia.Services;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class RawCodePersistenceTests
+{
+    [Fact]
+    public void PdkComponentDraft_roundtrips_rawcode_through_saver_and_loader()
+    {
+        var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "lunima-rawcode-" + System.Guid.NewGuid().ToString("N"));
+        System.IO.Directory.CreateDirectory(dir);
+        var path = System.IO.Path.Combine(dir, "p.json");
+        var pdk = new PdkDraft
+        {
+            Name = "My P", Backend = "gdsfactory", Components = new()
+            {
+                new PdkComponentDraft
+                {
+                    Name = "My Cell", WidthMicrometers = 10, HeightMicrometers = 2,
+                    RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()",
+                    RawCodeBackend = "gdsfactory",
+                    Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+                }
+            }
+        };
+        new PdkJsonSaver().SaveToFile(pdk, path);
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+        var c = reloaded.Components[0];
+        c.RawCode.ShouldContain("gf.components.straight");
+        c.RawCodeBackend.ShouldBe("gdsfactory");
+        System.IO.Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public void ConvertToTemplate_carries_rawcode_onto_the_template()
+    {
+        var draft = new PdkComponentDraft
+        {
+            Name = "My Cell", WidthMicrometers = 10, HeightMicrometers = 2,
+            RawCode = "component = gf.components.straight()", RawCodeBackend = "gdsfactory",
+            Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+        };
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, "My P", null);
+        template.RawCode.ShouldBe("component = gf.components.straight()");
+        template.RawCodeBackend.ShouldBe("gdsfactory");
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails** — `py "$env:USERPROFILE\.cap-tools\smart_test.py" RawCodePersistence` → FAIL (Properties fehlen).
+
+- [ ] **Step 4: Implement** — Auf `PdkComponentDraft` zwei Properties ergänzen (mit `[JsonPropertyName("rawCode")]`/`("rawCodeBackend")` im Stil der Nachbar-Properties). Auf `ComponentTemplate` zwei `string?`-Properties `RawCode`/`RawCodeBackend`. In `ConvertToTemplate` beide vom Draft auf das Template kopieren. XML-Doku.
+
+- [ ] **Step 5: Run to verify it passes** — `... RawCodePersistence` → PASS (2/2).
+
+- [ ] **Step 6: Commit** — `git commit -m "(+) PDK raw-code persistence: PdkComponentDraft.RawCode/RawCodeBackend -> ComponentTemplate"`
+
+---
+
+### Task 2: Override-Seeding beim Platzieren
+
+**Files:**
+- Modify: `CAP.Avalonia/Commands/PlaceComponentCommand.cs`
+- Modify (falls nötig, Aufrufer): `CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs` (Übergabe des Override-Stores)
+- Test: `UnitTests/Components/AddCustomComponent/RawCodePlacementSeedingTests.cs`
+
+**Interfaces:**
+- Consumes: `ComponentTemplate.RawCode`/`RawCodeBackend` (Task 1); `NazcaCodeOverride` (`RawCode`, `Backend` : `OverrideBackend`); `Component.Identifier`.
+- Produces: nach dem Platzieren eines Templates mit `RawCode != null` existiert `overrides[component.Identifier]` mit passendem `RawCode`+`Backend`.
+
+- [ ] **Step 1: Read** `CAP.Avalonia/Commands/PlaceComponentCommand.cs` (ctor + `Execute`, Z37 `CreateFromTemplate`), wie das Command konstruiert wird und wer es aufruft (`DesignCanvasViewModel`/Placement). Lies `CAP.Avalonia/Selection/NazcaOverridePropagator.cs` — falls es eine passende Seed-Methode gibt, wiederverwenden. Lies `NazcaCodeOverride` (`RawCode`, `Backend`, `OverrideBackend`-Enum).
+
+- [ ] **Step 2: Write the failing test** (konstruiere das Command mit einem echten `Dictionary<string, NazcaCodeOverride>` als Override-Store und einem Rawcode-Template; nach `Execute` muss der Store einen Eintrag für die Instanz haben)
+
+```csharp
+using System.Collections.Generic;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class RawCodePlacementSeedingTests
+{
+    [Fact]
+    public void Placing_a_rawcode_template_seeds_a_per_instance_override()
+    {
+        // Baue ein minimales Rawcode-Template wie in bestehenden PlaceComponentCommand-Tests;
+        // siehe UnitTests, wie ComponentTemplate/Command dort konstruiert werden, und repliziere.
+        var template = TestTemplateFactory.RawCodeTemplate(
+            rawCode: "import gdsfactory as gf\ncomponent = gf.components.straight()",
+            backend: "gdsfactory");
+        var overrides = new Dictionary<string, NazcaCodeOverride>();
+
+        var cmd = /* PlaceComponentCommand mit template, x, y, overrides-Store */ null!;
+        cmd.Execute();
+
+        overrides.Count.ShouldBe(1);
+        var ovr = overrides.Values.First();
+        ovr.RawCode.ShouldContain("gf.components.straight");
+        ovr.Backend.ShouldBe(OverrideBackend.GdsFactory);
+    }
+}
+```
+
+Passe Konstruktion an die echte `PlaceComponentCommand`-Signatur an (siehe bestehende Command-Tests). Wenn es keine `TestTemplateFactory.RawCodeTemplate` gibt, baue das Template inline (setze `RawCode`/`RawCodeBackend` + minimale Pins/Maße).
+
+- [ ] **Step 3: Run to verify it fails.**
+
+- [ ] **Step 4: Implement** — `PlaceComponentCommand` einen optionalen `IDictionary<string, NazcaCodeOverride>? overrideStore` im ctor geben (die Aufrufer, v.a. `DesignCanvasViewModel`, reichen `FileOperations.StoredNazcaOverrides` durch — folge dem bestehenden Wiring). Nach `CreateFromTemplate`, wenn `template.RawCode` nicht leer ist UND der Store noch keinen Eintrag für `_component.Identifier` hat: `overrideStore[_component.Identifier] = new NazcaCodeOverride { RawCode = template.RawCode, Backend = template.RawCodeBackend == "gdsfactory" ? OverrideBackend.GdsFactory : OverrideBackend.Nazca }`. Bei `Undo` den geseedeten Eintrag wieder entfernen (Symmetrie zum bestehenden Undo). XML-Doku.
+   Falls `NazcaOverridePropagator` eine passende Methode bietet, diese nutzen statt Direktzugriff.
+
+- [ ] **Step 5: Run to verify it passes.** Zusätzlich bestehende `PlaceComponentCommand`-Tests laufen lassen (Regression): `... PlaceComponentCommand`.
+
+- [ ] **Step 6: Commit** — `git commit -m "(+) Placement seeds a per-instance raw-code override for custom raw-code components"`
+
+---
+
+### Task 3: Rawcode-Modus im Extractor
+
+**Files:**
+- Modify: `CAP.Avalonia/Services/AddCustomComponent/GeometryReference.cs`
+- Modify: `CAP.Avalonia/Services/AddCustomComponent/ComponentGeometryExtractor.cs`
+- Test: `UnitTests/Components/AddCustomComponent/RawCodeExtractionTests.cs`
+
+**Interfaces:**
+- Consumes: `IComponentPreviewRenderer.RenderRawCodeAsync` (nazca + gdsfactory Adapter aus v1); `OverridePinMapper.BuildOverridePins`.
+- Produces: eine Rawcode-Geometriequelle — entweder `GeometryReference` mit einem `RawCode`-Feld (nicht null ⇒ direkter Rawcode-Render) ODER ein neues Wertobjekt `RawCodeGeometry(GeometryBackend Backend, string Code)`. Der Extractor rendert Rawcode über den Backend-passenden `RenderRawCodeAsync(code)` und liefert dasselbe `GeometryExtractResult` wie v1.
+
+- [ ] **Step 1: Read** `GeometryReference.cs` + `ComponentGeometryExtractor.cs` (v1). Entscheide: erweitere `GeometryReference` um `string? RawCode` (wenn gesetzt, hat es Vorrang vor `module.function`), das ist die kleinste Änderung.
+
+- [ ] **Step 2: Write the failing tests**
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class RawCodeExtractionTests
+{
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 8, YMax = 1.5,
+        Pins = new System.Collections.Generic.List<NazcaPreviewPin>
+        { new() { Name="o1", X=0, Y=0.75, Angle=180 }, new() { Name="o2", X=8, Y=0.75, Angle=0 } }
+    };
+
+    [Fact]
+    public async Task RawCode_gdsfactory_renders_code_verbatim()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync("component = gf.components.mmi1x2()", It.IsAny<CancellationToken>()))
+           .ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+
+        var res = await extractor.ExtractAsync(GeometryReference.RawCode(GeometryBackend.GdsFactory, "component = gf.components.mmi1x2()"));
+
+        res.Success.ShouldBeTrue();
+        res.WidthUm.ShouldBe(8);
+        res.Pins.Count.ShouldBe(2);
+        gds.Verify(g => g.RenderRawCodeAsync("component = gf.components.mmi1x2()", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+Passe an, falls der Extractor-Ctor konkrete Typen statt `IComponentPreviewRenderer` nimmt (v1 nutzt `IComponentPreviewRenderer` — bestätige).
+
+- [ ] **Step 3: Run to verify it fails.**
+
+- [ ] **Step 4: Implement** — Auf `GeometryReference` `string? RawCode` ergänzen + statische Factory `RawCode(GeometryBackend, string code)`. In `ComponentGeometryExtractor.ExtractAsync`: wenn `reference.RawCode` gesetzt ist, direkt `renderer.RenderRawCodeAsync(reference.RawCode, ct)` mit dem backend-passenden Renderer aufrufen (gdsfactory-Renderer für GdsFactory, nazca-Renderer für Nazca); sonst der bestehende v1-Pfad. Rest (bbox, `BuildOverridePins`, Fehlerpfad) unverändert.
+
+- [ ] **Step 5: Run to verify it passes.** Auch v1-Extractor-Tests laufen lassen (Regression): `... ComponentGeometryExtractor`.
+
+- [ ] **Step 6: Commit** — `git commit -m "(+) ComponentGeometryExtractor: render pasted raw code directly (both backends)"`
+
+---
+
+### Task 4: „Eigener Code"-Modus im NewComponentViewModel (+ .py laden)
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs`
+- Modify: `CAP.Avalonia/Services/AddCustomComponent/CustomComponentDraftFactory.cs`
+- Test: `UnitTests/Components/AddCustomComponent/NewComponentViewModelRawCodeTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1 (`ComponentTemplate.RawCode`), Task 3 (`GeometryReference.RawCode(...)`), v1 (`ComponentGeometryExtractor`, FDTD, `UserPdkStore`, `CustomComponentDraftFactory`).
+- Produces: `NewComponentViewModel.InputMode` (enum `ReferenceMode`/`OwnCodeMode`), `Code` (string), `SelectedBackend` (im Code-Modus wieder gdsfactory ODER nazca wählbar), `LoadCodeFromFileCommand` (liest eine `.py` in `Code`); Save schreibt `RawCode`+`RawCodeBackend` in den Draft, wenn im Code-Modus. `CustomComponentDraftFactory.Build(...)` bekommt einen optionalen `rawCode`/`rawCodeBackend`-Parameter.
+- Für den Dateizugriff: injiziere einen `Func<Task<string?>>? pickPyFile` (Datei-Dialog-Öffner), analog zum v1-`ConfirmOverwrite`-Muster — im Test durch ein Fake ersetzbar. KEINE direkte View-Kopplung.
+
+- [ ] **Step 1: Read** v1 `NewComponentViewModel.cs` + `CustomComponentDraftFactory.cs` (Save-Pfad, wie `GeometryReference` gebaut wird, wie `AvailableBackends` gesetzt ist).
+
+- [ ] **Step 2: Write the failing tests** (mocke Extractor-Renderer wie in v1; Store = echter `UserPdkStore` mit Temp-Root)
+
+```csharp
+// Test A: Im OwnCodeMode mit Code -> RunPreview nutzt GeometryReference.RawCode -> Save schreibt draft.RawCode + RawCodeBackend, GdsFactoryFunction bleibt null.
+// Test B: LoadCodeFromFileCommand füllt Code aus dem injizierten pickPyFile-Fake.
+// Test C: OwnCodeMode erlaubt nazca als Backend (AvailableBackends enthält im Code-Modus beide).
+```
+
+Schreibe die drei Tests mit konkreten Asserts (`vm.SavedDraft.RawCode.ShouldContain(...)`, `vm.SavedDraft.RawCodeBackend.ShouldBe("gdsfactory")`, `vm.SavedDraft.GdsFactoryFunction.ShouldBeNull()`; `vm.Code.ShouldBe("...")` nach LoadFromFile; `vm.AvailableBackends`-Inhalt je Modus).
+
+- [ ] **Step 3: Run to verify it fails.**
+
+- [ ] **Step 4: Implement** — `InputMode`-Enum + `[ObservableProperty]`; im OwnCodeMode baut `RunPreview` `GeometryReference.RawCode(SelectedBackend, Code)` statt der Referenz; `AvailableBackends` liefert im Code-Modus `{ GdsFactory, Nazca }`, im Referenz-Modus weiterhin nur `{ GdsFactory }` (v1). `LoadCodeFromFileCommand` ruft `pickPyFile()` und setzt `Code`. `Save`/`CustomComponentDraftFactory.Build` schreibt `RawCode`+`RawCodeBackend` (Backend-String) in den Draft, wenn Code-Modus (dann `GdsFactoryFunction`/`NazcaFunction` leer lassen). Halte das VM ≤250 Zeilen (ggf. Modus-spezifische Referenz-Erzeugung in eine kleine private Methode). Preview-Invalidierung (`InvalidatePreview`) auch bei `Code`/`InputMode`-Änderung auslösen.
+
+- [ ] **Step 5: Run to verify it passes.** Auch v1 `NewComponentViewModel`-Tests (Regression).
+
+- [ ] **Step 6: Commit** — `git commit -m "(+) NewComponentViewModel: own-code mode (paste / load .py), writes raw-code draft"`
+
+---
+
+### Task 5: UI — Modus-Umschalter + Code-Editor + „.py laden"
+
+**Files:**
+- Modify: `CAP.Avalonia/Views/NewComponentWindow.axaml`
+- Modify: `CAP.Avalonia/Views/MainWindow.axaml.cs` (den `pickPyFile`-Dialog an das VM hängen, dort wo das Fenster geöffnet wird — via `NewComponentWindowLauncher`)
+- Modify: `CAP.Avalonia/Services/AddCustomComponent/NewComponentWindowLauncher.cs` (pickPyFile-Func setzen)
+- Test: manuell (headless nicht sinnvoll für Datei-Dialog); Build-/Binding-Verifikation.
+
+**Interfaces:** Consumes Task 4 (`InputMode`, `Code`, `LoadCodeFromFileCommand`, `AvailableBackends`).
+
+- [ ] **Step 1: Read** `NewComponentWindow.axaml` (v1-Layout) + `NewComponentWindowLauncher.cs` (wie das VM gebaut/gezeigt wird) + ein bestehendes File-Open-Dialog-Beispiel (`FileDialogService`).
+
+- [ ] **Step 2: AXAML** — Ein `TabControl` oder `RadioButton`-Paar „Funktionsreferenz" / „Eigener Code" gebunden an `InputMode`. Im Code-Modus: mehrzeiliges `TextBox` (`AcceptsReturn=True`, monospace) gebunden an `Code` + Button „Aus .py laden…" (`LoadCodeFromFileCommand`). Backend-ComboBox bindet an `AvailableBackends`/`SelectedBackend` (zeigt im Code-Modus beide). Referenz-Felder (Module/Function/Parameters) nur im Referenz-Modus sichtbar. `x:DataType` beibehalten.
+
+- [ ] **Step 3: Launcher/Dialog** — In `NewComponentWindowLauncher` (bzw. beim Öffnen in `MainWindow.axaml.cs`) `vm`-`pickPyFile` auf einen echten Datei-Dialog setzen (`.py`-Filter), analog zum bestehenden `FileDialogService`-Muster. Kein direkter `Process.Start`.
+
+- [ ] **Step 4: Build** — `dotnet build -clp:ErrorsOnly` = 0 Fehler (XAML-Compile inklusive).
+
+- [ ] **Step 5: Commit** — `git commit -m "(+) New Component window: reference/own-code mode toggle, code editor, load-.py button"`
+
+---
+
+### Task 6: Integrations-Test — Rawcode-Komponente end-to-end (Draft → Template → Placement-Override)
+
+**Files:**
+- Test: `UnitTests/Components/AddCustomComponent/RawCodeEndToEndTests.cs`
+
+**Interfaces:** Consumes Tasks 1-3.
+
+- [ ] **Step 1: Write the test** — Baue einen `PdkComponentDraft` mit `RawCode`+`RawCodeBackend`, speichere via `UserPdkStore`, lade via `PdkLoader.LoadFromFileForEditing`, konvertiere via `PdkTemplateConverter.ConvertToTemplate` → Template trägt RawCode; platziere via `PlaceComponentCommand` (mit Override-Store) → Store hat einen `NazcaCodeOverride` mit dem RawCode für die Instanz. Ein Assert pro Stufe.
+
+- [ ] **Step 2: Run to verify it passes** (die Bausteine existieren nach Tasks 1-3). `... RawCodeEndToEnd`.
+
+- [ ] **Step 3: Commit** — `git commit -m "(+) End-to-end test: raw-code custom component from draft to placement override"`
+
+---
+
+## Self-Review
+
+- **Spec-Coverage:** Editor+Code → Task 4/5; .py laden → Task 4/5; Persistenz → Task 1; Export ohne Umbau via Placement-Seeding → Task 2 (+ End-to-End Task 6); Render/FDTD-Reuse → Task 3. nazca im Code-Modus erlaubt (Rawcode-Export deckt nazca via Override, kein Offset-Problem, weil Export den Code direkt nutzt).
+- **Placeholder-Scan:** Tasks 2 & 4 verweisen für Testkonstruktion auf bestehende Command-/VM-Tests statt vollständigen Code — bewusst, weil die echten Ctor-Signaturen dort abzulesen sind; die Asserts sind konkret genannt.
+- **Typkonsistenz:** `RawCode`/`RawCodeBackend` (Task 1) → Template (Task 1) → Placement-Override (Task 2) → Draft (Task 4). `GeometryReference.RawCode(...)` (Task 3) → VM (Task 4).
+- **Verifikationspunkte für Implementer:** echte `PlaceComponentCommand`-ctor-Signatur + Undo-Symmetrie (Task 2); `NazcaOverridePropagator`-Wiederverwendung; `NewComponentWindowLauncher`-Dialog-Muster (Task 5).


### PR DESCRIPTION
## Was & Warum

Feld-Feedback zu #702: Nutzer (v.a. Studenten) haben oft **eigenen** gdsfactory-/nazca-Komponenten-Code (Snippet oder `.py`-Datei) und wollen den direkt reinbringen — nicht bloß eine bereits importierbare `modul.funktion`-Referenz angeben. Dieser PR ergänzt das „Neue Komponente"-Fenster um einen Modus **„Eigener Code"**: Code einfügen oder aus `.py` laden → live rendern → S-Matrix via FDTD → als wiederverwendbare Komponente ins eigene PDK.

Plan: `docs/superpowers/plans/2026-07-10-custom-component-rawcode.md` (baut auf #701).

## Kern-Architektur: kein Export-Umbau

Rawcode-Export läuft bei beiden Exportern (`SimpleNazcaExporter`, `GdsFactoryExporter`) bereits über die per-Instanz-Override-Map (`Identifier → NazcaCodeOverride.RawCode`+`Backend`, im `.lun`). Deshalb:
- Die PDK-Komponente speichert ihren Rawcode (`PdkComponentDraft.RawCode`/`RawCodeBackend` → `ComponentTemplate`).
- Beim **Platzieren** einer Rawcode-Komponente wird ein `NazcaCodeOverride` für die Instanz geseedet (`PlaceComponentCommand`, mit Undo-Symmetrie).
- Preview UND Export laufen dann über den bewährten #637/#559-Pfad — **die Exporter wurden nicht angefasst**.

Render/Extraktion (`RenderRawCodeAsync`) und FDTD-Request (`BuildFromPreview`) sind aus #702 wiederverwendet.

## Harte Randbedingung: keine erfundene Physik ✅

S-Matrix nur aus echtem FDTD / Blackbox / verlustfreiem 2-Port-Ideal; FDTD-Fehler → nichts gespeichert. Der Rawcode-Pfad ändert das nicht.

## UI

Modus-Umschalter „Funktionsreferenz" / „Eigener Code" (RadioButtons + `EnumToBooleanConverter`); monospace Code-Editor gebunden an `Code`; „Aus .py laden…"-Button (`FileDialogService` → Dateiinhalt). Im Code-Modus sind gdsfactory UND nazca wählbar.

## Tests

TDD, subagent-getrieben, Review nach jedem Task + finaler Whole-Branch-Review (Opus). Feature-Tests grün: NewComponentViewModel 10/10, AddCustomComponent 49/49, RawCode-Persistenz/Placement/Extraction + E2E.

> Hinweis: Die volle lokale Suite zeigt 4 gdsfactory/Python-Subprozess-Tests als FAIL, die ISOLIERT grün sind (9/9) — reine Parallel-Contention der schweren Python-Tests, keine Regression (#685-Umfeld).

## Bekannte Limitierung / Follow-up

- **#720** — Rawcode-/Override-Komponenten in **gespeicherten Gruppen-Templates** verlieren beim Re-Platzieren ihre Geometrie (die Group-Library trägt den per-Instanz-Override nicht mit). Vorbestehend — gilt genauso für #637-Overrides —, durch dieses Feature nur sichtbarer. Nicht in diesem PR gefixt (wäre Scope-Creep in die Gruppen-Serialisierung).
- Der echte Fenster-E2E-Flow (Toggle, Datei-Dialog, Monospace-Rendering, FDTD-Docker-Solve) ist nur zur Laufzeit prüfbar — Smoke-Test empfohlen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)