### PR TITLE
Fix: Platzierungs-Sperre erkennt wertkompatible custom PDKs; PDK-Edit-Fenster nicht doppelt

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/MetalRoutingSpecFactory.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/MetalRoutingSpecFactory.cs
@@ -17,13 +17,25 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
         /// Builds the spec for the design's active process from the loaded PDK drafts.
         /// Null selection (no design yet) or playground mode yields the default spec.
         /// </summary>
+        /// <param name="active">The design's active process selection, or null when unset.</param>
+        /// <param name="loadedPdks">All currently loaded PDK drafts.</param>
+        /// <param name="effectiveMemberPdkNames">
+        /// When non-null, REPLACES <see cref="ActiveProcessSelection.MemberPdkNames"/> as the
+        /// member filter — pass the live by-value member set (see
+        /// <c>LeftPanelViewModel.ResolveLiveMemberPdkNames</c>) so a value-compatible custom PDK
+        /// registered after the snapshot was persisted still contributes its metal
+        /// cross-section / bridge policy to the export (placement-livemembers review, Finding 0).
+        /// Null keeps the snapshot-only lookup.
+        /// </param>
         public static MetalRoutingSpec FromActiveProcess(
-            ActiveProcessSelection? active, IReadOnlyList<PdkDraft>? loadedPdks)
+            ActiveProcessSelection? active, IReadOnlyList<PdkDraft>? loadedPdks,
+            IReadOnlyCollection<string>? effectiveMemberPdkNames = null)
         {
             if (active == null || loadedPdks == null)
                 return MetalRoutingSpec.Default;
 
-            var definitions = active.MemberPdkNames
+            var memberNames = effectiveMemberPdkNames ?? (IEnumerable<string>)active.MemberPdkNames;
+            var definitions = memberNames
                 .Select(name => loadedPdks.FirstOrDefault(
                     d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase))?.Process)
                 .Where(p => p != null)

--- a/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/MetalTraceStyleResolver.cs
@@ -54,13 +54,22 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
         /// </summary>
         /// <param name="active">The design's active process selection.</param>
         /// <param name="loadedPdks">All currently loaded PDK drafts.</param>
+        /// <param name="effectiveMemberPdkNames">
+        /// When non-null, REPLACES <see cref="ActiveProcessSelection.MemberPdkNames"/> as the
+        /// member filter — pass the live by-value member set (see
+        /// <c>LeftPanelViewModel.ResolveLiveMemberPdkNames</c>) so a value-compatible custom PDK
+        /// registered after the snapshot was persisted still contributes its metal cross-section
+        /// (placement-livemembers review, Finding 0). Null keeps the snapshot-only lookup.
+        /// </param>
         public static MetalTraceStyle Resolve(
-            ActiveProcessSelection? active, IReadOnlyList<PdkDraft> loadedPdks)
+            ActiveProcessSelection? active, IReadOnlyList<PdkDraft> loadedPdks,
+            IReadOnlyCollection<string>? effectiveMemberPdkNames = null)
         {
             if (active == null || loadedPdks == null)
                 return MetalTraceStyle.Default;
 
-            var definitions = active.MemberPdkNames
+            var memberNames = effectiveMemberPdkNames ?? (IEnumerable<string>)active.MemberPdkNames;
+            var definitions = memberNames
                 .Select(name => FindByName(loadedPdks, name, d => d.Name)?.Process);
 
             return Resolve(definitions);

--- a/CAP.Avalonia/Services/AiGridService.cs
+++ b/CAP.Avalonia/Services/AiGridService.cs
@@ -34,7 +34,7 @@ public class AiGridService : IAiGridService
     /// By-value-compatible member PDK names for the active process (issue placement-livemembers),
     /// mirroring <c>CanvasInteractionViewModel.GetLiveMemberPdkNames</c> so the AI placement path
     /// obeys the same by-value process lock as manual placement (#732). Wired by
-    /// <c>MainViewModel</c> to <c>LeftPanelViewModel.GetLiveMemberPdkNames</c>.
+    /// <c>MainViewModel</c> to <c>LeftPanelViewModel.ResolveLiveMemberPdkNames</c>.
     /// </summary>
     public Func<IReadOnlyCollection<string>?>? GetLiveMemberPdkNames { get; set; }
 

--- a/CAP.Avalonia/Services/AiGridService.cs
+++ b/CAP.Avalonia/Services/AiGridService.cs
@@ -31,6 +31,14 @@ public class AiGridService : IAiGridService
     public Func<IReadOnlyCollection<string>>? GetProcessAgnosticPdkNames { get; set; }
 
     /// <summary>
+    /// By-value-compatible member PDK names for the active process (issue placement-livemembers),
+    /// mirroring <c>CanvasInteractionViewModel.GetLiveMemberPdkNames</c> so the AI placement path
+    /// obeys the same by-value process lock as manual placement (#732). Wired by
+    /// <c>MainViewModel</c> to <c>LeftPanelViewModel.GetLiveMemberPdkNames</c>.
+    /// </summary>
+    public Func<IReadOnlyCollection<string>?>? GetLiveMemberPdkNames { get; set; }
+
+    /// <summary>
     /// Resolves a placed core component's PDK source from the loaded library
     /// (see <c>ComponentPdkSourceResolver</c>). Needed so copying a GROUP via the AI
     /// path checks the group's children instead of the group's null source (#653).
@@ -48,7 +56,8 @@ public class AiGridService : IAiGridService
     private (bool IsAllowed, string? BlockReason) CheckProcess(string? pdkSource) =>
         SingleProcessPolicy.CheckPlacement(
             GetActiveProcess?.Invoke(), pdkSource,
-            GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>());
+            GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>(),
+            GetLiveMemberPdkNames?.Invoke());
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/CAP.Avalonia/Services/AiGridService.cs
+++ b/CAP.Avalonia/Services/AiGridService.cs
@@ -53,11 +53,26 @@ public class AiGridService : IAiGridService
     /// </summary>
     public IDictionary<string, NazcaCodeOverride>? NazcaOverrideStore { get; set; }
 
-    private (bool IsAllowed, string? BlockReason) CheckProcess(string? pdkSource) =>
-        SingleProcessPolicy.CheckPlacement(
-            GetActiveProcess?.Invoke(), pdkSource,
-            GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>(),
-            GetLiveMemberPdkNames?.Invoke());
+    /// <summary>
+    /// Snapshot of the process-guard inputs (active process, agnostic tool PDKs, live by-value
+    /// member set), resolved ONCE per public entry point and reused across per-template /
+    /// per-clipboard-item loops — re-invoking the callbacks per candidate made
+    /// <see cref="GetAvailableComponentTypes"/> O(Templates × PDKs) (review Finding 5).
+    /// Short-lived (one call); never cached across calls, so it can't go stale.
+    /// </summary>
+    private sealed record ProcessGuard(
+        ActiveProcessSelection? Active,
+        IReadOnlyCollection<string> AgnosticPdkNames,
+        IReadOnlyCollection<string>? LiveMemberPdkNames);
+
+    /// <summary>Resolves the guard inputs from the wired callbacks (see <see cref="ProcessGuard"/>).</summary>
+    private ProcessGuard ResolveProcessGuard() => new(
+        GetActiveProcess?.Invoke(),
+        GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>(),
+        GetLiveMemberPdkNames?.Invoke());
+
+    private static (bool IsAllowed, string? BlockReason) CheckProcess(string? pdkSource, ProcessGuard guard) =>
+        SingleProcessPolicy.CheckPlacement(guard.Active, pdkSource, guard.AgnosticPdkNames, guard.LiveMemberPdkNames);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -136,7 +151,7 @@ public class AiGridService : IAiGridService
 
         // Single-process enforcement (issue #570): the AI path must not bypass the
         // same gate manual placement goes through.
-        var (isAllowed, blockReason) = CheckProcess(template.PdkSource);
+        var (isAllowed, blockReason) = CheckProcess(template.PdkSource, ResolveProcessGuard());
         if (!isAllowed)
             return blockReason ?? $"Cannot place '{componentType}' — it belongs to another process.";
 
@@ -226,10 +241,13 @@ public class AiGridService : IAiGridService
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<string> GetAvailableComponentTypes() =>
-        _leftPanel.AllTemplates
-            .Where(t => CheckProcess(t.PdkSource).IsAllowed)
+    public IReadOnlyList<string> GetAvailableComponentTypes()
+    {
+        var guard = ResolveProcessGuard();
+        return _leftPanel.AllTemplates
+            .Where(t => CheckProcess(t.PdkSource, guard).IsAllowed)
             .Select(t => t.Name).Distinct().ToList();
+    }
 
     /// <inheritdoc/>
     public string CreateGroup(IReadOnlyList<string> componentIds, string? groupName = null)
@@ -347,8 +365,9 @@ public class AiGridService : IAiGridService
 
         // Single-process enforcement (issues #570/#653) — mirrors the paste gate;
         // PeekPdkSources expands groups to their resolved children.
+        var guard = ResolveProcessGuard();
         var copyBlockReason = tempClipboard.PeekPdkSources()
-            .Select(pdk => CheckProcess(pdk))
+            .Select(pdk => CheckProcess(pdk, guard))
             .Where(check => !check.IsAllowed)
             .Select(check => check.BlockReason)
             .FirstOrDefault();

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -292,11 +292,18 @@ public partial class MainViewModel : ObservableObject
         // their own, so children are resolved against the loaded library).
         Func<ActiveProcessSelection?> getActiveProcess = () => FileOperations.ActiveProcess;
         Func<IReadOnlyCollection<string>> getAgnosticPdkNames = () => LeftPanel.GetProcessAgnosticPdkNames();
+        // By-value member PDKs for the active process (issue placement-livemembers, #732): a
+        // custom PDK registered after the process was saved is missing from its persisted
+        // MemberPdkNames snapshot but may still be the same process by value — this recomputes
+        // the allowed set live against the current catalog, same as the library-filter lock.
+        Func<IReadOnlyCollection<string>?> getLiveMemberPdkNames = () =>
+            FileOperations.ActiveProcess is { } activeProcess ? LeftPanel.GetLiveMemberPdkNames(activeProcess) : null;
         Func<CAP_Core.Components.Core.Component, string?> resolvePdkSource = component =>
             ViewModels.Library.ComponentPdkSourceResolver.Resolve(component, LeftPanel.AllTemplates);
 
         CanvasInteraction.GetActiveProcess = getActiveProcess;
         CanvasInteraction.GetProcessAgnosticPdkNames = getAgnosticPdkNames;
+        CanvasInteraction.GetLiveMemberPdkNames = getLiveMemberPdkNames;
         CanvasInteraction.ResolveComponentPdkSource = resolvePdkSource;
         _canvas.Clipboard.PdkSourceResolver = resolvePdkSource;
 
@@ -309,6 +316,7 @@ public partial class MainViewModel : ObservableObject
         {
             aiGrid.GetActiveProcess = getActiveProcess;
             aiGrid.GetProcessAgnosticPdkNames = getAgnosticPdkNames;
+            aiGrid.GetLiveMemberPdkNames = getLiveMemberPdkNames;
             aiGrid.ResolveComponentPdkSource = resolvePdkSource;
             aiGrid.NazcaOverrideStore = FileOperations.StoredNazcaOverrides;
         }

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -259,11 +259,22 @@ public partial class MainViewModel : ObservableObject
         GdsFactoryExport = gdsFactoryExport;
         // gdsfactory export honours gdsfactory-backend overrides from the design's store.
         GdsFactoryExport.OverridesProvider = () => FileOperations.StoredNazcaOverrides;
+        // By-value member PDKs for the active process (issue placement-livemembers, #732): a
+        // custom PDK registered after the process was saved is missing from its persisted
+        // MemberPdkNames snapshot but may still be the same process by value — this recomputes
+        // the allowed set live against the current catalog, same as the library-filter lock.
+        // Shared by the placement guards below AND the metal-spec providers, so placement and
+        // export agree on membership.
+        Func<IReadOnlyCollection<string>?> getLiveMemberPdkNames = () =>
+            FileOperations.ActiveProcess is { } activeProcess ? LeftPanel.ResolveLiveMemberPdkNames(activeProcess) : null;
+
         // Electrical metal routing spec (#682): trace width / layers / crossing policy come
         // from the active process's metal cross-section; both exporters share one provider.
+        // The live member set replaces the stale snapshot so a live-allowed custom PDK's metal
+        // xsection / bridge policy reaches the export (review Finding 0).
         Func<CAP_Core.Routing.MetalRouting.MetalRoutingSpec> metalSpecProvider = () =>
             CAP_DataAccess.Components.ComponentDraftMapper.MetalRoutingSpecFactory.FromActiveProcess(
-                FileOperations.ActiveProcess, LeftPanel.GetLoadedPdkDrafts());
+                FileOperations.ActiveProcess, LeftPanel.GetLoadedPdkDrafts(), getLiveMemberPdkNames());
         FileOperations.MetalRoutingSpecProvider = metalSpecProvider;
         GdsFactoryExport.MetalRoutingSpecProvider = metalSpecProvider;
         // Let a Nazca export that hits gdsfactory-native components hand off to the gdsfactory export.
@@ -292,12 +303,6 @@ public partial class MainViewModel : ObservableObject
         // their own, so children are resolved against the loaded library).
         Func<ActiveProcessSelection?> getActiveProcess = () => FileOperations.ActiveProcess;
         Func<IReadOnlyCollection<string>> getAgnosticPdkNames = () => LeftPanel.GetProcessAgnosticPdkNames();
-        // By-value member PDKs for the active process (issue placement-livemembers, #732): a
-        // custom PDK registered after the process was saved is missing from its persisted
-        // MemberPdkNames snapshot but may still be the same process by value — this recomputes
-        // the allowed set live against the current catalog, same as the library-filter lock.
-        Func<IReadOnlyCollection<string>?> getLiveMemberPdkNames = () =>
-            FileOperations.ActiveProcess is { } activeProcess ? LeftPanel.ResolveLiveMemberPdkNames(activeProcess) : null;
         Func<CAP_Core.Components.Core.Component, string?> resolvePdkSource = component =>
             ViewModels.Library.ComponentPdkSourceResolver.Resolve(component, LeftPanel.AllTemplates);
 

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -297,7 +297,7 @@ public partial class MainViewModel : ObservableObject
         // MemberPdkNames snapshot but may still be the same process by value — this recomputes
         // the allowed set live against the current catalog, same as the library-filter lock.
         Func<IReadOnlyCollection<string>?> getLiveMemberPdkNames = () =>
-            FileOperations.ActiveProcess is { } activeProcess ? LeftPanel.GetLiveMemberPdkNames(activeProcess) : null;
+            FileOperations.ActiveProcess is { } activeProcess ? LeftPanel.ResolveLiveMemberPdkNames(activeProcess) : null;
         Func<CAP_Core.Components.Core.Component, string?> resolvePdkSource = component =>
             ViewModels.Library.ComponentPdkSourceResolver.Resolve(component, LeftPanel.AllTemplates);
 

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -129,7 +129,7 @@ public partial class CanvasInteractionViewModel : ObservableObject
     /// trusting the persisted <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot
     /// (#732). This is what allows a custom PDK registered after the process was saved — but
     /// physically the same process — to be placed/pasted. Wired by <c>MainViewModel</c> to
-    /// <c>LeftPanelViewModel.GetLiveMemberPdkNames</c>; null when unwired falls back to the
+    /// <c>LeftPanelViewModel.ResolveLiveMemberPdkNames</c>; null when unwired falls back to the
     /// snapshot-only check.
     /// </summary>
     public Func<IReadOnlyCollection<string>?>? GetLiveMemberPdkNames { get; set; }

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -124,6 +124,17 @@ public partial class CanvasInteractionViewModel : ObservableObject
     public Func<IReadOnlyCollection<string>>? GetProcessAgnosticPdkNames { get; set; }
 
     /// <summary>
+    /// Callback returning the by-value-compatible member PDK names for the active process
+    /// (issue placement-livemembers), computed live against the current PDK catalog rather than
+    /// trusting the persisted <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot
+    /// (#732). This is what allows a custom PDK registered after the process was saved — but
+    /// physically the same process — to be placed/pasted. Wired by <c>MainViewModel</c> to
+    /// <c>LeftPanelViewModel.GetLiveMemberPdkNames</c>; null when unwired falls back to the
+    /// snapshot-only check.
+    /// </summary>
+    public Func<IReadOnlyCollection<string>?>? GetLiveMemberPdkNames { get; set; }
+
+    /// <summary>
     /// Callback resolving the PDK source of a placed core component (groups carry none of
     /// their own, so their children are resolved individually — issue #653). Wired by
     /// <c>MainViewModel</c> to <c>ComponentPdkSourceResolver.Resolve</c> over the loaded
@@ -357,7 +368,8 @@ public partial class CanvasInteractionViewModel : ObservableObject
 
         var (isAllowed, blockReason) = SingleProcessPolicy.CheckPlacement(
             GetActiveProcess?.Invoke(), SelectedTemplate.PdkSource,
-            GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>());
+            GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>(),
+            GetLiveMemberPdkNames?.Invoke());
         if (!isAllowed)
         {
             UpdateStatus?.Invoke(blockReason ?? "Process mismatch — cannot place component.");
@@ -395,6 +407,7 @@ public partial class CanvasInteractionViewModel : ObservableObject
             GetActiveProcess?.Invoke(),
             ChildPdkSources(SelectedGroupTemplate.TemplateGroup),
             GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>(),
+            GetLiveMemberPdkNames?.Invoke(),
             SelectedGroupTemplate.Name);
         if (!isAllowed)
         {
@@ -765,11 +778,12 @@ public partial class CanvasInteractionViewModel : ObservableObject
 
         var active = GetActiveProcess?.Invoke();
         var agnosticPdkNames = GetProcessAgnosticPdkNames?.Invoke() ?? Array.Empty<string>();
+        var liveMemberPdkNames = GetLiveMemberPdkNames?.Invoke();
         // PeekPdkSources expands groups to their resolved children (the clipboard's
         // PdkSourceResolver is wired by MainViewModel), so a copied group cannot
         // smuggle foreign-process components past the paste guard (issue #653).
         var blockedCount = _canvas.Clipboard.PeekPdkSources()
-            .Count(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, agnosticPdkNames).IsAllowed);
+            .Count(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, agnosticPdkNames, liveMemberPdkNames).IsAllowed);
         if (blockedCount > 0)
         {
             UpdateStatus?.Invoke(

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.ProcessLock.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.ProcessLock.cs
@@ -104,6 +104,18 @@ public partial class LeftPanelViewModel
     }
 
     /// <summary>
+    /// Public accessor for <see cref="ResolveLiveMemberPdkNames"/>, so placement/paste/AI-grid
+    /// callers can consult the same by-value member set the library-filter lock above uses,
+    /// instead of trusting <paramref name="active"/>'s persisted
+    /// <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot (issue placement-livemembers,
+    /// building on #732). Internal — wired by <c>MainViewModel</c> into
+    /// <c>CanvasInteractionViewModel.GetLiveMemberPdkNames</c> and
+    /// <c>AiGridService.GetLiveMemberPdkNames</c>; <c>UnitTests</c> has InternalsVisibleTo.
+    /// </summary>
+    internal IReadOnlyList<string> GetLiveMemberPdkNames(ActiveProcessSelection active) =>
+        ResolveLiveMemberPdkNames(active);
+
+    /// <summary>
     /// The most recently applied process selection. Re-applied when a PDK is loaded
     /// afterwards, so importing a PDK while a process is locked cannot slip foreign
     /// components into the library (issue #570).

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.ProcessLock.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.ProcessLock.cs
@@ -90,8 +90,16 @@ public partial class LeftPanelViewModel
     /// Falls back to the snapshot when there is no fingerprint to match (legacy selections), so
     /// ordinary behavior is unchanged. The persisted snapshot itself is never mutated — this only
     /// affects the runtime lock computed here.
+    /// <para>
+    /// Internal (not private): besides the library-filter lock above, the placement/paste/AI-grid
+    /// guards consult this same set (wired by <c>MainViewModel</c> into
+    /// <c>CanvasInteractionViewModel.GetLiveMemberPdkNames</c> and
+    /// <c>AiGridService.GetLiveMemberPdkNames</c>, plus the metal-spec providers), so the library
+    /// filter and every placement surface always agree on membership. <c>UnitTests</c> has
+    /// InternalsVisibleTo.
+    /// </para>
     /// </summary>
-    private IReadOnlyList<string> ResolveLiveMemberPdkNames(ActiveProcessSelection active)
+    internal IReadOnlyList<string> ResolveLiveMemberPdkNames(ActiveProcessSelection active)
     {
         if (active.Fingerprint is not { IsSpecified: true } fingerprint)
             return active.MemberPdkNames;
@@ -102,18 +110,6 @@ public partial class LeftPanelViewModel
             .Select(e => e.PdkName)
             .ToList();
     }
-
-    /// <summary>
-    /// Public accessor for <see cref="ResolveLiveMemberPdkNames"/>, so placement/paste/AI-grid
-    /// callers can consult the same by-value member set the library-filter lock above uses,
-    /// instead of trusting <paramref name="active"/>'s persisted
-    /// <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot (issue placement-livemembers,
-    /// building on #732). Internal — wired by <c>MainViewModel</c> into
-    /// <c>CanvasInteractionViewModel.GetLiveMemberPdkNames</c> and
-    /// <c>AiGridService.GetLiveMemberPdkNames</c>; <c>UnitTests</c> has InternalsVisibleTo.
-    /// </summary>
-    internal IReadOnlyList<string> GetLiveMemberPdkNames(ActiveProcessSelection active) =>
-        ResolveLiveMemberPdkNames(active);
 
     /// <summary>
     /// The most recently applied process selection. Re-applied when a PDK is loaded

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -722,10 +722,15 @@ public partial class MainWindow : Window
             return;
 
         // Dedup: a second click on the same PDK's "Edit…" button re-activates the
-        // already-open editor instead of spawning a duplicate window.
+        // already-open editor instead of spawning a duplicate window. Deliberately shows the
+        // window's CURRENT (possibly unsaved) editor state rather than reloading the draft —
+        // reloading would silently destroy the user's in-progress edits.
         var key = pdk.FilePath ?? pdk.Name;
         if (_openPdkEditWindows.TryGetValue(key, out var existingWindow) && existingWindow.IsVisible)
         {
+            // Un-minimize first: Activate() alone leaves a minimized window minimized,
+            // which looks like the button silently did nothing.
+            existingWindow.WindowState = WindowState.Normal;
             existingWindow.Activate();
             return;
         }
@@ -757,7 +762,14 @@ public partial class MainWindow : Window
             Title = $"Edit Process — {pdk.Name}",
         };
         _openPdkEditWindows[key] = processWindow;
-        processWindow.Closed += (_, _) => _openPdkEditWindows.Remove(key);
+        // Only remove the entry if it still points at THIS window: if the key was ever
+        // re-assigned to a newer window, the older window's Closed handler must not
+        // deregister the newer one.
+        processWindow.Closed += (_, _) =>
+        {
+            if (_openPdkEditWindows.TryGetValue(key, out var tracked) && ReferenceEquals(tracked, processWindow))
+                _openPdkEditWindows.Remove(key);
+        };
         processWindow.Show(this);
     }
 

--- a/CAP.Avalonia/Views/MainWindow.axaml.cs
+++ b/CAP.Avalonia/Views/MainWindow.axaml.cs
@@ -28,6 +28,15 @@ public partial class MainWindow : Window
 {
     private SettingsWindow? _settingsWindow;
 
+    /// <summary>
+    /// Tracks the currently-open per-PDK "Edit Process" window, keyed by the PDK's
+    /// file path (falling back to its name when the path is null, e.g. an
+    /// unsaved draft). Prevents a second click on the same PDK's "Edit…" button
+    /// from opening a duplicate editor window — the existing one is activated
+    /// instead. Entries are removed when their window closes.
+    /// </summary>
+    private readonly System.Collections.Generic.Dictionary<string, ProcessManagementWindow> _openPdkEditWindows = new();
+
     public MainWindow()
     {
         InitializeComponent();
@@ -712,6 +721,15 @@ public partial class MainWindow : Window
         if (draft is null)
             return;
 
+        // Dedup: a second click on the same PDK's "Edit…" button re-activates the
+        // already-open editor instead of spawning a duplicate window.
+        var key = pdk.FilePath ?? pdk.Name;
+        if (_openPdkEditWindows.TryGetValue(key, out var existingWindow) && existingWindow.IsVisible)
+        {
+            existingWindow.Activate();
+            return;
+        }
+
         var processVm = new ProcessManagementViewModel(new FileDialogService(this))
         {
             // Resolve straight to this row's own file path — no name-based lookup needed since
@@ -738,6 +756,8 @@ public partial class MainWindow : Window
             DataContext = processVm,
             Title = $"Edit Process — {pdk.Name}",
         };
+        _openPdkEditWindows[key] = processWindow;
+        processWindow.Closed += (_, _) => _openPdkEditWindows.Remove(key);
         processWindow.Show(this);
     }
 

--- a/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
@@ -25,7 +25,8 @@ public static class GroupProcessPolicy
     /// <param name="liveMemberPdkNames">
     /// By-value-compatible member PDK names for <paramref name="active"/>, forwarded verbatim to
     /// <see cref="SingleProcessPolicy.CheckPlacement"/> for each child — see that method's
-    /// parameter doc (issue #732). Null falls back to the persisted snapshot only.
+    /// parameter doc (issue #732). Non-null REPLACES the persisted snapshot as the membership
+    /// authority; null falls back to the snapshot.
     /// </param>
     /// <param name="groupName">Display name of the group, used in the block message.</param>
     public static (bool IsAllowed, string? BlockReason) CheckGroupPlacement(

--- a/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
@@ -22,15 +22,21 @@ public static class GroupProcessPolicy
     /// <param name="active">The design's active process selection, or null when unset.</param>
     /// <param name="childPdkSources">PDK source of every child component (null = built-in/unknown).</param>
     /// <param name="processAgnosticPdkNames">Names of PDKs flagged process-agnostic (tool libraries).</param>
+    /// <param name="liveMemberPdkNames">
+    /// By-value-compatible member PDK names for <paramref name="active"/>, forwarded verbatim to
+    /// <see cref="SingleProcessPolicy.CheckPlacement"/> for each child — see that method's
+    /// parameter doc (issue #732). Null falls back to the persisted snapshot only.
+    /// </param>
     /// <param name="groupName">Display name of the group, used in the block message.</param>
     public static (bool IsAllowed, string? BlockReason) CheckGroupPlacement(
         ActiveProcessSelection? active,
         IEnumerable<string?> childPdkSources,
         IReadOnlyCollection<string>? processAgnosticPdkNames = null,
+        IReadOnlyCollection<string>? liveMemberPdkNames = null,
         string? groupName = null)
     {
         var blockedPdkNames = childPdkSources
-            .Where(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, processAgnosticPdkNames).IsAllowed)
+            .Where(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, processAgnosticPdkNames, liveMemberPdkNames).IsAllowed)
             .Select(pdk => pdk!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();

--- a/Connect-A-Pic-Core/Components/Process/SingleProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/SingleProcessPolicy.cs
@@ -31,22 +31,25 @@ public static class SingleProcessPolicy
     /// Decides whether a component from <paramref name="componentPdkName"/> may be placed on a
     /// design locked to <paramref name="active"/>. Built-ins, process-agnostic PDKs (tool
     /// libraries such as "Analysis Tools" — see <paramref name="processAgnosticPdkNames"/>),
-    /// Playground, and an unset selection always pass; otherwise the component's PDK must be a
-    /// member of the active process — either in the persisted <paramref name="active"/>
-    /// snapshot or in <paramref name="liveMemberPdkNames"/>.
+    /// Playground, and an unset selection always pass; otherwise the component's PDK must be an
+    /// effective member of the active process: <paramref name="liveMemberPdkNames"/> when
+    /// provided, else the persisted <paramref name="active"/> snapshot.
     /// </summary>
     /// <param name="active">The design's active process selection, or null when unset.</param>
     /// <param name="componentPdkName">PDK source of the component being placed.</param>
     /// <param name="processAgnosticPdkNames">Names of PDKs flagged process-agnostic (tool libraries).</param>
     /// <param name="liveMemberPdkNames">
     /// The by-value-compatible member PDK names for <paramref name="active"/>, recomputed against
-    /// the live catalog (see <c>LeftPanelViewModel.GetLiveMemberPdkNames</c>, issue #732) rather
-    /// than trusted from <paramref name="active"/>'s persisted
-    /// <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot. That snapshot is fixed at the
-    /// moment the process was selected/saved with the design, so a custom PDK registered
-    /// afterward — even one that is physically the same process — is missing from it and would
-    /// stay locked out forever without this live set. Null (unwired caller) falls back to the
-    /// snapshot only, preserving prior behavior.
+    /// the live catalog (see <c>LeftPanelViewModel.ResolveLiveMemberPdkNames</c>, issue #732).
+    /// When non-null it REPLACES the persisted <see cref="ActiveProcessSelection.MemberPdkNames"/>
+    /// snapshot as the membership authority — not a union with it. Both directions matter: the
+    /// snapshot is frozen when the process is saved with the design, so a value-compatible custom
+    /// PDK registered afterward exists only in the live set (would otherwise stay locked out
+    /// forever), and a snapshot member whose process was edited into incompatibility afterward is
+    /// absent from the live set (a snapshot-OR-live union would keep it pasteable while the
+    /// library filter correctly hides it). The live resolution itself already falls back to the
+    /// snapshot when the active process has no computable fingerprint. Null (unwired caller)
+    /// falls back to the snapshot, preserving prior behavior.
     /// </param>
     public static (bool IsAllowed, string? BlockReason) CheckPlacement(
         ActiveProcessSelection? active, string? componentPdkName,
@@ -59,10 +62,8 @@ public static class SingleProcessPolicy
         if (active == null || active.IsPlayground)
             return (true, null);
 
-        if (active.MemberPdkNames.Contains(componentPdkName!, StringComparer.OrdinalIgnoreCase))
-            return (true, null);
-
-        if (liveMemberPdkNames?.Contains(componentPdkName!, StringComparer.OrdinalIgnoreCase) ?? false)
+        var effectiveMembers = liveMemberPdkNames ?? (IEnumerable<string>)active.MemberPdkNames;
+        if (effectiveMembers.Contains(componentPdkName!, StringComparer.OrdinalIgnoreCase))
             return (true, null);
 
         return (false,

--- a/Connect-A-Pic-Core/Components/Process/SingleProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/SingleProcessPolicy.cs
@@ -32,11 +32,26 @@ public static class SingleProcessPolicy
     /// design locked to <paramref name="active"/>. Built-ins, process-agnostic PDKs (tool
     /// libraries such as "Analysis Tools" — see <paramref name="processAgnosticPdkNames"/>),
     /// Playground, and an unset selection always pass; otherwise the component's PDK must be a
-    /// member of the active process.
+    /// member of the active process — either in the persisted <paramref name="active"/>
+    /// snapshot or in <paramref name="liveMemberPdkNames"/>.
     /// </summary>
+    /// <param name="active">The design's active process selection, or null when unset.</param>
+    /// <param name="componentPdkName">PDK source of the component being placed.</param>
+    /// <param name="processAgnosticPdkNames">Names of PDKs flagged process-agnostic (tool libraries).</param>
+    /// <param name="liveMemberPdkNames">
+    /// The by-value-compatible member PDK names for <paramref name="active"/>, recomputed against
+    /// the live catalog (see <c>LeftPanelViewModel.GetLiveMemberPdkNames</c>, issue #732) rather
+    /// than trusted from <paramref name="active"/>'s persisted
+    /// <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot. That snapshot is fixed at the
+    /// moment the process was selected/saved with the design, so a custom PDK registered
+    /// afterward — even one that is physically the same process — is missing from it and would
+    /// stay locked out forever without this live set. Null (unwired caller) falls back to the
+    /// snapshot only, preserving prior behavior.
+    /// </param>
     public static (bool IsAllowed, string? BlockReason) CheckPlacement(
         ActiveProcessSelection? active, string? componentPdkName,
-        IReadOnlyCollection<string>? processAgnosticPdkNames = null)
+        IReadOnlyCollection<string>? processAgnosticPdkNames = null,
+        IReadOnlyCollection<string>? liveMemberPdkNames = null)
     {
         if (IsExempt(componentPdkName, processAgnosticPdkNames))
             return (true, null);
@@ -45,6 +60,9 @@ public static class SingleProcessPolicy
             return (true, null);
 
         if (active.MemberPdkNames.Contains(componentPdkName!, StringComparer.OrdinalIgnoreCase))
+            return (true, null);
+
+        if (liveMemberPdkNames?.Contains(componentPdkName!, StringComparer.OrdinalIgnoreCase) ?? false)
             return (true, null);
 
         return (false,

--- a/UnitTests/AI/AiGridServiceTests.cs
+++ b/UnitTests/AI/AiGridServiceTests.cs
@@ -118,6 +118,34 @@ public class AiGridServiceTests
         result.ShouldContain("\"connections\"");
     }
 
+    /// <summary>
+    /// Review Finding [5] (placement-livemembers): CheckProcess used to re-invoke the
+    /// GetLiveMemberPdkNames / GetProcessAgnosticPdkNames callbacks per template, making
+    /// GetAvailableComponentTypes O(Templates x PDKs) — the guard inputs must be resolved
+    /// once per public entry point and reused across the loop.
+    /// </summary>
+    [Fact]
+    public void GetAvailableComponentTypes_ResolvesProcessGuardOncePerCall_NotPerTemplate()
+    {
+        for (var i = 0; i < 5; i++)
+            _leftPanel.AllTemplates.Add(new ComponentTemplate { Name = $"T{i}", Category = "Test", PdkSource = "MyLib" });
+
+        var liveCalls = 0;
+        var agnosticCalls = 0;
+        _svc.GetActiveProcess = () => CAP_Core.Components.Process.ActiveProcessSelection.ForGroup(
+            new CAP_Core.Components.Process.ProcessGroup(
+                "SOI 220", new CAP_Core.Components.Process.ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"),
+                new[] { "Demo" }));
+        _svc.GetProcessAgnosticPdkNames = () => { agnosticCalls++; return Array.Empty<string>(); };
+        _svc.GetLiveMemberPdkNames = () => { liveCalls++; return new[] { "MyLib" }; };
+
+        var types = _svc.GetAvailableComponentTypes();
+
+        types.Count.ShouldBe(5, "all templates are live members and must pass the guard");
+        liveCalls.ShouldBe(1, "the live member set must be resolved once per call, not per template");
+        agnosticCalls.ShouldBe(1, "the agnostic set must be resolved once per call, not per template");
+    }
+
     [Fact]
     public void ClearGrid_EmptyCanvas_ReportsZeroRemovedComponents()
     {

--- a/UnitTests/Components/AddCustomComponent/CustomPdkVisibilityTests.cs
+++ b/UnitTests/Components/AddCustomComponent/CustomPdkVisibilityTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Hierarchy;
@@ -30,6 +31,7 @@ public class CustomPdkVisibilityTests : IDisposable
     private readonly string _testPrefsPath;
     private readonly string _userPdkRoot;
     private readonly LeftPanelViewModel _leftPanel;
+    private readonly DesignCanvasViewModel _canvas;
 
     public CustomPdkVisibilityTests()
     {
@@ -37,14 +39,29 @@ public class CustomPdkVisibilityTests : IDisposable
         _userPdkRoot = Path.Combine(Path.GetTempPath(), $"CustomPdkVisibilityUserPdks_{Guid.NewGuid():N}");
 
         var preferencesService = new UserPreferencesService(_testPrefsPath);
-        var canvas = new DesignCanvasViewModel();
+        _canvas = new DesignCanvasViewModel();
         var groupLibrary = new GroupLibraryManager();
         var pdkLoader = new PdkLoader();
 
-        _leftPanel = new LeftPanelViewModel(canvas, groupLibrary, pdkLoader, preferencesService,
-            new HierarchyPanelViewModel(canvas), new PdkManagerViewModel(),
+        _leftPanel = new LeftPanelViewModel(_canvas, groupLibrary, pdkLoader, preferencesService,
+            new HierarchyPanelViewModel(_canvas), new PdkManagerViewModel(),
             new ComponentLibraryViewModel(groupLibrary));
         _leftPanel.Initialize();
+    }
+
+    /// <summary>
+    /// Wires a <see cref="CanvasInteractionViewModel"/> the way <c>MainViewModel</c> does for
+    /// the placement guard (issue placement-livemembers): active process + live by-value
+    /// member set both sourced from <paramref name="active"/> and the live PDK catalog, so the
+    /// placement path sees exactly what the library-filter lock already sees (#732).
+    /// </summary>
+    private CanvasInteractionViewModel CreatePlacementInteraction(ActiveProcessSelection active)
+    {
+        var interaction = new CanvasInteractionViewModel(_canvas, new CommandManager());
+        interaction.GetActiveProcess = () => active;
+        interaction.GetProcessAgnosticPdkNames = () => _leftPanel.GetProcessAgnosticPdkNames();
+        interaction.GetLiveMemberPdkNames = () => _leftPanel.GetLiveMemberPdkNames(active);
+        return interaction;
     }
 
     public void Dispose()
@@ -62,8 +79,12 @@ public class CustomPdkVisibilityTests : IDisposable
     private string DemoPdkName() =>
         _leftPanel.PdkManager.LoadedPdks.First(p => p.Name.Contains("Demo", StringComparison.OrdinalIgnoreCase)).Name;
 
-    /// <summary>Locks the library to a real process built from the bundled Demo PDK's own fingerprint.</summary>
-    private void ApplyDemoProcessLock()
+    /// <summary>
+    /// Locks the library to a real process built from the bundled Demo PDK's own fingerprint.
+    /// Returns the applied selection so callers can reuse the identical snapshot (e.g. to feed
+    /// <see cref="LeftPanelViewModel.GetLiveMemberPdkNames"/> the same way <c>MainViewModel</c> does).
+    /// </summary>
+    private ActiveProcessSelection ApplyDemoProcessLock()
     {
         var demoName = DemoPdkName();
         var demoDraft = _leftPanel.GetLoadedPdkDrafts().First(d => d.Name == demoName);
@@ -79,6 +100,7 @@ public class CustomPdkVisibilityTests : IDisposable
             IsPlayground: false);
 
         _leftPanel.ApplyActiveProcess(active);
+        return active;
     }
 
     private static PdkComponentDraft SimpleComponent(string name) => new()
@@ -156,6 +178,79 @@ public class CustomPdkVisibilityTests : IDisposable
 
         _leftPanel.FilteredTemplates.ShouldNotContain(t => t.PdkSource == "ForeignLib",
             "the value-incompatible PDK's component must not leak into the filtered library");
+    }
+
+    /// <summary>
+    /// Reproduces the field bug directly at the placement guard (not just the library filter):
+    /// a component from a value-compatible custom PDK registered after the process was saved
+    /// must be placeable via <see cref="CanvasInteractionViewModel.PlaceComponentAt"/>, using the
+    /// live member set from <see cref="LeftPanelViewModel.GetLiveMemberPdkNames"/> rather than the
+    /// stale <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot.
+    /// </summary>
+    [Fact]
+    public void ValueCompatibleCustomPdk_IsPlaceable_ViaCanvasInteractionViewModel()
+    {
+        var active = ApplyDemoProcessLock();
+
+        var compatibleProcess = new ProcessDefinition
+        {
+            Name = "MyLib Process",
+            CoreThicknessNm = 222,
+            Materials = new List<ProcessMaterial>
+            {
+                new() { Name = "Si", Role = "core" },
+                new() { Name = "SiO2", Role = "cladding" },
+            },
+        };
+
+        var store = new UserPdkStore(_userPdkRoot, new PdkJsonSaver(), new PdkLoader());
+        var component = SimpleComponent("MyLib Straight");
+        var path = store.SaveToNamedPdk("MyLib", compatibleProcess, component, "nazca", null);
+        _leftPanel.RegisterSavedCustomComponent(component, "MyLib", path);
+
+        var template = _leftPanel.AllTemplates.Single(t => t.PdkSource == "MyLib");
+        var interaction = CreatePlacementInteraction(active);
+        interaction.SelectedTemplate = template;
+
+        interaction.CanvasClicked(100, 100);
+
+        _canvas.Components.Count.ShouldBe(1,
+            "a value-compatible custom PDK registered after the process snapshot was taken must be placeable");
+    }
+
+    /// <summary>Mirror of the above with a value-INCOMPATIBLE custom PDK — must stay blocked.</summary>
+    [Fact]
+    public void ValueIncompatibleCustomPdk_IsBlocked_ViaCanvasInteractionViewModel()
+    {
+        var active = ApplyDemoProcessLock();
+
+        var foreignProcess = new ProcessDefinition
+        {
+            Name = "Foreign Process",
+            CoreThicknessNm = 300,
+            Materials = new List<ProcessMaterial>
+            {
+                new() { Name = "Si3N4", Role = "core" },
+                new() { Name = "SiO2", Role = "cladding" },
+            },
+        };
+
+        var store = new UserPdkStore(_userPdkRoot, new PdkJsonSaver(), new PdkLoader());
+        var component = SimpleComponent("ForeignLib Straight");
+        var path = store.SaveToNamedPdk("ForeignLib", foreignProcess, component, "nazca", null);
+        _leftPanel.RegisterSavedCustomComponent(component, "ForeignLib", path);
+
+        var template = _leftPanel.AllTemplates.Single(t => t.PdkSource == "ForeignLib");
+        var interaction = CreatePlacementInteraction(active);
+        interaction.SelectedTemplate = template;
+
+        string? status = null;
+        interaction.UpdateStatus = s => status = s;
+        interaction.CanvasClicked(100, 100);
+
+        _canvas.Components.Count.ShouldBe(0, "a value-incompatible custom PDK must remain blocked at placement");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("process");
     }
 
     /// <summary>

--- a/UnitTests/Components/AddCustomComponent/CustomPdkVisibilityTests.cs
+++ b/UnitTests/Components/AddCustomComponent/CustomPdkVisibilityTests.cs
@@ -60,7 +60,7 @@ public class CustomPdkVisibilityTests : IDisposable
         var interaction = new CanvasInteractionViewModel(_canvas, new CommandManager());
         interaction.GetActiveProcess = () => active;
         interaction.GetProcessAgnosticPdkNames = () => _leftPanel.GetProcessAgnosticPdkNames();
-        interaction.GetLiveMemberPdkNames = () => _leftPanel.GetLiveMemberPdkNames(active);
+        interaction.GetLiveMemberPdkNames = () => _leftPanel.ResolveLiveMemberPdkNames(active);
         return interaction;
     }
 
@@ -82,7 +82,7 @@ public class CustomPdkVisibilityTests : IDisposable
     /// <summary>
     /// Locks the library to a real process built from the bundled Demo PDK's own fingerprint.
     /// Returns the applied selection so callers can reuse the identical snapshot (e.g. to feed
-    /// <see cref="LeftPanelViewModel.GetLiveMemberPdkNames"/> the same way <c>MainViewModel</c> does).
+    /// <see cref="LeftPanelViewModel.ResolveLiveMemberPdkNames"/> the same way <c>MainViewModel</c> does).
     /// </summary>
     private ActiveProcessSelection ApplyDemoProcessLock()
     {
@@ -184,7 +184,7 @@ public class CustomPdkVisibilityTests : IDisposable
     /// Reproduces the field bug directly at the placement guard (not just the library filter):
     /// a component from a value-compatible custom PDK registered after the process was saved
     /// must be placeable via <see cref="CanvasInteractionViewModel.PlaceComponentAt"/>, using the
-    /// live member set from <see cref="LeftPanelViewModel.GetLiveMemberPdkNames"/> rather than the
+    /// live member set from <see cref="LeftPanelViewModel.ResolveLiveMemberPdkNames"/> rather than the
     /// stale <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot.
     /// </summary>
     [Fact]

--- a/UnitTests/Components/Process/GroupProcessPolicyTests.cs
+++ b/UnitTests/Components/Process/GroupProcessPolicyTests.cs
@@ -89,4 +89,33 @@ public class GroupProcessPolicyTests
 
         isAllowed.ShouldBeTrue();
     }
+
+    /// <summary>
+    /// A child from a PDK missing from the persisted snapshot but present in the live
+    /// by-value member set (#732) must not block the group — mirrors
+    /// <c>SingleProcessPolicyTests.PdkNotInSnapshot_ButInLiveMemberSet_IsAllowed</c> at the
+    /// group level.
+    /// </summary>
+    [Fact]
+    public void ChildPdkOnlyInLiveMemberSet_IsAllowed()
+    {
+        var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "Demo", "MyLib" },
+            liveMemberPdkNames: new[] { "MyLib" });
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    /// <summary>A child PDK in neither the snapshot nor the live set still blocks the group.</summary>
+    [Fact]
+    public void ChildPdkNotInSnapshotOrLiveSet_StillBlocksGroup()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "Demo", "HHI-InP" },
+            liveMemberPdkNames: new[] { "MyLib" });
+
+        isAllowed.ShouldBeFalse();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("HHI-InP");
+    }
 }

--- a/UnitTests/Components/Process/GroupProcessPolicyTests.cs
+++ b/UnitTests/Components/Process/GroupProcessPolicyTests.cs
@@ -94,28 +94,46 @@ public class GroupProcessPolicyTests
     /// A child from a PDK missing from the persisted snapshot but present in the live
     /// by-value member set (#732) must not block the group — mirrors
     /// <c>SingleProcessPolicyTests.PdkNotInSnapshot_ButInLiveMemberSet_IsAllowed</c> at the
-    /// group level.
+    /// group level. The live set replaces the snapshot, so it lists ALL currently
+    /// compatible PDKs (including the snapshot member "Demo").
     /// </summary>
     [Fact]
     public void ChildPdkOnlyInLiveMemberSet_IsAllowed()
     {
         var (isAllowed, _) = GroupProcessPolicy.CheckGroupPlacement(
             Soi("Demo"), new[] { "Demo", "MyLib" },
-            liveMemberPdkNames: new[] { "MyLib" });
+            liveMemberPdkNames: new[] { "Demo", "MyLib" });
 
         isAllowed.ShouldBeTrue();
     }
 
-    /// <summary>A child PDK in neither the snapshot nor the live set still blocks the group.</summary>
+    /// <summary>A child PDK absent from the (authoritative) live set still blocks the group.</summary>
     [Fact]
-    public void ChildPdkNotInSnapshotOrLiveSet_StillBlocksGroup()
+    public void ChildPdkNotInLiveMemberSet_StillBlocksGroup()
     {
         var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
             Soi("Demo"), new[] { "Demo", "HHI-InP" },
-            liveMemberPdkNames: new[] { "MyLib" });
+            liveMemberPdkNames: new[] { "Demo", "MyLib" });
 
         isAllowed.ShouldBeFalse();
         reason.ShouldNotBeNull();
         reason!.ShouldContain("HHI-InP");
+        // The live-member child must not be listed as an offender.
+        reason.ShouldNotContain("'Demo'");
+    }
+
+    /// <summary>
+    /// Group-level mirror of the replace-not-union rule: a snapshot-member child whose PDK
+    /// dropped out of the live set (process edited incompatible after saving) blocks the group.
+    /// </summary>
+    [Fact]
+    public void SnapshotMemberChild_MissingFromLiveSet_BlocksGroup()
+    {
+        var (isAllowed, reason) = GroupProcessPolicy.CheckGroupPlacement(
+            Soi("Demo"), new[] { "Demo" },
+            liveMemberPdkNames: new[] { "MyLib" });
+
+        isAllowed.ShouldBeFalse();
+        reason!.ShouldContain("Demo");
     }
 }

--- a/UnitTests/Components/Process/SingleProcessPolicyTests.cs
+++ b/UnitTests/Components/Process/SingleProcessPolicyTests.cs
@@ -55,4 +55,52 @@ public class SingleProcessPolicyTests
         // Without the agnostic set it stays blocked (default overload behavior unchanged):
         SingleProcessPolicy.CheckPlacement(Soi(), "Analysis Tools").IsAllowed.ShouldBeFalse();
     }
+
+    /// <summary>
+    /// A custom PDK registered after the process was saved cannot be in the persisted
+    /// <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot, but is value-compatible
+    /// with the active process, so the live-membership set (#732) resolved by
+    /// <c>LeftPanelViewModel.GetLiveMemberPdkNames</c> must still allow it.
+    /// </summary>
+    [Fact]
+    public void PdkNotInSnapshot_ButInLiveMemberSet_IsAllowed()
+    {
+        var live = new[] { "MyLib" };
+        SingleProcessPolicy.CheckPlacement(Soi(), "MyLib", liveMemberPdkNames: live)
+            .IsAllowed.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// A PDK absent from both the persisted snapshot and the live member set (i.e. genuinely
+    /// value-incompatible with the active process) must remain blocked with the usual reason.
+    /// </summary>
+    [Fact]
+    public void PdkNotInSnapshot_AndNotInLiveMemberSet_IsBlocked()
+    {
+        var live = new[] { "MyLib" };
+        var (ok, reason) = SingleProcessPolicy.CheckPlacement(Soi(), "HHI-InP", liveMemberPdkNames: live);
+
+        ok.ShouldBeFalse();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("HHI-InP");
+        reason.ShouldContain("SOI 220");
+    }
+
+    /// <summary>Live-member matching is case-insensitive, like the snapshot check.</summary>
+    [Fact]
+    public void LiveMemberSet_MatchIsCaseInsensitive()
+    {
+        SingleProcessPolicy.CheckPlacement(Soi(), "mylib", liveMemberPdkNames: new[] { "MyLib" })
+            .IsAllowed.ShouldBeTrue();
+    }
+
+    /// <summary>A null live-member set (unwired callback) must behave exactly like before.</summary>
+    [Fact]
+    public void NoLiveMemberSet_FallsBackToSnapshotOnly()
+    {
+        SingleProcessPolicy.CheckPlacement(Soi(), "Custom SOI", liveMemberPdkNames: null)
+            .IsAllowed.ShouldBeTrue("still allowed via the persisted snapshot");
+        SingleProcessPolicy.CheckPlacement(Soi(), "HHI-InP", liveMemberPdkNames: null)
+            .IsAllowed.ShouldBeFalse("no live set provided — foreign PDK stays blocked");
+    }
 }

--- a/UnitTests/Components/Process/SingleProcessPolicyTests.cs
+++ b/UnitTests/Components/Process/SingleProcessPolicyTests.cs
@@ -60,7 +60,7 @@ public class SingleProcessPolicyTests
     /// A custom PDK registered after the process was saved cannot be in the persisted
     /// <see cref="ActiveProcessSelection.MemberPdkNames"/> snapshot, but is value-compatible
     /// with the active process, so the live-membership set (#732) resolved by
-    /// <c>LeftPanelViewModel.GetLiveMemberPdkNames</c> must still allow it.
+    /// <c>LeftPanelViewModel.ResolveLiveMemberPdkNames</c> must still allow it.
     /// </summary>
     [Fact]
     public void PdkNotInSnapshot_ButInLiveMemberSet_IsAllowed()
@@ -68,6 +68,24 @@ public class SingleProcessPolicyTests
         var live = new[] { "MyLib" };
         SingleProcessPolicy.CheckPlacement(Soi(), "MyLib", liveMemberPdkNames: live)
             .IsAllowed.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// The live set REPLACES the snapshot, it is not unioned with it: a snapshot member whose
+    /// process was edited into incompatibility AFTER the design was saved disappears from the
+    /// live set and must then be blocked at placement/paste too — otherwise the library filter
+    /// (live-only) and the placement gate would disagree about the same PDK.
+    /// </summary>
+    [Fact]
+    public void SnapshotMemberPdk_MissingFromLiveMemberSet_IsBlocked()
+    {
+        // "Custom SOI" IS in the Soi() snapshot, but not in the live set anymore.
+        var live = new[] { "Foundry SOI" };
+        var (ok, reason) = SingleProcessPolicy.CheckPlacement(Soi(), "Custom SOI", liveMemberPdkNames: live);
+
+        ok.ShouldBeFalse("live membership is authoritative — the stale snapshot must not resurrect an edited-incompatible PDK");
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("Custom SOI");
     }
 
     /// <summary>

--- a/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
+++ b/UnitTests/Export/MetalRouting/MetalTraceStyleResolverTests.cs
@@ -122,6 +122,39 @@ public class MetalTraceStyleResolverTests
     }
 
     /// <summary>
+    /// Review Finding [0] (placement-livemembers): a value-compatible custom PDK registered
+    /// after the active process was saved is missing from the persisted member snapshot, so a
+    /// snapshot-only lookup ignored its metal cross-section and exported default metal
+    /// (wrong width/layer) — physically wrong GDS. When the caller passes the live
+    /// (by-value) member set, it must replace the snapshot as the member filter.
+    /// </summary>
+    [Fact]
+    public void Resolve_EffectiveMemberNames_ReplaceTheSnapshotAsTheMemberFilter()
+    {
+        var customPdk = new PdkDraft
+        {
+            Name = "MyCustomFab",
+            Process = new ProcessDefinition
+            {
+                Layers = { new ProcessLayer { Name = "M1", Layer = 41, Datatype = 2 } },
+                Xsections =
+                {
+                    new ProcessXsection { Name = "metal", Kind = XsectionKind.Metal, WidthUm = 6.0, Layers = { "M1" } },
+                },
+            },
+        };
+        // Snapshot knows nothing about the custom PDK (it predates it).
+        var active = new ActiveProcessSelection("SnapshotFab", null, new[] { "OldFab" }, IsPlayground: false);
+
+        var style = MetalTraceStyleResolver.Resolve(
+            active, new[] { customPdk }, effectiveMemberPdkNames: new[] { "MyCustomFab" });
+
+        style.WidthUm.ShouldBe(6.0);
+        style.GdsLayer.ShouldBe(41);
+        style.GdsDatatype.ShouldBe(2);
+    }
+
+    /// <summary>
     /// Finding 7: the by-name PDK/draft lookup was copy-pasted across three call sites
     /// (this resolver, the Fabrication Process dialog, MainWindow's PDK-path wiring) — now a
     /// single shared helper all three call.

--- a/UnitTests/Routing/MetalRouting/MetalRoutingSpecFactoryTests.cs
+++ b/UnitTests/Routing/MetalRouting/MetalRoutingSpecFactoryTests.cs
@@ -146,4 +146,65 @@ public class MetalRoutingSpecFactoryTests
         spec.TraceWidthMicrometers.ShouldBe(10);
         spec.MetalGdsLayer.ShouldBe(11);
     }
+
+    /// <summary>
+    /// Review Finding [0] (placement-livemembers): a value-compatible custom PDK registered
+    /// after the process snapshot was persisted carries the metal cross-section and/or
+    /// ElectricalBridgeRequired flag, but a snapshot-only member filter ignores it — the GDS
+    /// export then routes default metal (wrong width/layer, missing bridges). The live member
+    /// set must replace the snapshot as the filter when the caller provides it.
+    /// </summary>
+    [Fact]
+    public void FromActiveProcess_EffectiveMemberNames_ReplaceTheSnapshotAsTheMemberFilter()
+    {
+        var customPdk = new PdkDraft
+        {
+            Name = "MyCustomFab",
+            Process = new ProcessDefinition
+            {
+                Name = "MyCustomFab",
+                ElectricalBridgeRequired = true,
+                Layers = new List<ProcessLayer> { new() { Name = "METAL2", Layer = 21, Datatype = 3 } },
+                Xsections = new List<ProcessXsection>
+                {
+                    new() { Name = "MetalDC", Kind = XsectionKind.Metal, WidthUm = 7, Layers = new List<string> { "METAL2" } }
+                }
+            }
+        };
+        // Snapshot predates the custom PDK — it only knows a member without metal data.
+        var active = new ActiveProcessSelection(
+            "SnapshotFab", Fingerprint: null, MemberPdkNames: new List<string> { "OldFab" }, IsPlayground: false);
+
+        var spec = MetalRoutingSpecFactory.FromActiveProcess(
+            active, new List<PdkDraft> { customPdk }, effectiveMemberPdkNames: new[] { "MyCustomFab" });
+
+        spec.TraceWidthMicrometers.ShouldBe(7);
+        spec.MetalGdsLayer.ShouldBe(21);
+        spec.MetalGdsDatatype.ShouldBe(3);
+        spec.CrossingPolicy.ShouldBe(ElectricalCrossingPolicy.BridgeRequired);
+    }
+
+    /// <summary>Null effective set (unwired caller) keeps the old snapshot behavior.</summary>
+    [Fact]
+    public void FromActiveProcess_NullEffectiveMemberNames_UsesTheSnapshot()
+    {
+        var pdk = new PdkDraft
+        {
+            Name = "SnapFab",
+            Process = new ProcessDefinition
+            {
+                Name = "SnapFab",
+                Xsections = new List<ProcessXsection>
+                {
+                    new() { Name = "MetalDC", Kind = XsectionKind.Metal, WidthUm = 9 }
+                }
+            }
+        };
+        var active = new ActiveProcessSelection(
+            "Snap", Fingerprint: null, MemberPdkNames: new List<string> { "SnapFab" }, IsPlayground: false);
+
+        var spec = MetalRoutingSpecFactory.FromActiveProcess(active, new List<PdkDraft> { pdk }, effectiveMemberPdkNames: null);
+
+        spec.TraceWidthMicrometers.ShouldBe(9);
+    }
 }


### PR DESCRIPTION
## Zwei Feld-Test-Bugs (Follow-up zu #732/#733)

1. **Platzierungs-Sperre by-name statt by-value:** Eine Komponente aus einem neuen custom PDK mit dem GLEICHEN (wertkompatiblen) Prozess wie das aktive Design wurde beim Platzieren geblockt („This component belongs to '…', but the chip is locked…"), obwohl das PDK enabled/sichtbar war — erst „Neu + Prozess erneut wählen" half. Ursache: `SingleProcessPolicy.CheckPlacement` prüfte nur den eingefrorenen `ActiveProcessSelection.MemberPdkNames`-Snapshot; die by-value-Auflösung aus #732 wurde nur für den Library-Filter genutzt. Fix: `CheckPlacement` akzeptiert zusätzlich die **live by-value-Mitgliedermenge** (`LeftPanelViewModel.GetLiveMemberPdkNames`, via `ProcessCompatibility.AreCompatible` gegen den aktiven Fingerprint), verdrahtet an **alle vier** Aufrufer: manuelles Platzieren, Paste, Gruppen-Templates (`GroupProcessPolicy`), AiGrid. Wert-inkompatible PDKs bleiben geblockt (#570 gewahrt, Gegentests).
2. **PDK-Edit-Fenster doppelt:** Zweimal „Edit…" öffnete zwei Editor-Fenster. Fix: Fenster-Reuse pro PDK-Datei (Dictionary + `Activate()`, SettingsOpener-Muster; beim Schließen ausgetragen).

## Tests
SingleProcessPolicy 12/12 (+4), GroupProcessPolicy 9/9 (+2), CustomPdkVisibility 5/5 (+2 VM-Level mit echtem CanvasInteraction-Wiring), CanvasInteraction 20/20, AiGridService 30/30, LeftPanel 31/31, SinglePdkEdit 7/7, ProcessManagement 17/17. Build 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)