### PR TITLE
New Component: Fixes + Struktur-Preview (Thumbnail/Popup) + Edit/Recompute

### DIFF
--- a/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
@@ -35,6 +35,9 @@ public static class CustomComponentLibraryRegistrar
         Action filterComponents)
     {
         var template = PdkTemplateConverter.ConvertToTemplate(draft, pdkName, null);
+        // A saved custom component always lands in a user PDK — editable via the library's
+        // "Edit…" action (issue #656 follow-up, task 6).
+        template.IsCustom = true;
         allTemplates.Add(template);
         if (!categories.Contains(template.Category))
             categories.Add(template.Category);

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.ComputeProgress.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.ComputeProgress.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CAP_Core.Solvers.Fdtd;
+
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>
+/// Live-progress and cancellation support for
+/// <see cref="NewComponentViewModel.ComputeSMatrix"/>: runs the FDTD solve while keeping
+/// <see cref="NewComponentViewModel.StatusText"/> alive with a once-per-second elapsed-time
+/// heartbeat plus the latest Meep progress line (split out purely to keep
+/// <c>NewComponentViewModel.Save.cs</c> under the project's line-count limit; still one
+/// partial class, one responsibility).
+/// </summary>
+public partial class NewComponentViewModel
+{
+    /// <summary>Cancellation source for the FDTD solve currently in flight, if any.</summary>
+    private CancellationTokenSource? _computeCts;
+
+    /// <summary>
+    /// Cancels a running <see cref="NewComponentViewModel.ComputeSMatrix"/> solve — e.g. when
+    /// the host window is closed while FDTD is still running. A no-op if nothing is running.
+    /// </summary>
+    public void CancelCompute() => _computeCts?.Cancel();
+
+    /// <summary>
+    /// Runs the FDTD solve while keeping <see cref="NewComponentViewModel.StatusText"/> alive:
+    /// a once-per-second elapsed-time heartbeat (so a multi-minute Docker image build/solve
+    /// never looks frozen) plus the latest progress line streamed from Meep. The progress
+    /// callback updates <see cref="NewComponentViewModel.StatusText"/> directly as soon as a
+    /// line is reported — it does not wait for the heartbeat timer to tick, so the status is
+    /// visible even where nothing pumps the UI dispatcher (e.g. in tests).
+    /// </summary>
+    private async Task<FdtdSMatrixResult> RunSolveWithLiveStatusAsync(FdtdSMatrixRequest request, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string baseMessage = "Running FDTD (Meep). First run builds the solver image (several minutes)";
+
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        timer.Tick += (_, _) => StatusText = $"{baseMessage} — {stopwatch.Elapsed:m\\:ss} elapsed…";
+        StatusText = $"{baseMessage}…";
+        timer.Start();
+
+        var progress = new Progress<string>(
+            line => StatusText = $"FDTD running ({stopwatch.Elapsed:m\\:ss}): {Shorten(line)}");
+        try
+        {
+            return await _fdtd!.SolveAsync(request, progress, ct);
+        }
+        finally
+        {
+            timer.Stop();
+        }
+    }
+
+    /// <summary>Truncates a solver progress line so a single noisy line can't blow up the status bar.</summary>
+    private static string Shorten(string s) => s.Length <= 80 ? s : s[..80] + "…";
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Library;
+
+namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+
+/// <summary>
+/// Edit-mode entry point for <see cref="NewComponentViewModel"/>: prefills the wizard from an
+/// existing custom component's <see cref="ComponentTemplate"/> so the user can revise it in
+/// place, rather than authoring a new component from scratch. Split out purely to keep each
+/// file under the project's line-count limit; still one partial class, one responsibility.
+/// </summary>
+public partial class NewComponentViewModel
+{
+    /// <summary>
+    /// Prefills <see cref="NewComponentViewModel.ComponentName"/>, <see cref="NewComponentViewModel.Code"/>,
+    /// <see cref="NewComponentViewModel.SelectedBackend"/>, and the fixed target PDK from
+    /// <paramref name="template"/>, then sets <see cref="NewComponentViewModel.IsEditMode"/>.
+    /// The target PDK is resolved by matching <see cref="ComponentTemplate.PdkSource"/> against
+    /// the existing custom PDKs in <see cref="NewComponentViewModel.PdkChoices"/> — never the
+    /// "New PDK…" sentinel, so this never invokes <see cref="NewComponentViewModel.CreateNewPdk"/>.
+    /// <see cref="NewComponentViewModel.Save"/> is unchanged: it always overwrites-by-name via
+    /// <c>AppendToExistingPdk</c>, which is exactly the desired edit behaviour. Missing stored
+    /// code, or no matching custom PDK, is reported via <see cref="NewComponentViewModel.StatusText"/>
+    /// rather than guessed; a missing PDK also leaves <see cref="NewComponentViewModel.IsEditMode"/>
+    /// false (defensive — there is no valid overwrite target).
+    /// </summary>
+    public void LoadForEdit(ComponentTemplate template)
+    {
+        var match = PdkChoices.FirstOrDefault(c => !c.IsNewPdk && c.Pdk?.Name == template.PdkSource);
+        if (match is null)
+        {
+            StatusText = $"Cannot edit '{template.Name}': its PDK '{template.PdkSource}' is not a custom PDK.";
+            return;
+        }
+
+        ComponentName = template.Name;
+        SelectedBackend = template.RawCodeBackend == "nazca" ? GeometryBackend.Nazca : GeometryBackend.GdsFactory;
+        // Assigned last: OnSelectedBackendChanged may auto-load a starter snippet when Code is
+        // still blank, and that auto-load must never win over the template's own stored code.
+        Code = template.RawCode ?? string.Empty;
+        if (string.IsNullOrEmpty(template.RawCode))
+        {
+            StatusText = "No stored code for this component — enter code to edit.";
+        }
+        SelectedPdkChoice = match;
+
+        IsEditMode = true;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
@@ -13,13 +13,24 @@ namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
 public partial class NewComponentViewModel
 {
     /// <summary>
+    /// The name of the component being edited, captured by <see cref="LoadForEdit"/>. Used by
+    /// <c>Save</c> to distinguish a self-overwrite (re-saving the same component, which must
+    /// proceed without a collision prompt) from a rename onto a <em>different</em> existing
+    /// component (which must still go through the normal <c>ConfirmOverwrite</c> path so it is
+    /// never silently clobbered). Null outside edit mode.
+    /// </summary>
+    private string? _editingOriginalName;
+
+    /// <summary>
     /// Prefills <see cref="NewComponentViewModel.ComponentName"/>, <see cref="NewComponentViewModel.Code"/>,
     /// <see cref="NewComponentViewModel.SelectedBackend"/>, and the fixed target PDK from
     /// <paramref name="template"/>, then sets <see cref="NewComponentViewModel.IsEditMode"/>.
     /// The target PDK is resolved by matching <see cref="ComponentTemplate.PdkSource"/> against
     /// the existing custom PDKs in <see cref="NewComponentViewModel.PdkChoices"/> — never the
     /// "New PDK…" sentinel, so this never invokes <see cref="NewComponentViewModel.CreateNewPdk"/>.
-    /// <see cref="NewComponentViewModel.Save"/> is unchanged: it always overwrites-by-name via
+    /// Also records the original name in <see cref="_editingOriginalName"/> so <c>Save</c> can
+    /// tell a self-overwrite (no prompt) from a rename onto another existing component (still
+    /// prompts). Re-saving the edited component under its own name overwrites-by-name via
     /// <c>AppendToExistingPdk</c>, which is exactly the desired edit behaviour. Missing stored
     /// code, or no matching custom PDK, is reported via <see cref="NewComponentViewModel.StatusText"/>
     /// rather than guessed; a missing PDK also leaves <see cref="NewComponentViewModel.IsEditMode"/>
@@ -45,6 +56,7 @@ public partial class NewComponentViewModel
         }
         SelectedPdkChoice = match;
 
+        _editingOriginalName = template.Name;
         IsEditMode = true;
     }
 }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.PdkSelection.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.PdkSelection.cs
@@ -21,6 +21,21 @@ public partial class NewComponentViewModel
     /// <summary>The last selected non-sentinel choice, restored when a "New PDK…" creation is cancelled.</summary>
     private PdkChoice? _previousPdkChoice;
 
+    /// <summary>
+    /// True only while <see cref="RefreshPdkChoices"/> itself runs. <see
+    /// cref="PdkChoice.NewPdkSentinel"/> is a single shared static instance, so a bound
+    /// dropdown reacting to <see cref="PdkChoices"/>'s change notification (clearing its
+    /// selection, then reselecting whatever it previously held, since that same object is
+    /// still present in the refreshed list) can reselect the sentinel a second time
+    /// synchronously, nested inside that very notification — re-entering <see
+    /// cref="OnSelectedPdkChoiceChanged"/> with the guard in <see
+    /// cref="HandleNewPdkSentinelAsync"/> already lifted, reopening the "New PDK…" modal.
+    /// Suppressing sentinel handling for just this window closes that gap without swallowing
+    /// the real target selection's notifications (that assignment always runs afterwards,
+    /// with the flag back off).
+    /// </summary>
+    private bool _suppressSentinelHandling;
+
     /// <summary>Named custom PDKs already on disk, refreshed after a new one is created.</summary>
     public IReadOnlyList<UserPdkInfo> AvailableCustomPdks { get; private set; } = Array.Empty<UserPdkInfo>();
 
@@ -50,6 +65,8 @@ public partial class NewComponentViewModel
     /// </summary>
     partial void OnSelectedPdkChoiceChanged(PdkChoice? value)
     {
+        if (_suppressSentinelHandling) return;
+
         if (value is { IsNewPdk: false })
         {
             _previousPdkChoice = value;
@@ -97,9 +114,23 @@ public partial class NewComponentViewModel
             return;
         }
 
-        RefreshPdkChoices();
-        SelectedPdkChoice = _pdkChoices.FirstOrDefault(
+        try
+        {
+            _suppressSentinelHandling = true;
+            RefreshPdkChoices();
+        }
+        finally
+        {
+            _suppressSentinelHandling = false;
+        }
+
+        var createdChoice = _pdkChoices.FirstOrDefault(
             c => !c.IsNewPdk && c.Pdk!.FilePath == created.FilePath);
+        // The created PDK should always be found post-refresh; falling back instead of
+        // leaving the sentinel selected is a defensive last resort, not the expected path.
+        SelectedPdkChoice = createdChoice
+            ?? _previousPdkChoice
+            ?? _pdkChoices.FirstOrDefault(c => !c.IsNewPdk);
     }
 
     /// <summary>Re-reads <see cref="AvailableCustomPdks"/> from the store and rebuilds <see cref="PdkChoices"/>.</summary>

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CAP.Avalonia.Services.AddCustomComponent;
 using CAP.Avalonia.Services.Solvers;
@@ -25,10 +26,13 @@ public partial class NewComponentViewModel
     partial void OnIsBusyChanged(bool value) => SaveCommand.NotifyCanExecuteChanged();
 
     /// <summary>
-    /// Recomputes the S-matrix from the rendered geometry via the FDTD solver. Any failure —
-    /// no solver configured, an unavailable backend, or a failed solve — clears the pending
-    /// model and reports the reason via <see cref="NewComponentViewModel.StatusText"/>; a
-    /// black-box save is the only fallback, never a fabricated matrix.
+    /// Recomputes the S-matrix from the rendered geometry via the FDTD solver, showing live
+    /// progress (Meep lines + an elapsed-time heartbeat) via
+    /// <see cref="NewComponentViewModel.StatusText"/> while it runs and cancellable via
+    /// <see cref="NewComponentViewModel.CancelCompute"/>. Any failure — no solver configured,
+    /// an unavailable backend, a failed solve, or a cancel — clears the pending model and
+    /// reports the reason (raw, never guessed) via <c>StatusText</c>; a black-box save is the
+    /// only fallback, never a fabricated matrix.
     /// </summary>
     [RelayCommand]
     private async Task ComputeSMatrix()
@@ -46,9 +50,10 @@ public partial class NewComponentViewModel
         }
 
         IsBusy = true;
+        _computeCts = new CancellationTokenSource();
         try
         {
-            var availability = await _fdtd.CheckAvailabilityAsync();
+            var availability = await _fdtd.CheckAvailabilityAsync(_computeCts.Token);
             if (!availability.IsAvailable)
             {
                 _computedModel = null;
@@ -58,7 +63,7 @@ public partial class NewComponentViewModel
 
             var portNames = preview.Pins.Select(p => p.Name).ToList();
             var request = ComponentFdtdRequestFactory.BuildFromPreview(preview.Raw, portNames);
-            var result = await _fdtd.SolveAsync(request);
+            var result = await RunSolveWithLiveStatusAsync(request, _computeCts.Token);
             if (!result.Success)
             {
                 _computedModel = null;
@@ -67,11 +72,18 @@ public partial class NewComponentViewModel
             }
 
             _computedModel = FdtdSMatrixConverter.ToComponentSMatrixData(result, "FDTD Meep");
-            StatusText = "S-matrix computed.";
+            StatusText = $"S-matrix computed ({result.Wavelengths.Count} wavelength(s)).";
+        }
+        catch (OperationCanceledException)
+        {
+            _computedModel = null;
+            StatusText = "S-matrix computation cancelled.";
         }
         finally
         {
             IsBusy = false;
+            _computeCts?.Dispose();
+            _computeCts = null;
         }
     }
 

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
@@ -95,7 +95,10 @@ public partial class NewComponentViewModel
     /// name, a rendered preview, and a selected PDK — missing any of these reports why via
     /// <see cref="NewComponentViewModel.StatusText"/> and leaves
     /// <see cref="NewComponentViewModel.SavedDraft"/> null. A name collision is reported unless
-    /// <see cref="NewComponentViewModel.ConfirmOverwrite"/> confirms it. The S-matrix is either
+    /// <see cref="NewComponentViewModel.ConfirmOverwrite"/> confirms it — except in
+    /// <see cref="NewComponentViewModel.IsEditMode"/>, where the name always already exists (the
+    /// component being edited) and overwriting it in place is exactly the intended save, so the
+    /// collision check and confirm are skipped entirely. The S-matrix is either
     /// the last FDTD result or a black box when none was computed — never fabricated. The
     /// draft's source is always the user's own code (raw code + backend), never a
     /// module/function reference. A black-box save preserves any pending diagnostic and
@@ -133,7 +136,9 @@ public partial class NewComponentViewModel
             var backend = SelectedBackend == GeometryBackend.GdsFactory ? "gdsfactory" : "nazca";
             var draft = CustomComponentDraftFactory.Build(name, reference, preview, sMatrix, Code, backend);
 
-            if (_store.ComponentExistsInFile(pdk.FilePath, name) && !await ConfirmCollision(name, pdk.Name))
+            // Edit mode always overwrites the same name by design (see LoadForEdit) — the
+            // collision it would report is not a real conflict, so skip the confirm entirely.
+            if (!IsEditMode && _store.ComponentExistsInFile(pdk.FilePath, name) && !await ConfirmCollision(name, pdk.Name))
             {
                 return;
             }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
@@ -141,7 +141,7 @@ public partial class NewComponentViewModel
 
             SavedDraft = draft;
             StatusText = _computedModel is null
-                ? $"Saved as black box. {StatusText}".Trim()
+                ? $"Saved without simulation model (black box). {StatusText}".Trim()
                 : "Saved with FDTD S-matrix.";
             Saved?.Invoke(this, EventArgs.Empty);
         }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
@@ -95,10 +95,11 @@ public partial class NewComponentViewModel
     /// name, a rendered preview, and a selected PDK — missing any of these reports why via
     /// <see cref="NewComponentViewModel.StatusText"/> and leaves
     /// <see cref="NewComponentViewModel.SavedDraft"/> null. A name collision is reported unless
-    /// <see cref="NewComponentViewModel.ConfirmOverwrite"/> confirms it — except in
-    /// <see cref="NewComponentViewModel.IsEditMode"/>, where the name always already exists (the
-    /// component being edited) and overwriting it in place is exactly the intended save, so the
-    /// collision check and confirm are skipped entirely. The S-matrix is either
+    /// <see cref="NewComponentViewModel.ConfirmOverwrite"/> confirms it — except for a
+    /// self-overwrite in <see cref="NewComponentViewModel.IsEditMode"/> (re-saving the edited
+    /// component under its own original name), which is the intended save and skips the prompt. A
+    /// rename onto a <em>different</em> existing component still collides and still prompts, so it
+    /// is never silently clobbered. The S-matrix is either
     /// the last FDTD result or a black box when none was computed — never fabricated. The
     /// draft's source is always the user's own code (raw code + backend), never a
     /// module/function reference. A black-box save preserves any pending diagnostic and
@@ -136,9 +137,13 @@ public partial class NewComponentViewModel
             var backend = SelectedBackend == GeometryBackend.GdsFactory ? "gdsfactory" : "nazca";
             var draft = CustomComponentDraftFactory.Build(name, reference, preview, sMatrix, Code, backend);
 
-            // Edit mode always overwrites the same name by design (see LoadForEdit) — the
-            // collision it would report is not a real conflict, so skip the confirm entirely.
-            if (!IsEditMode && _store.ComponentExistsInFile(pdk.FilePath, name) && !await ConfirmCollision(name, pdk.Name))
+            // A self-overwrite (re-saving the edited component under its own name) is exactly the
+            // intended edit and needs no prompt. A rename onto a DIFFERENT existing component is a
+            // real collision and must still go through ConfirmOverwrite — AppendToExistingPdk
+            // removes-by-name, so skipping it would silently clobber the other component.
+            var isSelfEdit = IsEditMode &&
+                string.Equals(name, _editingOriginalName, StringComparison.OrdinalIgnoreCase);
+            if (!isSelfEdit && _store.ComponentExistsInFile(pdk.FilePath, name) && !await ConfirmCollision(name, pdk.Name))
             {
                 return;
             }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -50,6 +50,14 @@ public partial class NewComponentViewModel : ObservableObject
     [ObservableProperty] private string _code = string.Empty;
 
     /// <summary>
+    /// True when the wizard was opened via <see cref="LoadForEdit"/> to edit an existing custom
+    /// component in place, rather than to author a new one. Purely a display flag consumed by
+    /// <see cref="WindowTitle"/>/<see cref="SaveButtonLabel"/> — the save path itself
+    /// (<c>AppendToExistingPdk</c>, overwrite-by-name) is identical either way.
+    /// </summary>
+    [ObservableProperty] private bool _isEditMode;
+
+    /// <summary>
     /// Rasterised thumbnail of the last successful <see cref="RunPreview"/>, rendered via
     /// <see cref="PreviewBitmapFactory.FromResult"/>. Null before any preview, after a failed
     /// preview, or when the current environment has no rendering backend (e.g. headless tests) —
@@ -62,6 +70,12 @@ public partial class NewComponentViewModel : ObservableObject
 
     /// <summary>Geometry backends selectable for the rendered code: always both, since saving is always own-code.</summary>
     public IReadOnlyList<GeometryBackend> AvailableBackends => _availableBackends;
+
+    /// <summary>Window title: reflects <see cref="IsEditMode"/> so Task 6's view can bind it directly.</summary>
+    public string WindowTitle => IsEditMode ? "Edit Component" : "New Component";
+
+    /// <summary>Save button label: reflects <see cref="IsEditMode"/> so Task 6's view can bind it directly.</summary>
+    public string SaveButtonLabel => IsEditMode ? "Save changes" : "Save";
 
     /// <summary>
     /// File-picker hook for <see cref="LoadCodeFromFile"/>: returns a ".py" file's already-read
@@ -137,6 +151,13 @@ public partial class NewComponentViewModel : ObservableObject
         InvalidatePreview();
     }
     partial void OnCodeChanged(string value) => InvalidatePreview();
+
+    /// <summary>Keeps the display-only <see cref="WindowTitle"/>/<see cref="SaveButtonLabel"/> in sync.</summary>
+    partial void OnIsEditModeChanged(bool value)
+    {
+        OnPropertyChanged(nameof(WindowTitle));
+        OnPropertyChanged(nameof(SaveButtonLabel));
+    }
 
     private void InvalidatePreview()
     {

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Avalonia.Media.Imaging;
+using CAP.Avalonia.Controls.Canvas.ComponentPreview;
 using CAP.Avalonia.Services.AddCustomComponent;
 using CAP.Avalonia.Services.Solvers;
 using CAP_Core.Solvers.Fdtd;
@@ -27,6 +29,9 @@ namespace CAP.Avalonia.ViewModels.Components.AddCustomComponent;
 /// </summary>
 public partial class NewComponentViewModel : ObservableObject
 {
+    /// <summary>Pixel budget passed to <see cref="PreviewBitmapFactory.FromResult"/> for the thumbnail.</summary>
+    private const int PreviewBitmapPixels = 512;
+
     private static readonly IReadOnlyList<GeometryBackend> _availableBackends =
         new[] { GeometryBackend.GdsFactory, GeometryBackend.Nazca };
 
@@ -43,6 +48,14 @@ public partial class NewComponentViewModel : ObservableObject
     [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private bool _hasPreview;
     [ObservableProperty] private string _code = string.Empty;
+
+    /// <summary>
+    /// Rasterised thumbnail of the last successful <see cref="RunPreview"/>, rendered via
+    /// <see cref="PreviewBitmapFactory.FromResult"/>. Null before any preview, after a failed
+    /// preview, or when the current environment has no rendering backend (e.g. headless tests) —
+    /// all non-fatal, callers must tolerate null.
+    /// </summary>
+    [ObservableProperty] private Bitmap? _previewBitmap;
 
     /// <summary>Fabrication processes offered by <see cref="CreateNewPdk"/>'s modal (not chosen here).</summary>
     public IReadOnlyList<ProcessDefinition> Processes { get; }
@@ -129,6 +142,7 @@ public partial class NewComponentViewModel : ObservableObject
     {
         _lastPreview = null;
         HasPreview = false;
+        PreviewBitmap = null;
     }
 
     /// <summary>The rendered geometry reference: always the user's own code, verbatim.</summary>
@@ -143,7 +157,12 @@ public partial class NewComponentViewModel : ObservableObject
         if (content is not null) Code = content;
     }
 
-    /// <summary>Renders the configured geometry reference and extracts its size and pins.</summary>
+    /// <summary>
+    /// Renders the configured geometry reference, extracts its size and pins, and rasterises a
+    /// thumbnail into <see cref="PreviewBitmap"/> via <see cref="PreviewBitmapFactory.FromResult"/>.
+    /// A failed render (or a render with nothing to rasterise) clears <see cref="PreviewBitmap"/>
+    /// rather than leaving a stale bitmap behind.
+    /// </summary>
     [RelayCommand]
     private async Task RunPreview()
     {
@@ -155,6 +174,9 @@ public partial class NewComponentViewModel : ObservableObject
             var result = await _extractor.ExtractAsync(reference);
             _lastPreview = result;
             HasPreview = result.Success;
+            PreviewBitmap = result.Success
+                ? PreviewBitmapFactory.FromResult(result.Raw, PreviewBitmapPixels)
+                : null;
             StatusText = result.Success
                 ? $"Preview rendered: {result.WidthUm:0.###} x {result.HeightUm:0.###} um, {result.Pins.Count} pins."
                 : result.Error ?? "Preview render failed.";

--- a/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
@@ -217,6 +217,20 @@ public partial class ComponentTemplate : ObservableObject
     /// <c>"gdsfactory"</c>. Null when <see cref="RawCode"/> is not set.
     /// </summary>
     public string? RawCodeBackend { get; set; }
+
+    /// <summary>
+    /// True when this template comes from a non-bundled (user-imported or custom-authored) PDK,
+    /// i.e. the inverse of <see cref="Library.PdkInfoViewModel.IsBundled"/> for its
+    /// <see cref="PdkSource"/> at the time it was added to the library. Set once by
+    /// <c>LeftPanelViewModel</c>/<c>CustomComponentLibraryRegistrar</c> alongside the
+    /// corresponding <c>PdkManagerViewModel.RegisterPdk(..., isBundled, ...)</c> call, purely so
+    /// the library list's "Edit…" context menu item (issue #656 follow-up) can bind
+    /// visibility/enablement directly instead of looking up the PDK manager per item. The
+    /// authoritative check for the edit action itself is
+    /// <c>LeftPanelViewModel.CanEditTemplate</c>, which re-derives this from the live PDK
+    /// registry rather than trusting this flag alone.
+    /// </summary>
+    public bool IsCustom { get; set; }
 }
 
 public class PinDefinition

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.AddCustomComponent.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.AddCustomComponent.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using CommunityToolkit.Mvvm.Input;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP.Avalonia.ViewModels.Panels;
+
+/// <summary>
+/// "New Component" assistant entry points for <see cref="LeftPanelViewModel"/> — opening it for a
+/// brand-new component (issue #656) and opening it prefilled to edit an existing custom one
+/// (issue #656 follow-up, task 6). Split out purely to keep <c>LeftPanelViewModel.cs</c> under
+/// the project's line-count limit; still one partial class, one cohesive feature area.
+/// </summary>
+public partial class LeftPanelViewModel
+{
+    /// <summary>Opens the "New Component" window (issue #656); see <see cref="NewComponentWindowLauncher"/>.</summary>
+    [RelayCommand]
+    private async Task OpenNewComponent()
+    {
+        if (ShowNewComponentWindowAsync is null || _addCustomComponentDeps is null) return;
+
+        await ShowNewComponentWindowAsync(NewComponentWindowLauncher.BuildViewModel(_addCustomComponentDeps, _pdkLoader, GetLoadedPdkDrafts(), RegisterSavedCustomComponent));
+    }
+
+    /// <summary>Registers a saved custom component into the library; see <see cref="CustomComponentLibraryRegistrar"/>.</summary>
+    public void RegisterSavedCustomComponent(PdkComponentDraft draft, string pdkName, string filePath) =>
+        CustomComponentLibraryRegistrar.Register(draft, pdkName, filePath, AllTemplates, Categories, PdkManager, _preferencesService, _pdkLoader, _loadedPdkDrafts, ReapplyActiveProcessAfterPdkChange, FilterComponents);
+
+    /// <summary>
+    /// True when <paramref name="template"/> belongs to a currently-loaded, non-bundled PDK —
+    /// the only components the "New Component" assistant is allowed to edit in place. Foundry
+    /// (bundled) PDKs are read-only, so a template whose <see cref="ComponentTemplate.PdkSource"/>
+    /// resolves to a bundled entry (or to none at all — e.g. a stale reference) is not editable.
+    /// Re-derives the answer from the live <see cref="PdkManager"/> registry rather than trusting
+    /// <see cref="ComponentTemplate.IsCustom"/> alone, so it stays correct even if that flag was
+    /// never set (defensive default).
+    /// </summary>
+    public bool CanEditTemplate(ComponentTemplate template) =>
+        PdkManager.LoadedPdks.FirstOrDefault(p => p.Name == template.PdkSource) is { IsBundled: false };
+
+    /// <summary>
+    /// Opens the "New Component" assistant prefilled to edit an existing custom component
+    /// (issue #656 follow-up, task 6). No-ops for a bundled/Foundry template — see
+    /// <see cref="CanEditTemplate"/> — since those are read-only.
+    /// </summary>
+    [RelayCommand]
+    private async Task EditCustomComponent(ComponentTemplate? template)
+    {
+        if (template is null || !CanEditTemplate(template)) return;
+        if (ShowNewComponentWindowAsync is null || _addCustomComponentDeps is null) return;
+
+        var vm = NewComponentWindowLauncher.BuildViewModel(
+            _addCustomComponentDeps, _pdkLoader, GetLoadedPdkDrafts(), RegisterSavedCustomComponent);
+        vm.LoadForEdit(template);
+        await ShowNewComponentWindowAsync(vm);
+    }
+}

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -196,6 +196,8 @@ public partial class LeftPanelViewModel : ObservableObject
                 {
                     var template = ConvertPdkComponentToTemplate(
                         pdkComp, pdk.Name, pdk.NazcaModuleName, pdk.GdsFactoryRoutingCrossSection);
+                    // Bundled PDK — never editable (Foundry read-only).
+                    template.IsCustom = false;
                     AllTemplates.Add(template);
                     componentCount++;
                 }
@@ -388,6 +390,8 @@ public partial class LeftPanelViewModel : ObservableObject
             foreach (var pdkComp in pdk.Components)
             {
                 var template = ConvertPdkComponentToTemplate(pdkComp, pdk.Name, pdk.NazcaModuleName);
+                // User-loaded PDK — editable via the library's "Edit…" action.
+                template.IsCustom = true;
                 AllTemplates.Add(template);
                 if (!Categories.Contains(template.Category))
                     Categories.Add(template.Category);
@@ -416,17 +420,10 @@ public partial class LeftPanelViewModel : ObservableObject
         => PdkTemplateConverter.ConvertToTemplate(
             pdkComp, pdkName, nazcaModuleName, gdsFactoryRoutingCrossSection);
 
-    /// <summary>Opens the "New Component" window (issue #656); see <see cref="NewComponentWindowLauncher"/>.</summary>
-    [RelayCommand]
-    private async Task OpenNewComponent()
-    {
-        if (ShowNewComponentWindowAsync is null || _addCustomComponentDeps is null) return;
+    // OpenNewComponent, RegisterSavedCustomComponent, CanEditTemplate, EditCustomComponent:
+    // see LeftPanelViewModel.AddCustomComponent.cs (kept out of this file to respect the
+    // project's per-file line-count limit).
 
-        await ShowNewComponentWindowAsync(NewComponentWindowLauncher.BuildViewModel(_addCustomComponentDeps, _pdkLoader, GetLoadedPdkDrafts(), RegisterSavedCustomComponent));
-    }
-    /// <summary>Registers a saved custom component into the library; see <see cref="CustomComponentLibraryRegistrar"/>.</summary>
-    public void RegisterSavedCustomComponent(PdkComponentDraft draft, string pdkName, string filePath) =>
-        CustomComponentLibraryRegistrar.Register(draft, pdkName, filePath, AllTemplates, Categories, PdkManager, _preferencesService, _pdkLoader, _loadedPdkDrafts, ReapplyActiveProcessAfterPdkChange, FilterComponents);
     /// <summary>
     /// Process fingerprints of all loaded PDKs, for single-process grouping (#570).
     /// Excludes process-agnostic tool PDKs (e.g. "Analysis Tools") — they are not a

--- a/CAP.Avalonia/Views/ComponentPreviewWindow.axaml
+++ b/CAP.Avalonia/Views/ComponentPreviewWindow.axaml
@@ -1,0 +1,20 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CAP.Avalonia.Views.ComponentPreviewWindow"
+        Title="Preview"
+        Width="640" Height="480"
+        MinWidth="240" MinHeight="180"
+        CanResize="True"
+        Background="#1e1e1e"
+        WindowStartupLocation="CenterOwner">
+
+    <!-- ClipToBounds keeps a zoomed/panned image from painting outside the window;
+         the Image itself carries the zoom/pan transform (see code-behind). -->
+    <Border x:Name="ViewportBorder" Background="#101018" ClipToBounds="True">
+        <Image x:Name="PreviewImage"
+               Stretch="None"
+               HorizontalAlignment="Left"
+               VerticalAlignment="Top"
+               RenderTransformOrigin="0,0"/>
+    </Border>
+</Window>

--- a/CAP.Avalonia/Views/ComponentPreviewWindow.axaml.cs
+++ b/CAP.Avalonia/Views/ComponentPreviewWindow.axaml.cs
@@ -1,0 +1,119 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+
+namespace CAP.Avalonia.Views;
+
+/// <summary>
+/// Zoom/pan popup for a single rendered component-preview bitmap, opened from the "New
+/// Component" thumbnail (see <see cref="NewComponentWindow"/>). Mousewheel zooms toward the
+/// cursor and left-drag pans, mirroring <see cref="CAP.Avalonia.Controls.DesignCanvas"/>'s
+/// zoom-at-cursor convention (factor 1.1/0.9 per notch, clamped 0.1-10).
+/// </summary>
+public partial class ComponentPreviewWindow : Window
+{
+    private const double ZoomInFactor = 1.1;
+    private const double ZoomOutFactor = 0.9;
+    private const double MinZoom = 0.1;
+    private const double MaxZoom = 10.0;
+
+    private readonly ScaleTransform _scale = new();
+    private readonly TranslateTransform _translate = new();
+
+    private Point? _lastPanPosition;
+    private bool _isPanning;
+
+    /// <summary>Initializes the popup with the bitmap to display.</summary>
+    /// <param name="bitmap">The already-rendered preview bitmap to show, zoomed/panned in place.</param>
+    public ComponentPreviewWindow(Bitmap bitmap)
+    {
+        InitializeComponent();
+        PreviewImage.Source = bitmap;
+        PreviewImage.RenderTransform = new TransformGroup { Children = { _scale, _translate } };
+    }
+
+    /// <summary>
+    /// Zooms toward the cursor: the image point under the pointer stays fixed on screen while
+    /// the scale changes, matching <c>DesignCanvas.OnPointerWheelChanged</c>'s convention.
+    /// </summary>
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        base.OnPointerWheelChanged(e);
+
+        var point = e.GetPosition(ViewportBorder);
+        var factor = e.Delta.Y > 0 ? ZoomInFactor : ZoomOutFactor;
+        var newScale = Math.Clamp(_scale.ScaleX * factor, MinZoom, MaxZoom);
+
+        // Image-space point currently under the cursor (inverse of the render transform).
+        var imageX = (point.X - _translate.X) / _scale.ScaleX;
+        var imageY = (point.Y - _translate.Y) / _scale.ScaleY;
+
+        _scale.ScaleX = newScale;
+        _scale.ScaleY = newScale;
+
+        // Re-derive the translate so that image point renders back under the cursor.
+        _translate.X = point.X - (imageX * newScale);
+        _translate.Y = point.Y - (imageY * newScale);
+
+        e.Handled = true;
+    }
+
+    /// <summary>Starts a drag-pan on left-button press; double-click resets zoom/pan.</summary>
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+
+        if (!e.GetCurrentPoint(ViewportBorder).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        if (e.ClickCount >= 2)
+        {
+            ResetView();
+            return;
+        }
+
+        _isPanning = true;
+        _lastPanPosition = e.GetPosition(ViewportBorder);
+        e.Pointer.Capture(ViewportBorder);
+    }
+
+    /// <summary>Applies the pointer delta to the pan translation while dragging.</summary>
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+
+        if (!_isPanning || _lastPanPosition is not { } last)
+        {
+            return;
+        }
+
+        var current = e.GetPosition(ViewportBorder);
+        _translate.X += current.X - last.X;
+        _translate.Y += current.Y - last.Y;
+        _lastPanPosition = current;
+    }
+
+    /// <summary>Ends the drag-pan gesture and releases pointer capture.</summary>
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+
+        _isPanning = false;
+        _lastPanPosition = null;
+        e.Pointer.Capture(null);
+    }
+
+    /// <summary>Resets zoom to 1x and pan to the origin (double-click on the preview).</summary>
+    private void ResetView()
+    {
+        _scale.ScaleX = 1.0;
+        _scale.ScaleY = 1.0;
+        _translate.X = 0.0;
+        _translate.Y = 0.0;
+    }
+}

--- a/CAP.Avalonia/Views/MainWindow.axaml
+++ b/CAP.Avalonia/Views/MainWindow.axaml
@@ -605,6 +605,10 @@
                                         <StackPanel.ContextMenu>
                                             <ContextMenu>
                                                 <MenuItem Header="Component Settings…" Click="TemplateComponentSettings_Click"/>
+                                                <!-- Custom (non-Foundry) components only: opens the "New Component"
+                                                     assistant prefilled to edit this component in place (#656 follow-up). -->
+                                                <MenuItem Header="Edit…" Click="TemplateEditComponent_Click"
+                                                          IsVisible="{Binding IsCustom}" IsEnabled="{Binding IsCustom}"/>
                                             </ContextMenu>
                                         </StackPanel.ContextMenu>
                                         <controls:ComponentPreview

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -694,6 +694,23 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Handles "Edit…" click in the PDK template list context menu (issue #656 follow-up, task 6).
+    /// Only wired to a visible/enabled menu item for custom (non-Foundry) templates — see the
+    /// <c>IsCustom</c> binding in <c>MainWindow.axaml</c> — but delegates the authoritative
+    /// bundled/custom check to <see cref="LeftPanelViewModel.CanEditTemplate"/> via the command.
+    /// </summary>
+    private void TemplateEditComponent_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel vm)
+            return;
+
+        if (sender is MenuItem { DataContext: ComponentTemplate template })
+        {
+            vm.LeftPanel.EditCustomComponentCommand.Execute(template);
+        }
+    }
+
+    /// <summary>
     /// Creates and shows the Component Settings dialog for the given entity.
     ///
     /// Per-Instance mode (<paramref name="liveComponent"/> non-null): the dialog

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -106,6 +106,11 @@ public partial class MainWindow : Window
                     // window itself) so the dropdown cannot be left mid-selection while the modal
                     // is open.
                     var window = new NewComponentWindow { DataContext = newComponentVm };
+                    // Save closes the window; closing the window (via Save, the titlebar X, or
+                    // Alt+F4) always cancels any Meep compute still running so it doesn't keep
+                    // burning CPU/Docker resources after the user has moved on.
+                    newComponentVm.Saved += (_, _) => window.Close();
+                    window.Closing += (_, _) => newComponentVm.CancelCompute();
                     newComponentVm.CreateNewPdk = async () =>
                     {
                         var userPdkStore = App.Services.GetService(typeof(UserPdkStore)) as UserPdkStore;

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -6,7 +6,7 @@
         xmlns:controls="using:CAP.Avalonia.Controls"
         x:Class="CAP.Avalonia.Views.NewComponentWindow"
         x:DataType="vm:NewComponentViewModel"
-        Title="New Component"
+        Title="{Binding WindowTitle}"
         Width="520" Height="740"
         MinWidth="440" MinHeight="560"
         WindowStartupLocation="CenterOwner"
@@ -18,7 +18,7 @@
         <!-- Save — always visible at the bottom -->
         <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
                     HorizontalAlignment="Right" Spacing="8" Margin="0,12,0,0">
-            <Button Content="Save" Command="{Binding SaveCommand}"
+            <Button Content="{Binding SaveButtonLabel}" Command="{Binding SaveCommand}"
                     Width="90" Background="#2a4a2a"
                     ToolTip.Tip="Saves the component into the selected PDK. A save with no computed S-matrix is stored as a black box, never a fabricated one."/>
         </StackPanel>

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -114,6 +114,18 @@
                             ToolTip.Tip="Renders the geometry and extracts its size and pins"/>
                 </Grid>
 
+                <!-- Rendered preview thumbnail; hidden until a render succeeds (PreviewBitmap can be
+                     null on a headless/no-render-backend session). Click opens a zoom/pan popup. -->
+                <Image x:Name="PreviewThumbnail"
+                       Source="{Binding PreviewBitmap}"
+                       Height="120"
+                       Stretch="Uniform"
+                       HorizontalAlignment="Left"
+                       Cursor="Hand"
+                       IsVisible="{Binding PreviewBitmap, Converter={x:Static ObjectConverters.IsNotNull}}"
+                       PointerPressed="OnPreviewThumbnailPointerPressed"
+                       ToolTip.Tip="Click to enlarge"/>
+
                 <Separator Background="#3d3d3d"/>
 
                 <!-- S-matrix -->

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml.cs
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml.cs
@@ -1,5 +1,7 @@
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
 
 namespace CAP.Avalonia.Views;
 
@@ -14,6 +16,18 @@ public partial class NewComponentWindow : Window
     public NewComponentWindow()
     {
         InitializeComponent();
+    }
+
+    /// <summary>
+    /// Opens the rendered preview in a zoom/pan popup (<see cref="ComponentPreviewWindow"/>) when
+    /// the thumbnail is clicked. No-ops if a preview hasn't rendered yet (null-tolerant).
+    /// </summary>
+    private void OnPreviewThumbnailPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is NewComponentViewModel vm && vm.PreviewBitmap is { } bitmap)
+        {
+            new ComponentPreviewWindow(bitmap).Show(this);
+        }
     }
 
     /// <summary>Copies the help flyout's gdsfactory example code to the clipboard.</summary>

--- a/UnitTests/Components/AddCustomComponent/ComputeProgressTests.cs
+++ b/UnitTests/Components/AddCustomComponent/ComputeProgressTests.cs
@@ -104,28 +104,45 @@ public class ComputeProgressTests : IDisposable
     [Fact]
     public async Task ComputeSMatrix_surfaces_a_reported_progress_line_in_StatusText()
     {
-        var (vm, fdtd) = Build();
-        fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(FdtdAvailability.Available(""));
-        fdtd.Setup(f => f.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
-            .Callback<FdtdSMatrixRequest, IProgress<string>?, CancellationToken>((_, progress, _) =>
-                progress?.Report("Meep step 50%"))
-            .ReturnsAsync(SuccessResult());
-
-        // The final "S-matrix computed" status overwrites the last progress line once the
-        // solve completes, so capture every StatusText value seen while the command runs
-        // (rather than only the value after it finishes) to prove the reported line was
-        // actually surfaced live, not just passed through and discarded.
-        var seenStatuses = new List<string>();
-        vm.PropertyChanged += (_, e) =>
+        // The VM reports progress through a UI-thread-safe Progress<string>, which marshals its
+        // callback onto the SynchronizationContext captured when it is constructed. Under xUnit's
+        // async context that callback would run non-deterministically off-thread, so pin a context
+        // that runs posted callbacks inline (synchronously) for the duration of this test — the
+        // production code is unchanged, only the test's context is controlled. The Moq mock returns
+        // already-completed tasks, so every await continuation runs inline too; the only thing that
+        // posts to the context is Progress.Report, so there is no reentrancy or deadlock.
+        var original = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(new InlineSynchronizationContext());
+        try
         {
-            if (e.PropertyName == nameof(NewComponentViewModel.StatusText)) seenStatuses.Add(vm.StatusText);
-        };
+            var (vm, fdtd) = Build();
+            fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(FdtdAvailability.Available(""));
+            fdtd.Setup(f => f.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
+                .Callback<FdtdSMatrixRequest, IProgress<string>?, CancellationToken>((_, progress, _) =>
+                    progress?.Report("Meep step 50%"))
+                .ReturnsAsync(SuccessResult());
 
-        await vm.RunPreviewCommand.ExecuteAsync(null);
-        await vm.ComputeSMatrixCommand.ExecuteAsync(null);
+            // The final "S-matrix computed" status overwrites the last progress line once the
+            // solve completes, so capture every StatusText value seen while the command runs
+            // (rather than only the value after it finishes) to prove the reported line was
+            // actually surfaced live, not just passed through and discarded. With the inline
+            // context this recorder is deterministic — the report runs synchronously.
+            var seenStatuses = new List<string>();
+            vm.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(NewComponentViewModel.StatusText)) seenStatuses.Add(vm.StatusText);
+            };
 
-        seenStatuses.ShouldContain(s => s.Contains("Meep step 50%"));
+            await vm.RunPreviewCommand.ExecuteAsync(null);
+            await vm.ComputeSMatrixCommand.ExecuteAsync(null);
+
+            seenStatuses.ShouldContain(s => s.Contains("Meep step 50%"));
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(original);
+        }
     }
 
     [Fact]
@@ -150,6 +167,17 @@ public class ComputeProgressTests : IDisposable
     {
         var (vm, _) = Build();
         Should.NotThrow(() => vm.CancelCompute());
+    }
+
+    /// <summary>
+    /// A <see cref="SynchronizationContext"/> that runs posted callbacks inline (synchronously)
+    /// on the calling thread, so a <see cref="Progress{T}"/> report is observed deterministically
+    /// within the test rather than being marshalled off-thread by xUnit's async context.
+    /// </summary>
+    private sealed class InlineSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object? state) => d(state);
+        public override void Send(SendOrPostCallback d, object? state) => d(state);
     }
 
     public void Dispose()

--- a/UnitTests/Components/AddCustomComponent/ComputeProgressTests.cs
+++ b/UnitTests/Components/AddCustomComponent/ComputeProgressTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers the live-progress + cancellation path of
+/// <see cref="NewComponentViewModel"/>'s <c>ComputeSMatrix</c> command: the FDTD solver must
+/// always be given a non-null progress sink, and a line reported through it must reach
+/// <see cref="NewComponentViewModel.StatusText"/> without depending on the once-per-second
+/// heartbeat timer actually ticking (this test never pumps the Avalonia dispatcher).
+/// </summary>
+public class ComputeProgressTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "lunima-nc-progress-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 10, YMax = 2,
+        Polygons = new List<NazcaPreviewPolygon>
+        {
+            new() { Layer = 1, Vertices = new List<(double, double)> { (0, 0), (10, 0), (10, 2), (0, 2) } }
+        },
+        Pins = new List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 1, Angle = 180 },
+            new() { Name = "o2", X = 10, Y = 1, Angle = 0 }
+        }
+    };
+
+    private static PdkComponentDraft SeedComponent(string n) => new()
+    {
+        Name = n, WidthMicrometers = 5, HeightMicrometers = 1,
+        RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()", RawCodeBackend = "gdsfactory",
+        Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+    };
+
+    private static FdtdSMatrixResult SuccessResult() => new()
+    {
+        Success = true,
+        Ports = new[] { "o1", "o2" },
+        Wavelengths = new[] { 1.55 },
+        Entries = new[]
+        {
+            new FdtdSEntry { Key = "o2@0,o1@0", Values = new[] { new Complex(0.95, 0.0) } },
+            new FdtdSEntry { Key = "o1@0,o2@0", Values = new[] { new Complex(0.95, 0.0) } },
+        },
+        EnergySumPerInput = new Dictionary<string, double> { ["o1@0"] = 0.9, ["o2@0"] = 0.9 },
+    };
+
+    private (NewComponentViewModel vm, Mock<IFdtdSMatrixService> fdtd) Build()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var fdtd = new Mock<IFdtdSMatrixService>();
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var process = new ProcessDefinition { Name = "P" };
+        // PDK-first: Save always appends to a selected existing named custom PDK, so seed one
+        // and let the ctor pre-select it (same pattern as NewComponentViewModelTests).
+        store.SaveToNamedPdk("My PDK", process, SeedComponent("seed"), "gdsfactory", null);
+        var vm = new NewComponentViewModel(extractor, fdtd.Object, store, new List<ProcessDefinition> { process });
+        vm.ComponentName = "My Comp";
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+        vm.Code = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        return (vm, fdtd);
+    }
+
+    [Fact]
+    public async Task ComputeSMatrix_passes_a_non_null_progress_sink_to_the_solver()
+    {
+        var (vm, fdtd) = Build();
+        fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FdtdAvailability.Available(""));
+        fdtd.Setup(f => f.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessResult());
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.ComputeSMatrixCommand.ExecuteAsync(null);
+
+        fdtd.Verify(f => f.SolveAsync(
+                It.IsAny<FdtdSMatrixRequest>(),
+                It.Is<IProgress<string>?>(p => p != null),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ComputeSMatrix_surfaces_a_reported_progress_line_in_StatusText()
+    {
+        var (vm, fdtd) = Build();
+        fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FdtdAvailability.Available(""));
+        fdtd.Setup(f => f.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
+            .Callback<FdtdSMatrixRequest, IProgress<string>?, CancellationToken>((_, progress, _) =>
+                progress?.Report("Meep step 50%"))
+            .ReturnsAsync(SuccessResult());
+
+        // The final "S-matrix computed" status overwrites the last progress line once the
+        // solve completes, so capture every StatusText value seen while the command runs
+        // (rather than only the value after it finishes) to prove the reported line was
+        // actually surfaced live, not just passed through and discarded.
+        var seenStatuses = new List<string>();
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(NewComponentViewModel.StatusText)) seenStatuses.Add(vm.StatusText);
+        };
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.ComputeSMatrixCommand.ExecuteAsync(null);
+
+        seenStatuses.ShouldContain(s => s.Contains("Meep step 50%"));
+    }
+
+    [Fact]
+    public async Task ComputeSMatrix_failure_still_reports_the_raw_error_and_clears_the_model()
+    {
+        var (vm, fdtd) = Build();
+        fdtd.Setup(f => f.CheckAvailabilityAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FdtdAvailability.Available(""));
+        fdtd.Setup(f => f.SolveAsync(It.IsAny<FdtdSMatrixRequest>(), It.IsAny<IProgress<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FdtdSMatrixResult.Fail("solver blew up"));
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.ComputeSMatrixCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.StatusText.ShouldContain("solver blew up");
+        vm.SavedDraft!.SMatrix.ShouldBeNull(); // failed FDTD => still no model, never fake
+    }
+
+    [Fact]
+    public void CancelCompute_before_any_run_is_a_no_op()
+    {
+        var (vm, _) = Build();
+        Should.NotThrow(() => vm.CancelCompute());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, true);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
@@ -69,6 +69,20 @@ public class EditComponentModeTests : IDisposable
         return (vm, path, rawCode);
     }
 
+    /// <summary>Seeds a PDK with two components ("comp1" and "comp2") so a rename-onto-existing collision can be exercised.</summary>
+    private (NewComponentViewModel vm, string filePath, string rawCode) BuildWithTwoSeededComponents()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        const string rawCode = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        var path = store.CreateNamedPdkWithProcess("Lib", process, "gdsfactory", null);
+        store.AppendToExistingPdk(path, SeedComponent("comp1", rawCode));
+        store.AppendToExistingPdk(path, SeedComponent("comp2", rawCode));
+
+        var (vm, _) = Build(store, new List<ProcessDefinition> { process });
+        return (vm, path, rawCode);
+    }
+
     private static ComponentTemplate BuildTemplate(string rawCode) => new()
     {
         Name = "comp1",
@@ -140,6 +154,28 @@ public class EditComponentModeTests : IDisposable
 
         confirmCalls.ShouldBe(0);
         vm.SavedDraft.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task Save_afterLoadForEdit_renamedOntoADifferentExistingComponent_stillPromptsAndAbortsWhenDeclined()
+    {
+        var (vm, filePath, rawCode) = BuildWithTwoSeededComponents();
+        vm.LoadForEdit(BuildTemplate(rawCode)); // editing comp1
+        var confirmCalls = 0;
+        // Rename comp1 → comp2 (which already exists): NOT a self-overwrite, so the collision
+        // prompt must fire — and declining it must abort without clobbering comp2.
+        vm.ConfirmOverwrite = (_, _) => { confirmCalls++; return Task.FromResult(false); };
+        vm.ComponentName = "comp2";
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        confirmCalls.ShouldBe(1);
+        vm.SavedDraft.ShouldBeNull(); // aborted
+        var pdk = new PdkLoader().LoadFromFileForEditing(filePath);
+        pdk.Components.Count.ShouldBe(2); // both originals intact — comp2 not overwritten
+        pdk.Components.Count(c => c.Name == "comp1").ShouldBe(1);
+        pdk.Components.Count(c => c.Name == "comp2").ShouldBe(1);
     }
 
     [Fact]

--- a/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
@@ -126,6 +126,23 @@ public class EditComponentModeTests : IDisposable
     }
 
     [Fact]
+    public async Task Save_afterLoadForEdit_neverCallsConfirmOverwrite_evenThoughTheNameAlwaysExists()
+    {
+        var (vm, _, rawCode) = BuildWithSeededPdk();
+        vm.LoadForEdit(BuildTemplate(rawCode));
+        var confirmCalls = 0;
+        // Edit-mode intentionally overwrites the same name — the collision that would trigger
+        // this hook in the non-edit path must never fire here (task 6's collision fix).
+        vm.ConfirmOverwrite = (_, _) => { confirmCalls++; return Task.FromResult(true); };
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        confirmCalls.ShouldBe(0);
+        vm.SavedDraft.ShouldNotBeNull();
+    }
+
+    [Fact]
     public void LoadForEdit_withNoMatchingCustomPdk_reportsStatusAndLeavesEditModeFalse()
     {
         var (vm, _, rawCode) = BuildWithSeededPdk();

--- a/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="NewComponentViewModel.LoadForEdit"/>: prefilling the wizard from an
+/// existing custom component's <see cref="ComponentTemplate"/> for in-place editing (name,
+/// own-code, backend, fixed target PDK), and that the subsequent <c>Save</c> overwrites the
+/// original entry in its named custom PDK file rather than duplicating it. Also covers the
+/// <see cref="NewComponentViewModel.WindowTitle"/>/<see cref="NewComponentViewModel.SaveButtonLabel"/>
+/// display properties Task 6's view binds to.
+/// </summary>
+public class EditComponentModeTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-nc-vm-edit-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 8, YMax = 1.5,
+        Pins = new List<NazcaPreviewPin> { new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 }, new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 } }
+    };
+
+    private static PdkComponentDraft SeedComponent(string n, string rawCode) => new()
+    {
+        Name = n, WidthMicrometers = 5, HeightMicrometers = 1,
+        RawCode = rawCode, RawCodeBackend = "gdsfactory",
+        Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+    };
+
+    private UserPdkStore Store() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    private (NewComponentViewModel vm, Mock<IFdtdSMatrixService> fdtd) Build(
+        UserPdkStore store, IReadOnlyList<ProcessDefinition> processes)
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var fdtd = new Mock<IFdtdSMatrixService>();
+        var vm = new NewComponentViewModel(extractor, fdtd.Object, store, processes);
+        return (vm, fdtd);
+    }
+
+    private (NewComponentViewModel vm, string filePath, string rawCode) BuildWithSeededPdk()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        const string rawCode = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        var path = store.CreateNamedPdkWithProcess("Lib", process, "gdsfactory", null);
+        store.AppendToExistingPdk(path, SeedComponent("comp1", rawCode));
+
+        var (vm, _) = Build(store, new List<ProcessDefinition> { process });
+        return (vm, path, rawCode);
+    }
+
+    private static ComponentTemplate BuildTemplate(string rawCode) => new()
+    {
+        Name = "comp1",
+        RawCode = rawCode,
+        RawCodeBackend = "gdsfactory",
+        PdkSource = "Lib",
+    };
+
+    [Fact]
+    public void LoadForEdit_prefillsFieldsAndSelectsThePdk_withoutTriggeringTheNewPdkSentinel()
+    {
+        var (vm, _, rawCode) = BuildWithSeededPdk();
+        var createNewPdkCalls = 0;
+        vm.CreateNewPdk = () => { createNewPdkCalls++; return Task.FromResult<UserPdkInfo?>(null); };
+
+        vm.LoadForEdit(BuildTemplate(rawCode));
+
+        vm.IsEditMode.ShouldBeTrue();
+        vm.ComponentName.ShouldBe("comp1");
+        vm.Code.ShouldBe(rawCode);
+        vm.SelectedBackend.ShouldBe(GeometryBackend.GdsFactory);
+        vm.SelectedCustomPdk.ShouldNotBeNull();
+        vm.SelectedCustomPdk!.Name.ShouldBe("Lib");
+        createNewPdkCalls.ShouldBe(0); // selecting an existing PDK entry must never invoke the "New PDK…" hook
+    }
+
+    [Fact]
+    public void WindowTitle_and_SaveButtonLabel_reflectEditMode()
+    {
+        var (vm, _, rawCode) = BuildWithSeededPdk();
+
+        vm.WindowTitle.ShouldBe("New Component");
+        vm.SaveButtonLabel.ShouldBe("Save");
+
+        vm.LoadForEdit(BuildTemplate(rawCode));
+
+        vm.WindowTitle.ShouldBe("Edit Component");
+        vm.SaveButtonLabel.ShouldBe("Save changes");
+    }
+
+    [Fact]
+    public async Task Save_afterLoadForEdit_overwritesTheOriginalComponent_inPlace_notDuplicated()
+    {
+        var (vm, filePath, rawCode) = BuildWithSeededPdk();
+        vm.LoadForEdit(BuildTemplate(rawCode));
+        vm.ConfirmOverwrite = (_, _) => Task.FromResult(true); // editing intentionally overwrites the same name
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.SavedDraft.ShouldNotBeNull();
+        var pdk = new PdkLoader().LoadFromFileForEditing(filePath);
+        pdk.Components.Count(c => c.Name == "comp1").ShouldBe(1); // overwritten, not duplicated
+        pdk.Components.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void LoadForEdit_withNoMatchingCustomPdk_reportsStatusAndLeavesEditModeFalse()
+    {
+        var (vm, _, rawCode) = BuildWithSeededPdk();
+        var template = BuildTemplate(rawCode);
+        template.PdkSource = "Unknown Pdk";
+
+        vm.LoadForEdit(template);
+
+        vm.IsEditMode.ShouldBeFalse();
+        vm.StatusText.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void LoadForEdit_withNoStoredCode_setsCodeEmpty_andReportsStatus()
+    {
+        var (vm, _, _) = BuildWithSeededPdk();
+        var template = BuildTemplate(null!);
+        template.RawCode = null;
+
+        vm.LoadForEdit(template);
+
+        vm.Code.ShouldBe(string.Empty);
+        vm.StatusText.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}

--- a/UnitTests/Components/AddCustomComponent/LibraryEditActionTests.cs
+++ b/UnitTests/Components/AddCustomComponent/LibraryEditActionTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Hierarchy;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Export;
+using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers <see cref="LeftPanelViewModel.CanEditTemplate"/> and
+/// <see cref="LeftPanelViewModel.EditCustomComponent"/> (issue #656 follow-up, task 6): the
+/// library's "Edit…" action must only ever act on a template that belongs to a currently-loaded,
+/// non-bundled (custom) PDK, and must open the "New Component" assistant prefilled via
+/// <see cref="NewComponentViewModel.LoadForEdit"/> — never the window itself, which cannot be
+/// opened headlessly.
+/// </summary>
+public class LibraryEditActionTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    /// <summary>Builds a <see cref="LeftPanelViewModel"/>, optionally with the "add custom component" collaborators wired.</summary>
+    private LeftPanelViewModel CreateLeftPanelViewModel(UserPdkStore? userPdkStore = null)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var libraryManager = new GroupLibraryManager();
+        var pdkLoader = new PdkLoader();
+        var preferencesPath = Path.Combine(Path.GetTempPath(), $"test-preferences-{Guid.NewGuid()}.json");
+        var preferencesService = new UserPreferencesService(preferencesPath);
+
+        AddCustomComponentDependencies? deps = null;
+        if (userPdkStore != null)
+        {
+            var nazca = new Mock<IComponentPreviewRenderer>();
+            var gds = new Mock<IComponentPreviewRenderer>();
+            var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+            deps = new AddCustomComponentDependencies(extractor, Fdtd: null, UserPdkStore: userPdkStore);
+        }
+
+        return new LeftPanelViewModel(
+            canvas, libraryManager, pdkLoader, preferencesService,
+            new HierarchyPanelViewModel(canvas),
+            new PdkManagerViewModel(),
+            new ComponentLibraryViewModel(libraryManager),
+            addCustomComponentDeps: deps);
+    }
+
+    /// <summary>Creates a <see cref="UserPdkStore"/> rooted at a fresh temp directory, tracked for cleanup.</summary>
+    private UserPdkStore CreateUserPdkStore()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"lunima-lea-{Guid.NewGuid():N}");
+        _tempDirs.Add(root);
+        return new UserPdkStore(root, new PdkJsonSaver(), new PdkLoader());
+    }
+
+    /// <summary>Writes a real user-PDK file containing a sample component into <paramref name="store"/>, mirroring <c>LeftPanelNewComponentTests</c>.</summary>
+    private static (string filePath, string pdkName, PdkComponentDraft draft) SaveUserPdk(UserPdkStore store, string processName)
+    {
+        var process = new ProcessDefinition { Name = processName };
+        var draft = new PdkComponentDraft
+        {
+            Name = "My Coupler", Category = "Custom",
+            RawCode = "import gdsfactory as gf\ncomponent = gf.components.coupler()",
+            RawCodeBackend = "gdsfactory",
+            WidthMicrometers = 10, HeightMicrometers = 2,
+            Pins = new List<PhysicalPinDraft>
+            {
+                new() { Name = "o1", OffsetXMicrometers = 0, OffsetYMicrometers = 1, AngleDegrees = 180 },
+                new() { Name = "o2", OffsetXMicrometers = 10, OffsetYMicrometers = 1, AngleDegrees = 0 },
+            }
+        };
+        var path = store.Save(process, draft, "gdsfactory", null);
+        var pdkName = new PdkLoader().LoadFromFileForEditing(path).Name;
+        return (path, pdkName, draft);
+    }
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs.Where(Directory.Exists))
+        {
+            try { Directory.Delete(dir, true); } catch { /* best effort */ }
+        }
+    }
+
+    [Fact]
+    public void CanEditTemplate_true_forTemplateBelongingToALoadedCustomPdk()
+    {
+        var vm = CreateLeftPanelViewModel();
+        vm.PdkManager.RegisterPdk("My Custom Pdk", "/tmp/x.json", isBundled: false, componentCount: 1);
+        var template = new ComponentTemplate { Name = "X", PdkSource = "My Custom Pdk" };
+
+        vm.CanEditTemplate(template).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CanEditTemplate_false_forTemplateBelongingToABundledFoundryPdk()
+    {
+        var vm = CreateLeftPanelViewModel();
+        vm.PdkManager.RegisterPdk("Foundry Pdk", null, isBundled: true, componentCount: 1);
+        var template = new ComponentTemplate { Name = "X", PdkSource = "Foundry Pdk" };
+
+        vm.CanEditTemplate(template).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanEditTemplate_false_whenTheTemplatesPdkIsNotCurrentlyLoaded()
+    {
+        var vm = CreateLeftPanelViewModel();
+        var template = new ComponentTemplate { Name = "X", PdkSource = "Never Loaded" };
+
+        vm.CanEditTemplate(template).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task EditCustomComponent_forBundledTemplate_doesNothing()
+    {
+        var vm = CreateLeftPanelViewModel(CreateUserPdkStore());
+        vm.PdkManager.RegisterPdk("Foundry Pdk", null, isBundled: true, componentCount: 1);
+        var template = new ComponentTemplate { Name = "Grating Coupler", PdkSource = "Foundry Pdk" };
+
+        var showCalls = 0;
+        vm.ShowNewComponentWindowAsync = _ => { showCalls++; return Task.CompletedTask; };
+
+        await vm.EditCustomComponentCommand.ExecuteAsync(template);
+
+        showCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task EditCustomComponent_forCustomTemplate_opensTheAssistantPrefilledForEdit()
+    {
+        // Same UserPdkStore instance for both the assistant's deps and the on-disk PDK, so
+        // NewComponentViewModel's PdkChoices (read from the store) actually contain "ActiveProc"
+        // — a real bug caught by this test: two separate stores would silently leave PdkChoices
+        // empty and LoadForEdit unable to find a match.
+        var store = CreateUserPdkStore();
+        var vm = CreateLeftPanelViewModel(store);
+        var (filePath, pdkName, draft) = SaveUserPdk(store, "ActiveProc");
+        vm.RegisterSavedCustomComponent(draft, pdkName, filePath);
+        var template = vm.AllTemplates.First(t => t.Name == draft.Name);
+
+        NewComponentViewModel? shownVm = null;
+        vm.ShowNewComponentWindowAsync = shown => { shownVm = shown; return Task.CompletedTask; };
+
+        await vm.EditCustomComponentCommand.ExecuteAsync(template);
+
+        shownVm.ShouldNotBeNull();
+        shownVm!.IsEditMode.ShouldBeTrue();
+        shownVm.ComponentName.ShouldBe(draft.Name);
+        shownVm.Code.ShouldBe(draft.RawCode);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/NewPdkReopenGuardTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewPdkReopenGuardTests.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Regression coverage for the "New PDK…" reopen bug: after a successful modal creation,
+/// <see cref="NewComponentViewModel.PdkSelection"/>'s <c>RefreshPdkChoices</c> rebuilds
+/// <see cref="NewComponentViewModel.PdkChoices"/> and raises its property-changed
+/// notification. A bound <c>ComboBox</c> reacts to that <c>ItemsSource</c> swap by clearing
+/// <c>SelectedItem</c> and then reselecting whatever it previously held, if that object is
+/// still present (by reference) in the new source — and since
+/// <see cref="PdkChoice.NewPdkSentinel"/> is a single shared static instance, it always is.
+/// That replay used to reselect the sentinel a second time, and because it happens
+/// synchronously nested inside the creation handler (after its <c>IsBusy</c> guard has
+/// already been lifted), the "new PDK" modal reopened immediately. These tests simulate that
+/// ComboBox replay directly against the view model (no Avalonia control needed) and assert
+/// the modal-creation hook fires exactly once.
+/// </summary>
+public class NewPdkReopenGuardTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "lunima-nc-vm-reopen-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult Ok() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 8, YMax = 1.5,
+        Pins = new List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 },
+            new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 }
+        }
+    };
+
+    private UserPdkStore Store() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    private NewComponentViewModel Build(UserPdkStore store)
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(Ok());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var vm = new NewComponentViewModel(extractor, fdtd: null, store,
+            new List<ProcessDefinition> { new() { Name = "P" } });
+        vm.ComponentName = "My Comp";
+        vm.Code = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        return vm;
+    }
+
+    /// <summary>
+    /// Wires a <see cref="PropertyChanged"/> listener that reproduces the bound ComboBox's
+    /// real reaction to an <c>ItemsSource</c> swap: clear the selection, then reselect the
+    /// previously-held item if it is still present in the new source.
+    /// </summary>
+    private static void SimulateComboBoxReselectOnItemsSourceSwap(NewComponentViewModel vm)
+    {
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(vm.PdkChoices)) return;
+
+            var previouslyHeld = vm.SelectedPdkChoice;
+            vm.SelectedPdkChoice = null;
+            if (previouslyHeld is not null && vm.PdkChoices.Contains(previouslyHeld))
+            {
+                vm.SelectedPdkChoice = previouslyHeld;
+            }
+        };
+    }
+
+    [Fact]
+    public async Task SelectingTheSentinel_withComboBoxReplayAfterRefresh_invokesCreateNewPdkExactlyOnce()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        store.CreateNamedPdkWithProcess("Existing Lib", process, "gdsfactory", null);
+        var vm = Build(store);
+        SimulateComboBoxReselectOnItemsSourceSwap(vm);
+
+        var callCount = 0;
+        vm.CreateNewPdk = () =>
+        {
+            callCount++;
+            var path = store.CreateNamedPdkWithProcess("Brand New Lib", process, "gdsfactory", null);
+            return Task.FromResult<UserPdkInfo?>(new UserPdkInfo("Brand New Lib", path, process));
+        };
+
+        vm.SelectedPdkChoice = vm.PdkChoices[^1]; // select the sentinel
+        await Task.Yield();
+        await Task.Yield(); // pump any nested re-fired handler too
+
+        callCount.ShouldBe(1);
+        vm.SelectedCustomPdk.ShouldNotBeNull();
+        vm.SelectedCustomPdk!.Name.ShouldBe("Brand New Lib");
+        vm.SelectedPdkChoice.ShouldNotBeNull();
+        vm.SelectedPdkChoice!.IsNewPdk.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SelectingTheSentinel_whenTheCreatedPdkCannotBeFoundAfterRefresh_fallsBackInsteadOfStayingOnTheSentinel()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        store.CreateNamedPdkWithProcess("Existing Lib", process, "gdsfactory", null);
+        var vm = Build(store);
+        var existingChoice = vm.PdkChoices[0]; // ctor already pre-selected this one
+
+        // The hook reports a path that ListCustomPdks() will never see (e.g. an out-of-store
+        // location or a save that failed after all) -- RefreshPdkChoices' FirstOrDefault(...)
+        // legitimately returns null.
+        vm.CreateNewPdk = () => Task.FromResult<UserPdkInfo?>(
+            new UserPdkInfo("Ghost Lib", Path.Combine(_root, "ghost.json"), process));
+
+        vm.SelectedPdkChoice = vm.PdkChoices[^1]; // select the sentinel
+        await Task.Yield();
+
+        vm.SelectedPdkChoice.ShouldNotBeNull();
+        vm.SelectedPdkChoice!.IsNewPdk.ShouldBeFalse();
+        vm.SelectedPdkChoice.ShouldBe(existingChoice);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, true);
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/PreviewBitmapAndBlackBoxSaveTests.cs
+++ b/UnitTests/Components/AddCustomComponent/PreviewBitmapAndBlackBoxSaveTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_Core.Solvers.Fdtd;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Covers task 3 of the PDK-first component wizard: <see cref="NewComponentViewModel.RunPreview"/>
+/// rasterising a thumbnail into <see cref="NewComponentViewModel.PreviewBitmap"/>, and
+/// <see cref="NewComponentViewModel.Save"/> being reachable (and clearly reporting a black box)
+/// without ever having run <c>ComputeSMatrix</c>.
+/// </summary>
+public class PreviewBitmapAndBlackBoxSaveTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "lunima-nc-vm-bitmap-" + Guid.NewGuid().ToString("N"));
+
+    // Includes >= 1 polygon so PreviewBitmapFactory.FromResult has something to rasterise —
+    // a bbox-only result (no polygons) always returns null regardless of rendering backend.
+    private static NazcaPreviewResult OkWithPolygon() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 10, YMax = 2,
+        Polygons = new List<NazcaPreviewPolygon>
+        {
+            new() { Layer = 1, Vertices = new List<(double, double)> { (0, 0), (10, 0), (10, 2), (0, 2) } }
+        },
+        Pins = new List<NazcaPreviewPin> { new() { Name = "o1", X = 0, Y = 1, Angle = 180 }, new() { Name = "o2", X = 10, Y = 1, Angle = 0 } }
+    };
+
+    private static PdkComponentDraft SeedComponent(string n) => new()
+    {
+        Name = n, WidthMicrometers = 5, HeightMicrometers = 1,
+        RawCode = "import gdsfactory as gf\ncomponent = gf.components.straight()", RawCodeBackend = "gdsfactory",
+        Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+    };
+
+    private (NewComponentViewModel vm, Mock<IFdtdSMatrixService> fdtd) Build(bool withFdtd = false)
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(OkWithPolygon());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var fdtd = new Mock<IFdtdSMatrixService>();
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var process = new ProcessDefinition { Name = "P" };
+        store.SaveToNamedPdk("My PDK", process, SeedComponent("seed"), "gdsfactory", null);
+        var vm = new NewComponentViewModel(extractor, withFdtd ? fdtd.Object : null, store,
+            new List<ProcessDefinition> { process });
+        vm.ComponentName = "My Comp";
+        vm.SelectedBackend = GeometryBackend.GdsFactory;
+        vm.Code = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        return (vm, fdtd);
+    }
+
+    // (A) RunPreview must reach PreviewBitmapFactory.FromResult on a successful render and never
+    // crash doing so. Verified confirmed on this machine: the xunit/dotnet-test host used by
+    // smart_test.py has no Avalonia.Platform.IPlatformRenderInterface registered at all (checked
+    // directly — even constructing a bare WriteableBitmap throws "Unable to locate
+    // 'Avalonia.Platform.IPlatformRenderInterface'"), so PreviewBitmapFactory.FromResult's
+    // try/catch around RasterizeToBitmap always lands on null here, regardless of pixel budget or
+    // input. That is exactly the non-fatal path PreviewBitmapFactory documents for headless
+    // environments, so asserting PreviewBitmap tolerantly (null-or-Bitmap) is not a cop-out here —
+    // it is the only assertion that is both true and portable to environments where a rendering
+    // backend does exist. The load-bearing checks are: (1) the command completes without throwing
+    // despite exercising the bitmap path (the brief's "kein Crash" requirement), and (2) HasPreview
+    // flips correctly for a polygon-bearing result.
+    [Fact]
+    public async Task RunPreview_withPolygons_setsHasPreview_andDoesNotCrashRasterizing()
+    {
+        var (vm, _) = Build();
+        vm.PreviewBitmap.ShouldBeNull(); // nothing rendered yet
+
+        await vm.RunPreviewCommand.ExecuteAsync(null); // must not throw
+
+        vm.HasPreview.ShouldBeTrue();
+        if (vm.PreviewBitmap is null)
+        {
+            return; // expected in this test host — see comment above
+        }
+        vm.PreviewBitmap.PixelSize.Width.ShouldBeGreaterThan(0);
+        vm.PreviewBitmap.PixelSize.Height.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task RunPreview_failure_clearsAnyPreviousBitmap()
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.SetupSequence(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkWithPolygon())
+            .ReturnsAsync(NazcaPreviewResult.Fail("boom"));
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        var store = new UserPdkStore(_root, new PdkJsonSaver(), new PdkLoader());
+        var process = new ProcessDefinition { Name = "P" };
+        store.SaveToNamedPdk("My PDK", process, SeedComponent("seed"), "gdsfactory", null);
+        var vm = new NewComponentViewModel(extractor, null, store, new List<ProcessDefinition> { process });
+        vm.Code = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+
+        await vm.RunPreviewCommand.ExecuteAsync(null); // first render succeeds
+        await vm.RunPreviewCommand.ExecuteAsync(null); // second render fails
+
+        vm.HasPreview.ShouldBeFalse();
+        vm.PreviewBitmap.ShouldBeNull(); // no stale thumbnail survives a failed re-render
+    }
+
+    // (B) Save without ever calling ComputeSMatrix must still succeed as an explicit black box.
+    [Fact]
+    public async Task Save_withoutCompute_savesBlackBox_andStatusNamesIt()
+    {
+        var (vm, _) = Build(withFdtd: false);
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        vm.SavedDraft.ShouldNotBeNull();
+        vm.SavedDraft!.SMatrix.ShouldBeNull(); // blackbox: no invented physics
+        vm.StatusText.ShouldContain("black box");
+    }
+
+    // (C) CanSave must not require a computed S-matrix — only preview + PDK.
+    [Fact]
+    public async Task CanSave_isTrue_assoonAs_previewAndPdk_arePresent_withoutCompute()
+    {
+        var (vm, _) = Build(withFdtd: true); // FDTD configured but never invoked
+        vm.SaveCommand.CanExecute(null).ShouldBeFalse(); // no preview yet
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+
+        vm.SelectedCustomPdk.ShouldNotBeNull();
+        vm.SaveCommand.CanExecute(null).ShouldBeTrue(); // preview + PDK, no compute needed
+    }
+
+    public void Dispose() { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+}

--- a/UnitTests/Components/AddCustomComponent/PreviewEditFlowTests.cs
+++ b/UnitTests/Components/AddCustomComponent/PreviewEditFlowTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Task 7 end-to-end coverage for the PDK-first component wizard, tying together the three
+/// previously-independent behaviours in a single integration test: (a) <see
+/// cref="NewComponentViewModel.RunPreview"/> against a mocked geometry renderer flips <see
+/// cref="NewComponentViewModel.HasPreview"/> (see <see cref="PreviewBitmapAndBlackBoxSaveTests"/>
+/// for why <see cref="NewComponentViewModel.PreviewBitmap"/> itself is left untested here — it is
+/// legitimately null in this headless test host); (b) <see cref="NewComponentViewModel.LoadForEdit"/>
+/// prefilling from a <see cref="ComponentTemplate"/> followed by <c>Save</c> overwrites the
+/// original entry in its named custom PDK file rather than duplicating it (see <see
+/// cref="EditComponentModeTests"/>); and (c) the "New PDK…" sentinel's reopen guard still fires
+/// its creation hook exactly once after a <c>PdkChoices</c> refresh (see <see
+/// cref="NewPdkReopenGuardTests"/>). One focused assertion per stage.
+/// </summary>
+public class PreviewEditFlowTests : IDisposable
+{
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "lunima-nc-vm-e2e-" + Guid.NewGuid().ToString("N"));
+
+    private static NazcaPreviewResult OkWithPolygon() => new()
+    {
+        Success = true, XMin = 0, YMin = 0, XMax = 8, YMax = 1.5,
+        Polygons = new List<NazcaPreviewPolygon>
+        {
+            new() { Layer = 1, Vertices = new List<(double, double)> { (0, 0), (8, 0), (8, 1.5), (0, 1.5) } }
+        },
+        Pins = new List<NazcaPreviewPin>
+        {
+            new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 },
+            new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 }
+        }
+    };
+
+    private UserPdkStore Store() => new(_root, new PdkJsonSaver(), new PdkLoader());
+
+    private NewComponentViewModel Build(UserPdkStore store, IReadOnlyList<ProcessDefinition> processes)
+    {
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(OkWithPolygon());
+        var extractor = new ComponentGeometryExtractor(nazca.Object, gds.Object);
+        return new NewComponentViewModel(extractor, fdtd: null, store, processes);
+    }
+
+    // (a) A successful mocked render must flip HasPreview, independent of whether this host can
+    // rasterise a bitmap (it cannot — see PreviewBitmapAndBlackBoxSaveTests for the documented
+    // headless-renderer null path).
+    [Fact]
+    public async Task RunPreview_withMockedPolygonResult_setsHasPreviewTrue()
+    {
+        var process = new ProcessDefinition { Name = "P" };
+        var vm = Build(Store(), new List<ProcessDefinition> { process });
+        vm.ComponentName = "My Comp";
+        vm.Code = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+
+        vm.HasPreview.ShouldBeTrue();
+    }
+
+    // (b) LoadForEdit prefills from an existing custom component, and Save overwrites it in
+    // place in its named custom PDK file rather than appending a duplicate entry.
+    [Fact]
+    public async Task LoadForEdit_thenSave_overwritesTheOriginalComponent_withoutDuplicating()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        const string rawCode = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        var path = store.CreateNamedPdkWithProcess("Lib", process, "gdsfactory", null);
+        store.AppendToExistingPdk(path, new PdkComponentDraft
+        {
+            Name = "comp1", WidthMicrometers = 5, HeightMicrometers = 1,
+            RawCode = rawCode, RawCodeBackend = "gdsfactory",
+            Pins = new() { new PhysicalPinDraft { Name = "o1" }, new PhysicalPinDraft { Name = "o2" } }
+        });
+        var vm = Build(store, new List<ProcessDefinition> { process });
+        vm.LoadForEdit(new ComponentTemplate { Name = "comp1", RawCode = rawCode, RawCodeBackend = "gdsfactory", PdkSource = "Lib" });
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        var pdk = new PdkLoader().LoadFromFileForEditing(path);
+        pdk.Components.Count(c => c.Name == "comp1").ShouldBe(1); // overwritten in place, not duplicated
+    }
+
+    // (c) Selecting the "New PDK…" sentinel, followed by the bound-ComboBox reselect replay that
+    // used to reopen the modal a second time (see NewPdkReopenGuardTests), must invoke the
+    // creation hook exactly once and land on the newly created PDK.
+    [Fact]
+    public async Task SelectingTheSentinel_withReselectReplayAfterRefresh_invokesCreateNewPdkExactlyOnce()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        store.CreateNamedPdkWithProcess("Existing Lib", process, "gdsfactory", null);
+        var vm = Build(store, new List<ProcessDefinition> { process });
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(vm.PdkChoices)) return;
+            var previouslyHeld = vm.SelectedPdkChoice;
+            vm.SelectedPdkChoice = null;
+            if (previouslyHeld is not null && vm.PdkChoices.Contains(previouslyHeld))
+            {
+                vm.SelectedPdkChoice = previouslyHeld;
+            }
+        };
+        var callCount = 0;
+        vm.CreateNewPdk = () =>
+        {
+            callCount++;
+            var path = store.CreateNamedPdkWithProcess("Brand New Lib", process, "gdsfactory", null);
+            return Task.FromResult<UserPdkInfo?>(new UserPdkInfo("Brand New Lib", path, process));
+        };
+
+        vm.SelectedPdkChoice = vm.PdkChoices[^1]; // select the sentinel
+        await Task.Yield();
+        await Task.Yield(); // pump any nested re-fired handler too
+
+        callCount.ShouldBe(1);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, true);
+    }
+}

--- a/docs/superpowers/plans/2026-07-13-new-component-preview-edit.md
+++ b/docs/superpowers/plans/2026-07-13-new-component-preview-edit.md
@@ -1,0 +1,132 @@
+# New-Component: Fixes + Preview + Edit/Recompute — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Reopen-Bug, fehlender Meep-Fortschritt und Save-schließt-Fenster fixen; Struktur-Preview als inline-Thumbnail + Popup-Viewer (Zoom/Pan); Speichern ohne S-Matrix explizit; Edit/Recompute bestehender custom-Komponenten.
+
+**Architecture:** Evolution von #723/#727. Wiederverwendet `PreviewBitmapFactory`, das Zoom/Pan-Muster aus `DesignCanvas`, das FDTD-Live-Status-Muster aus `ComponentSettingsDialogViewModel.Fdtd.cs`, `NewComponentViewModel.Saved`, und `ComponentTemplate.RawCode`/`RawCodeBackend`.
+
+**Tech Stack:** C#/.NET 10/Avalonia 11/CommunityToolkit.Mvvm; xUnit+Shouldly+Moq.
+
+## Global Constraints
+- Keine erfundene Physik; S-Matrix nur echtes FDTD / Blackbox / 2-Port-Ideal; bleibt DI-Service `IFdtdSMatrixService`.
+- Edit nur für custom (nicht-bundled) Komponenten; Foundry-PDKs read-only.
+- Cross-Platform: kein `Process.Start`; `x:DataType`/compiled bindings; `InvariantCulture`.
+- Max. 250 Zeilen/neue Datei; bestehende ≤500 (VM-Partials nutzen). XML-Doku. Nur feature-bezogene Dateien.
+
+## File Structure
+- `CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel*.cs` (MODIFY) — Reopen-Fix, Progress, PreviewBitmap, Save-ohne-Modell, Edit-Modus.
+- `CAP.Avalonia/Views/ComponentPreviewWindow.axaml(.cs)` (CREATE) — Popup-Viewer mit Zoom/Pan.
+- `CAP.Avalonia/Views/NewComponentWindow.axaml` (MODIFY) — Thumbnail + „Edit"-Titel.
+- `CAP.Avalonia/Views/MainWindow.axaml.cs` (MODIFY) — Save-Close, Thumbnail-Klick→Popup, Edit-Einstieg-Wiring.
+- `CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs` + Library-View (MODIFY) — „Edit…"-Aktion an custom-Komponenten.
+- Tests unter `UnitTests/Components/AddCustomComponent/`.
+
+---
+
+### Task 1: Reopen-Bug — Sentinel-Suppress-Flag
+
+**Files:** Modify `.../NewComponentViewModel.PdkSelection.cs`; Test `UnitTests/Components/AddCustomComponent/NewPdkReopenGuardTests.cs`
+
+**Interfaces:** Consumes `PdkChoices`/`SelectedPdkChoice`/`CreateNewPdk`/`RefreshPdkChoices`/`HandleNewPdkSentinelAsync`.
+
+- [ ] **Step 1: Read** `NewComponentViewModel.PdkSelection.cs` (`OnSelectedPdkChoiceChanged`, `HandleNewPdkSentinelAsync`, `RefreshPdkChoices`).
+- [ ] **Step 2: Write failing test** — `NewComponentViewModel` mit `UserPdkStore`(TempRoot, 1 vorhandenes custom PDK) + `CreateNewPdk`-Fake, der einen Zähler hochzählt und ein neues `UserPdkInfo` (echte via `CreateNamedPdkWithProcess` geschriebene Datei) zurückgibt. Setze `SelectedPdkChoice = <Sentinel>`, warte den Task ab; assert: `CreateNewPdk` wurde GENAU EINMAL aufgerufen, `SelectedCustomPdk` ist das neue PDK, `SelectedPdkChoice` ist NICHT der Sentinel.
+- [ ] **Step 3: Run → FAIL** (`py .cap-tools/smart_test.py NewPdkReopenGuard`).
+- [ ] **Step 4: Implement** — `private bool _suppressSentinelHandling;` In `RefreshPdkChoices` + der anschließenden Ziel-Selektion `_suppressSentinelHandling = true;` setzen (try/finally zurücksetzen). In `OnSelectedPdkChoiceChanged`: früh `if (_suppressSentinelHandling) return;` bevor der Sentinel-Zweig läuft. Zusätzlich: falls das neue PDK nicht gefunden wird (`FirstOrDefault == null`), NICHT auf dem Sentinel hängen bleiben (auf `_previousPdkChoice` oder erstes reales PDK zurückfallen).
+- [ ] **Step 5: Run → PASS** + Regression `... NewComponentViewModel`, `... NewComponentNewPdkSentinel`.
+- [ ] **Step 6: Commit** `(=) New Component: guard against sentinel re-trigger after PDK refresh (reopen bug)` && `git push`
+
+---
+
+### Task 2: Meep-Live-Fortschritt + Abbruch
+
+**Files:** Modify `.../NewComponentViewModel.Save.cs` (+ ggf. `.cs`); Test `.../ComputeProgressTests.cs`
+
+**Interfaces:** Consumes `IFdtdSMatrixService.SolveAsync(request, IProgress<string>?, CancellationToken)`; `StatusText`; `_computedModel`.
+
+- [ ] **Step 1: Read** `NewComponentViewModel.Save.cs` `ComputeSMatrix`; `ComponentSettingsDialogViewModel.Fdtd.cs` `RunWithLiveStatusAsync`/`Shorten`/`BuildSolverStatus`.
+- [ ] **Step 2: Write failing test** — Mock `IFdtdSMatrixService.SolveAsync`, der `progress.Report("Meep step 50%")` aufruft und dann ein Erfolgs-`FdtdSMatrixResult` liefert; nach `ComputeSMatrixCommand.Execute` enthält `StatusText` den gemeldeten Fortschrittstext (oder eine daraus gebaute Zusammenfassung). Zweiter Test: `SolveAsync` wird mit einem NICHT-null `IProgress<string>` aufgerufen (`It.IsAny<IProgress<string>>()` + `It.IsNotNull`).
+- [ ] **Step 3: Run → FAIL.**
+- [ ] **Step 4: Implement** — In `ComputeSMatrix` ein `Progress<string>` erstellen (→ `StatusText = Shorten(line)` bzw. mit Laufzeit-Präfix), einen `CancellationTokenSource _computeCts` halten und `await _fdtd.SolveAsync(request, progress, _computeCts.Token)` aufrufen. Optional 1-s-`DispatcherTimer`-Heartbeat wie im Vorbild (falls in Tests problematisch: Heartbeat hinter einer kleinen, in Tests umgehbaren Methode kapseln — der Kerntest prüft nur, dass `progress` durchgereicht + gemeldete Zeilen sichtbar werden). Bei Fehler: roher Fehler in `StatusText`, `_computedModel=null` (unverändert ehrlich). Ein `CancelCompute()`/Cleanup, das beim Fensterschließen aufgerufen werden kann (VM-Methode; Wiring optional in Task 4).
+- [ ] **Step 5: Run → PASS** + Regression `... NewComponentViewModel`.
+- [ ] **Step 6: Commit** `(+) New Component: live Meep progress + cancellation during S-matrix compute` && `git push`
+
+---
+
+### Task 3: PreviewBitmap + Speichern ohne Modell (explizit)
+
+**Files:** Modify `.../NewComponentViewModel.cs` (+ `.Save.cs`); Test `.../PreviewBitmapAndBlackBoxSaveTests.cs`
+
+**Interfaces:** Consumes `PreviewBitmapFactory.FromResult(NazcaPreviewResult, int pixels)`; `_lastPreview.Raw`; `CanSave`; `FdtdSMatrixToDraftConverter.BlackBox()`.
+
+- [ ] **Step 1: Read** `PreviewBitmapFactory.cs` (`FromResult`-Signatur/Null-Verhalten); `NewComponentViewModel.RunPreview`; `CanSave`/`Save`.
+- [ ] **Step 2: Write failing test** — (A) Mit gemocktem Renderer, der ein `NazcaPreviewResult` mit ≥1 Polygon liefert: nach `RunPreviewCommand.Execute` ist `PreviewBitmap != null` (headless: falls `FromResult` null liefert, Test tolerant formulieren — assert „RunPreview versucht das Bitmap zu setzen", z.B. über eine injizierbare Factory-Func ODER `PreviewBitmap`-Property existiert und wird nach Erfolg gesetzt/`HasPreview==true`). (B) Save OHNE vorheriges Compute → `SavedDraft.SMatrix == null` (Blackbox) UND `StatusText` enthält einen Blackbox-Hinweis. (C) `CanSave` ist true, sobald Preview+PDK da sind, auch ohne Compute.
+- [ ] **Step 3: Run → FAIL.**
+- [ ] **Step 4: Implement** — `[ObservableProperty] private Bitmap? _previewBitmap;` (using `Avalonia.Media.Imaging`). In `RunPreview` nach Erfolg `PreviewBitmap = PreviewBitmapFactory.FromResult(result.Raw, 512);` (bei Fehler/kein Preview: `PreviewBitmap = null`). Save-Status: nach erfolgreichem Save `StatusText` klar setzen: `_computedModel is null ? "Saved without simulation model (black box)." : "Saved with FDTD S-matrix."`. `CanSave` unverändert lassen (hängt NICHT an `_computedModel`).
+- [ ] **Step 5: Run → PASS** + Regression `... NewComponentViewModel`.
+- [ ] **Step 6: Commit** `(+) New Component: render preview thumbnail bitmap; explicit black-box save status` && `git push`
+
+---
+
+### Task 4: `ComponentPreviewWindow` (Zoom/Pan) + Thumbnail-Klick + Save-Close
+
+**Files:** Create `CAP.Avalonia/Views/ComponentPreviewWindow.axaml(.cs)`; Modify `CAP.Avalonia/Views/NewComponentWindow.axaml`, `CAP.Avalonia/Views/MainWindow.axaml.cs`; Test: Build + Regression.
+
+**Interfaces:** Consumes `NewComponentViewModel.PreviewBitmap`, `.Saved`; `DesignCanvas`-Zoom/Pan-Muster.
+
+- [ ] **Step 1: Read** `NewComponentWindow.axaml` (wo das Thumbnail hin passt, nahe Preview/Code); `DesignCanvas.cs` `OnPointerWheelChanged` (Zoom-am-Cursor, delta 1.1/0.9, Clamp 0.1–10) + Pan; `ComponentSettingsDialog.axaml:198` (`<Image Source=…>`-Muster); `MainWindow.axaml.cs` `ShowNewComponentWindowAsync` (Fenster-Instanz `window`, `Saved`-Event).
+- [ ] **Step 2: `ComponentPreviewWindow.axaml(.cs)`** — ein Fenster mit einem `Image` (Konstruktor-Param `Bitmap`), umgeben von einem `Border`/`Panel`. Code-behind: `RenderTransform` = `TransformGroup{ScaleTransform sc; TranslateTransform tr}`. `PointerWheelChanged` → Zoom am Cursor (Faktor 1.1/0.9, Clamp 0.1–10, Pan-Korrektur auf Cursor-Fokus, analog `DesignCanvas`). `PointerPressed`(Left)+`PointerMoved`+`PointerReleased` → Drag-Pan (Delta auf `tr`). ≤250 Zeilen. Ctor: `public ComponentPreviewWindow(Bitmap bitmap)`.
+- [ ] **Step 3: `NewComponentWindow.axaml`** — ein kleines `Image` (`Source={Binding PreviewBitmap}`, feste Höhe ~120, `Stretch=Uniform`, `Cursor=Hand`, Tooltip „Click to enlarge"), sichtbar nur wenn `PreviewBitmap != null`. (Klick-Handler wird in Task via code-behind/`MainWindow` verdrahtet — da compiled bindings kein Command am Image haben, nutze ein `Button` mit transparentem Style um das Image ODER ein `PointerPressed` im NewComponentWindow-code-behind, das ein Event/Callback am VM auslöst.)
+- [ ] **Step 4: Wiring in `MainWindow.axaml.cs`** (`ShowNewComponentWindowAsync`): `newComponentVm.Saved += (_, _) => window.Close();` (Save schließt Fenster). Für den Thumbnail-Klick: einen Callback `newComponentVm.ShowPreviewPopup` (`Action?`) ODER — einfacher — im `NewComponentWindow`-code-behind einen `PreviewImage_PointerPressed`-Handler, der `new ComponentPreviewWindow(vm.PreviewBitmap).Show(this)` öffnet (nur wenn `PreviewBitmap != null`). Wähle den saubersten Weg; kein `Process.Start`.
+- [ ] **Step 5: Build** `dotnet build -clp:ErrorsOnly` = 0 (XAML inkl.). Regression `... NewComponentViewModel`.
+- [ ] **Step 6: Commit** `(+) ComponentPreviewWindow (mousewheel-zoom + drag-pan); thumbnail click-to-open; Save closes window` && `git push`
+
+---
+
+### Task 5: Edit-Modus im ViewModel
+
+**Files:** Modify `.../NewComponentViewModel*.cs`; Test `.../EditComponentModeTests.cs`
+
+**Interfaces:** Consumes `ComponentTemplate` (`Name`, `RawCode`, `RawCodeBackend`, `PdkSource`), `store.ListCustomPdks()`, `AppendToExistingPdk`.
+
+- [ ] **Step 1: Read** `NewComponentViewModel.cs`/`.Save.cs`/`.PdkSelection.cs` (ctor, `ComponentName`, `Code`, `SelectedBackend`, `SelectedPdkChoice`, Save-Routing); `ComponentTemplate` (RawCode/RawCodeBackend/PdkSource).
+- [ ] **Step 2: Write failing test** — `LoadForEdit(ComponentTemplate)`: setzt `ComponentName`, `Code = template.RawCode`, `SelectedBackend` aus `template.RawCodeBackend`, wählt das PDK (per `PdkSource`-Name → passendes `PdkChoice`) und fixiert es; `IsEditMode == true`. Save → `AppendToExistingPdk(<PDK-Datei>, draft)` (überschreibt per Name). Test: nach `LoadForEdit` sind die Felder gesetzt + `IsEditMode`; nach `Save` (Preview gemockt) landet der Draft im richtigen PDK-File.
+- [ ] **Step 3: Run → FAIL.**
+- [ ] **Step 4: Implement** — `[ObservableProperty] bool _isEditMode;` + `public void LoadForEdit(ComponentTemplate template)` (prefill; PDK-Auswahl über vorhandenes `PdkChoices`/`SelectedPdkChoice`; falls `RawCode` leer → `Code=""` + Status-Hinweis). Save-Pfad unverändert (`AppendToExistingPdk`) — funktioniert für Edit (Overwrite by Name) wie für Append. `WindowTitle`/`SaveButtonLabel`-Properties (z.B. `IsEditMode ? "Edit Component" : "New Component"`), damit Task-6-View sie binden kann.
+- [ ] **Step 5: Run → PASS** + Regression `... NewComponentViewModel`, `... AddCustomComponent`.
+- [ ] **Step 6: Commit** `(+) New Component: edit mode (LoadForEdit prefill + overwrite existing custom component)` && `git push`
+
+---
+
+### Task 6: Library-„Edit…"-Aktion + Öffnen im Edit-Modus
+
+**Files:** Modify `CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs`, die Library-View (MainWindow.axaml Komponentenliste), `CAP.Avalonia/Views/MainWindow.axaml.cs`, `CAP.Avalonia/Views/NewComponentWindow.axaml` (Titel/Label-Bindings). Test: LeftPanel-seitige Logik.
+
+**Interfaces:** Consumes Task 5 (`LoadForEdit`), `NewComponentWindowLauncher`, `PdkManagerViewModel.IsBundled`, `ComponentTemplate.PdkSource`.
+
+- [ ] **Step 1: Read** wie die PDK-Komponenten in der linken Library gelistet werden (`FilteredTemplates` in `LeftPanelViewModel`, zugehörige `MainWindow.axaml`-Liste) + ob es dort schon ein Kontextmenü gibt; wie `OpenNewComponent` das Fenster öffnet (Task 4/#727-Wiring).
+- [ ] **Step 2: Write failing test** — `LeftPanelViewModel`: eine Methode `EditCustomComponent(ComponentTemplate)` / ein `[RelayCommand]`, das nur für custom (nicht-bundled) Templates greift und den Öffnungs-Hook mit einem im Edit-Modus vorbefüllten VM aufruft. Testbar analog zum bestehenden `OpenNewComponent`/`RegisterSavedCustomComponent`-Muster (nur die Bestimmung „ist custom" + Prefill delegieren, nicht das Fenster). Assert: für ein bundled Template passiert nichts / für custom wird der Prefill-Pfad (`LoadForEdit`) angestoßen.
+- [ ] **Step 3: Run → FAIL.**
+- [ ] **Step 4: Implement** — `[RelayCommand] EditCustomComponent(ComponentTemplate template)` in `LeftPanelViewModel`, das (a) prüft, ob `template` zu einem nicht-bundled PDK gehört (`PdkManager`/`PdkSource`), sonst no-op; (b) über `NewComponentWindowLauncher` ein VM baut, `vm.LoadForEdit(template)` ruft und `ShowNewComponentWindowAsync(vm)` öffnet. Im AXAML: an den Library-Komponenten ein Kontextmenü „Edit…" (nur sichtbar/enabled für custom — z.B. via ein `IsCustom`-Flag am Item-VM oder `PdkManager`-Lookup). `NewComponentWindow.axaml` Titel/Save-Label an `WindowTitle`/`SaveButtonLabel` binden.
+- [ ] **Step 5: Build** = 0 Fehler; Regression `... LeftPanel`, `... NewComponentViewModel`.
+- [ ] **Step 6: Commit** `(+) Library: 'Edit…' action on custom components opens the assistant in edit mode` && `git push`
+
+---
+
+### Task 7: Integrationstest + Aufräumen
+
+**Files:** Test `.../PreviewEditFlowTests.cs`
+
+- [ ] **Step 1: Write test** — (a) `RunPreview` (gemockt) → `PreviewBitmap` gesetzt/`HasPreview`; (b) `LoadForEdit(template)` prefillt + `Save` überschreibt im PDK (`AppendToExistingPdk`, geladene Datei hat die Komponente 1×); (c) Sentinel feuert nach Refresh nur 1×. Ein Assert pro Stufe.
+- [ ] **Step 2: Run → PASS.**
+- [ ] **Step 3: Grep-Check** — keine toten Members aus den Umbauten; `NewComponentViewModel`-Dateien ≤250; `dotnet build` 0.
+- [ ] **Step 4: Commit** `(+) End-to-end test: preview bitmap + edit-mode overwrite + reopen guard` && `git push`
+
+---
+
+## Self-Review
+- **Spec-Coverage:** Reopen-Fix → T1; Progress → T2; PreviewBitmap+Blackbox-Save → T3; Popup-Viewer+Thumbnail+Save-Close → T4; Edit-Modus → T5; Library-Edit-Einstieg → T6; E2E → T7.
+- **Placeholder:** T4/T6 lassen den genauen Klick-/Kontextmenü-Andockpunkt bewusst offen mit klarer Anweisung „sauberste Variante, dokumentieren" (AXAML-Bindbarkeit erst am Control entscheidbar); Verhalten + Asserts konkret.
+- **Typkonsistenz:** `PreviewBitmap` (T3) → Thumbnail/Popup (T4). `LoadForEdit`/`IsEditMode`/`WindowTitle` (T5) → Library-Einstieg + Titel-Binding (T6). Reopen-Guard (T1) → E2E (T7).
+- **Verifikationspunkte:** `PreviewBitmapFactory.FromResult`-Null-Verhalten headless (T3-Test tolerant); `DesignCanvas`-Zoom/Pan-Konstanten (T4); Kontextmenü-Mechanik der Library (T6); `RunWithLiveStatusAsync`-Heartbeat testbar kapseln (T2).

--- a/docs/superpowers/specs/2026-07-13-new-component-preview-edit-design.md
+++ b/docs/superpowers/specs/2026-07-13-new-component-preview-edit-design.md
@@ -1,0 +1,90 @@
+# New-Component-Assistent: Fixes, Preview, Edit/Recompute — Design
+
+**Datum:** 2026-07-13
+**Status:** Freigegeben (Brainstorm)
+**Baut auf:** #723/#727 (PDK-first-Assistent)
+
+## Ziel
+
+Feld-Test-Feedback am „Neue Komponente"-Assistenten umsetzen: drei Bugfixes, eine visuelle
+Struktur-Preview (Thumbnail + Popup-Viewer), klare S-Matrix-Optionalität, und ein
+Edit/Recompute-Flow für bestehende custom-Komponenten.
+
+## Umfang
+
+### 1. Bugfixes
+- **Reopen-Bug:** Nach „Create PDK" im modalen Prozess-Editor öffnete sich dieser sofort wieder,
+  weil nach `RefreshPdkChoices()` die ComboBox den neu angehängten Sentinel „New PDK…" erneut
+  selektierte und `HandleNewPdkSentinelAsync` ein zweites Mal feuerte (Guard `IsBusy` war bereits
+  false). Fix: dediziertes Suppress-Flag `_suppressSentinelHandling`, das den Sentinel-Zweig
+  während Refresh + Ziel-Selektion abschirmt.
+- **Compute-Progress:** `ComputeSMatrix` ruft `IFdtdSMatrixService.SolveAsync` bisher ohne
+  `IProgress`/`ct`. Übernimm das `RunWithLiveStatusAsync`-Muster aus
+  `ComponentSettingsDialogViewModel.Fdtd.cs`: `Progress<string>` (live Meep-Zeilen) + 1-s-Heartbeat
+  (Laufzeit) → `StatusText`; `CancellationTokenSource`, das beim Fensterschließen abbricht.
+- **Save schließt Fenster:** `NewComponentViewModel.Saved` (existiert) in `MainWindow.axaml.cs` an
+  `window.Close()` binden.
+
+### 2. Struktur-Preview: Thumbnail + Popup-Viewer
+- VM: `[ObservableProperty] Bitmap? PreviewBitmap`, in `RunPreview` via
+  `PreviewBitmapFactory.FromResult(_lastPreview.Raw)` befüllt (Rohdaten liegen in
+  `GeometryExtractResult.Raw : NazcaPreviewResult`).
+- Fenster: kleines **statisches** `Image` (`PreviewBitmap`). Klick → **Popup-Fenster**
+  `ComponentPreviewWindow` mit hochauflösendem Bild und **Mausrad-Zoom am Cursor + Links-Drag-Pan +
+  Scrollen** (Zoom/Pan-Logik analog `DesignCanvas.OnPointerWheelChanged`, angewandt auf ein `Image`
+  mit `ScaleTransform`+`TranslateTransform`; kein voller `DesignCanvas`).
+
+### 3. Ohne S-Matrix speichern (explizit)
+Compute bleibt optional. „Save" ist aktiv, sobald Preview + PDK vorhanden sind (kein Compute-Zwang);
+ohne berechnetes Modell wird als Blackbox gespeichert und der Status sagt klar „gespeichert ohne
+Simulationsmodell (Blackbox)". Keine erfundene Physik.
+
+### 4. Edit/Recompute bestehender custom-Komponente
+- **Einstieg:** custom (nicht-bundled) Komponenten in der linken Library bekommen eine
+  **„Edit…"-Aktion** (Kontextmenü). Foundry-Komponenten bleiben read-only (keine Edit-Aktion).
+- **Prefill:** öffnet das Fenster im **Edit-Modus** — PDK fix auf das besitzende, `ComponentName`
+  gesetzt, `Code` aus `ComponentTemplate.RawCode`, `SelectedBackend` aus `RawCodeBackend`.
+- **Speichern** überschreibt die Komponente im selben PDK (`UserPdkStore.AppendToExistingPdk` ersetzt
+  per Name). Meep-Recompute wie im Create-Flow (langer Lauf später nachholbar).
+- Fenstertitel + Save-Label spiegeln „Edit" vs. „New".
+
+## Architektur / Wiederverwendung
+
+- `PreviewBitmapFactory.FromResult(NazcaPreviewResult, pixels)` (vorhanden) für Thumbnail + Popup.
+- Zoom/Pan-Muster aus `DesignCanvas` (`OnPointerWheelChanged`, delta 1.1/0.9, Clamp 0.1–10, Pan über
+  Cursor-Fokus) — auf ein `Image` im neuen `ComponentPreviewWindow` übertragen.
+- `RunWithLiveStatusAsync`/`Shorten` aus `ComponentSettingsDialogViewModel.Fdtd.cs` (Muster) für den
+  Meep-Live-Status.
+- `NewComponentViewModel.Saved`-Event → Fenster-Close-Wiring.
+- `ComponentTemplate.RawCode`/`RawCodeBackend` (seit #721/#723) für den Edit-Prefill.
+- `UserPdkStore.AppendToExistingPdk` (Overwrite-by-Name) für Edit-Save.
+
+## Neue Dateien (jeweils ≤250 Zeilen)
+- `CAP.Avalonia/Views/ComponentPreviewWindow.axaml(.cs)` — Popup-Viewer mit Zoom/Pan.
+- Ggf. `CAP.Avalonia/Controls/ZoomablePreview.cs` (kleines Control) falls sauberer als Code-behind.
+
+## Fehlerbehandlung
+- Compute-Fehler/Abbruch → roher Solver-Fehler bzw. „abgebrochen"; keine Fake-S-Matrix.
+- Preview-Render-Fehler → kein Thumbnail, klare Meldung; Save bleibt gesperrt (kein Preview).
+- Edit einer Komponente ohne gespeicherten RawCode (z.B. reine Funktionsreferenz-Altbestände) →
+  Code-Feld leer + Hinweis; Nutzer kann Code ergänzen. Foundry-Komponenten: keine Edit-Aktion.
+- `PreviewBitmapFactory` gibt headless evtl. `null` → Thumbnail-Bereich bleibt leer, kein Crash.
+
+## Testing
+- Reopen-Fix: nach simuliertem `CreateNewPdk`-Erfolg + Refresh feuert der Sentinel-Handler NICHT
+  erneut (VM-Test mit Zähler auf dem `CreateNewPdk`-Fake).
+- Compute-Progress: `SolveAsync` wird mit einem `IProgress<string>` aufgerufen; gemeldete Zeilen
+  landen in `StatusText` (Mock-Service, der `progress.Report(...)` aufruft).
+- PreviewBitmap: nach `RunPreview` ist `PreviewBitmap != null` (mit gemocktem Renderer, der ein
+  `NazcaPreviewResult` mit Polygonen liefert) — bzw. dokumentiert headless-null-tolerant.
+- Save ohne Compute → Blackbox-Draft (`SMatrix == null`), StatusText-Hinweis.
+- Edit-Modus: `LoadForEdit(template)` prefillt Name/Code/Backend + fixes PDK; Save → `AppendToExistingPdk`.
+- Zoom/Pan-Popup: nur Laufzeit (Smoke-Test).
+
+## Cross-Platform / Constraints
+`x:DataType`/compiled bindings; kein `Process.Start`; `InvariantCulture`; keine erfundene Physik;
+S-Matrix bleibt DI-Service; max. 250 Zeilen/neue Datei, bestehende ≤500 (VM-Partials nutzen).
+
+## Out of Scope (YAGNI)
+Prozess bestehender PDKs umstellen (#726); Edit/Delete ganzer PDKs; Pop-out des eingebetteten
+Bereichs über das Popup hinaus; Startup-Reload (#700).


### PR DESCRIPTION
## Was & Warum (WIP — Draft, Feld-Test-Feedback zu #723/#727)

- **Bugfix — Reopen:** nach „Create PDK" öffnete sich der modale Prozess-Editor sofort wieder (Sentinel „New PDK…" re-triggerte den Hook nach dem Refresh). → Suppress-Flag.
- **Bugfix — Meep-Fortschritt:** „Compute with Meep" zeigt jetzt Live-Fortschritt (Progress-Stream + Heartbeat) statt nur „S-matrix computed".
- **Bugfix — Save schließt Fenster.**
- **Preview:** kleines statisches Vorschaubild inline; Klick → Popup-Fenster mit Mausrad-Zoom + Links-Drag-Pan + Scrollen.
- **Ohne S-Matrix speichern (explizit):** Compute bleibt optional → Blackbox, klar kommuniziert.
- **Edit/Recompute:** bestehende custom-Komponente über eine „Edit…"-Aktion in der Library wieder öffnen (vorbefüllt), ändern, S-Matrix neu rechnen, überschreibend speichern.

Spec: `docs/superpowers/specs/2026-07-13-new-component-preview-edit-design.md`
Plan: `docs/superpowers/plans/2026-07-13-new-component-preview-edit.md`

## Constraints
Keine erfundene Physik; S-Matrix bleibt DI-Service; Edit nur für custom (nicht-bundled) Komponenten; Foundry-PDKs read-only. Prozess bestehender PDKs umstellen bleibt separat (#726).

## Status (Tasks)
- [ ] T1 Reopen-Guard  - [ ] T2 Meep-Live-Progress  - [ ] T3 PreviewBitmap + Blackbox-Save
- [ ] T4 Popup-Viewer + Thumbnail + Save-Close  - [ ] T5 Edit-Modus VM  - [ ] T6 Library-Edit-Aktion  - [ ] T7 E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)