### PR TITLE
PDK-first v-next: modales 'New PDK'-Fenster + Backend-Beispielcode-Autoload

### DIFF
--- a/CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs
+++ b/CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs
@@ -95,6 +95,37 @@ public sealed class UserPdkStore
     /// <summary>True when a named custom PDK file already exists for that name.</summary>
     public bool NamedPdkExists(string pdkName) => File.Exists(ResolveNamedPath(pdkName));
 
+    /// <summary>
+    /// Creates a new, empty named custom PDK file (no components yet) bound to a
+    /// fabrication process, for the "PDK first, then add components" wizard flow.
+    /// Callers must check <see cref="NamedPdkExists"/> first; this method refuses to
+    /// silently overwrite an existing file with the same name.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">A named PDK with that name already exists.</exception>
+    public string CreateNamedPdkWithProcess(string pdkName, ProcessDefinition process, string backend, string? routingCrossSection)
+    {
+        if (NamedPdkExists(pdkName))
+        {
+            throw new InvalidOperationException($"A custom PDK named '{pdkName}' already exists.");
+        }
+
+        var path = ResolveNamedPath(pdkName);
+        Directory.CreateDirectory(_root);
+
+        var draft = new PdkDraft
+        {
+            Name = pdkName,
+            Foundry = process.Foundry,
+            Backend = backend,
+            Process = process,
+            GdsFactoryRoutingCrossSection = routingCrossSection,
+            Components = new()
+        };
+
+        _saver.SaveToFile(draft, path);
+        return path;
+    }
+
     /// <summary>True when a component of that name exists in the PDK file at <paramref name="filePath"/>.</summary>
     public bool ComponentExistsInFile(string filePath, string componentName)
     {

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/BackendCodeExamples.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/BackendCodeExamples.cs
@@ -1,0 +1,23 @@
+using CAP.Avalonia.Services.AddCustomComponent;
+
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>
+/// The starter Python snippet shown for each <see cref="GeometryBackend"/> in the "New
+/// Component" editor. Kept as named constants (rather than only inline in XAML) so
+/// <see cref="NewComponentViewModel"/> can autoload the same text into the editor and later
+/// recognize it as an untouched, auto-inserted example (as opposed to user-authored code).
+/// The strings are the single source of truth; the XAML help-box literals mirror them.
+/// </summary>
+public static class BackendCodeExamples
+{
+    /// <summary>Starter snippet for <see cref="GeometryBackend.GdsFactory"/>.</summary>
+    public const string GdsFactory = "import gdsfactory as gf\ncomponent = gf.components.mmi1x2()";
+
+    /// <summary>Starter snippet for <see cref="GeometryBackend.Nazca"/>.</summary>
+    public const string Nazca = "import nazca as nd\ncomponent = nd.Cell(name='my_component')";
+
+    /// <summary>Returns the starter snippet matching <paramref name="backend"/>.</summary>
+    public static string For(GeometryBackend backend) =>
+        backend == GeometryBackend.GdsFactory ? GdsFactory : Nazca;
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.PdkSelection.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.PdkSelection.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>
+/// PDK-dropdown selection path for <see cref="NewComponentViewModel"/>: the
+/// <see cref="PdkChoices"/> list (existing named custom PDKs plus the trailing "New PDK…"
+/// sentinel), and the sentinel's modal-creation hook. Split out purely to keep each file under
+/// the project's line-count limit; still one partial class, one responsibility.
+/// </summary>
+public partial class NewComponentViewModel
+{
+    private List<PdkChoice> _pdkChoices = new();
+
+    /// <summary>The last selected non-sentinel choice, restored when a "New PDK…" creation is cancelled.</summary>
+    private PdkChoice? _previousPdkChoice;
+
+    /// <summary>Named custom PDKs already on disk, refreshed after a new one is created.</summary>
+    public IReadOnlyList<UserPdkInfo> AvailableCustomPdks { get; private set; } = Array.Empty<UserPdkInfo>();
+
+    /// <summary>
+    /// The PDK dropdown's bindable source: one entry per <see cref="AvailableCustomPdks"/>,
+    /// followed by the <see cref="PdkChoice.NewPdkSentinel"/> entry.
+    /// </summary>
+    public IReadOnlyList<PdkChoice> PdkChoices => _pdkChoices;
+
+    /// <summary>The existing named custom PDK selected as the save target, or null while none is chosen.</summary>
+    public UserPdkInfo? SelectedCustomPdk => SelectedPdkChoice?.Pdk;
+
+    /// <summary>The process the component will be saved under: inherited, read-only, from <see cref="SelectedCustomPdk"/>.</summary>
+    public ProcessDefinition? SelectedProcess => SelectedCustomPdk?.Process;
+
+    /// <summary>
+    /// Modal creation hook invoked when the "New PDK…" sentinel is selected: opens the "create
+    /// PDK" dialog and returns the newly created PDK, or null if the user cancelled. A no-op
+    /// (selection reverts to the previous choice) when null.
+    /// </summary>
+    public Func<Task<UserPdkInfo?>>? CreateNewPdk { get; set; }
+
+    /// <summary>
+    /// Selecting an existing PDK inherits its process and invalidates the preview (the S-matrix
+    /// backend may differ). Selecting the "New PDK…" sentinel invokes <see cref="CreateNewPdk"/>;
+    /// selecting a real choice simply remembers it for a future revert.
+    /// </summary>
+    partial void OnSelectedPdkChoiceChanged(PdkChoice? value)
+    {
+        if (value is { IsNewPdk: false })
+        {
+            _previousPdkChoice = value;
+        }
+
+        OnPropertyChanged(nameof(SelectedCustomPdk));
+        OnPropertyChanged(nameof(SelectedProcess));
+        InvalidatePreview();
+        SaveCommand.NotifyCanExecuteChanged();
+
+        if (value is { IsNewPdk: true })
+        {
+            _ = HandleNewPdkSentinelAsync();
+        }
+    }
+
+    /// <summary>
+    /// Runs <see cref="CreateNewPdk"/> after selecting the sentinel: reentrancy-guarded by
+    /// <see cref="NewComponentViewModel.IsBusy"/>, refreshes <see cref="PdkChoices"/> and selects
+    /// the new PDK on success, or reverts to the previous choice when cancelled (null result), no
+    /// hook is wired, or a creation is already in flight.
+    /// </summary>
+    private async Task HandleNewPdkSentinelAsync()
+    {
+        if (IsBusy || CreateNewPdk is null)
+        {
+            SelectedPdkChoice = _previousPdkChoice;
+            return;
+        }
+
+        IsBusy = true;
+        UserPdkInfo? created;
+        try
+        {
+            created = await CreateNewPdk();
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+
+        if (created is null)
+        {
+            SelectedPdkChoice = _previousPdkChoice;
+            return;
+        }
+
+        RefreshPdkChoices();
+        SelectedPdkChoice = _pdkChoices.FirstOrDefault(
+            c => !c.IsNewPdk && c.Pdk!.FilePath == created.FilePath);
+    }
+
+    /// <summary>Re-reads <see cref="AvailableCustomPdks"/> from the store and rebuilds <see cref="PdkChoices"/>.</summary>
+    private void RefreshPdkChoices()
+    {
+        AvailableCustomPdks = _store.ListCustomPdks();
+        _pdkChoices = AvailableCustomPdks.Select(PdkChoice.For).Append(PdkChoice.NewPdkSentinel).ToList();
+        OnPropertyChanged(nameof(PdkChoices));
+    }
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
@@ -18,18 +18,11 @@ public partial class NewComponentViewModel
 {
     private ComponentSMatrixData? _computedModel;
 
-    /// <summary>
-    /// Save requires a rendered preview, no work in flight, a resolved target process, and —
-    /// for a new PDK — a non-blank name to create it under.
-    /// </summary>
-    private bool CanSave =>
-        HasPreview && !IsBusy && EffectiveProcess is not null &&
-        (!IsNewPdk || !string.IsNullOrWhiteSpace(NewPdkName));
+    /// <summary>Save requires a rendered preview, no work in flight, and a selected target PDK.</summary>
+    private bool CanSave => HasPreview && !IsBusy && SelectedCustomPdk is not null;
 
     partial void OnHasPreviewChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
     partial void OnIsBusyChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
-    partial void OnSelectedProcessChanged(ProcessDefinition? value) => SaveCommand.NotifyCanExecuteChanged();
-    partial void OnNewPdkNameChanged(string value) => SaveCommand.NotifyCanExecuteChanged();
 
     /// <summary>
     /// Recomputes the S-matrix from the rendered geometry via the FDTD solver. Any failure —
@@ -41,9 +34,9 @@ public partial class NewComponentViewModel
     private async Task ComputeSMatrix()
     {
         if (IsBusy) return;
-        if (_lastPreview is not { Success: true } preview || EffectiveProcess is null)
+        if (_lastPreview is not { Success: true } preview || SelectedProcess is null)
         {
-            StatusText = "Render a preview and select a process before computing the S-matrix.";
+            StatusText = "Render a preview and select a PDK before computing the S-matrix.";
             return;
         }
         if (_fdtd is null)
@@ -83,15 +76,16 @@ public partial class NewComponentViewModel
     }
 
     /// <summary>
-    /// Saves the current component as a PDK component draft, either into a brand-new named
-    /// custom PDK (<see cref="NewComponentViewModel.IsNewPdk"/>) or appended to the selected
-    /// existing one (<see cref="NewComponentViewModel.SelectedCustomPdk"/>). Requires a name, a
-    /// rendered preview, and a resolved target process — missing any of these reports why via
+    /// Saves the current component as a PDK component draft, appended to the selected existing
+    /// named custom PDK (<see cref="NewComponentViewModel.SelectedCustomPdk"/>) — a brand-new
+    /// PDK is never created here, only via the <see cref="NewComponentViewModel.CreateNewPdk"/>
+    /// modal hook, so by the time <c>Save</c> runs the target file already exists. Requires a
+    /// name, a rendered preview, and a selected PDK — missing any of these reports why via
     /// <see cref="NewComponentViewModel.StatusText"/> and leaves
-    /// <see cref="NewComponentViewModel.SavedDraft"/> null. A name/PDK collision is reported
-    /// unless <see cref="NewComponentViewModel.ConfirmOverwrite"/> confirms it. The S-matrix is
-    /// either the last FDTD result or a black box when none was computed — never fabricated.
-    /// The draft's source is always the user's own code (raw code + backend), never a
+    /// <see cref="NewComponentViewModel.SavedDraft"/> null. A name collision is reported unless
+    /// <see cref="NewComponentViewModel.ConfirmOverwrite"/> confirms it. The S-matrix is either
+    /// the last FDTD result or a black box when none was computed — never fabricated. The
+    /// draft's source is always the user's own code (raw code + backend), never a
     /// module/function reference. A black-box save preserves any pending diagnostic and
     /// prefixes it with a save confirmation.
     /// </summary>
@@ -110,15 +104,10 @@ public partial class NewComponentViewModel
             StatusText = "Render a preview before saving.";
             return;
         }
-        var process = EffectiveProcess;
-        if (process is null)
+        var pdk = SelectedCustomPdk;
+        if (pdk is null)
         {
-            StatusText = "Select a fabrication process before saving.";
-            return;
-        }
-        if (IsNewPdk && string.IsNullOrWhiteSpace(NewPdkName))
-        {
-            StatusText = "Enter a name for the new PDK before saving.";
+            StatusText = "Select a PDK before saving.";
             return;
         }
 
@@ -132,23 +121,11 @@ public partial class NewComponentViewModel
             var backend = SelectedBackend == GeometryBackend.GdsFactory ? "gdsfactory" : "nazca";
             var draft = CustomComponentDraftFactory.Build(name, reference, preview, sMatrix, Code, backend);
 
-            if (IsNewPdk)
+            if (_store.ComponentExistsInFile(pdk.FilePath, name) && !await ConfirmCollision(name, pdk.Name))
             {
-                if (_store.NamedPdkExists(NewPdkName) && !await ConfirmCollision(name, NewPdkName))
-                {
-                    return;
-                }
-                SavedFilePath = _store.SaveToNamedPdk(NewPdkName, process, draft, backend, null);
+                return;
             }
-            else
-            {
-                var filePath = SelectedCustomPdk!.FilePath;
-                if (_store.ComponentExistsInFile(filePath, name) && !await ConfirmCollision(name, SelectedCustomPdk.Name))
-                {
-                    return;
-                }
-                SavedFilePath = _store.AppendToExistingPdk(filePath, draft);
-            }
+            SavedFilePath = _store.AppendToExistingPdk(pdk.FilePath, draft);
 
             SavedDraft = draft;
             StatusText = _computedModel is null

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -13,14 +13,17 @@ using CommunityToolkit.Mvvm.Input;
 namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
 
 /// <summary>
-/// Orchestrates adding a user-authored component to a PDK-first target: either an existing
-/// named custom PDK (<see cref="SelectedCustomPdk"/>, process inherited) or a brand-new one
-/// (<see cref="IsNewPdk"/>, name + process chosen). Renders the component's own Python code
-/// (nazca or gdsfactory), optionally recomputes its S-matrix via the FDTD solver, and saves the
-/// result as a <see cref="PdkComponentDraft"/>. Never invents physics — a missing solver, an
-/// unavailable backend, or a failed solve always saves the component as a black box (no
-/// S-matrix), never a fabricated one. The save/FDTD-compute path lives in the
-/// <c>NewComponentViewModel.Save.cs</c> partial (kept a separate file for size).
+/// Orchestrates adding a user-authored component to a PDK-first target: a named custom PDK
+/// chosen from <see cref="PdkChoices"/> (<see cref="SelectedCustomPdk"/>, process always
+/// inherited). A brand-new PDK is never created inline — picking the trailing
+/// <see cref="PdkChoice.NewPdkSentinel"/> entry invokes the modal hook <see cref="CreateNewPdk"/>
+/// instead (PDK-selection logic lives in the <c>NewComponentViewModel.PdkSelection.cs</c>
+/// partial). Renders the component's own Python code (nazca or gdsfactory), optionally
+/// recomputes its S-matrix via the FDTD solver, and saves the result as a
+/// <see cref="PdkComponentDraft"/>. Never invents physics — a missing solver, an unavailable
+/// backend, or a failed solve always saves the component as a black box (no S-matrix), never a
+/// fabricated one. The save/FDTD-compute path lives in the <c>NewComponentViewModel.Save.cs</c>
+/// partial (kept a separate file for size).
 /// </summary>
 public partial class NewComponentViewModel : ObservableObject
 {
@@ -35,29 +38,17 @@ public partial class NewComponentViewModel : ObservableObject
 
     [ObservableProperty] private string _componentName = string.Empty;
     [ObservableProperty] private GeometryBackend _selectedBackend = GeometryBackend.GdsFactory;
-    [ObservableProperty] private ProcessDefinition? _selectedProcess;
-    [ObservableProperty] private UserPdkInfo? _selectedCustomPdk;
-    [ObservableProperty] private bool _isNewPdk;
-    [ObservableProperty] private string _newPdkName = string.Empty;
+    [ObservableProperty] private PdkChoice? _selectedPdkChoice;
     [ObservableProperty] private string _statusText = string.Empty;
     [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private bool _hasPreview;
     [ObservableProperty] private string _code = string.Empty;
 
-    /// <summary>Fabrication processes available for a new PDK's process selection.</summary>
+    /// <summary>Fabrication processes offered by <see cref="CreateNewPdk"/>'s modal (not chosen here).</summary>
     public IReadOnlyList<ProcessDefinition> Processes { get; }
-
-    /// <summary>Named custom PDKs already on disk, offered as an alternative to creating a new one.</summary>
-    public IReadOnlyList<UserPdkInfo> AvailableCustomPdks { get; }
 
     /// <summary>Geometry backends selectable for the rendered code: always both, since saving is always own-code.</summary>
     public IReadOnlyList<GeometryBackend> AvailableBackends => _availableBackends;
-
-    /// <summary>
-    /// The process the component will be saved under: <see cref="SelectedProcess"/> for a new
-    /// PDK, or the selected existing custom PDK's (inherited, read-only) process otherwise.
-    /// </summary>
-    private ProcessDefinition? EffectiveProcess => IsNewPdk ? SelectedProcess : SelectedCustomPdk?.Process;
 
     /// <summary>
     /// File-picker hook for <see cref="LoadCodeFromFile"/>: returns a ".py" file's already-read
@@ -65,19 +56,12 @@ public partial class NewComponentViewModel : ObservableObject
     /// </summary>
     public Func<Task<string?>>? PickPyFile { get; set; }
 
-    /// <summary>
-    /// Hook invoked by <see cref="OpenProcessEditorCmd"/> to open a fabrication-process editor
-    /// (e.g. from the "New PDK" section). A no-op when null.
-    /// </summary>
-    public Func<Task>? OpenProcessEditor { get; set; }
-
     /// <summary>The draft last written by <c>Save</c>, or null before a successful save.</summary>
     public PdkComponentDraft? SavedDraft { get; private set; }
 
     /// <summary>
-    /// The user-PDK file path <c>Save</c> actually wrote to (named custom PDK, new or
-    /// existing) — never derived from <see cref="SelectedProcess"/>, since a process's default
-    /// per-process file is no longer where a PDK-first save lands. Null before a successful save.
+    /// The user-PDK file path <c>Save</c> actually wrote to (the selected named custom PDK's
+    /// file). Null before a successful save.
     /// </summary>
     public string? SavedFilePath { get; private set; }
 
@@ -86,15 +70,17 @@ public partial class NewComponentViewModel : ObservableObject
 
     /// <summary>
     /// Optional confirmation hook invoked with (componentName, pdkName) when a save would
-    /// overwrite an existing component or PDK file; returning true proceeds with the overwrite.
-    /// When null, a collision is reported via <see cref="StatusText"/> and the save is aborted.
+    /// overwrite an existing component in the target PDK file; returning true proceeds with the
+    /// overwrite. When null, a collision is reported via <see cref="StatusText"/> and the save is
+    /// aborted.
     /// </summary>
     public Func<string, string, Task<bool>>? ConfirmOverwrite { get; set; }
 
     /// <summary>
-    /// Initializes the view model with its collaborators, the available processes (for a new
-    /// PDK), and the already-existing named custom PDKs read from <paramref name="store"/>.
-    /// Defaults to "new PDK" mode when no custom PDK exists yet.
+    /// Initializes the view model with its collaborators, the fabrication processes offered to
+    /// a "create new PDK" modal, and the already-existing named custom PDKs read from
+    /// <paramref name="store"/>. Pre-selects the first existing custom PDK, if any; otherwise no
+    /// PDK is selected until the user picks one or creates one via <see cref="CreateNewPdk"/>.
     /// </summary>
     public NewComponentViewModel(
         ComponentGeometryExtractor extractor,
@@ -106,18 +92,11 @@ public partial class NewComponentViewModel : ObservableObject
         _fdtd = fdtd;
         _store = store;
         Processes = processes;
-        AvailableCustomPdks = store.ListCustomPdks();
 
-        // Pre-select the first existing custom PDK rather than leaving the transient
-        // "one exists but none chosen" state (SelectedCustomPdk null, IsNewPdk false)
-        // hanging around; falls back to "new PDK" only when none exist yet.
+        RefreshPdkChoices();
         if (AvailableCustomPdks.Count > 0)
         {
-            SelectedCustomPdk = AvailableCustomPdks[0];
-        }
-        else
-        {
-            IsNewPdk = true;
+            SelectedPdkChoice = PdkChoices[0];
         }
 
         // Seed the editor with a starter snippet so it is never blank on first open; the user
@@ -146,17 +125,6 @@ public partial class NewComponentViewModel : ObservableObject
     }
     partial void OnCodeChanged(string value) => InvalidatePreview();
 
-    /// <summary>Switching the custom-PDK selection re-derives <see cref="IsNewPdk"/> and inherits its process.</summary>
-    partial void OnSelectedCustomPdkChanged(UserPdkInfo? value)
-    {
-        IsNewPdk = value is null;
-        SelectedProcess = value?.Process;
-        InvalidatePreview();
-        SaveCommand.NotifyCanExecuteChanged();
-    }
-
-    partial void OnIsNewPdkChanged(bool value) => InvalidatePreview();
-
     private void InvalidatePreview()
     {
         _lastPreview = null;
@@ -173,13 +141,6 @@ public partial class NewComponentViewModel : ObservableObject
         if (PickPyFile is null) return;
         var content = await PickPyFile();
         if (content is not null) Code = content;
-    }
-
-    /// <summary>Invokes <see cref="OpenProcessEditor"/> if set; a no-op otherwise.</summary>
-    [RelayCommand]
-    private async Task OpenProcessEditorCmd()
-    {
-        if (OpenProcessEditor is not null) await OpenProcessEditor();
     }
 
     /// <summary>Renders the configured geometry reference and extracts its size and pins.</summary>

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -119,13 +119,31 @@ public partial class NewComponentViewModel : ObservableObject
         {
             IsNewPdk = true;
         }
+
+        // Seed the editor with a starter snippet so it is never blank on first open; the user
+        // still has to press Preview, so this cannot mask a stale/mismatched preview.
+        if (string.IsNullOrWhiteSpace(Code))
+        {
+            Code = BackendCodeExamples.For(SelectedBackend);
+        }
     }
 
     // A change to any input the preview was rendered from invalidates the preview — otherwise
     // a saved draft could be built from a rendered preview that no longer matches the current
     // inputs. Clearing _lastPreview is the load-bearing part: Save gates on that field, so a
     // stale preview cannot be saved; HasPreview (Save button's enablement) tracks it.
-    partial void OnSelectedBackendChanged(GeometryBackend value) => InvalidatePreview();
+    partial void OnSelectedBackendChanged(GeometryBackend value)
+    {
+        // Autoload the new backend's starter snippet, but only over an empty editor or one
+        // still holding the OTHER backend's untouched auto-example — never over user-authored
+        // code, which is anything else (including the new backend's own example, re-affirmed).
+        var otherBackend = value == GeometryBackend.GdsFactory ? GeometryBackend.Nazca : GeometryBackend.GdsFactory;
+        if (string.IsNullOrWhiteSpace(Code) || Code == BackendCodeExamples.For(otherBackend))
+        {
+            Code = BackendCodeExamples.For(value);
+        }
+        InvalidatePreview();
+    }
     partial void OnCodeChanged(string value) => InvalidatePreview();
 
     /// <summary>Switching the custom-PDK selection re-derives <see cref="IsNewPdk"/> and inherits its process.</summary>

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/PdkChoice.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/PdkChoice.cs
@@ -1,0 +1,21 @@
+using CAP_DataAccess.Components.AddCustomComponent;
+
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>
+/// One selectable entry in <see cref="NewComponentViewModel.PdkChoices"/>: either an existing
+/// named custom PDK (<see cref="Pdk"/> set, <see cref="IsNewPdk"/> false) or the trailing
+/// "New PDK…" sentinel (<see cref="Pdk"/> null, <see cref="IsNewPdk"/> true). Selecting the
+/// sentinel invokes <see cref="NewComponentViewModel.CreateNewPdk"/> rather than being a savable
+/// target itself — chosen over a raw <c>bool</c> flag alongside <c>AvailableCustomPdks</c>
+/// because a single strongly-typed dropdown item (rather than a list plus a side flag) binds
+/// cleanly to one Avalonia <c>ComboBox</c> with one <c>SelectedItem</c>.
+/// </summary>
+public sealed record PdkChoice(string DisplayName, UserPdkInfo? Pdk, bool IsNewPdk)
+{
+    /// <summary>The sentinel entry always appended as the dropdown's last item.</summary>
+    public static readonly PdkChoice NewPdkSentinel = new("New PDK…", null, true);
+
+    /// <summary>Wraps an existing named custom PDK as a selectable dropdown entry.</summary>
+    public static PdkChoice For(UserPdkInfo pdk) => new(pdk.Name, pdk, false);
+}

--- a/CAP.Avalonia/ViewModels/ProcessManagementViewModel.PdkCreation.cs
+++ b/CAP.Avalonia/ViewModels/ProcessManagementViewModel.PdkCreation.cs
@@ -1,0 +1,80 @@
+using System;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CAP.Avalonia.ViewModels;
+
+/// <summary>
+/// PDK-creation mode for <see cref="ProcessManagementViewModel"/>: lets the "New Component"
+/// wizard reuse this dialog's process editor (layers/cross-sections/materials) to build a
+/// brand-new, named user PDK from scratch, distinct from its normal role of viewing/editing the
+/// design's already-active process. Deliberately never touches
+/// <c>FileOperationsViewModel</c>/<c>ActiveProcess</c>/<c>SetActiveProcess</c> — wiring a newly
+/// created PDK into the active design is out of scope here (tracked separately as bug #726).
+/// </summary>
+public partial class ProcessManagementViewModel
+{
+    /// <summary>True while the dialog is being used to create a new named PDK rather than to
+    /// view/edit the design's active process.</summary>
+    [ObservableProperty]
+    private bool _isPdkCreationMode;
+
+    /// <summary>The name for the new PDK being created, bound to the "PDK name" field.</summary>
+    [ObservableProperty]
+    private string _pdkName = string.Empty;
+
+    /// <summary>
+    /// Creates a new named user PDK from the given name and process definition, returning the
+    /// path it was written to. Wired by the caller to
+    /// <c>UserPdkStore.CreateNamedPdkWithProcess</c>; left null (e.g. in tests) disables
+    /// <see cref="CreatePdkCommand"/>.
+    /// </summary>
+    public Func<string, ProcessDefinition, string>? CreateUserPdk { get; set; }
+
+    /// <summary>
+    /// Optional collision check for the chosen PDK name. Wired by the caller to
+    /// <c>UserPdkStore.NamedPdkExists</c>; left null skips the check.
+    /// </summary>
+    public Func<string, bool>? PdkNameExists { get; set; }
+
+    /// <summary>Raised with the written PDK's file path after <see cref="CreatePdkCommand"/> succeeds.</summary>
+    public event EventHandler<string>? PdkCreated;
+
+    /// <summary>
+    /// Switches the dialog into PDK-creation mode and starts it with a fresh, blank process
+    /// (same defaults as the regular "New process" action) so the user can pick a preset or
+    /// build layers/cross-sections/materials by hand. Does not read or write
+    /// <c>ActiveProcess</c> — this mode is only ever about the process being newly authored.
+    /// </summary>
+    public void EnterPdkCreationMode()
+    {
+        IsPdkCreationMode = true;
+        NewProcess();
+    }
+
+    /// <summary>
+    /// Writes the currently edited process to a new named user PDK via <see cref="CreateUserPdk"/>
+    /// and raises <see cref="PdkCreated"/> with the resulting path. If <see cref="PdkNameExists"/>
+    /// reports a collision, no PDK is written; the caller can offer an overwrite confirmation in a
+    /// later iteration — for now this just surfaces the collision via <see cref="StatusText"/>.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanCreatePdk))]
+    private void CreatePdk()
+    {
+        if (PdkNameExists?.Invoke(PdkName) == true)
+        {
+            StatusText = $"A PDK named '{PdkName}' already exists. Choose a different name.";
+            return;
+        }
+
+        var path = CreateUserPdk!(PdkName, ToProcess());
+        PdkCreated?.Invoke(this, path);
+    }
+
+    private bool CanCreatePdk() => IsPdkCreationMode && !string.IsNullOrWhiteSpace(PdkName) && CreateUserPdk != null;
+
+    partial void OnPdkNameChanged(string value) => CreatePdkCommand.NotifyCanExecuteChanged();
+
+    partial void OnIsPdkCreationModeChanged(bool value) => CreatePdkCommand.NotifyCanExecuteChanged();
+}

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -99,14 +99,9 @@ public partial class MainWindow : Window
                             "Overwrite?", new[] { "Cancel", "Overwrite" });
                         return choice == 1;
                     };
-                    // Opens the same Fabrication Process editor as the toolbar button (#570).
-                    // No back-channel for a newly-defined process: the user reopens this
-                    // assistant afterwards to pick it up (known limitation).
-                    newComponentVm.OpenProcessEditor = () =>
-                    {
-                        vm.OpenProcessManagerCommand.Execute(null);
-                        return System.Threading.Tasks.Task.CompletedTask;
-                    };
+                    // "New PDK…" sentinel modal creation hook (#723/#727 follow-up, task 5):
+                    // not yet wired here — selecting the sentinel is currently a no-op that
+                    // reverts to the previous PDK choice until the create-PDK dialog exists.
                     var window = new NewComponentWindow { DataContext = newComponentVm };
                     window.Show(this);
                     return System.Threading.Tasks.Task.CompletedTask;

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -8,6 +8,7 @@ using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Analysis.OnaAnalysis;
 using CAP.Avalonia.ViewModels.ComponentSettings;
 using CAP_Core.Components.Core;
+using CAP_DataAccess.Components.AddCustomComponent;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP.Avalonia.ViewModels.Hierarchy;
 using CAP.Avalonia.ViewModels.Library;
@@ -100,9 +101,51 @@ public partial class MainWindow : Window
                         return choice == 1;
                     };
                     // "New PDK…" sentinel modal creation hook (#723/#727 follow-up, task 5):
-                    // not yet wired here — selecting the sentinel is currently a no-op that
-                    // reverts to the previous PDK choice until the create-PDK dialog exists.
+                    // reuses the Fabrication Process editor's layer/cross-section/material UI in
+                    // "PDK creation" mode, blocking modally (ShowDialog, owner = the New Component
+                    // window itself) so the dropdown cannot be left mid-selection while the modal
+                    // is open.
                     var window = new NewComponentWindow { DataContext = newComponentVm };
+                    newComponentVm.CreateNewPdk = async () =>
+                    {
+                        var userPdkStore = App.Services.GetService(typeof(UserPdkStore)) as UserPdkStore;
+                        if (userPdkStore is null) return null;
+
+                        var processVm = new ProcessManagementViewModel(new FileDialogService(this),
+                            new IProcessImporter[]
+                            {
+                                new UpdkYamlProcessImporter(),
+                                new NazcaCsvProcessImporter(),
+                            }, new PdkJsonSaver());
+                        processVm.CreateUserPdk = (name, proc) =>
+                            userPdkStore.CreateNamedPdkWithProcess(name, proc, "gdsfactory", null);
+                        processVm.PdkNameExists = name => userPdkStore.NamedPdkExists(name);
+                        processVm.SetAvailablePresets(vm.LeftPanel.GetLoadedPdkDrafts());
+                        // Must run after CreateUserPdk is set, so CreatePdkCommand's CanExecute
+                        // (which requires CreateUserPdk != null) refreshes correctly.
+                        processVm.EnterPdkCreationMode();
+
+                        string? createdPath = null;
+                        var processWindow = new ProcessManagementWindow { DataContext = processVm };
+                        processVm.PdkCreated += (_, path) =>
+                        {
+                            createdPath = path;
+                            processWindow.Close();
+                        };
+
+                        try
+                        {
+                            await processWindow.ShowDialog(window);
+                        }
+                        catch
+                        {
+                            return null;
+                        }
+
+                        return createdPath is null
+                            ? null
+                            : userPdkStore.ListCustomPdks().FirstOrDefault(i => i.FilePath == createdPath);
+                    };
                     window.Show(this);
                     return System.Threading.Tasks.Task.CompletedTask;
                 };

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -1,8 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:CAP.Avalonia.ViewModels.Components.AddCustomComponent"
-        xmlns:dto="using:CAP_DataAccess.Components.ComponentDraftMapper.DTOs"
-        xmlns:pdk="using:CAP_DataAccess.Components.AddCustomComponent"
         xmlns:edit="using:AvaloniaEdit"
         xmlns:behaviors="using:CAP.Avalonia.Behaviors"
         xmlns:controls="using:CAP.Avalonia.Controls"
@@ -28,50 +26,24 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
             <StackPanel Spacing="10">
 
-                <!-- PDK -->
+                <!-- PDK: existing named custom PDKs plus a trailing "New PDK…" sentinel that
+                     opens the PDK-creation modal (wired in MainWindow.axaml.cs) -->
                 <TextBlock Text="PDK" Foreground="#aaaaaa" FontSize="11" FontWeight="SemiBold"/>
-                <Grid ColumnDefinitions="*,8,Auto">
-                    <ComboBox Grid.Column="0"
-                              ItemsSource="{Binding AvailableCustomPdks}"
-                              SelectedItem="{Binding SelectedCustomPdk}"
-                              IsEnabled="{Binding !IsNewPdk}"
-                              Background="#2d2d2d" Foreground="White" HorizontalAlignment="Stretch">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate x:DataType="pdk:UserPdkInfo">
-                                <TextBlock Text="{Binding Name}"/>
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
-                    <ToggleButton Grid.Column="2" Content="+ New PDK"
-                                  IsChecked="{Binding IsNewPdk, Mode=TwoWay}"
-                                  FontSize="11" Background="#3d4d6d"
-                                  ToolTip.Tip="Create a brand-new named custom PDK instead of appending to an existing one"/>
-                </Grid>
-                <TextBox Text="{Binding NewPdkName}" Watermark="New PDK name"
-                         IsVisible="{Binding IsNewPdk}"
-                         Background="#2d2d2d" Foreground="White"/>
+                <ComboBox ItemsSource="{Binding PdkChoices}"
+                          SelectedItem="{Binding SelectedPdkChoice}"
+                          Background="#2d2d2d" Foreground="White" HorizontalAlignment="Stretch">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="vm:PdkChoice">
+                            <TextBlock Text="{Binding DisplayName}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
                 <Separator Background="#3d3d3d"/>
 
-                <!-- Fabrication process: chosen only for a new PDK, inherited (read-only) otherwise -->
+                <!-- Fabrication process: always inherited (read-only) from the selected PDK -->
                 <TextBlock Text="Fabrication process" Foreground="#aaaaaa" FontSize="11" FontWeight="SemiBold"/>
-                <Grid ColumnDefinitions="*,8,Auto" IsVisible="{Binding IsNewPdk}">
-                    <ComboBox Grid.Column="0"
-                              ItemsSource="{Binding Processes}"
-                              SelectedItem="{Binding SelectedProcess}"
-                              Background="#2d2d2d" Foreground="White" HorizontalAlignment="Stretch">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate x:DataType="dto:ProcessDefinition">
-                                <TextBlock Text="{Binding Name}"/>
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
-                    <Button Grid.Column="2" Content="Process editor…" Command="{Binding OpenProcessEditorCmdCommand}"
-                            FontSize="11" Background="#3d4d6d"
-                            ToolTip.Tip="Opens the Fabrication Process window to define or edit a process. Reopen this window afterwards to pick it up."/>
-                </Grid>
-                <TextBlock Text="{Binding SelectedProcess.Name}" Foreground="White" FontSize="12"
-                           IsVisible="{Binding !IsNewPdk}"/>
+                <TextBlock Text="{Binding SelectedProcess.Name}" Foreground="White" FontSize="12"/>
 
                 <Separator Background="#3d3d3d"/>
 

--- a/CAP.Avalonia/Views/ProcessManagementWindow.axaml
+++ b/CAP.Avalonia/Views/ProcessManagementWindow.axaml
@@ -12,6 +12,17 @@
 
     <DockPanel Margin="14">
 
+        <!-- PDK-creation mode (#727 task 5): shown only when this dialog is reused by the
+             "New Component" wizard's "New PDK…" sentinel to author a brand-new named PDK,
+             instead of viewing/editing the design's already-active process. -->
+        <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,10"
+                    IsVisible="{Binding IsPdkCreationMode}">
+            <TextBlock Text="PDK name:" VerticalAlignment="Center" Foreground="#aaa"/>
+            <TextBox Text="{Binding PdkName}" Watermark="PDK name" Width="240" VerticalAlignment="Center"/>
+            <Button Content="Create PDK" Command="{Binding CreatePdkCommand}"
+                    Padding="12,6" Background="#2a4a2a"/>
+        </StackPanel>
+
         <!-- Header -->
         <StackPanel DockPanel.Dock="Top" Spacing="6" Margin="0,0,0,10">
             <StackPanel Orientation="Horizontal" Spacing="8">

--- a/UnitTests/Components/AddCustomComponent/BackendCodeAutoloadTests.cs
+++ b/UnitTests/Components/AddCustomComponent/BackendCodeAutoloadTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="BackendCodeExamples"/> and the autoload behavior in
+/// <see cref="NewComponentViewModel"/>: switching <see cref="GeometryBackend"/> loads the
+/// matching starter snippet into an empty or untouched-example editor, but never overwrites
+/// user-authored code.
+/// </summary>
+public class BackendCodeAutoloadTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-nc-autoload-" + Guid.NewGuid().ToString("N"));
+
+    private NewComponentViewModel Build()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var fdtd = new Mock<IFdtdSMatrixService>();
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        return new NewComponentViewModel(extractor, fdtd.Object, store,
+            new List<ProcessDefinition> { new() { Name = "P" } });
+    }
+
+    [Fact]
+    public void Ctor_loads_the_default_backends_example_into_an_empty_editor()
+    {
+        var vm = Build();
+        vm.Code.ShouldBe(BackendCodeExamples.For(vm.SelectedBackend));
+    }
+
+    [Fact]
+    public void Test_A_empty_code_then_switch_to_gdsfactory_loads_its_example()
+    {
+        var vm = Build();
+        vm.SelectedBackend = GeometryBackend.Nazca; // move away from the ctor's default first
+        vm.Code = string.Empty;
+
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+
+        vm.Code.ShouldBe(BackendCodeExamples.GdsFactory);
+    }
+
+    [Fact]
+    public void Test_B_untouched_gdsfactory_example_then_switch_to_nazca_replaces_it()
+    {
+        var vm = Build();
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+        vm.Code = BackendCodeExamples.GdsFactory; // untouched auto-example, re-affirmed explicitly
+
+        vm.SelectedBackend = GeometryBackend.Nazca;
+
+        vm.Code.ShouldBe(BackendCodeExamples.Nazca);
+    }
+
+    [Fact]
+    public void Test_C_user_authored_code_survives_a_backend_switch()
+    {
+        var vm = Build();
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+        vm.Code = "mein eigener code";
+
+        vm.SelectedBackend = GeometryBackend.Nazca;
+
+        vm.Code.ShouldBe("mein eigener code");
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}

--- a/UnitTests/Components/AddCustomComponent/NewComponentNewPdkSentinelTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentNewPdkSentinelTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers the "New PDK…" dropdown sentinel that replaces the old inline new-PDK/process UI
+/// (task 4 of the PDK-first component wizard, #723/#727 follow-up):
+/// <see cref="NewComponentViewModel.PdkChoices"/> always ends with the sentinel, selecting it
+/// invokes <see cref="NewComponentViewModel.CreateNewPdk"/> and adopts a successful result,
+/// a cancelled (null) creation reverts to the previously selected PDK, and saving against an
+/// existing PDK always appends to that PDK's own file (never a new "SaveToNamedPdk" branch).
+/// </summary>
+public class NewComponentNewPdkSentinelTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "lunima-nc-vm-sentinel-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 8, YMax = 1.5,
+        Pins = new List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 },
+            new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 }
+        }
+    };
+
+    private static PdkComponentDraft SeedComponent(string n) => new()
+    {
+        Name = n, WidthMicrometers = 5, HeightMicrometers = 1,
+        RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()", RawCodeBackend = "gdsfactory",
+        Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+    };
+
+    private UserPdkStore Store() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    private NewComponentViewModel Build(UserPdkStore store)
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var vm = new NewComponentViewModel(extractor, fdtd: null, store,
+            new List<ProcessDefinition> { new() { Name = "P" } });
+        vm.ComponentName = "My Comp";
+        vm.Code = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        return vm;
+    }
+
+    [Fact]
+    public void PdkChoices_alwaysEndsWithTheNewPdkSentinel()
+    {
+        var store = Store();
+        store.SaveToNamedPdk("Lib A", new ProcessDefinition { Name = "P" }, SeedComponent("x"), "gdsfactory", null);
+        var vm = Build(store);
+
+        vm.PdkChoices.Count.ShouldBe(2); // one existing PDK + the sentinel
+        vm.PdkChoices[^1].IsNewPdk.ShouldBeTrue();
+        vm.PdkChoices[^1].DisplayName.ShouldBe("New PDK…");
+        vm.PdkChoices[^1].Pdk.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SelectingTheSentinel_withACreatedPdk_adoptsItAsTheSelection()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        var vm = Build(store);
+        vm.PdkChoices.Count.ShouldBe(1); // no custom PDKs yet -> only the sentinel
+
+        vm.CreateNewPdk = () =>
+        {
+            var path = store.CreateNamedPdkWithProcess("Brand New Lib", process, "gdsfactory", null);
+            return Task.FromResult<UserPdkInfo?>(new UserPdkInfo("Brand New Lib", path, process));
+        };
+
+        vm.SelectedPdkChoice = vm.PdkChoices[0]; // the sentinel (only entry)
+        await Task.Yield(); // let the fire-and-forget creation task settle
+
+        vm.SelectedCustomPdk.ShouldNotBeNull();
+        vm.SelectedCustomPdk!.Name.ShouldBe("Brand New Lib");
+        vm.AvailableCustomPdks.ShouldContain(i => i.Name == "Brand New Lib");
+        vm.PdkChoices.ShouldContain(c => !c.IsNewPdk && c.Pdk!.Name == "Brand New Lib");
+    }
+
+    [Fact]
+    public async Task SelectingTheSentinel_thenCancelling_revertsToThePreviousSelection()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "P" };
+        store.SaveToNamedPdk("Existing Lib", process, SeedComponent("x"), "gdsfactory", null);
+        var vm = Build(store);
+        var existingChoice = vm.PdkChoices[0]; // ctor already pre-selected this one
+
+        vm.CreateNewPdk = () => Task.FromResult<UserPdkInfo?>(null); // user cancels the modal
+
+        vm.SelectedPdkChoice = vm.PdkChoices[^1]; // the sentinel
+        await Task.Yield();
+
+        vm.SelectedPdkChoice.ShouldBe(existingChoice);
+        vm.SelectedCustomPdk!.Name.ShouldBe("Existing Lib");
+    }
+
+    [Fact]
+    public async Task SelectingTheSentinel_withNoCreateHookWired_revertsImmediately()
+    {
+        var store = Store();
+        store.SaveToNamedPdk("Existing Lib", new ProcessDefinition { Name = "P" }, SeedComponent("x"), "gdsfactory", null);
+        var vm = Build(store);
+        var existingChoice = vm.PdkChoices[0];
+
+        vm.SelectedPdkChoice = vm.PdkChoices[^1]; // sentinel, but CreateNewPdk was never set
+        await Task.Yield();
+
+        vm.SelectedPdkChoice.ShouldBe(existingChoice);
+    }
+
+    [Fact]
+    public async Task Save_withAnExistingSelectedPdk_appendsToItsOwnFile()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        store.SaveToNamedPdk("My SiN Lib", process, SeedComponent("existing"), "gdsfactory", null);
+        var vm = Build(store);
+        var pdkInfo = vm.AvailableCustomPdks.ShouldHaveSingleItem();
+        vm.SelectedPdkChoice = vm.PdkChoices[0];
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.SavedDraft.ShouldNotBeNull();
+        vm.SavedFilePath.ShouldBe(pdkInfo.FilePath); // appended to the selected PDK's own file
+        var pdk = new PdkLoader().LoadFromFileForEditing(pdkInfo.FilePath);
+        pdk.Components.Count.ShouldBe(2); // appended, not replacing the file
+        pdk.Components.ShouldContain(c => c.Name == "My Comp");
+    }
+
+    [Fact]
+    public async Task CanSave_isFalse_untilAPdkIsSelected()
+    {
+        var store = Store();
+        var vm = Build(store); // no custom PDKs -> nothing selected
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        vm.HasPreview.ShouldBeTrue();
+
+        vm.SelectedCustomPdk.ShouldBeNull();
+        vm.SaveCommand.CanExecute(null).ShouldBeFalse();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, true);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelPdkFirstTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelPdkFirstTests.cs
@@ -17,12 +17,13 @@ using Xunit;
 namespace UnitTests.Components.AddCustomComponent;
 
 /// <summary>
-/// Covers the PDK-first redesign of <see cref="NewComponentViewModel"/>: choosing between an
-/// existing named custom PDK (<see cref="NewComponentViewModel.SelectedCustomPdk"/>, process
-/// inherited and read-only) and creating a new one (<see cref="NewComponentViewModel.IsNewPdk"/>,
-/// name + process chosen), and routing <c>Save</c> to <see cref="UserPdkStore.SaveToNamedPdk"/>
-/// or <see cref="UserPdkStore.AppendToExistingPdk"/> accordingly. Function-reference mode no
-/// longer exists — every save is the user's own code.
+/// Covers the PDK-first redesign of <see cref="NewComponentViewModel"/>: choosing an existing
+/// named custom PDK (<see cref="NewComponentViewModel.SelectedCustomPdk"/>, process inherited and
+/// read-only) via <see cref="NewComponentViewModel.SelectedPdkChoice"/>, and routing
+/// <c>Save</c> to <see cref="UserPdkStore.AppendToExistingPdk"/>. A brand-new PDK is never
+/// created inline anymore — see <c>NewComponentNewPdkSentinelTests</c> for the "New PDK…"
+/// dropdown sentinel that replaced it (task 4 of the PDK-first component wizard). Function-
+/// reference mode no longer exists either — every save is the user's own code.
 /// </summary>
 public class NewComponentViewModelPdkFirstTests : IDisposable
 {
@@ -59,27 +60,6 @@ public class NewComponentViewModelPdkFirstTests : IDisposable
     }
 
     [Fact]
-    public async Task NoCustomPdks_defaultsToNewPdk_andSavesToNamedPdk()
-    {
-        var store = Store();
-        var (vm, _) = Build(store, withFdtd: false);
-
-        vm.AvailableCustomPdks.ShouldBeEmpty();
-        vm.IsNewPdk.ShouldBeTrue(); // Test A: no custom PDKs yet -> defaults to "new PDK"
-
-        vm.SelectedProcess = vm.Processes[0];
-        vm.NewPdkName = "My New PDK";
-
-        await vm.RunPreviewCommand.ExecuteAsync(null);
-        await vm.SaveCommand.ExecuteAsync(null);
-
-        vm.SavedDraft.ShouldNotBeNull();
-        vm.SavedDraft!.RawCode.ShouldContain("gf.components.coupler");
-
-        store.ListCustomPdks().ShouldContain(i => i.Name == "My New PDK" && i.Process.Name == "P");
-    }
-
-    [Fact]
     public async Task ExistingCustomPdkSelected_inheritsProcess_andAppendsToItsFile()
     {
         var store = Store();
@@ -90,9 +70,7 @@ public class NewComponentViewModelPdkFirstTests : IDisposable
         var pdkInfo = vm.AvailableCustomPdks.ShouldHaveSingleItem();
         pdkInfo.Name.ShouldBe("My SiN Lib");
 
-        vm.SelectedCustomPdk = pdkInfo;
-
-        vm.IsNewPdk.ShouldBeFalse(); // Test B: selecting an existing PDK switches out of "new"
+        vm.SelectedCustomPdk.ShouldBe(pdkInfo); // ctor pre-selects the only existing PDK
         vm.SelectedProcess.ShouldBe(pdkInfo.Process); // process is inherited from the PDK
 
         await vm.RunPreviewCommand.ExecuteAsync(null);
@@ -108,47 +86,29 @@ public class NewComponentViewModelPdkFirstTests : IDisposable
     public async Task Save_setsSavedFilePath_toTheActualWrittenFile_notTheProcessDefaultPath()
     {
         var store = Store();
-        var (vm, _) = Build(store, withFdtd: false);
-        vm.SelectedProcess = vm.Processes[0];
-        vm.NewPdkName = "My New PDK";
+        var process = new ProcessDefinition { Name = "P" };
+        var path = store.SaveToNamedPdk("My PDK", process, SeedComponent("seed"), "gdsfactory", null);
+        var (vm, _) = Build(store, new List<ProcessDefinition> { process }, withFdtd: false);
 
         vm.SavedFilePath.ShouldBeNull(); // nothing saved yet
 
         await vm.RunPreviewCommand.ExecuteAsync(null);
         await vm.SaveCommand.ExecuteAsync(null);
 
-        // Must be the named-PDK file the store actually wrote to (SaveToNamedPdk's return
-        // value) — never ResolvePath(process)'s per-process default file, which is wrong for
-        // a PDK-first save (the bug NewComponentWindowLauncher.OnSaved used to have).
-        vm.SavedFilePath.ShouldBe(store.ResolveNamedPath("My New PDK"));
-        vm.SavedFilePath.ShouldNotBe(store.ResolvePath(vm.Processes[0]));
-    }
-
-    [Fact]
-    public async Task CanSave_isFalse_whenNewPdkNameIsBlank()
-    {
-        var store = Store();
-        var (vm, _) = Build(store, withFdtd: false);
-        vm.SelectedProcess = vm.Processes[0];
-        vm.NewPdkName = "";
-
-        await vm.RunPreviewCommand.ExecuteAsync(null);
-        vm.HasPreview.ShouldBeTrue();
-
-        vm.IsNewPdk.ShouldBeTrue();
-        vm.SaveCommand.CanExecute(null).ShouldBeFalse(); // Test C: new PDK requires a name
-
-        vm.NewPdkName = "Now Named";
-        vm.SaveCommand.CanExecute(null).ShouldBeTrue();
+        // Must be the named-PDK file the store actually wrote to — never ResolvePath(process)'s
+        // per-process default file, which is wrong for a PDK-first save (the bug
+        // NewComponentWindowLauncher.OnSaved used to have).
+        vm.SavedFilePath.ShouldBe(path);
+        vm.SavedFilePath.ShouldNotBe(store.ResolvePath(process));
     }
 
     [Fact]
     public async Task FdtdFailure_savesBlackBox_andReportsTheError()
     {
         var store = Store();
-        var (vm, fdtd) = Build(store, withFdtd: true);
-        vm.SelectedProcess = vm.Processes[0];
-        vm.NewPdkName = "PDK";
+        var process = new ProcessDefinition { Name = "P" };
+        store.SaveToNamedPdk("PDK", process, SeedComponent("seed"), "gdsfactory", null);
+        var (vm, fdtd) = Build(store, new List<ProcessDefinition> { process }, withFdtd: true);
 
         fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(FdtdAvailability.Available(""));
@@ -159,7 +119,7 @@ public class NewComponentViewModelPdkFirstTests : IDisposable
         await vm.ComputeSMatrixCommand.ExecuteAsync(null);
         await vm.SaveCommand.ExecuteAsync(null);
 
-        vm.StatusText.ShouldContain("solver blew up"); // Test D: failure reported, never fabricated
+        vm.StatusText.ShouldContain("solver blew up"); // failure reported, never fabricated
         vm.SavedDraft!.SMatrix.ShouldBeNull();
     }
 
@@ -169,7 +129,7 @@ public class NewComponentViewModelPdkFirstTests : IDisposable
         var store = Store();
         var (vm, _) = Build(store, withFdtd: false);
 
-        vm.AvailableBackends.Count.ShouldBe(2); // Test E: own-code mode is the only mode now
+        vm.AvailableBackends.Count.ShouldBe(2); // own-code mode is the only mode now
         vm.AvailableBackends.ShouldContain(GeometryBackend.GdsFactory);
         vm.AvailableBackends.ShouldContain(GeometryBackend.Nazca);
     }

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelRawCodeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelRawCodeTests.cs
@@ -31,6 +31,13 @@ public class NewComponentViewModelRawCodeTests : IDisposable
         Pins = new List<NazcaPreviewPin> { new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 }, new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 } }
     };
 
+    private static PdkComponentDraft SeedComponent(string n) => new()
+    {
+        Name = n, WidthMicrometers = 5, HeightMicrometers = 1,
+        RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()", RawCodeBackend = "gdsfactory",
+        Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+    };
+
     private NewComponentViewModel Build()
     {
         var nazca = new Mock<IComponentPreviewRenderer>();
@@ -38,11 +45,13 @@ public class NewComponentViewModelRawCodeTests : IDisposable
         gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
         var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
         var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var process = new ProcessDefinition { Name = "P" };
+        // PDK-first: Save always appends to a selected existing named custom PDK now (no more
+        // inline "new PDK" creation), so seed one and let the ctor pre-select it.
+        store.SaveToNamedPdk("My PDK", process, SeedComponent("seed"), "gdsfactory", null);
         var vm = new NewComponentViewModel(extractor, fdtd: null, store,
-            new List<ProcessDefinition> { new() { Name = "P" } });
+            new List<ProcessDefinition> { process });
         vm.ComponentName = "My Raw Comp";
-        vm.SelectedProcess = vm.Processes[0];
-        vm.NewPdkName = "My PDK"; // no custom PDKs exist yet -> IsNewPdk defaults true, needs a name
         return vm;
     }
 

--- a/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentViewModelTests.cs
@@ -32,6 +32,13 @@ public class NewComponentViewModelTests : IDisposable
         Pins = new List<NazcaPreviewPin> { new() { Name = "o1", X = 0, Y = 1, Angle = 180 }, new() { Name = "o2", X = 10, Y = 1, Angle = 0 } }
     };
 
+    private static PdkComponentDraft SeedComponent(string n) => new()
+    {
+        Name = n, WidthMicrometers = 5, HeightMicrometers = 1,
+        RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()", RawCodeBackend = "gdsfactory",
+        Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+    };
+
     private (NewComponentViewModel vm, Mock<IFdtdSMatrixService> fdtd) Build(bool withFdtd = true)
     {
         var nazca = new Mock<IComponentPreviewRenderer>();
@@ -40,13 +47,15 @@ public class NewComponentViewModelTests : IDisposable
         var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
         var fdtd = new Mock<IFdtdSMatrixService>();
         var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var process = new ProcessDefinition { Name = "P" };
+        // PDK-first: Save always appends to a selected existing named custom PDK now (no more
+        // inline "new PDK" creation), so seed one and let the ctor pre-select it.
+        store.SaveToNamedPdk("My PDK", process, SeedComponent("seed"), "gdsfactory", null);
         var vm = new NewComponentViewModel(extractor, withFdtd ? fdtd.Object : null, store,
-            new List<ProcessDefinition> { new() { Name = "P" } });
+            new List<ProcessDefinition> { process });
         vm.ComponentName = "My Comp";
         vm.SelectedBackend = GeometryBackend.GdsFactory;
         vm.Code = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
-        vm.SelectedProcess = vm.Processes[0];
-        vm.NewPdkName = "My PDK"; // no custom PDKs exist yet -> IsNewPdk defaults true, needs a name
         return (vm, fdtd);
     }
 

--- a/UnitTests/Components/AddCustomComponent/NewPdkModalFlowTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewPdkModalFlowTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// End-to-end test for the PDK-first "New PDK…" modal flow (issue #726 follow-up, task 6): a
+/// named custom PDK is created empty via <see cref="UserPdkStore"/>, a component is appended to
+/// it afterwards, and <see cref="ProcessManagementViewModel"/>'s PDK-creation mode drives the
+/// same store method end to end from the wizard's perspective. Mirrors
+/// <c>UserPdkCreateEmptyTests</c>, <c>ProcessManagementPdkCreationTests</c> and
+/// <c>UserPdkNamedStoreTests</c>.
+/// </summary>
+public class NewPdkModalFlowTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-newpdkmodal-" + Guid.NewGuid().ToString("N"));
+    private UserPdkStore Store() => new(_root, new PdkJsonSaver(), new PdkLoader());
+    private static ProcessDefinition Proc(string n) => new() { Name = n };
+    private static PdkComponentDraft Comp(string n) => new()
+    {
+        Name = n, WidthMicrometers = 10, HeightMicrometers = 2,
+        RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()", RawCodeBackend = "gdsfactory",
+        Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } },
+    };
+
+    [Fact]
+    public void CreateNamedPdkWithProcess_produces_listed_pdk_with_no_components()
+    {
+        var store = Store();
+
+        var path = store.CreateNamedPdkWithProcess("Lib", Proc("P"), "gdsfactory", null);
+
+        store.ListCustomPdks().ShouldContain(i => i.Name == "Lib");
+        new PdkLoader().LoadFromFileForEditing(path).Components.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AppendToExistingPdk_after_empty_creation_adds_one_component()
+    {
+        var store = Store();
+        var path = store.CreateNamedPdkWithProcess("Lib", Proc("P"), "gdsfactory", null);
+
+        store.AppendToExistingPdk(path, Comp("mmi"));
+
+        new PdkLoader().LoadFromFileForEditing(path).Components.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ProcessManagementViewModel_creation_mode_creates_pdk_file_and_raises_event()
+    {
+        var store = Store();
+        var vm = new ProcessManagementViewModel(Mock.Of<IFileDialogService>())
+        {
+            CreateUserPdk = (name, process) => store.CreateNamedPdkWithProcess(name, process, "gdsfactory", null),
+        };
+        vm.EnterPdkCreationMode();
+        vm.PdkName = "Lib2";
+        string? raisedPath = null;
+        vm.PdkCreated += (_, path) => raisedPath = path;
+
+        vm.CreatePdkCommand.Execute(null);
+
+        store.ListCustomPdks().ShouldContain(i => i.Name == "Lib2");
+        raisedPath.ShouldNotBeNullOrEmpty();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, true);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/UserPdkCreateEmptyTests.cs
+++ b/UnitTests/Components/AddCustomComponent/UserPdkCreateEmptyTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class UserPdkCreateEmptyTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-createempty-" + Guid.NewGuid().ToString("N"));
+    private UserPdkStore Store() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    [Fact]
+    public void CreateNamedPdkWithProcess_writes_named_pdk_with_process_and_no_components()
+    {
+        var s = Store();
+        var path = s.CreateNamedPdkWithProcess("My SiN Lib", new ProcessDefinition { Name = "CornerStone SiN 300" }, "gdsfactory", null);
+        Path.GetFileName(path).ShouldBe("my-sin-lib.json");
+        var pdk = new PdkLoader().LoadFromFileForEditing(path);
+        pdk.Name.ShouldBe("My SiN Lib");
+        pdk.Process!.Name.ShouldBe("CornerStone SiN 300");
+        pdk.Components.ShouldBeEmpty();
+        s.ListCustomPdks().ShouldContain(i => i.Name == "My SiN Lib" && i.Process.Name == "CornerStone SiN 300");
+    }
+
+    [Fact]
+    public void CreateNamedPdkWithProcess_throws_when_name_already_exists()
+    {
+        var s = Store();
+        s.CreateNamedPdkWithProcess("Lib", new ProcessDefinition { Name = "P" }, "gdsfactory", null);
+        Should.Throw<InvalidOperationException>(() =>
+            s.CreateNamedPdkWithProcess("Lib", new ProcessDefinition { Name = "P" }, "gdsfactory", null));
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}

--- a/UnitTests/ViewModels/ProcessManagementPdkCreationTests.cs
+++ b/UnitTests/ViewModels/ProcessManagementPdkCreationTests.cs
@@ -1,0 +1,102 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels;
+
+/// <summary>
+/// Verifies the PDK-creation mode of <see cref="ProcessManagementViewModel"/>: entering the
+/// mode starts a fresh process, and <c>CreatePdkCommand</c> hands the name + edited process to
+/// the caller-supplied <see cref="ProcessManagementViewModel.CreateUserPdk"/> callback and raises
+/// <see cref="ProcessManagementViewModel.PdkCreated"/> with the resulting path. This mode must
+/// never touch <c>ActiveProcess</c>/<c>FileOperationsViewModel</c> (out of scope, bug #726).
+/// </summary>
+public class ProcessManagementPdkCreationTests
+{
+    private static ProcessManagementViewModel Vm()
+        => new(Mock.Of<IFileDialogService>());
+
+    [Fact]
+    public void CreatePdk_invokes_callback_with_name_and_process_and_raises_event()
+    {
+        var vm = Vm();
+        vm.EnterPdkCreationMode();
+        vm.PdkName = "My Lib";
+        string? gotName = null;
+        ProcessDefinition? gotProc = null;
+        string? raised = null;
+        vm.CreateUserPdk = (n, p) => { gotName = n; gotProc = p; return "C:/tmp/my-lib.json"; };
+        vm.PdkCreated += (_, path) => raised = path;
+
+        vm.CreatePdkCommand.Execute(null);
+
+        gotName.ShouldBe("My Lib");
+        gotProc.ShouldNotBeNull();
+        raised.ShouldBe("C:/tmp/my-lib.json");
+    }
+
+    [Fact]
+    public void CanCreatePdk_false_when_name_blank()
+    {
+        var vm = Vm();
+        vm.EnterPdkCreationMode();
+        vm.CreateUserPdk = (_, _) => "x";
+        vm.PdkName = "   ";
+
+        vm.CreatePdkCommand.CanExecute(null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanCreatePdk_false_when_not_in_creation_mode()
+    {
+        var vm = Vm();
+        vm.PdkName = "My Lib";
+        vm.CreateUserPdk = (_, _) => "x";
+
+        vm.CreatePdkCommand.CanExecute(null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanCreatePdk_false_when_no_callback_wired()
+    {
+        var vm = Vm();
+        vm.EnterPdkCreationMode();
+        vm.PdkName = "My Lib";
+
+        vm.CreatePdkCommand.CanExecute(null).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void EnterPdkCreationMode_starts_with_a_fresh_process()
+    {
+        var vm = Vm();
+
+        vm.EnterPdkCreationMode();
+
+        vm.IsPdkCreationMode.ShouldBeTrue();
+        vm.HasProcess.ShouldBeTrue();
+        vm.ProcessName.ShouldBe("New process");
+    }
+
+    [Fact]
+    public void CreatePdk_on_name_collision_sets_status_and_does_not_invoke_callback()
+    {
+        var vm = Vm();
+        vm.EnterPdkCreationMode();
+        vm.PdkName = "Existing";
+        var invoked = false;
+        vm.CreateUserPdk = (_, _) => { invoked = true; return "should-not-happen"; };
+        vm.PdkNameExists = _ => true;
+        string? raised = null;
+        vm.PdkCreated += (_, path) => raised = path;
+
+        vm.CreatePdkCommand.Execute(null);
+
+        invoked.ShouldBeFalse();
+        raised.ShouldBeNull();
+        vm.StatusText.ShouldContain("Existing");
+    }
+}

--- a/docs/superpowers/plans/2026-07-13-pdk-first-new-pdk-modal.md
+++ b/docs/superpowers/plans/2026-07-13-pdk-first-new-pdk-modal.md
@@ -1,0 +1,278 @@
+# PDK-first v-next: modales „New PDK" + Backend-Autoload — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** „New PDK…" als Dropdown-Eintrag → modales PDK-Erstellungsfenster (Name + Prozess inkl. Breiten, legt neue benannte User-PDK an), das das New-Component-Fenster sperrt; Backend-Beispielcode-Autoload bei leerem/unangetastetem Editor.
+
+**Architecture:** Evolution von #723. `UserPdkStore` bekommt „leeres benanntes PDK mit Prozess anlegen". `ProcessManagementViewModel` bekommt einen Creation-Mode (PDK-Name + `CreatePdk` via Callback), der NUR neue User-PDKs anlegt und `ActiveProcess` NICHT anfasst (Umstellen bestehender Prozesse = #726, out of scope). `NewComponentViewModel` bekommt einen „New PDK…"-Sentinel im PDK-Dropdown + `CreateNewPdk`-Hook (modal) + Backend-Autoload. `MainWindow.axaml.cs` öffnet den Prozess-Editor im Creation-Mode modal (`ShowDialog`).
+
+**Tech Stack:** C#/.NET 10/Avalonia 11/CommunityToolkit.Mvvm; xUnit+Shouldly+Moq.
+
+## Global Constraints
+
+- Keine erfundene Physik: S-Matrix nur echtes FDTD / Blackbox / 2-Port-Ideal; S-Matrix bleibt DI-Service `IFdtdSMatrixService`.
+- Foundry-JSONs (`CAP-DataAccess/PDKs/*.json`) nie geschrieben; custom PDKs nur unter `%LOCALAPPDATA%/Lunima/user-pdks/`.
+- Der Creation-Mode fasst `FileOperations.ActiveProcess`/`SetActiveProcess` NICHT an (#726 bleibt unberührt).
+- Cross-Platform: `Path.Combine`+`SpecialFolder`; kein `Process.Start`; `x:DataType`/compiled bindings; `InvariantCulture`.
+- Max. 250 Zeilen/neue Datei; bestehende ≤500. `ProcessManagementViewModel` unter 500 halten (Creation-Mode ggf. in Partial `.PdkCreation.cs`). XML-Doku public members. Nur feature-bezogene Dateien.
+
+## File Structure
+
+- `CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs` (MODIFY) — `CreateNamedPdkWithProcess`.
+- `CAP.Avalonia/ViewModels/ProcessManagementViewModel.PdkCreation.cs` (CREATE, partial) — Creation-Mode.
+- `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs` (+ `.Save.cs`) (MODIFY) — Sentinel + CreateNewPdk + Backend-Autoload; inline New-PDK/Prozess raus.
+- `CAP.Avalonia/ViewModels/Components/AddCustomComponent/BackendCodeExamples.cs` (CREATE) — gemeinsame Beispielcode-Konstanten.
+- `CAP.Avalonia/Views/NewComponentWindow.axaml` (MODIFY) — Dropdown-Sentinel, inline-UI raus, Prozess read-only.
+- `CAP.Avalonia/Views/ProcessManagementWindow.axaml` (MODIFY) — PDK-Name-Feld + „Create PDK"-Button (nur im Creation-Mode sichtbar).
+- `CAP.Avalonia/Views/MainWindow.axaml.cs` (MODIFY) — `CreateNewPdk` modal wiring.
+- Tests unter `UnitTests/Components/AddCustomComponent/` und `UnitTests/ViewModels/`.
+
+---
+
+### Task 1: `UserPdkStore.CreateNamedPdkWithProcess`
+
+**Files:**
+- Modify: `CAP-DataAccess/Components/AddCustomComponent/UserPdkStore.cs`
+- Test: `UnitTests/Components/AddCustomComponent/UserPdkCreateEmptyTests.cs`
+
+**Interfaces:**
+- Produces: `public string CreateNamedPdkWithProcess(string pdkName, ProcessDefinition process, string backend, string? routingCrossSection)` — schreibt `<Slug(pdkName)>.json` mit `PdkDraft { Name = pdkName, Process = process, Backend = backend, GdsFactoryRoutingCrossSection = routingCrossSection, Components = new() }`; gibt Pfad zurück. Wenn Datei existiert: überschreibt NICHT still — wirft `InvalidOperationException`, wenn `NamedPdkExists(pdkName)` (Aufrufer prüft Kollision vorher via `NamedPdkExists`). Nutzt `Directory.CreateDirectory(_root)` + `_saver.SaveToFile`.
+- Consumes: bestehendes `Slug`, `_root`, `_saver`, `ResolveNamedPath`, `NamedPdkExists`, `PdkDraft`, `ProcessDefinition`.
+
+- [ ] **Step 1: Read** `UserPdkStore.cs` (`SaveToNamedPdk`/`NewNamedPdk`/`ResolveNamedPath`/`NamedPdkExists`/`Slug`).
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+using System;
+using System.IO;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+public class UserPdkCreateEmptyTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-createempty-" + Guid.NewGuid().ToString("N"));
+    private UserPdkStore Store() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    [Fact]
+    public void CreateNamedPdkWithProcess_writes_named_pdk_with_process_and_no_components()
+    {
+        var s = Store();
+        var path = s.CreateNamedPdkWithProcess("My SiN Lib", new ProcessDefinition { Name = "CornerStone SiN 300" }, "gdsfactory", null);
+        Path.GetFileName(path).ShouldBe("my-sin-lib.json");
+        var pdk = new PdkLoader().LoadFromFileForEditing(path);
+        pdk.Name.ShouldBe("My SiN Lib");
+        pdk.Process!.Name.ShouldBe("CornerStone SiN 300");
+        pdk.Components.ShouldBeEmpty();
+        s.ListCustomPdks().ShouldContain(i => i.Name == "My SiN Lib" && i.Process.Name == "CornerStone SiN 300");
+    }
+
+    [Fact]
+    public void CreateNamedPdkWithProcess_throws_when_name_already_exists()
+    {
+        var s = Store();
+        s.CreateNamedPdkWithProcess("Lib", new ProcessDefinition { Name = "P" }, "gdsfactory", null);
+        Should.Throw<InvalidOperationException>(() =>
+            s.CreateNamedPdkWithProcess("Lib", new ProcessDefinition { Name = "P" }, "gdsfactory", null));
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails** — `py "$env:USERPROFILE\.cap-tools\smart_test.py" UserPdkCreateEmpty` → FAIL.
+- [ ] **Step 4: Implement** die Methode. XML-Doku.
+- [ ] **Step 5: Run to verify it passes** (2/2) + Regression `... UserPdk`.
+- [ ] **Step 6: Commit** — `git commit -m "(+) UserPdkStore: create empty named PDK with a process"` && `git push`
+
+---
+
+### Task 2: `ProcessManagementViewModel` — PDK-Creation-Mode
+
+**Files:**
+- Create: `CAP.Avalonia/ViewModels/ProcessManagementViewModel.PdkCreation.cs` (partial)
+- Test: `UnitTests/ViewModels/ProcessManagementPdkCreationTests.cs`
+
+**Interfaces:**
+- Consumes: bestehendes `ToProcess()`, `NewProcess()`, `AvailablePresets`/`SelectedPreset`, `ProcessName`.
+- Produces (auf `public partial class ProcessManagementViewModel`):
+  - `[ObservableProperty] private bool _isPdkCreationMode;`
+  - `[ObservableProperty] private string _pdkName = string.Empty;`
+  - `public Func<string, ProcessDefinition, string>? CreateUserPdk { get; set; }` — (pdkName, process) → geschriebener Pfad (vom Aufrufer auf `UserPdkStore.CreateNamedPdkWithProcess` gesetzt).
+  - `public Func<string, bool>? PdkNameExists { get; set; }` — Kollisionsprüfung (auf `UserPdkStore.NamedPdkExists`); optional.
+  - `public event EventHandler<string>? PdkCreated;` — feuert mit dem Pfad nach erfolgreicher Anlage.
+  - `[RelayCommand(CanExecute = nameof(CanCreatePdk))] private void CreatePdk()` — validiert Name; ruft `CreateUserPdk(PdkName, ToProcess())`; feuert `PdkCreated(path)`. `CanCreatePdk => IsPdkCreationMode && !string.IsNullOrWhiteSpace(PdkName) && CreateUserPdk != null`.
+  - `public void EnterPdkCreationMode()` — setzt `IsPdkCreationMode = true`; startet mit frischem Prozess (`NewProcess()`), damit Presets wählbar/leer editierbar sind; berührt NICHT `ActiveProcess`.
+  - `OnPdkNameChanged` → `CreatePdkCommand.NotifyCanExecuteChanged()`.
+- **Verbindlich:** KEIN Zugriff auf `FileOperations`/`ActiveProcess`/`SetActiveProcess`. Bestehendes Verhalten (Toolbar/non-modal/`SaveProcess`) unverändert.
+
+- [ ] **Step 1: Read** `ProcessManagementViewModel.cs` (+ `.ActiveProcess.cs`): `ToProcess()`, `NewProcess()`, `AvailablePresets`/`OnSelectedPresetChanged`/`Load`, `ProcessName`, ctor. Bestätige Zeilenzahl (Partial nötig, um ≤500 zu bleiben).
+
+- [ ] **Step 2: Write the failing test**
+
+```csharp
+using CAP.Avalonia.Services;   // IFileDialogService fake / vorhandenes Test-Muster
+using CAP.Avalonia.ViewModels;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels;
+
+public class ProcessManagementPdkCreationTests
+{
+    private static ProcessManagementViewModel Vm()
+        => new(/* IFileDialogService-Fake wie in bestehenden ProcessManagement-Tests */ null!);
+
+    [Fact]
+    public void CreatePdk_invokes_callback_with_name_and_process_and_raises_event()
+    {
+        var vm = Vm();
+        vm.EnterPdkCreationMode();
+        vm.PdkName = "My Lib";
+        string? gotName = null; ProcessDefinition? gotProc = null; string? raised = null;
+        vm.CreateUserPdk = (n, p) => { gotName = n; gotProc = p; return "C:/tmp/my-lib.json"; };
+        vm.PdkCreated += (_, path) => raised = path;
+
+        vm.CreatePdkCommand.Execute(null);
+
+        gotName.ShouldBe("My Lib");
+        gotProc.ShouldNotBeNull();
+        raised.ShouldBe("C:/tmp/my-lib.json");
+    }
+
+    [Fact]
+    public void CanCreatePdk_false_when_name_blank()
+    {
+        var vm = Vm();
+        vm.EnterPdkCreationMode();
+        vm.CreateUserPdk = (_, _) => "x";
+        vm.PdkName = "   ";
+        vm.CreatePdkCommand.CanExecute(null).ShouldBeFalse();
+    }
+}
+```
+Passe die VM-Konstruktion an das echte Test-Muster an (siehe bestehende `ProcessManagement*Tests` unter `UnitTests/`, wie `IFileDialogService` gefaked wird).
+
+- [ ] **Step 3: Run to verify it fails.**
+- [ ] **Step 4: Implement** im Partial `.PdkCreation.cs`. Keine `ActiveProcess`-Berührung.
+- [ ] **Step 5: Run to verify it passes** + Regression `... ProcessManagement`. `wc -l` der VM-Dateien ≤500.
+- [ ] **Step 6: Commit** — `git commit -m "(+) ProcessManagementViewModel: PDK-creation mode (name + CreatePdk, no ActiveProcess touch)"` && `git push`
+
+---
+
+### Task 3: Backend-Beispielcode-Konstante + Autoload
+
+**Files:**
+- Create: `CAP.Avalonia/ViewModels/Components/AddCustomComponent/BackendCodeExamples.cs`
+- Modify: `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs`
+- Test: `UnitTests/Components/AddCustomComponent/BackendCodeAutoloadTests.cs`
+
+**Interfaces:**
+- Produces: `public static class BackendCodeExamples { public static string For(GeometryBackend backend); public const string GdsFactory = "import gdsfactory as gf\ncomponent = gf.components.mmi1x2()"; public const string Nazca = "import nazca as nd\ncomponent = nd.Cell(name='my_component')"; }` (exakte Strings aus dem heutigen XAML übernehmen).
+- Verhalten in `NewComponentViewModel`: in `OnSelectedBackendChanged(GeometryBackend value)` — wenn `string.IsNullOrWhiteSpace(Code)` ODER `Code` gleich dem Beispiel des jeweils ANDEREN Backends (unangetastetes Auto-Beispiel) → `Code = BackendCodeExamples.For(value)`. Sonst Code unangetastet lassen. (Nach dem Setzen weiterhin `InvalidatePreview()` wie bisher.)
+
+- [ ] **Step 1: Read** `NewComponentViewModel.cs` (`OnSelectedBackendChanged`, `Code`, `InvalidatePreview`) + `NewComponentWindow.axaml` (aktuelle Beispiel-Strings in den Help-Boxen, Zeilen ~96/107).
+- [ ] **Step 2: Write the failing tests**
+
+```csharp
+using CAP.Avalonia.Services.AddCustomComponent;  // GeometryBackend
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using Shouldly;
+using Xunit;
+// ... Build(vm) wie in bestehenden NewComponentViewModel-Tests (Extractor-Mocks + UserPdkStore-TempRoot)
+
+// Test A: leerer Code, Backend→GdsFactory => Code == BackendCodeExamples.GdsFactory
+// Test B: Code == BackendCodeExamples.GdsFactory (unangetastet), Backend→Nazca => Code == BackendCodeExamples.Nazca
+// Test C: Code == "mein eigener code", Backend-Wechsel => Code UNVERÄNDERT
+```
+- [ ] **Step 3: Run to verify it fails.**
+- [ ] **Step 4: Implement** `BackendCodeExamples` + Autoload-Logik in `OnSelectedBackendChanged`. Beim VM-Ctor: falls `Code` leer, initial das Beispiel des Default-Backends laden (damit von Anfang an ein Beispiel steht).
+- [ ] **Step 5: Run to verify it passes** + Regression `... NewComponentViewModel`.
+- [ ] **Step 6: Commit** — `git commit -m "(+) New Component: backend example code constant + autoload into empty/untouched editor"` && `git push`
+
+---
+
+### Task 4: `NewComponentViewModel` — „New PDK…"-Sentinel + Modal-Hook + Verschlankung
+
+**Files:**
+- Modify: `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs` (+ `.Save.cs`)
+- Test: `UnitTests/Components/AddCustomComponent/NewComponentNewPdkSentinelTests.cs`
+
+**Interfaces:**
+- Consumes: `UserPdkInfo`, `store.ListCustomPdks()`.
+- Produces:
+  - Entfernt: `IsNewPdk`, `NewPdkName`, `OpenProcessEditor`/`OpenProcessEditorCmd`, inline Prozess-Wählbarkeit. (Prozess wird ausschließlich aus `SelectedCustomPdk.Process` geerbt.)
+  - PDK-Dropdown-Quelle: `public IReadOnlyList<PdkChoice> PdkChoices { get; }` — Wrapper: je ein Eintrag pro `UserPdkInfo` + ein Sentinel `PdkChoice.NewPdk` (DisplayName „New PDK…"). ODER simpler: `AvailableCustomPdks` bleibt `IReadOnlyList<UserPdkInfo>` und ein separater bool-Sentinel wird über einen zusätzlichen ListenEintrag modelliert — wähle die Variante, die im AXAML-ComboBox sauber bindet (dokumentiere die Wahl).
+  - `public Func<Task<UserPdkInfo?>>? CreateNewPdk { get; set; }` — vom MainWindow gesetzt (öffnet Modal, liefert neues PDK oder null).
+  - Auswahl-Handler: wird der Sentinel gewählt → `await CreateNewPdk()`; bei Ergebnis `!= null` → `RefreshCustomPdks()` (neu aus `store.ListCustomPdks()`) + `SelectedCustomPdk = <neues>`; bei null → zurück auf vorherige (nicht-Sentinel-)Auswahl. Reentrancy via `IsBusy` schützen.
+  - `SelectedProcess`/`EffectiveProcess` = `SelectedCustomPdk?.Process` (read-only). `CanSave => HasPreview && !IsBusy && SelectedCustomPdk != null` (kein IsNewPdk-Zweig mehr). Save-Routing: immer `AppendToExistingPdk(SelectedCustomPdk.FilePath, draft)` (das neue PDK existiert nach der Modal-Erstellung bereits).
+
+- [ ] **Step 1: Read** `NewComponentViewModel.cs` + `.Save.cs` (aktuelle `IsNewPdk`/`NewPdkName`/`SaveToNamedPdk`-Zweige, `OnSelectedCustomPdkChanged`, ctor-Vorauswahl). Prüfe im AXAML, wie das PDK-Dropdown heute bindet.
+- [ ] **Step 2: Write the failing tests**
+
+```csharp
+// Test A: PdkChoices enthält den "New PDK…"-Sentinel als letzten Eintrag.
+// Test B: Sentinel gewählt + CreateNewPdk liefert ein neues UserPdkInfo => nach Auswahl ist SelectedCustomPdk das neue PDK und in AvailableCustomPdks enthalten.
+// Test C: Sentinel gewählt + CreateNewPdk liefert null (Abbruch) => SelectedCustomPdk bleibt/kehrt auf die vorherige Auswahl (kein Sentinel) zurück.
+// Test D: Save mit gewähltem bestehendem PDK => AppendToExistingPdk in dessen FilePath; SavedFilePath == dessen Pfad.
+```
+Konkrete Asserts ausformulieren; `CreateNewPdk` als Fake-Func; `UserPdkStore` mit Temp-Root (echte Dateien für ListCustomPdks).
+- [ ] **Step 3: Run to verify it fails.**
+- [ ] **Step 4: Implement.** `IsNewPdk`/`NewPdkName`/`OpenProcessEditor` entfernen (inkl. AXAML-Referenzen in Task 5). Sentinel-Modell + Refresh/Revert + Reentrancy. Save-Routing auf `AppendToExistingPdk` vereinfachen. VM-Dateien ≤250.
+- [ ] **Step 5: Run to verify it passes** + Slice-Regression `... AddCustomComponent`.
+- [ ] **Step 6: Commit** — `git commit -m "(~) New Component: 'New PDK…' dropdown sentinel + modal create hook; drop inline new-PDK/process UI"` && `git push`
+
+---
+
+### Task 5: Fenster — Dropdown-Sentinel, Prozess read-only, Prozess-Editor Creation-UI, Modal-Wiring
+
+**Files:**
+- Modify: `CAP.Avalonia/Views/NewComponentWindow.axaml`
+- Modify: `CAP.Avalonia/Views/ProcessManagementWindow.axaml`
+- Modify: `CAP.Avalonia/Views/MainWindow.axaml.cs`
+- Test: Build + Regression.
+
+**Interfaces:** Consumes Task 2 (`IsPdkCreationMode`/`PdkName`/`CreatePdkCommand`), Task 4 (`PdkChoices`/`CreateNewPdk`/`SelectedCustomPdk`).
+
+- [ ] **Step 1: Read** `NewComponentWindow.axaml` (aktuelles PDK/Prozess-Layout), `ProcessManagementWindow.axaml` (wo ein PDK-Name-Feld + „Create PDK"-Button oben eingefügt werden, sichtbar via `IsVisible={Binding IsPdkCreationMode}`), `MainWindow.axaml.cs` (`ShowNewComponentWindowAsync`-Lambda + `ShowProcessManagerRequested`-Handler als Muster für VM-Bau/Resolver/ConfirmSaveToPdk).
+- [ ] **Step 2: `NewComponentWindow.axaml`** — PDK-`ComboBox` bindet an `PdkChoices`/`SelectedPdkChoice` (bzw. das in Task 4 gewählte Modell), Sentinel „New PDK…" als Eintrag; inline „+ Neues PDK"-Textbox + inline Prozess-Picker + „Prozess-Editor öffnen…"-Button ENTFERNEN; Prozess als read-only `TextBlock` (`SelectedCustomPdk.Process.Name`). Rest unverändert.
+- [ ] **Step 3: `ProcessManagementWindow.axaml`** — oben eine Sektion, sichtbar nur `IsVisible={Binding IsPdkCreationMode}`: `TextBox {Binding PdkName}` (Watermark „PDK name") + Button „Create PDK" (`CreatePdkCommand`). Bestehendes Prozess-Editor-Layout unverändert.
+- [ ] **Step 4: `MainWindow.axaml.cs`** — im `ShowNewComponentWindowAsync`-Lambda `newComponentVm.CreateNewPdk = async () => {`
+    - `var processVm = new ProcessManagementViewModel(new FileDialogService(this), <importers wie im bestehenden Handler>, new PdkJsonSaver());`
+    - `processVm.EnterPdkCreationMode();`
+    - `processVm.SetAvailablePresets(vm.LeftPanel.GetLoadedPdkDrafts());` (Presets übernehmbar)
+    - `processVm.CreateUserPdk = (name, proc) => userPdkStore.CreateNamedPdkWithProcess(name, proc, "gdsfactory", null);` (userPdkStore aus DI/deps)
+    - `processVm.PdkNameExists = name => userPdkStore.NamedPdkExists(name);`
+    - `string? createdPath = null; processVm.PdkCreated += (_, path) => { createdPath = path; processWindow.Close(); };`
+    - `var processWindow = new ProcessManagementWindow { DataContext = processVm }; await processWindow.ShowDialog(newComponentWindow);` (MODAL, Owner = New-Component-Fenster)
+    - `return createdPath is null ? null : new UserPdkInfo(<Name>, createdPath, <proc>);` — ODER schlichter: `return userPdkStore.ListCustomPdks().FirstOrDefault(i => i.FilePath == createdPath);` `}`
+   Setze außerdem (falls noch nicht) `newComponentVm.ConfirmOverwrite` wie in #723. Kein `Process.Start`.
+- [ ] **Step 5: Build** — `dotnet build -clp:ErrorsOnly` = 0 Fehler (XAML inkl.). Regression `... NewComponentViewModel`, `... ProcessManagement`.
+- [ ] **Step 6: Commit** — `git commit -m "(~) Windows: New-PDK dropdown sentinel, read-only process, modal PDK-creation editor + wiring"` && `git push`
+
+---
+
+### Task 6: Integrationstest + Aufräumen
+
+**Files:**
+- Test: `UnitTests/Components/AddCustomComponent/NewPdkModalFlowTests.cs`
+
+- [ ] **Step 1: Write the test** — (a) `store.CreateNamedPdkWithProcess("Lib", proc, "gdsfactory", null)` → `ListCustomPdks()` enthält es mit leerer Komponentenliste; (b) danach `store.AppendToExistingPdk(path, comp)` → 1 Komponente; (c) `ProcessManagementViewModel`-Creation-Mode `CreatePdk` mit `CreateUserPdk = (n,p)=>store.CreateNamedPdkWithProcess(n,p,"gdsfactory",null)` → Datei existiert + `PdkCreated` gefeuert. Ein Assert pro Stufe.
+- [ ] **Step 2: Run to verify it passes.**
+- [ ] **Step 3: Grep-Check** — keine verwaisten Referenzen auf entfernte `IsNewPdk`/`NewPdkName`/`OpenProcessEditor` (in `CAP.Avalonia` + `NewComponentWindow.axaml`). Falls doch: entfernen.
+- [ ] **Step 4: Commit** — `git commit -m "(+) End-to-end test: modal new-PDK creation + append flow"` && `git push`
+
+---
+
+## Self-Review
+
+- **Spec-Coverage:** „New PDK…"-Sentinel → Task 4/5; modales Erstellungsfenster (Name+Prozess) → Task 2/5; neue User-PDK-Anlage → Task 1; Backend-Autoload → Task 3; New-Component verschlankt → Task 4/5; kein ActiveProcess-Touch (#726 getrennt) → Task 2 (Constraint). 
+- **Placeholder:** Task 4 lässt die genaue Sentinel-Modellierung (Wrapper-Liste vs. Zusatz-Eintrag) offen mit klarer Anweisung „wähle, was im ComboBox sauber bindet, dokumentiere" — bewusst, da AXAML-Bindbarkeit erst am echten Control entscheidbar; Verhalten + Asserts sind konkret.
+- **Typkonsistenz:** `CreateNamedPdkWithProcess` (T1) → `CreateUserPdk`-Callback (T2) → MainWindow-Wiring (T5). `CreateNewPdk`-Hook (T4) → MainWindow-Wiring (T5). `BackendCodeExamples` (T3) → VM-Autoload + XAML-Help (T5 kann XAML-Boxen auf die Konstante umstellen, optional).
+- **Verifikationspunkte:** `ProcessManagementViewModel`-ctor/`ToProcess`/`NewProcess`/`SetAvailablePresets` (T2); `IFileDialogService`-Fake-Muster in bestehenden Tests (T2); ComboBox-Sentinel-Bindung (T4/T5); `ShowDialog`-Owner + Importer-Liste im MainWindow-Handler (T5).

--- a/docs/superpowers/specs/2026-07-13-pdk-first-new-pdk-modal-design.md
+++ b/docs/superpowers/specs/2026-07-13-pdk-first-new-pdk-modal-design.md
@@ -1,0 +1,91 @@
+# PDK-first-Assistent v-next: modales „New PDK", Backend-Autoload — Design
+
+**Datum:** 2026-07-13
+**Status:** Freigegeben (Brainstorm)
+**Baut auf:** #723 (PDK-first-Assistent)
+
+## Ziel
+
+Verfeinerung des „Neue Komponente"-Assistenten: (1) „New PDK…" als Eintrag im PDK-Dropdown statt
+separatem Button; (2) Auswahl von „New PDK…" öffnet ein **modales PDK-Erstellungsfenster** (Name +
+Fabrikationsprozess inkl. Breiten), das das New-Component-Fenster sperrt, bis das PDK erstellt (oder
+abgebrochen) ist; (3) beim Umschalten des Backends wird der Beispielcode automatisch in den Editor
+geladen — nur solange der Editor leer oder noch unangetastetes Beispiel ist.
+
+## Nicht-Ziel (bewusst getrennt)
+
+Den Prozess eines **bestehenden** PDK umstellen — das ist ein separater, vorbestehender Bug/Design-Gap
+(**#726**, analysiert) und bleibt außerhalb dieses Features. Der Erstellungs-Modus legt nur NEUE PDKs
+an und fasst den `FileOperations.ActiveProcess`-Pfad nicht an.
+
+## Flow
+
+New-Component-Fenster → PDK-Dropdown = custom PDKs **+ Sentinel „New PDK…"**. Wählt man den Sentinel:
+1. Modales PDK-Erstellungsfenster öffnet sich (`ShowDialog`, Owner = New-Component-Fenster → blockiert).
+2. Dort: **PDK-Name** + Prozess (leeren „New process" starten ODER bestehenden als Preset übernehmen,
+   Breiten/Layer/Cross-Sections editierbar — alles vorhandene Editor-Funktion). „Create PDK" legt via
+   `UserPdkStore` eine neue benannte User-PDK an (Name + `ToProcess()`, leere Komponentenliste).
+3. Zurück im New-Component-Fenster: `AvailableCustomPdks` wird neu geladen, das neue PDK vorausgewählt
+   (Prozess geerbt/read-only). Bei Abbruch: Dropdown-Auswahl springt zurück auf den vorherigen Wert.
+
+Danach wie gehabt: Name → own-code (Editor) → S-Matrix (Meep) → Speichern (hängt Komponente an das PDK).
+
+## Architektur / Komponenten
+
+- **`UserPdkStore`** (CAP-DataAccess): neue Methode
+  `CreateNamedPdkWithProcess(string pdkName, ProcessDefinition process, string backend, string? routingCrossSection) : string`
+  — schreibt `<slug(pdkName)>.json` mit `Name=pdkName`, `Process=process`, **leerer** `Components`-Liste.
+  Foundry-JSONs unangetastet.
+- **`ProcessManagementViewModel`** (CAP.Avalonia): **PDK-Erstellungs-Modus** — neue Properties
+  `[ObservableProperty] string PdkName`, `[ObservableProperty] bool IsPdkCreationMode`; neuer
+  `[RelayCommand] CreatePdk` (nur aktiv in Creation-Mode + Name nicht leer), der über einen injizierten
+  Callback `Func<string, ProcessDefinition, string?>? CreateUserPdk` (Name, Prozess → Pfad) das PDK
+  anlegt und ein `PdkCreated`-Event/Result feuert. Startzustand im Creation-Mode: frischer Prozess
+  (`NewProcess()` bzw. Preset wählbar). Berührt `ActiveProcess`/`SetActiveProcess` NICHT. Bestehendes
+  Verhalten (Toolbar-Öffnung, non-modal, `SaveProcess`) bleibt unverändert.
+- **`NewComponentViewModel`** (CAP.Avalonia): PDK-Dropdown-Quelle = custom PDKs + Sentinel `NewPdkOption`
+  (z.B. `UserPdkInfo?`-Sentinel bzw. eine Wrapper-Liste). `OnSelectedCustomPdkChanged`: ist der Sentinel
+  gewählt → `Func<Task<UserPdkInfo?>>? CreateNewPdk` aufrufen; bei Erfolg `AvailableCustomPdks` neu aus
+  `store.ListCustomPdks()` + neues PDK auswählen; bei null (Abbruch) → auf vorherige Auswahl zurück.
+  Entfernt: `IsNewPdk`/`NewPdkName` + inline Prozess-Picker (wandern ins Modal). Prozess weiterhin aus
+  `SelectedCustomPdk.Process` geerbt (read-only).
+- **Backend-Beispielcode:** gemeinsame Konstante `BackendCodeExamples` (gdsfactory/nazca) als einzige
+  Quelle; `OnSelectedBackendChanged` lädt das Beispiel in `Code`, wenn `Code` leer ODER == dem
+  anderen Backend-Beispiel (unangetastet). XAML-Hilfe-Flyout nutzt dieselbe Quelle.
+- **`NewComponentWindow.axaml`:** Dropdown inkl. Sentinel; inline New-PDK/Prozess-UI entfernt; Prozess
+  read-only angezeigt.
+- **`MainWindow.axaml.cs`:** `newComponentVm.CreateNewPdk = async () => {…}` öffnet ein
+  `ProcessManagementWindow` im Creation-Mode **modal** (`ShowDialog(newComponentWindow)`); `CreateUserPdk`
+  des Prozess-VM ruft `UserPdkStore.CreateNamedPdkWithProcess`; nach Schließen wird der erzeugte
+  `UserPdkInfo` (oder null) zurückgegeben.
+
+## Fehlerbehandlung
+
+- Leerer PDK-Name → „Create PDK" deaktiviert. Namenskollision (`NamedPdkExists`) → Überschreiben/umbenennen
+  abfragen (`MessageBoxService`).
+- Prozess ohne Cross-Sections/leer → Hinweis; Anlegen erlaubt (Prozess kann später ergänzt werden), aber
+  klar kommuniziert.
+- Abbruch des Modals → keine PDK-Anlage, Dropdown zurückgesetzt.
+- Keine erfundene Physik; S-Matrix bleibt `IFdtdSMatrixService` (DI). `InvariantCulture` für Slug/JSON.
+
+## Testing
+
+- `UserPdkStore.CreateNamedPdkWithProcess`: legt Datei mit Name+Prozess+leerer Komponentenliste an;
+  `ListCustomPdks` findet sie; Foundry-JSONs nie geschrieben.
+- `ProcessManagementViewModel` Creation-Mode: `CreatePdk` ruft `CreateUserPdk` mit Name+`ToProcess()`,
+  feuert `PdkCreated`; `CanCreatePdk` false bei leerem Namen; berührt `ActiveProcess` nicht (Regression:
+  bestehende ProcessManagement-Tests bleiben grün).
+- `NewComponentViewModel`: Sentinel-Auswahl ruft `CreateNewPdk`; Erfolg → Liste refreshed + neues PDK
+  gewählt; Abbruch → vorherige Auswahl; Backend-Autoload (leer/unangetastet vs. eigener Code).
+- Modal-Öffnung/Interaktion nur zur Laufzeit (Smoke-Test).
+
+## Cross-Platform / Constraints
+
+`Path.Combine`+`SpecialFolder`; kein `Process.Start`; `x:DataType`/compiled bindings; `InvariantCulture`;
+max. 250 Zeilen/neue Datei, bestehende ≤500 (`ProcessManagementViewModel` sorgfältig unter Limit halten,
+ggf. Creation-Mode in ein Partial `.PdkCreation.cs`).
+
+## Out of Scope (YAGNI)
+
+Prozess bestehender PDKs umstellen (#726); Edit/Delete von custom PDKs; Startup-Reload (#700); Rückkanal
+des non-modalen Toolbar-Prozess-Editors.


### PR DESCRIPTION
## Was & Warum (WIP — Draft)

Verfeinerung des „Neue Komponente"-Assistenten (#723, Feld-Feedback):
- **„New PDK…" als Dropdown-Eintrag** (statt Button daneben).
- Auswahl öffnet ein **modales PDK-Erstellungsfenster** (Name + Fabrikationsprozess inkl. Breiten — der bestehende Prozess-Editor im Creation-Mode), das das New-Component-Fenster sperrt, bis das PDK erstellt/abgebrochen ist. Legt eine **neue benannte User-PDK** an; danach im Assistenten vorausgewählt.
- **Backend-Beispielcode-Autoload:** beim Umschalten gdsfactory/nazca wird das Beispiel automatisch in den Editor geladen — nur bei leerem/unangetastetem Editor, nie über eigenen Code.
- New-Component-Fenster verschlankt (inline New-PDK/Prozess-UI raus; Prozess geerbt/read-only).

Spec: `docs/superpowers/specs/2026-07-13-pdk-first-new-pdk-modal-design.md`
Plan: `docs/superpowers/plans/2026-07-13-pdk-first-new-pdk-modal.md`

## Bewusst getrennt
Prozess eines **bestehenden** PDK umstellen ist ein separater, analysierter Bug (**#726**) — NICHT Teil dieses PRs. Der Creation-Mode legt nur neue PDKs an und fasst `FileOperations.ActiveProcess` nicht an.

## Constraints
Keine erfundene Physik; S-Matrix bleibt DI-Service `IFdtdSMatrixService`; Foundry-JSONs unangetastet (custom PDKs nur unter `%LOCALAPPDATA%/Lunima/user-pdks/`).

## Status (Tasks)
- [ ] T1 UserPdkStore: leeres benanntes PDK mit Prozess anlegen
- [ ] T2 ProcessManagementViewModel: PDK-Creation-Mode
- [ ] T3 Backend-Beispielcode-Konstante + Autoload
- [ ] T4 NewComponentViewModel: „New PDK…"-Sentinel + Modal-Hook + Verschlankung
- [ ] T5 Fenster + Modal-Wiring
- [ ] T6 Integrationstest + Aufräumen

🤖 Generated with [Claude Code](https://claude.com/claude-code)