### PR TITLE
test: gate slowest 31 classes [Category=Slow] to CI-only (fast local suite)

### DIFF
--- a/UnitTests/ComponentSettings/InstanceOverride/NazcaCodeTemplateBuilderTests.cs
+++ b/UnitTests/ComponentSettings/InstanceOverride/NazcaCodeTemplateBuilderTests.cs
@@ -1,6 +1,7 @@
 using CAP.Avalonia.Services;
 using CAP_Core.Export;
 using Shouldly;
+using Xunit;
 
 namespace UnitTests.ComponentSettings.InstanceOverride;
 
@@ -12,6 +13,7 @@ namespace UnitTests.ComponentSettings.InstanceOverride;
 /// integration test runs the generated code through the real preview script to prove
 /// the seeded template actually renders — the end-to-end check that was missing.
 /// </summary>
+[Trait("Category", "Slow")]
 public class NazcaCodeTemplateBuilderTests
 {
     [Fact]

--- a/UnitTests/Components/PolarizationDomain/PolarizationRotatorSimulationTests.cs
+++ b/UnitTests/Components/PolarizationDomain/PolarizationRotatorSimulationTests.cs
@@ -19,6 +19,7 @@ namespace UnitTests.Components.PolarizationDomain;
 /// source to a TM output. The TE→rotator and rotator→TM connections are
 /// polarization-legal, while a direct TE→TM connection is refused.
 /// </summary>
+[Trait("Category", "Slow")]
 public class PolarizationRotatorSimulationTests
 {
     private const int WavelengthNm = 1550;

--- a/UnitTests/Controls/KeyboardHandlerTests.cs
+++ b/UnitTests/Controls/KeyboardHandlerTests.cs
@@ -5,6 +5,7 @@ using CAP.Avalonia.ViewModels;
 using CAP.Avalonia.ViewModels.Canvas;
 using Shouldly;
 using UnitTests.Helpers;
+using Xunit;
 
 namespace UnitTests.Controls;
 
@@ -12,6 +13,7 @@ namespace UnitTests.Controls;
 /// Unit tests for <see cref="KeyboardHandler"/>.
 /// Verifies that keyboard shortcuts dispatch to the correct ViewModel commands.
 /// </summary>
+[Trait("Category", "Slow")]
 public class KeyboardHandlerTests
 {
     private static KeyEventArgs MakeKey(Key key, KeyModifiers modifiers = KeyModifiers.None)

--- a/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
+++ b/UnitTests/Export/GdsExportEnvironmentSelectionTests.cs
@@ -2,6 +2,7 @@ using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Export;
 using CAP_Core.Export;
 using Shouldly;
+using Xunit;
 
 namespace UnitTests.Export;
 
@@ -9,6 +10,7 @@ namespace UnitTests.Export;
 /// Tests for the managed-environment candidate list and the "install Nazca"
 /// offer on <see cref="GdsExportViewModel"/> (settings page integration).
 /// </summary>
+[Trait("Category", "Slow")]
 public class GdsExportEnvironmentSelectionTests
 {
     private static GdsExportViewModel CreateViewModel() =>

--- a/UnitTests/Export/GdsExportIntegrationTests.cs
+++ b/UnitTests/Export/GdsExportIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace UnitTests.Export;
 /// Integration tests for GdsExportViewModel and GdsExportService.
 /// Tests the complete flow from ViewModel to core service.
 /// </summary>
+[Trait("Category", "Slow")]
 public class GdsExportIntegrationTests
 {
     /// <summary>Pin the UI language so status-text assertions match the English literals

--- a/UnitTests/Export/GdsExportServiceTests.cs
+++ b/UnitTests/Export/GdsExportServiceTests.cs
@@ -8,6 +8,7 @@ namespace UnitTests.Export;
 /// Unit tests for GdsExportService.
 /// Tests Python detection, Nazca detection, and GDS export logic.
 /// </summary>
+[Trait("Category", "Slow")]
 public class GdsExportServiceTests
 {
     private readonly GdsExportService _service;

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryExportViewModelTests.cs
@@ -4,10 +4,12 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Export;
 using CAP_Core.Export;
 using Shouldly;
+using Xunit;
 
 namespace UnitTests.Export.GdsFactoryExport;
 
 /// <summary>Tests for the gdsfactory export dialog ViewModel (#581).</summary>
+[Trait("Category", "Slow")]
 public class GdsFactoryExportViewModelTests
 {
     /// <summary>Pin the UI language so status-text assertions match the English literals

--- a/UnitTests/Export/GdsFactoryExport/GdsFactoryScriptExecutionTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/GdsFactoryScriptExecutionTests.cs
@@ -2,6 +2,7 @@ using CAP.Avalonia.Services.GdsFactoryExport;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Export;
 using Shouldly;
+using Xunit;
 
 namespace UnitTests.Export.GdsFactoryExport;
 
@@ -12,6 +13,7 @@ namespace UnitTests.Export.GdsFactoryExport;
 /// <c>%LOCALAPPDATA%\Lunima\tools\uv.exe venv %TEMP%\gf-groundtruth --python 3.12</c>
 /// + <c>uv pip install gdsfactory ubcpdk</c>.
 /// </summary>
+[Trait("Category", "Slow")]
 public class GdsFactoryScriptExecutionTests
 {
     private static string? FindGdsFactoryPython()

--- a/UnitTests/Export/PdkResolution/PdkResolutionScriptExecutionTests.cs
+++ b/UnitTests/Export/PdkResolution/PdkResolutionScriptExecutionTests.cs
@@ -1,5 +1,6 @@
 using CAP_Core.Export.PdkResolution;
 using Shouldly;
+using Xunit;
 
 namespace UnitTests.Export.PdkResolution;
 
@@ -10,6 +11,7 @@ namespace UnitTests.Export.PdkResolution;
 /// activate-PDK-then-get_component path (issue #515 review). Skips silently when no
 /// cspdk-capable interpreter is present (e.g. CI), like the other script-execution tests.
 /// </summary>
+[Trait("Category", "Slow")]
 public class PdkResolutionScriptExecutionTests
 {
     [SkippableFact]

--- a/UnitTests/Export/PythonConfigurationIntegrationTests.cs
+++ b/UnitTests/Export/PythonConfigurationIntegrationTests.cs
@@ -9,6 +9,7 @@ namespace UnitTests.Export;
 /// Integration tests for Python configuration.
 /// Tests Core (GdsExportService, PythonDiscoveryService) + ViewModel (GdsExportViewModel) integration.
 /// </summary>
+[Trait("Category", "Slow")]
 public class PythonConfigurationIntegrationTests
 {
     [Fact]

--- a/UnitTests/Export/PythonDiscoveryServiceTests.cs
+++ b/UnitTests/Export/PythonDiscoveryServiceTests.cs
@@ -8,6 +8,7 @@ namespace UnitTests.Export;
 /// Unit tests for PythonDiscoveryService.
 /// Tests Python discovery in venv and system locations.
 /// </summary>
+[Trait("Category", "Slow")]
 public class PythonDiscoveryServiceTests
 {
     private readonly PythonDiscoveryService _service;

--- a/UnitTests/Export/SaxScriptExecutionTests.cs
+++ b/UnitTests/Export/SaxScriptExecutionTests.cs
@@ -32,6 +32,7 @@ namespace UnitTests.Export;
 /// <c>python3</c>, <c>python</c>.
 /// </para>
 /// </summary>
+[Trait("Category", "Slow")]
 public class SaxScriptExecutionTests
 {
     private readonly ITestOutputHelper _output;

--- a/UnitTests/Integration/FlattenGroupLightPreservationTests.cs
+++ b/UnitTests/Integration/FlattenGroupLightPreservationTests.cs
@@ -10,6 +10,7 @@ using CAP_Core.Tiles;
 using Shouldly;
 using System.Numerics;
 using UnitTests.Simulation;
+using Xunit;
 
 namespace UnitTests.Integration;
 
@@ -18,6 +19,7 @@ namespace UnitTests.Integration;
 /// Verifies that grouping/ungrouping is a purely organizational operation with no simulation effect.
 /// Covers issue #319: groups must not "swallow" light during simulation.
 /// </summary>
+[Trait("Category", "Slow")]
 public class FlattenGroupLightPreservationTests
 {
     private static readonly int[] AllWavelengths = { StandardWaveLengths.RedNM };

--- a/UnitTests/Integration/GdsCoordinateVerificationTests.cs
+++ b/UnitTests/Integration/GdsCoordinateVerificationTests.cs
@@ -47,6 +47,7 @@ namespace UnitTests.Integration;
 /// NazcaCoordinateMapperTests (hand-computed expectations) and by GdsExportAlignmentTests
 /// (verified against the real nazca engine that writes the GDS).
 /// </summary>
+[Trait("Category", "Slow")]
 public class GdsCoordinateVerificationTests
 {
     private const double PinAlignmentTolerance = 0.01; // µm — tight, 10 nm

--- a/UnitTests/Integration/GdsRoundtripTests.cs
+++ b/UnitTests/Integration/GdsRoundtripTests.cs
@@ -24,6 +24,7 @@ namespace UnitTests.Integration;
 ///   Phase 2 - Nazca script validation: positions/rotations verified via ExportValidator
 ///   Phase 3 - GDS binary validation: conditional on Python+Nazca availability
 /// </summary>
+[Trait("Category", "Slow")]
 public class GdsRoundtripTests
 {
     private readonly ObservableCollection<ComponentTemplate> _library;

--- a/UnitTests/Integration/GdsWaveguideAlignmentTests.cs
+++ b/UnitTests/Integration/GdsWaveguideAlignmentTests.cs
@@ -31,6 +31,7 @@ namespace UnitTests.Integration;
 ///   D - Absolute positioning, no chaining
 ///   E - Conditional GDS binary test (requires Python + Nazca)
 /// </summary>
+[Trait("Category", "Slow")]
 public class GdsWaveguideAlignmentTests
 {
     private const double Tolerance = 0.05; // µm — tight alignment tolerance

--- a/UnitTests/Routing/AsyncRoutingTests.cs
+++ b/UnitTests/Routing/AsyncRoutingTests.cs
@@ -13,6 +13,7 @@ namespace UnitTests.Routing;
 /// <summary>
 /// Tests for async routing infrastructure (deferred connections, async recalculation, cancellation).
 /// </summary>
+[Trait("Category", "Slow")]
 public class AsyncRoutingTests
 {
     [Fact]

--- a/UnitTests/Routing/CrossingInsertion/CrossingInsertionTests.cs
+++ b/UnitTests/Routing/CrossingInsertion/CrossingInsertionTests.cs
@@ -17,6 +17,7 @@ namespace UnitTests.Routing.CrossingInsertion;
 /// component is placed at the intersection and both nets are split into
 /// sub-connections docked at its ports.
 /// </summary>
+[Trait("Category", "Slow")]
 public class CrossingInsertionTests
 {
     /// <summary>Bend loss that makes the detour clearly worse than one crossing (~0.18 dB).</summary>

--- a/UnitTests/Routing/DiagonalRoutingTests.cs
+++ b/UnitTests/Routing/DiagonalRoutingTests.cs
@@ -9,6 +9,7 @@ namespace UnitTests.Routing;
 /// <summary>
 /// Tests for 8-direction (45° diagonal) octile routing (Issue #552).
 /// </summary>
+[Trait("Category", "Slow")]
 public class DiagonalRoutingTests
 {
     private const double CellSize = 1.0;

--- a/UnitTests/Routing/FrozenPathObstacleTests.cs
+++ b/UnitTests/Routing/FrozenPathObstacleTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.Routing;
 /// Tests that the waveguide router treats frozen group paths as obstacles.
 /// Issue #353: Router should proactively avoid frozen waveguide paths during A* pathfinding.
 /// </summary>
+[Trait("Category", "Slow")]
 public class FrozenPathObstacleTests
 {
     private const double CellSize = 4.0;

--- a/UnitTests/Routing/GroupRoutingIntegrationTests.cs
+++ b/UnitTests/Routing/GroupRoutingIntegrationTests.cs
@@ -11,6 +11,7 @@ namespace UnitTests.Routing;
 /// Integration tests for WaveguideRouter with ComponentGroup obstacles.
 /// Tests the full routing workflow from pin to pin through grouped components.
 /// </summary>
+[Trait("Category", "Slow")]
 public class GroupRoutingIntegrationTests
 {
     /// <summary>

--- a/UnitTests/Routing/HierarchicalPathfinderTests.cs
+++ b/UnitTests/Routing/HierarchicalPathfinderTests.cs
@@ -14,6 +14,7 @@ namespace UnitTests.Routing;
 /// <summary>
 /// Tests for HPA* hierarchical pathfinding, sector graph, and distance transform.
 /// </summary>
+[Trait("Category", "Slow")]
 public class HierarchicalPathfinderTests
 {
     [Fact]

--- a/UnitTests/Routing/ManhattanRoutingIntegrationTests.cs
+++ b/UnitTests/Routing/ManhattanRoutingIntegrationTests.cs
@@ -14,6 +14,7 @@ namespace UnitTests.Routing;
 /// Integration tests for Manhattan router obstacle registration and collision detection.
 /// Tests fix for issue #87: Manhattan router waveguides not registered in PathfindingGrid.
 /// </summary>
+[Trait("Category", "Slow")]
 public class ManhattanRoutingIntegrationTests
 {
     [Fact]

--- a/UnitTests/Routing/RoutingEdgeCaseTests.cs
+++ b/UnitTests/Routing/RoutingEdgeCaseTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.Routing;
 /// Tests close pins, all direction pairs, path quality (no loops/diagonals),
 /// and validates that A* produces professional-quality routes.
 /// </summary>
+[Trait("Category", "Slow")]
 public class RoutingEdgeCaseTests
 {
     private readonly ITestOutputHelper _output;

--- a/UnitTests/Simulation/GroupFlattenSimulationTests.cs
+++ b/UnitTests/Simulation/GroupFlattenSimulationTests.cs
@@ -19,6 +19,7 @@ namespace UnitTests.Simulation;
 /// Groups are purely organizational — ungrouping must not affect simulation results.
 /// Any discrepancy indicates a "light swallowing" bug in group S-Matrix computation.
 /// </summary>
+[Trait("Category", "Slow")]
 public class GroupFlattenSimulationTests
 {
     private const int WavelengthNm = 1550; // matches StandardWaveLengths.RedNM

--- a/UnitTests/Simulation/Reflection/DeepCavityConvergenceTests.cs
+++ b/UnitTests/Simulation/Reflection/DeepCavityConvergenceTests.cs
@@ -20,6 +20,7 @@ namespace UnitTests.Simulation.Reflection;
 /// 100 iterations to converge to 1e-9 — far beyond the old pinCount×2 ≈ 24-step limit.
 /// Issue #555.
 /// </summary>
+[Trait("Category", "Slow")]
 public class DeepCavityConvergenceTests
 {
     private const double HighReflectivity = 0.9;

--- a/UnitTests/Simulation/Reflection/FabryPerotResonanceTests.cs
+++ b/UnitTests/Simulation/Reflection/FabryPerotResonanceTests.cs
@@ -14,6 +14,7 @@ namespace UnitTests.Simulation.Reflection;
 /// Convergence note: with r=0.3 and pinCount×2=24 steps, truncation error ≈ 7×10⁻⁴.
 /// For r > 0.8 the heuristic is insufficient — see issue #536 follow-up.
 /// </summary>
+[Trait("Category", "Slow")]
 public class FabryPerotResonanceTests
 {
     // Moderate reflectivity chosen so the default step heuristic (pinCount × 2) converges.

--- a/UnitTests/Simulation/SimulationIntegrationTests.cs
+++ b/UnitTests/Simulation/SimulationIntegrationTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.Simulation;
 /// End-to-end integration tests verifying light propagation through a
 /// multi-component circuit: GC → Splitter → 2x DC → 4x GC outputs.
 /// </summary>
+[Trait("Category", "Slow")]
 public class SimulationIntegrationTests
 {
     private static readonly int[] AllWavelengths =

--- a/UnitTests/UI/Flows/UiFlowEditForkTests.cs
+++ b/UnitTests/UI/Flows/UiFlowEditForkTests.cs
@@ -16,6 +16,7 @@ namespace UnitTests.UI.Flows;
 /// </summary>
 [Trait("Category", "UiFlows")]
 [Collection("UiFlows")]
+[Trait("Category", "Slow")]
 public class UiFlowEditForkTests
 {
     private const string PdkName = "Demo PDK";

--- a/UnitTests/ViewModels/UndoRedoIntegrationTests.cs
+++ b/UnitTests/ViewModels/UndoRedoIntegrationTests.cs
@@ -15,6 +15,7 @@ namespace UnitTests.ViewModels;
 /// Integration tests for Undo/Redo functionality in MainViewModel.
 /// Tests the complete flow: User action → Command → CommandManager → UI update.
 /// </summary>
+[Trait("Category", "Slow")]
 public class UndoRedoIntegrationTests
 {
     [Fact]

--- a/UnitTests/ViewModels/ZoomToFitTests.cs
+++ b/UnitTests/ViewModels/ZoomToFitTests.cs
@@ -8,6 +8,7 @@ namespace UnitTests.ViewModels;
 /// <summary>
 /// Tests for <see cref="MainViewModel.ZoomToFit"/> and viewport centering.
 /// </summary>
+[Trait("Category", "Slow")]
 public class ZoomToFitTests
 {
     private static MainViewModel CreateViewModel() =>


### PR DESCRIPTION
## Gate the slowest test classes to CI-only (local speedup)

Local test runs were pinning all 20 cores and taking minutes; the heavy tail is a handful of integration tests. Measured with a TRX timing run: the **slowest 31 classes = ~80% of total test-time (2930s) but only ~260 of 3778 tests**. Almost all are integration tests — Python/subprocess GDS export, GDS binary roundtrips, heavy routing/pathfinding, reflection/FDTD simulation, and UI flows.

### Change
Tagged those 31 classes `[Trait("Category", "Slow")]` (attribute only — no test logic touched). This reuses the repo's existing `[Trait("Category", …)]` convention (FdtdIntegration / UiFlows / UiScreenshots).

### Behaviour
- **CI unchanged:** the workflow runs `dotnet test --no-restore` (unfiltered), so every Slow test still runs and is validated on every PR.
- **Local:** run `dotnet test --filter "Category!=Slow"` to skip them → the fast suite is **3519 tests in ~56s** (CPU-throttled) instead of several minutes. Include them with a plain `dotnet test`.

Tagged classes (by area): GDS/Python export + script-execution (GdsExport*, PythonDiscovery/Config, Gds*Roundtrip/Alignment/Verification, Sax/GdsFactory/PdkResolution ScriptExecution, GdsFactoryExportViewModel, NazcaCodeTemplateBuilder), routing (RoutingEdgeCase, Group/Diagonal/Manhattan/Async routing, HierarchicalPathfinder, FrozenPathObstacle, CrossingInsertion), simulation (DeepCavityConvergence, FabryPerotResonance, PolarizationRotator, GroupFlatten, SimulationIntegration, FlattenGroupLightPreservation), and UI/commands (UiFlowEditFork, UndoRedoIntegration, KeyboardHandler, ZoomToFit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6xGFNsXL1ntWmGzKFJhrU
