### PR TITLE
Spike: durchklickbare User-Story-Tests (Avalonia.Headless UI-Flows)

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -12,6 +12,13 @@ public partial class App : Application
 {
     public static IServiceProvider Services { get; private set; } = null!;
 
+    /// <summary>
+    /// Test seam (InternalsVisibleTo UnitTests): headless UI-flow tests run without
+    /// <see cref="OnFrameworkInitializationCompleted"/>, so they install their own provider here —
+    /// MainWindow's code-behind resolves optional collaborators via <see cref="Services"/>.
+    /// </summary>
+    internal static void OverrideServicesForTesting(IServiceProvider services) => Services = services;
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -94,6 +94,13 @@ public partial class LeftPanelViewModel : ObservableObject
         PdkManager.OnFilterChanged = FilterComponents;
     }
 
+    /// <summary>
+    /// Test seam (InternalsVisibleTo UnitTests): when set, <see cref="Initialize"/> scans this
+    /// directory for user PDKs instead of the real per-user user-pdks folder, so headless UI
+    /// tests never pick up (or write into) the developer's real forks.
+    /// </summary>
+    internal string? UserPdkStartupRootOverride { get; set; }
+
     public void Initialize()
     {
         LoadComponentLibrary();
@@ -102,7 +109,7 @@ public partial class LeftPanelViewModel : ObservableObject
 
         try
         {
-            _ = ReloadUserPdksAtStartupAsync();
+            _ = ReloadUserPdksAtStartupAsync(UserPdkStartupRootOverride);
         }
         catch (Exception ex)
         {

--- a/UnitTests/Helpers/MainViewModelTestHelper.cs
+++ b/UnitTests/Helpers/MainViewModelTestHelper.cs
@@ -40,7 +40,8 @@ public static class MainViewModelTestHelper
         CommandManager? commandManager = null,
         UserPreferencesService? preferencesService = null,
         GroupLibraryManager? libraryManager = null,
-        DesignCanvasViewModel? canvas = null)
+        DesignCanvasViewModel? canvas = null,
+        LeftPanelViewModel? leftPanel = null)
     {
         canvas ??= new DesignCanvasViewModel();
         commandManager ??= new CommandManager();
@@ -52,7 +53,8 @@ public static class MainViewModelTestHelper
         simulationService ??= new SimulationService();
 
         var pdkLoader = new PdkLoader();
-        var leftPanel = CreateLeftPanelViewModel(canvas, libraryManager, pdkLoader, preferencesService, commandManager);
+        // A caller-supplied LeftPanel (UI-flow tests) must share canvas/prefs with the rest of the VM.
+        leftPanel ??= CreateLeftPanelViewModel(canvas, libraryManager, pdkLoader, preferencesService, commandManager);
         var rightPanel = CreateRightPanelViewModel(canvas, preferencesService);
         var bottomPanel = CreateBottomPanelViewModel(canvas, commandManager);
 

--- a/UnitTests/UI/Flows/UiFlowBoxSelectDeleteUndoTests.cs
+++ b/UnitTests/UI/Flows/UiFlowBoxSelectDeleteUndoTests.cs
@@ -1,0 +1,75 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using CAP.Avalonia.Controls;
+using CAP.Avalonia.ViewModels.Panels;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.UI.Flows;
+
+/// <summary>
+/// User story: place three components by clicking the canvas, rubber-band-select two of them
+/// with a mouse drag, press Delete, press Ctrl+Z — all through the real MainWindow input
+/// pipeline. The hierarchy panel must mirror the selection and the undo must restore both.
+/// </summary>
+[Trait("Category", "UiFlows")]
+public class UiFlowBoxSelectDeleteUndoTests
+{
+    private const string PdkName = "Demo PDK";
+    private const string ComponentName = "1x2 MMI Splitter"; // 80 × 55 µm
+
+    [AvaloniaFact]
+    public void BoxSelectTwoOfThree_deleteWithKey_undoRestoresBoth()
+    {
+        using var host = new UiFlowTestHost();
+        var vm = host.Vm;
+        var win = host.Window;
+
+        // Select the component in the library like a user: click its row → placement mode.
+        var template = vm.LeftPanel.AllTemplates.Single(t => t.PdkSource == PdkName && t.Name == ComponentName);
+        var library = host.LibraryListBox;
+        library.ScrollIntoView(template);
+        UiInput.RunJobs();
+        var row = (ListBoxItem)library.ContainerFromItem(template)!;
+        // Click the left part of the row — the right edge hosts the hover ✏/✕ actions.
+        UiInput.Click(win, row, relX: 0.35);
+        vm.CanvasInteraction.CurrentMode.ShouldBe(InteractionMode.PlaceComponent,
+            "clicking a library row must arm component placement");
+
+        var canvasControl = UiInput.Descendants<DesignCanvas>(win).First();
+        // Canvas µm → window point: default zoom 1, pan 0, grid snap off.
+        Point CanvasPoint(double x, double y) =>
+            canvasControl.TranslatePoint(
+                new Point(x * canvasControl.Zoom + vm.Canvas.PanX, y * canvasControl.Zoom + vm.Canvas.PanY), win)!.Value;
+
+        // Placement centers the 80×55 template on the click point.
+        UiInput.ClickAt(win, CanvasPoint(150, 150));
+        UiInput.ClickAt(win, CanvasPoint(150, 300));
+        UiInput.ClickAt(win, CanvasPoint(600, 150));
+        vm.Canvas.Components.Count.ShouldBe(3,
+            $"three canvas clicks must place three components (status: {vm.StatusText})");
+        vm.LeftPanel.HierarchyPanel.RootNodes.Count.ShouldBe(3);
+
+        // S = select mode (the canvas keyboard handler owns this shortcut).
+        UiInput.PressKey(win, Key.S);
+        vm.CanvasInteraction.CurrentMode.ShouldBe(InteractionMode.Select);
+
+        // Rubber-band over the two left components (both fully inside 60..260 × 60..380).
+        UiInput.DragMouse(win, CanvasPoint(60, 60), CanvasPoint(260, 380));
+        vm.Canvas.Selection.SelectedComponents.Count.ShouldBe(2,
+            "the box must select exactly the two components it covers");
+        vm.LeftPanel.HierarchyPanel.RootNodes.Count(n => n.IsSelected).ShouldBe(2,
+            "the hierarchy panel must mirror the box selection");
+
+        UiInput.PressKey(win, Key.Delete);
+        vm.Canvas.Components.Count.ShouldBe(1, "Delete must remove both selected components");
+        vm.LeftPanel.HierarchyPanel.RootNodes.Count.ShouldBe(1);
+
+        UiInput.PressKey(win, Key.Z, RawInputModifiers.Control);
+        vm.Canvas.Components.Count.ShouldBe(3, "a single Ctrl+Z must restore both deleted components");
+        vm.LeftPanel.HierarchyPanel.RootNodes.Count.ShouldBe(3);
+    }
+}

--- a/UnitTests/UI/Flows/UiFlowBoxSelectDeleteUndoTests.cs
+++ b/UnitTests/UI/Flows/UiFlowBoxSelectDeleteUndoTests.cs
@@ -16,6 +16,7 @@ namespace UnitTests.UI.Flows;
 /// pipeline. The hierarchy panel must mirror the selection and the undo must restore both.
 /// </summary>
 [Trait("Category", "UiFlows")]
+[Collection("UiFlows")]
 public class UiFlowBoxSelectDeleteUndoTests
 {
     private const string PdkName = "Demo PDK";

--- a/UnitTests/UI/Flows/UiFlowCreatePdkTests.cs
+++ b/UnitTests/UI/Flows/UiFlowCreatePdkTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.UI.Flows;
 /// appears in the PDK-Management list with its file in the (temp) user-pdks root.
 /// </summary>
 [Trait("Category", "UiFlows")]
+[Collection("UiFlows")]
 public class UiFlowCreatePdkTests
 {
     private const string NewPdkName = "My Flow PDK";

--- a/UnitTests/UI/Flows/UiFlowCreatePdkTests.cs
+++ b/UnitTests/UI/Flows/UiFlowCreatePdkTests.cs
@@ -1,0 +1,68 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP.Avalonia.Views;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.UI.Flows;
+
+/// <summary>
+/// User story: create a custom PDK from the PDK-Management "+" header button — type its name,
+/// keep "Use existing process", pick a loaded process, click "Create PDK" — and verify the PDK
+/// appears in the PDK-Management list with its file in the (temp) user-pdks root.
+/// </summary>
+[Trait("Category", "UiFlows")]
+public class UiFlowCreatePdkTests
+{
+    private const string NewPdkName = "My Flow PDK";
+
+    [AvaloniaFact]
+    public void CreateCustomPdk_throughPlusButtonAndModalDialog()
+    {
+        using var host = new UiFlowTestHost();
+        var vm = host.Vm;
+        var win = host.Window;
+
+        var plus = UiInput.Descendants<Button>(win).First(b =>
+            "+".Equals(b.Content as string, StringComparison.Ordinal)
+            && Equals(ToolTip.GetTip(b), "Create custom PDK…"));
+        UiInput.Click(win, plus);
+
+        var dialog = win.OwnedWindows.OfType<CreateCustomPdkWindow>().Single();
+        var dialogVm = (CreateCustomPdkViewModel)dialog.DataContext!;
+        dialogVm.AvailableProcesses.ShouldNotBeEmpty("bundled PDKs must contribute pickable processes");
+
+        // PDK name — typed into the focused TextBox through the input pipeline.
+        var nameBox = UiInput.Descendants<TextBox>(dialog).First(t => t.Watermark == "e.g. MyFoundryPDK");
+        UiInput.Click(dialog, nameBox);
+        UiInput.TypeText(dialog, NewPdkName);
+        dialogVm.PdkName.ShouldBe(NewPdkName, "typed keys must reach the PdkName binding");
+
+        // "Use existing process" is the default; pick the first loaded process by keyboard.
+        // (Opening the ComboBox popup and clicking an item is not reliably hit-testable headless —
+        // arrow keys on the closed ComboBox are the equivalent real keyboard interaction.)
+        var processCombo = UiInput.Descendants<ComboBox>(dialog).First(c => c.IsEffectivelyVisible);
+        processCombo.Focus();
+        UiInput.RunJobs();
+        UiInput.PressKey(dialog, Key.Down);
+        dialogVm.SelectedExistingProcess.ShouldNotBeNull("Down on the ComboBox must select the first process");
+
+        UiInput.Click(dialog, UiInput.FindButton(dialog, "Create PDK"));
+
+        // The dialog closed itself via PdkCreated and the main window registered the PDK.
+        win.OwnedWindows.OfType<CreateCustomPdkWindow>().ShouldBeEmpty(
+            $"Create must close the dialog (status: {dialogVm.StatusText})");
+        var row = vm.LeftPanel.PdkManager.LoadedPdks.SingleOrDefault(p => p.Name == NewPdkName);
+        row.ShouldNotBeNull("the new PDK must appear in the PDK-Management list");
+        row.IsBundled.ShouldBeFalse();
+        row.FilePath.ShouldNotBeNull();
+        File.Exists(row.FilePath).ShouldBeTrue();
+        Path.GetFullPath(row.FilePath!).ShouldStartWith(Path.GetFullPath(host.UserPdkRoot));
+
+        // The row is really rendered in the PDK-Management ItemsControl, not just in the VM.
+        UiInput.Descendants<TextBlock>(win).ShouldContain(t => t.Text == NewPdkName);
+    }
+}

--- a/UnitTests/UI/Flows/UiFlowEditForkTests.cs
+++ b/UnitTests/UI/Flows/UiFlowEditForkTests.cs
@@ -1,0 +1,85 @@
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using CAP.Avalonia.ViewModels.Components.AddCustomComponent;
+using CAP.Avalonia.Views;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.UI.Flows;
+
+/// <summary>
+/// User story: fork-on-edit of a bundled (foundry) component, driven entirely through the real
+/// MainWindow — hover the library row, click its ✏, type into the code editor, click
+/// "Save changes" — and verify the fork lands in the (temp) user-pdks root while the bundled
+/// JSON stays byte-identical.
+/// </summary>
+[Trait("Category", "UiFlows")]
+public class UiFlowEditForkTests
+{
+    private const string PdkName = "Demo PDK";
+    private const string ComponentName = "1x2 MMI Splitter";
+
+    [AvaloniaFact]
+    public void EditBundledComponent_forkOnSave_throughRealClicks()
+    {
+        using var host = new UiFlowTestHost();
+        var vm = host.Vm;
+        var win = host.Window;
+
+        var template = vm.LeftPanel.AllTemplates.Single(t => t.PdkSource == PdkName && t.Name == ComponentName);
+        var bundledRow = vm.LeftPanel.PdkManager.LoadedPdks.Single(p => p.Name == PdkName);
+        bundledRow.IsBundled.ShouldBeTrue("precondition: the Demo PDK loads as a bundled foundry PDK");
+        var bundledPath = bundledRow.FilePath!;
+        var bundledBytesBefore = File.ReadAllBytes(bundledPath);
+
+        // ✏ on the library row (hover reveals it; Click moves the pointer first).
+        host.LibraryListBox.ScrollIntoView(template);
+        UiInput.RunJobs();
+        UiInput.Click(win, UiInput.FindButton(win, "✏", template));
+
+        var editors = win.OwnedWindows.OfType<NewComponentWindow>().ToList();
+        editors.Count.ShouldBe(1, "the ✏ must open exactly one editor window");
+        editors[0].Title.ShouldBe($"Edit Component: {ComponentName}");
+
+        // A second ✏ click re-activates the existing editor instead of duplicating it.
+        UiInput.Click(win, UiInput.FindButton(win, "✏", template));
+        win.OwnedWindows.OfType<NewComponentWindow>().Count().ShouldBe(1,
+            "a second ✏ click on the same component must not open a second window");
+
+        var editor = win.OwnedWindows.OfType<NewComponentWindow>().Single();
+        var editorVm = (NewComponentViewModel)editor.DataContext!;
+        editorVm.IsEditMode.ShouldBeTrue();
+        var loadedCode = editorVm.Code;
+
+        // Real typing through AvaloniaEdit: click into the editor, jump to the document start
+        // (Ctrl+Home — a center click would land the caret mid-code), prepend a comment line.
+        var textEditor = UiInput.Descendants<AvaloniaEdit.TextEditor>(editor).First();
+        UiInput.Click(editor, textEditor);
+        UiInput.PressKey(editor, Key.Home, RawInputModifiers.Control);
+        UiInput.TypeText(editor, "# tweaked via ui flow");
+        UiInput.PressKey(editor, Key.Enter);
+        editorVm.Code.ShouldStartWith("# tweaked via ui flow",
+            customMessage: "typed keys must reach the view model through the editor binding");
+        editorVm.Code.ShouldContain(loadedCode.Trim());
+
+        UiInput.Click(editor, UiInput.FindButton(editor, "Save changes"));
+
+        // Fork file in the TEMP user-pdks root; bundled JSON untouched byte-for-byte.
+        var forkPath = host.UserPdkStore.ResolveNamedPath(PdkName);
+        File.Exists(forkPath).ShouldBeTrue($"save must fork the PDK to {forkPath} (status: {editorVm.StatusText})");
+        Path.GetFullPath(forkPath).ShouldStartWith(Path.GetFullPath(host.UserPdkRoot));
+        File.ReadAllBytes(bundledPath).ShouldBe(bundledBytesBefore, "the bundled JSON must never be written");
+        File.ReadAllText(forkPath).ShouldContain("# tweaked via ui flow");
+
+        // Library switched to the editable copy: custom, restorable (✕), shadowing the bundled entry.
+        var forked = vm.LeftPanel.AllTemplates.Single(t => t.PdkSource == PdkName && t.Name == ComponentName);
+        forked.IsCustom.ShouldBeTrue();
+        forked.IsDeletable.ShouldBeTrue("the edited copy must offer the Restore-Original ✕");
+        var row = vm.LeftPanel.PdkManager.LoadedPdks.Single(p => p.Name == PdkName);
+        row.IsBundled.ShouldBeFalse();
+        row.ShadowsBundledPdk.ShouldBeTrue();
+
+        win.OwnedWindows.OfType<NewComponentWindow>().ShouldBeEmpty("a successful save closes the editor");
+    }
+}

--- a/UnitTests/UI/Flows/UiFlowEditForkTests.cs
+++ b/UnitTests/UI/Flows/UiFlowEditForkTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.UI.Flows;
 /// JSON stays byte-identical.
 /// </summary>
 [Trait("Category", "UiFlows")]
+[Collection("UiFlows")]
 public class UiFlowEditForkTests
 {
     private const string PdkName = "Demo PDK";

--- a/UnitTests/UI/Flows/UiFlowTestHost.cs
+++ b/UnitTests/UI/Flows/UiFlowTestHost.cs
@@ -1,0 +1,135 @@
+using Avalonia.Threading;
+using CAP.Avalonia;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Hierarchy;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP.Avalonia.Views;
+using CAP_Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using UnitTests.Helpers;
+
+namespace UnitTests.UI.Flows;
+
+/// <summary>
+/// Boots the REAL <see cref="MainWindow"/> (code-behind wireups included) headless for
+/// click-through user-story tests: real views, real bindings, simulated mouse/keyboard.
+/// Only the outermost seams are faked — geometry rendering (no Python in tests), the
+/// user-pdks root (temp dir instead of the developer's real folder), preferences (temp file),
+/// and <c>App.Services</c> (a minimal provider carrying just the temp <see cref="UserPdkStore"/>).
+/// </summary>
+internal sealed class UiFlowTestHost : IDisposable
+{
+    public MainWindow Window { get; }
+
+    public MainViewModel Vm { get; }
+
+    /// <summary>Store rooted in <see cref="UserPdkRoot"/> — where forks and new PDKs land.</summary>
+    public UserPdkStore UserPdkStore { get; }
+
+    public string UserPdkRoot { get; }
+
+    private readonly string _prefsPath;
+
+    public UiFlowTestHost()
+    {
+        var id = Guid.NewGuid().ToString("N");
+        UserPdkRoot = Path.Combine(Path.GetTempPath(), $"lunima-uiflow-pdks-{id}");
+        _prefsPath = Path.Combine(Path.GetTempPath(), $"lunima-uiflow-prefs-{id}.json");
+
+        var prefs = new UserPreferencesService(_prefsPath);
+        var canvas = new DesignCanvasViewModel();
+        var commandManager = new CommandManager();
+        var libraryManager = new GroupLibraryManager();
+        UserPdkStore = new UserPdkStore(UserPdkRoot, new PdkJsonSaver(), new PdkLoader());
+
+        var leftPanel = new LeftPanelViewModel(
+            canvas, libraryManager, new PdkLoader(), prefs,
+            new HierarchyPanelViewModel(canvas), new PdkManagerViewModel(),
+            new ComponentLibraryViewModel(libraryManager),
+            errorConsole: new ErrorConsoleService(),
+            addCustomComponentDeps: new AddCustomComponentDependencies(
+                new ComponentGeometryExtractor(StubRenderer(), StubRenderer()),
+                Fdtd: null, UserPdkStore))
+        {
+            UserPdkStartupRootOverride = UserPdkRoot,
+        };
+
+        Vm = MainViewModelTestHelper.CreateMainViewModel(
+            commandManager: commandManager,
+            preferencesService: prefs,
+            libraryManager: libraryManager,
+            canvas: canvas,
+            leftPanel: leftPanel);
+
+        // The startup process picker (issue #570) would otherwise open modally over the window
+        // right after Loaded; a pre-established Playground process makes it a no-op.
+        Vm.FileOperations.SetActiveProcess(ActiveProcessSelection.Playground(), markDirty: false);
+
+        // MainWindow's code-behind resolves optional collaborators via App.Services (all
+        // null-tolerant except the flows under test, which need the UserPdkStore).
+        var services = new ServiceCollection();
+        services.AddSingleton(UserPdkStore);
+        App.OverrideServicesForTesting(services.BuildServiceProvider());
+
+        Window = new MainWindow { DataContext = Vm };
+        Window.Show();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>The library ListBox bound to <c>LeftPanel.FilteredTemplates</c>.</summary>
+    public global::Avalonia.Controls.ListBox LibraryListBox =>
+        UiInput.Descendants<global::Avalonia.Controls.ListBox>(Window)
+            .First(l => ReferenceEquals(l.ItemsSource, Vm.LeftPanel.FilteredTemplates));
+
+    /// <summary>
+    /// Geometry renderer stub: every render succeeds with a small 2-pin cell, so "Save changes"
+    /// (which re-renders the edited code) works without a Python environment.
+    /// </summary>
+    private static IComponentPreviewRenderer StubRenderer()
+    {
+        var ok = new NazcaPreviewResult
+        {
+            Success = true,
+            XMin = 0,
+            YMin = 0,
+            XMax = 8,
+            YMax = 1.5,
+            Pins = new List<NazcaPreviewPin>
+            {
+                new() { Name = "o1", X = 0, Y = 0.75, Angle = 180 },
+                new() { Name = "o2", X = 8, Y = 0.75, Angle = 0 },
+            },
+        };
+        var mock = new Mock<IComponentPreviewRenderer>();
+        mock.Setup(r => r.RenderAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ok);
+        mock.Setup(r => r.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ok);
+        return mock.Object;
+    }
+
+    public void Dispose()
+    {
+        foreach (var owned in Window.OwnedWindows.ToList())
+            owned.Close();
+        Window.Close();
+        Dispatcher.UIThread.RunJobs();
+
+        try { File.Delete(_prefsPath); } catch (IOException) { }
+        if (Directory.Exists(UserPdkRoot))
+        {
+            try { Directory.Delete(UserPdkRoot, true); } catch (IOException) { }
+        }
+    }
+}

--- a/UnitTests/UI/Flows/UiFlowTestHost.cs
+++ b/UnitTests/UI/Flows/UiFlowTestHost.cs
@@ -40,6 +40,7 @@ internal sealed class UiFlowTestHost : IDisposable
     public string UserPdkRoot { get; }
 
     private readonly string _prefsPath;
+    private readonly IServiceProvider? _previousServices;
 
     public UiFlowTestHost()
     {
@@ -80,6 +81,7 @@ internal sealed class UiFlowTestHost : IDisposable
         // null-tolerant except the flows under test, which need the UserPdkStore).
         var services = new ServiceCollection();
         services.AddSingleton(UserPdkStore);
+        _previousServices = App.Services;
         App.OverrideServicesForTesting(services.BuildServiceProvider());
 
         Window = new MainWindow { DataContext = Vm };
@@ -126,10 +128,14 @@ internal sealed class UiFlowTestHost : IDisposable
         Window.Close();
         Dispatcher.UIThread.RunJobs();
 
-        try { File.Delete(_prefsPath); } catch (IOException) { }
+        // App.Services is process-global static state — restore it so later suites in the same
+        // test process never resolve this host's (deleted) temp store.
+        App.OverrideServicesForTesting(_previousServices!);
+
+        try { File.Delete(_prefsPath); } catch (Exception e) when (e is IOException or UnauthorizedAccessException) { }
         if (Directory.Exists(UserPdkRoot))
         {
-            try { Directory.Delete(UserPdkRoot, true); } catch (IOException) { }
+            try { Directory.Delete(UserPdkRoot, true); } catch (Exception e) when (e is IOException or UnauthorizedAccessException) { }
         }
     }
 }

--- a/UnitTests/UI/Flows/UiInput.cs
+++ b/UnitTests/UI/Flows/UiInput.cs
@@ -1,0 +1,85 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace UnitTests.UI.Flows;
+
+/// <summary>
+/// Simulated-input helpers over <see cref="HeadlessWindowExtensions"/>: visual-tree lookup plus
+/// real mouse/keyboard event dispatch through Avalonia's input pipeline (hit testing included).
+/// Every action ends with <see cref="Dispatcher.UIThread.RunJobs"/> so bindings and async
+/// command continuations settle before the next assertion — never sleep, always pump.
+/// </summary>
+internal static class UiInput
+{
+    public static void RunJobs() => Dispatcher.UIThread.RunJobs();
+
+    public static IEnumerable<T> Descendants<T>(Visual root) where T : Visual =>
+        root.GetVisualDescendants().OfType<T>();
+
+    /// <summary>
+    /// Finds a Button by its literal string Content, optionally scoped to the row whose
+    /// DataContext is <paramref name="dataContext"/> (e.g. the ✏ of one library template).
+    /// </summary>
+    public static Button FindButton(Window window, string content, object? dataContext = null) =>
+        Descendants<Button>(window).First(b =>
+            content.Equals(b.Content as string, StringComparison.Ordinal)
+            && (dataContext is null || ReferenceEquals(b.DataContext, dataContext)));
+
+    /// <summary>Window-space point at the given relative position inside <paramref name="control"/>.</summary>
+    public static Point PointIn(Window window, Visual control, double relX = 0.5, double relY = 0.5)
+    {
+        var local = new Point(control.Bounds.Width * relX, control.Bounds.Height * relY);
+        var translated = control.TranslatePoint(local, window)
+            ?? throw new InvalidOperationException($"{control.GetType().Name} is not attached to {window.Title}.");
+        return translated;
+    }
+
+    /// <summary>
+    /// Left-clicks the control through the window's input pipeline. Moves the pointer first so
+    /// :pointerover styles (e.g. the library rows' hover-revealed ✏/✕ actions) apply like for
+    /// a real user.
+    /// </summary>
+    public static void Click(Window window, Visual control, double relX = 0.5, double relY = 0.5) =>
+        ClickAt(window, PointIn(window, control, relX, relY));
+
+    public static void ClickAt(Window window, Point point)
+    {
+        window.MouseMove(point);
+        window.MouseDown(point, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+        window.MouseUp(point, MouseButton.Left);
+        RunJobs();
+    }
+
+    /// <summary>Sends text to the focused control (TextBox, AvaloniaEdit TextArea, …).</summary>
+    public static void TypeText(Window window, string text)
+    {
+        window.KeyTextInput(text);
+        RunJobs();
+    }
+
+    public static void PressKey(Window window, Key key, RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        window.KeyPress(key, modifiers);
+        window.KeyRelease(key, modifiers);
+        RunJobs();
+    }
+
+    /// <summary>
+    /// Drags the left mouse button from <paramref name="from"/> to <paramref name="to"/> with an
+    /// intermediate move, matching how gesture recognizers see a real rubber-band drag.
+    /// </summary>
+    public static void DragMouse(Window window, Point from, Point to)
+    {
+        window.MouseMove(from);
+        window.MouseDown(from, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+        var mid = new Point((from.X + to.X) / 2, (from.Y + to.Y) / 2);
+        window.MouseMove(mid, RawInputModifiers.LeftMouseButton);
+        window.MouseMove(to, RawInputModifiers.LeftMouseButton);
+        window.MouseUp(to, MouseButton.Left);
+        RunJobs();
+    }
+}

--- a/UnitTests/UI/ScreenshotTestApp.cs
+++ b/UnitTests/UI/ScreenshotTestApp.cs
@@ -24,6 +24,17 @@ internal class ScreenshotTestApp : Application
         {
             Source = new Uri("avares://CAP.Avalonia/Styles/CompactControlHeights.axaml"),
         });
+        // Mirrors the production App.axaml includes: without them AvaloniaEdit's TextEditor and
+        // OxyPlot's PlotView have no control template, so UI-flow tests could not type into the
+        // component code editor (issue #556 rationale in App.axaml applies here too).
+        Styles.Add(new StyleInclude(new Uri("avares://CAP.Avalonia/Styles/"))
+        {
+            Source = new Uri("avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml"),
+        });
+        Styles.Add(new StyleInclude(new Uri("avares://CAP.Avalonia/Styles/"))
+        {
+            Source = new Uri("avares://OxyPlot.Avalonia/Themes/Default.axaml"),
+        });
     }
 }
 


### PR DESCRIPTION
Beweis-Spike: echte User-Flows headless durchklicken — echte Views, echte Bindings, simulierte Maus/Tastatur (`HeadlessWindowExtensions`), kein UI-Mocking.

**Drei Flows, alle grün (3/3, ~2s, 4/4 Läufe stabil, keine Sleeps):**
1. **Edit-Fork:** ✏ auf bundled Komponente → genau ein „Edit Component:"-Fenster → echtes Tippen in AvaloniaEdit → Save → Fork auf Platte, bundled JSON byte-identisch, Library zeigt Kopie
2. **Create-PDK:** „+" im PDK-Mgmt → Fenster → Name tippen, Prozess wählen, Create → PDK in Liste + Datei
3. **BoxSelect-Delete-Undo:** 3 Komponenten per Canvas-Klick platzieren → Rubber-Band-Drag selektiert 2 → Hierarchy spiegelt → ENTF → Ctrl+Z stellt wieder her

**Nötige Nähte (minimal-invasiv, `internal`):** `App.OverrideServicesForTesting(...)` + `LeftPanelViewModel.UserPdkStartupRootOverride` (sonst scannt der Test den echten user-pdks-Ordner des Entwicklers).

**Grenzen:** ComboBox-Popups/ContextMenus headless nicht zuverlässig klickbar (Tastatur-Äquivalent funktioniert); direkte `new MessageBoxService()`-Aufrufe im Code-Behind sind nicht abfangbar → MessageBox-Naht ist die wichtigste Empfehlung für den Ausbau.

**Empfehlung:** Infrastruktur (`UiFlowTestHost` + Input-Helper) als Standard etablieren; jede künftige Feld-Runde schreibt ihre Repro direkt als Flow-Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCVwvkXdUH9DSW8w12XB2q