### PR TITLE
Fix: editor rename within the same PDK no longer orphans the old component

### DIFF
--- a/CAP.Avalonia/Services/AddCustomComponent/NewComponentWindowLauncher.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/NewComponentWindowLauncher.cs
@@ -35,5 +35,7 @@ public static class NewComponentWindowLauncher
 
         if (vm.MigratedFromPdkName is { } fromPdk)
             removeMigratedTemplate?.Invoke(fromPdk, vm.MigratedFromComponentName ?? vm.SavedDraft.Name);
+        else if (vm.RenamedAwayComponentName is { } oldName)
+            removeMigratedTemplate?.Invoke(pdk.Name, oldName);
     }
 }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
@@ -30,6 +30,9 @@ public partial class NewComponentViewModel
     /// <summary>The component's original name in the PDK it was migrated out of (for library cleanup).</summary>
     public string? MigratedFromComponentName { get; private set; }
 
+    /// <summary>The old name a same-PDK rename left behind, so the library drops the stale template.</summary>
+    public string? RenamedAwayComponentName { get; private set; }
+
     /// <summary>
     /// With <see cref="EditingOriginalName"/> identifies the on-disk component being edited,
     /// independent of any in-progress rename — the main window keys its open-editor-window

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Save.cs
@@ -99,6 +99,7 @@ public partial class NewComponentViewModel
         }
 
         MigratedFromPdkName = null;
+        RenamedAwayComponentName = null;
         // While a bundled fork is pending, the "original" is the read-only built-in PDK — a save
         // into a different PDK is a copy-out, never a migration that would remove the original.
         var isMigration = IsEditMode
@@ -174,6 +175,15 @@ public partial class NewComponentViewModel
                 _editOriginalProcessName = SelectedProcess?.Name;
                 _editingOriginalName = name;
             }
+            else if (!isMigration && IsEditMode && _editingOriginalName is not null
+                     && !string.Equals(name, _editingOriginalName, StringComparison.OrdinalIgnoreCase))
+            {
+                // Same-PDK rename: AppendToExistingPdk keyed on the NEW name, so the old-named
+                // entry would orphan in the file (and library) without this removal.
+                TryRemoveRenamedOriginal(pdk.FilePath, _editingOriginalName);
+                RenamedAwayComponentName = _editingOriginalName;
+                _editingOriginalName = name;
+            }
 
             // A migration whose removal threw already set an explanatory StatusText (the component
             // now lives in both PDKs) — don't overwrite it with a plain save-success message.
@@ -221,6 +231,19 @@ public partial class NewComponentViewModel
             StatusText = $"Saved to '{SelectedCustomPdk?.Name}', but could not remove the original " +
                          $"copy from '{_editOriginalPdkName}': {ex.Message}";
             return false;
+        }
+    }
+
+    private void TryRemoveRenamedOriginal(string filePath, string originalName)
+    {
+        try
+        {
+            _store.RemoveComponent(filePath, originalName);
+        }
+        catch (Exception ex)
+        {
+            _errorConsole?.LogError(
+                $"Renamed component saved, but removing the old entry '{originalName}' failed: {ex.Message}", ex);
         }
     }
 

--- a/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
@@ -101,6 +101,24 @@ public class EditComponentModeTests : IDisposable
     }
 
     [Fact]
+    public async Task EditSave_renameWithinSamePdk_removesTheOriginal_noOrphan()
+    {
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        const string rawCode = "import gdsfactory as gf\ncomponent = gf.components.coupler()";
+        var path = store.CreateNamedPdkWithProcess("Lib", process, "gdsfactory", null);
+        store.AppendToExistingPdk(path, SeedComponent("comp1", rawCode));
+        var (vm, _) = Build(store, new List<ProcessDefinition> { process });
+
+        vm.LoadForEdit(BuildTemplate(rawCode));
+        vm.ComponentName = "comp1Renamed";
+        await vm.SaveCommand.ExecuteAsync(null);
+
+        store.ComponentExistsInFile(path, "comp1Renamed").ShouldBeTrue();
+        store.ComponentExistsInFile(path, "comp1").ShouldBeFalse();
+    }
+
+    [Fact]
     public void WindowTitle_and_SaveButtonLabel_reflectEditMode()
     {
         var (vm, _, rawCode) = BuildWithSeededPdk();


### PR DESCRIPTION
## Problem
Editing a component and renaming it **without switching PDK** left the original, old-named component behind — a duplicate in both the PDK file and the library.

Root cause (`NewComponentViewModel.Save.cs`): a same-PDK rename is neither a migration (`isMigration=false`, same PDK) nor a self-edit (`name` changed), so the collision/removal paths were skipped. `AppendToExistingPdk` keys on the **new** name, so the **old**-named entry survived. `TryRemoveFromOriginalPdk` only runs on a cross-PDK migration.

## Fix
After the append, when in edit mode with a changed name and no migration, remove the old-named entry:
- **File:** `UserPdkStore.RemoveComponent(pdk.FilePath, oldName)`.
- **Library:** the existing stale-template cleanup (`RenamedAwayComponentName` → `RemoveMigratedLibraryTemplate`), mirroring the cross-PDK migration path.

A removal failure is logged to the error console, never crashes the save.

## Test
`EditSave_renameWithinSamePdk_removesTheOriginal_noOrphan` (red before, green after). Full `AddCustomComponent` suite: 239/239 green; build 0/0.

Found during the post-#739/#742 PDK-stream triage (this is the salvageable core of the stale PR #731 / issue #730, re-implemented on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)