### PR TITLE
A* honors the process bend-radius floor — no more loops/crossings, design-rule warning on degradation

### DIFF
--- a/Connect-A-Pic-Core/Analysis/DesignIssue.cs
+++ b/Connect-A-Pic-Core/Analysis/DesignIssue.cs
@@ -35,7 +35,14 @@ public enum DesignIssueType
     /// was placed — issue #570 follow-up). New placements from that PDK are blocked, but the
     /// component itself is kept; this flags it for manual review.
     /// </summary>
-    PdkProcessMismatch
+    PdkProcessMismatch,
+
+    /// <summary>
+    /// The route could only be found with a bend radius below the active fabrication
+    /// process' minimum bend radius (the router's controlled degradation). The geometry
+    /// is clean, but fabrication rules are violated — free up space or reroute manually.
+    /// </summary>
+    BendRadiusBelowProcessMinimum
 }
 
 /// <summary>

--- a/Connect-A-Pic-Core/Analysis/DesignValidator.cs
+++ b/Connect-A-Pic-Core/Analysis/DesignValidator.cs
@@ -87,6 +87,18 @@ public class DesignValidator
                 midY,
                 $"Blocked path: {startName} to {endName}"));
         }
+
+        if (connection.RoutedPath?.ViolatesProcessMinBendRadius == true)
+        {
+            var startName = FormatPinName(connection.StartPin);
+            var endName = FormatPinName(connection.EndPin);
+            issues.Add(new DesignIssue(
+                DesignIssueType.BendRadiusBelowProcessMinimum,
+                connection,
+                midX,
+                midY,
+                $"Bend radius below process minimum: {startName} to {endName}"));
+        }
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -182,8 +182,10 @@ namespace CAP_Core.Components.Connections
                 BendRadiusOverrides.Clear();
             }
 
-            // Update router settings
-            router.MinBendRadiusMicrometers = effectiveBendRadius;
+            // Update router settings. The router owns the process floor: it first attempts
+            // max(connection radius, process minimum) and degrades to the connection radius
+            // with RoutedPath.ViolatesProcessMinBendRadius set when the floor finds no clean path.
+            router.MinBendRadiusMicrometers = BendRadiusMicrometers;
 
             // Route the connection using two-phase A* (Phase 1 quick, Phase 2 extended)
             RoutedPath = router.Route(StartPin, EndPin, cancellationToken);

--- a/Connect-A-Pic-Core/Routing/PathIntersectionDetector.cs
+++ b/Connect-A-Pic-Core/Routing/PathIntersectionDetector.cs
@@ -1,0 +1,155 @@
+namespace CAP_Core.Routing;
+
+/// <summary>
+/// Geometric intersection checks on routed paths: self-intersection of a single path
+/// (loops, teardrops) and crossings between two paths. Paths are sampled into
+/// polylines (arcs included) and tested with exact segment-segment intersection.
+/// </summary>
+public static class PathIntersectionDetector
+{
+    /// <summary>Sampling step along segments in micrometers.</summary>
+    private const double SampleStepMicrometers = 2.0;
+
+    /// <summary>
+    /// Distance below which two polyline points count as the same joint
+    /// (adjacent samples sharing an endpoint are not intersections).
+    /// </summary>
+    private const double JointToleranceMicrometers = 0.05;
+
+    /// <summary>
+    /// Returns true when the path crosses itself (e.g. a full-circle loop or a
+    /// teardrop produced by a fallback router).
+    /// </summary>
+    public static bool HasSelfIntersection(RoutedPath path)
+    {
+        var points = SamplePolyline(path);
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            // Skip the immediate neighbor: consecutive polyline segments share a joint.
+            for (int j = i + 2; j < points.Count - 1; j++)
+            {
+                if (SegmentsIntersect(points[i], points[i + 1], points[j], points[j + 1]))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the minimum distance (µm) between two paths. 0 means they cross,
+    /// touch, or run on top of each other. Intended for routes between distinct pin
+    /// pairs (no shared endpoints); use it to assert crossing-freedom and clearance.
+    /// </summary>
+    public static double MinimumDistance(RoutedPath first, RoutedPath second)
+    {
+        var a = SamplePolyline(first);
+        var b = SamplePolyline(second);
+        double min = double.MaxValue;
+        for (int i = 0; i < a.Count - 1; i++)
+        {
+            for (int j = 0; j < b.Count - 1; j++)
+            {
+                if (SegmentsIntersect(a[i], a[i + 1], b[j], b[j + 1]))
+                    return 0;
+                min = Math.Min(min, SegmentDistance(a[i], a[i + 1], b[j], b[j + 1]));
+            }
+        }
+        return min == double.MaxValue ? 0 : min;
+    }
+
+    /// <summary>
+    /// Samples the path's segments (straights and arcs) into one polyline.
+    /// Joints closer than <see cref="JointToleranceMicrometers"/> are merged so
+    /// touching segment ends never read as intersections.
+    /// </summary>
+    private static List<(double X, double Y)> SamplePolyline(RoutedPath path)
+    {
+        var points = new List<(double X, double Y)>();
+        foreach (var segment in path.Segments)
+        {
+            foreach (var point in SampleSegment(segment))
+            {
+                if (points.Count == 0 || Distance(points[^1], point) > JointToleranceMicrometers)
+                    points.Add(point);
+            }
+        }
+        return points;
+    }
+
+    private static IEnumerable<(double X, double Y)> SampleSegment(PathSegment segment)
+    {
+        if (segment is BendSegment bend)
+        {
+            double sweepRad = bend.SweepAngleDegrees * Math.PI / 180;
+            double arcLength = Math.Abs(sweepRad) * bend.RadiusMicrometers;
+            int steps = Math.Max(4, (int)Math.Ceiling(arcLength / SampleStepMicrometers));
+            double sign = Math.Sign(bend.SweepAngleDegrees) == 0 ? 1 : Math.Sign(bend.SweepAngleDegrees);
+            double startRad = bend.StartAngleDegrees * Math.PI / 180;
+
+            for (int i = 0; i <= steps; i++)
+            {
+                double angle = startRad + sweepRad * i / steps;
+                yield return (
+                    bend.Center.X + bend.RadiusMicrometers * Math.Cos(angle - Math.PI / 2 * sign),
+                    bend.Center.Y + bend.RadiusMicrometers * Math.Sin(angle - Math.PI / 2 * sign));
+            }
+            yield break;
+        }
+
+        yield return (segment.StartPoint.X, segment.StartPoint.Y);
+        yield return (segment.EndPoint.X, segment.EndPoint.Y);
+    }
+
+    /// <summary>
+    /// Exact 2D segment intersection (proper crossings and overlaps). Shared joints
+    /// were merged during sampling, so any remaining touch is a genuine intersection.
+    /// </summary>
+    private static bool SegmentsIntersect(
+        (double X, double Y) p1, (double X, double Y) p2,
+        (double X, double Y) q1, (double X, double Y) q2)
+    {
+        double d1 = Cross(q1, q2, p1);
+        double d2 = Cross(q1, q2, p2);
+        double d3 = Cross(p1, p2, q1);
+        double d4 = Cross(p1, p2, q2);
+
+        if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+            ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0)))
+            return true;
+
+        return false;
+    }
+
+    private static double Cross((double X, double Y) a, (double X, double Y) b, (double X, double Y) c)
+        => (b.X - a.X) * (c.Y - a.Y) - (b.Y - a.Y) * (c.X - a.X);
+
+    /// <summary>Minimum distance between two non-crossing segments (endpoint-to-segment).</summary>
+    private static double SegmentDistance(
+        (double X, double Y) p1, (double X, double Y) p2,
+        (double X, double Y) q1, (double X, double Y) q2)
+    {
+        return Math.Min(
+            Math.Min(PointToSegment(p1, q1, q2), PointToSegment(p2, q1, q2)),
+            Math.Min(PointToSegment(q1, p1, p2), PointToSegment(q2, p1, p2)));
+    }
+
+    /// <summary>Distance from a point to a segment.</summary>
+    private static double PointToSegment(
+        (double X, double Y) p, (double X, double Y) a, (double X, double Y) b)
+    {
+        double dx = b.X - a.X;
+        double dy = b.Y - a.Y;
+        double lengthSquared = dx * dx + dy * dy;
+        if (lengthSquared < 1e-12) return Distance(p, a);
+
+        double t = Math.Clamp(((p.X - a.X) * dx + (p.Y - a.Y) * dy) / lengthSquared, 0, 1);
+        return Distance(p, (a.X + t * dx, a.Y + t * dy));
+    }
+
+    private static double Distance((double X, double Y) a, (double X, double Y) b)
+    {
+        double dx = b.X - a.X;
+        double dy = b.Y - a.Y;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+}

--- a/Connect-A-Pic-Core/Routing/RoutedPath.cs
+++ b/Connect-A-Pic-Core/Routing/RoutedPath.cs
@@ -22,6 +22,14 @@ public class RoutedPath
     public bool IsInvalidGeometry { get; set; } = false;
 
     /// <summary>
+    /// True when the path could only be routed with a bend radius below the active
+    /// fabrication process' minimum (<see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>).
+    /// The geometry itself is clean, but the design violates the process rule; the
+    /// design checks surface it as a <c>BendRadiusBelowProcessMinimum</c> issue.
+    /// </summary>
+    public bool ViolatesProcessMinBendRadius { get; set; } = false;
+
+    /// <summary>
     /// Debug information: The raw A* grid path used to generate this path.
     /// Only populated when A* routing is used.
     /// </summary>

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
@@ -10,17 +10,22 @@ namespace CAP_Core.Routing;
 public class WaveguideRouter
 {
     /// <summary>
-    /// Minimum bend radius in micrometers. Violating this causes high loss.
+    /// The connection's minimum bend radius in micrometers. Violating this causes high loss.
     /// </summary>
     public double MinBendRadiusMicrometers { get; set; } = 10.0;
 
     /// <summary>
     /// Bend-radius floor (µm) imposed by the active fabrication process
-    /// (<c>WaveguideBendRadiusResolver</c>). <see cref="Components.Connections.WaveguideConnection.RecalculateTransmission"/>
-    /// combines it with the per-connection bend radius via <c>Math.Max</c>, so no automatic
-    /// route can bend tighter than the process permits. 0 means no process constraint.
+    /// (<c>WaveguideBendRadiusResolver</c>). <see cref="Route"/> first attempts the larger of
+    /// this floor and <see cref="MinBendRadiusMicrometers"/>; when no clean path exists at the
+    /// floor it retries at the connection radius and marks the result with
+    /// <see cref="RoutedPath.ViolatesProcessMinBendRadius"/> so the design checks surface the
+    /// violation. 0 means no process constraint.
     /// </summary>
     public double ProcessMinBendRadiusMicrometers { get; set; }
+
+    /// <summary>Tolerance (µm) below which two bend radii count as equal.</summary>
+    private const double RadiusToleranceMicrometers = 1e-6;
 
     /// <summary>
     /// Allowed bend radii in micrometers (foundry-style discrete values).
@@ -174,9 +179,13 @@ public class WaveguideRouter
 
     /// <summary>
     /// Routes a waveguide between two pins using two-phase A* pathfinding.
-    /// Phase 1 uses a limited node budget for fast results.
-    /// Phase 2 uses an extended node budget for complex routes (triggers <see cref="OnComplexRouteStarted"/>).
-    /// Falls back to Manhattan (marked as blocked) if both A* phases fail.
+    /// The first attempt honors the process bend-radius floor
+    /// (<see cref="ProcessMinBendRadiusMicrometers"/>); when no clean path exists at the floor,
+    /// it retries at the connection radius and marks the result with
+    /// <see cref="RoutedPath.ViolatesProcessMinBendRadius"/>. Falls back to Manhattan routing
+    /// if all A* attempts fail; a self-intersecting or blocked fallback at the floor radius
+    /// is discarded in favor of the connection radius, and unresolvable results are marked
+    /// <see cref="RoutedPath.IsBlockedFallback"/>.
     /// </summary>
     /// <param name="startPin">Source pin.</param>
     /// <param name="endPin">Target pin.</param>
@@ -191,33 +200,97 @@ public class WaveguideRouter
 
         double endInputAngle = AngleUtilities.NormalizeAngle(endAngle + 180);
 
+        double connectionRadius = MinBendRadiusMicrometers;
+        double effectiveRadius = Math.Max(connectionRadius, ProcessMinBendRadiusMicrometers);
+        bool floorRaisesRadius = effectiveRadius > connectionRadius + RadiusToleranceMicrometers;
+
         if (PathfindingGrid != null)
         {
             var astarPath = new RoutedPath();
-            if (TryRouteAStar(startX, startY, startAngle, endX, endY, endInputAngle,
-                              astarPath, startPin, endPin, cancellationToken))
+            if (TryRouteAStar(effectiveRadius, startX, startY, startAngle, endX, endY, endInputAngle,
+                              astarPath, startPin, endPin, cancellationToken)
+                && IsCleanAStarResult(astarPath))
             {
-                if (astarPath.IsValid) return astarPath;
+                return astarPath;
+            }
+
+            // Controlled degradation: the process floor found no clean path — retry at the
+            // connection radius and surface the violation instead of degenerate geometry.
+            if (floorRaisesRadius)
+            {
+                astarPath = new RoutedPath();
+                if (TryRouteAStar(connectionRadius, startX, startY, startAngle, endX, endY, endInputAngle,
+                                  astarPath, startPin, endPin, cancellationToken)
+                    && IsCleanAStarResult(astarPath))
+                {
+                    astarPath.ViolatesProcessMinBendRadius = true;
+                    return astarPath;
+                }
             }
         }
 
-        // A* failed - try Manhattan routing as fallback
-        var path = new RoutedPath();
-        // Use small lead-in/lead-out for smoother transitions (15% of bend radius)
-        double leadLength = MinBendRadiusMicrometers * 0.15;
-        var manhattan = new ManhattanRouter(MinBendRadiusMicrometers, leadOut: leadLength, leadIn: leadLength);
-        manhattan.Route(startX, startY, startAngle, endX, endY, endInputAngle, path);
+        return RouteManhattanFallback(startX, startY, startAngle, endX, endY, endInputAngle,
+                                      connectionRadius, effectiveRadius, floorRaisesRadius);
+    }
 
-        // Check if the Manhattan path collides with existing obstacles
-        // Manhattan routing doesn't use PathfindingGrid, so we check manually
-        if (path.Segments.Count == 0 || !path.IsValid || IsPathBlocked(path.Segments))
+    /// <summary>
+    /// Manhattan (CSC) fallback when all A* attempts fail. Tries the process floor radius
+    /// first; a result that loops through itself or crosses obstacles is discarded in favor
+    /// of the connection radius (marked as a process-minimum violation). A result that is
+    /// still blocked or self-intersecting is marked <see cref="RoutedPath.IsBlockedFallback"/>.
+    /// </summary>
+    private RoutedPath RouteManhattanFallback(
+        double startX, double startY, double startAngle,
+        double endX, double endY, double endInputAngle,
+        double connectionRadius, double effectiveRadius, bool floorRaisesRadius)
+    {
+        var path = RouteManhattan(startX, startY, startAngle, endX, endY, endInputAngle, effectiveRadius);
+        if (IsCleanFallback(path)) return path;
+
+        if (floorRaisesRadius)
         {
-            // Path is blocked - mark as faulty fallback
-            path.IsBlockedFallback = true;
+            var relaxed = RouteManhattan(startX, startY, startAngle, endX, endY, endInputAngle, connectionRadius);
+            relaxed.ViolatesProcessMinBendRadius = true;
+            if (IsCleanFallback(relaxed)) return relaxed;
+
+            // Both radii failed — keep the tighter (shorter, less loop-prone) geometry.
+            relaxed.IsBlockedFallback = true;
+            return relaxed;
         }
 
+        path.IsBlockedFallback = true;
         return path;
     }
+
+    /// <summary>Runs the Manhattan (CSC) router at the given bend radius.</summary>
+    private static RoutedPath RouteManhattan(
+        double startX, double startY, double startAngle,
+        double endX, double endY, double endInputAngle, double bendRadius)
+    {
+        var path = new RoutedPath();
+        // Use small lead-in/lead-out for smoother transitions (15% of bend radius)
+        double leadLength = bendRadius * 0.15;
+        var manhattan = new ManhattanRouter(bendRadius, leadOut: leadLength, leadIn: leadLength);
+        manhattan.Route(startX, startY, startAngle, endX, endY, endInputAngle, path);
+        return path;
+    }
+
+    /// <summary>
+    /// An A* result is accepted only when its segments connect and the smoothed geometry
+    /// does not intersect itself (arcs can drift when the grid path is tighter than planned).
+    /// </summary>
+    private static bool IsCleanAStarResult(RoutedPath path) =>
+        path.IsValid && !PathIntersectionDetector.HasSelfIntersection(path);
+
+    /// <summary>
+    /// A fallback path is acceptable as-is only when it has connected segments, does not
+    /// pass through obstacles, and does not intersect itself (no loops/teardrops).
+    /// </summary>
+    private bool IsCleanFallback(RoutedPath path) =>
+        path.Segments.Count > 0
+        && path.IsValid
+        && !IsPathBlocked(path.Segments)
+        && !PathIntersectionDetector.HasSelfIntersection(path);
 
     /// <summary>
     /// Checks if any segment in a path passes through blocked cells.
@@ -243,19 +316,28 @@ public class WaveguideRouter
     }
 
     /// <summary>
-    /// Attempts to route using two-phase A* pathfinding with obstacle avoidance.
+    /// Attempts to route using two-phase A* pathfinding with obstacle avoidance at the given
+    /// bend radius. The cost model (minimum straight run before turns) and the path smoother
+    /// are synced to that radius, so the grid path leaves room for the arcs that will be built.
     /// Phase 1 uses <see cref="Phase1MaxNodes"/> for fast results.
     /// Phase 2 uses <see cref="Phase2MaxNodes"/> and fires <see cref="OnComplexRouteStarted"/> if Phase 1 fails.
     /// </summary>
-    private bool TryRouteAStar(double startX, double startY, double startAngle,
+    private bool TryRouteAStar(double bendRadius,
+                                double startX, double startY, double startAngle,
                                 double endX, double endY, double endInputAngle,
                                 RoutedPath path, PhysicalPin startPin, PhysicalPin endPin,
                                 CancellationToken cancellationToken = default)
     {
         if (PathfindingGrid == null) return false;
 
-        double corridorLength = MinBendRadiusMicrometers * 3;
-        double corridorWidth = MinBendRadiusMicrometers;
+        // Sync the cost model to the radius of THIS attempt: turns must be spaced far
+        // enough apart that the smoother can realize them as arcs of this radius.
+        CostCalculator.MinBendRadiusMicrometers = bendRadius;
+        CostCalculator.MinStraightRunCells =
+            (int)Math.Ceiling(bendRadius * 2 / PathfindingGrid.CellSizeMicrometers);
+
+        double corridorLength = bendRadius * 3;
+        double corridorWidth = bendRadius;
 
         var clearedStart = PathfindingGrid.ClearPinCorridor(
             startX, startY, startAngle, corridorLength, corridorWidth);
@@ -378,7 +460,7 @@ public class WaveguideRouter
 
             if (gridPath == null || gridPath.Count < 2) return false;
 
-            var smoother = new PathSmoother(PathfindingGrid, MinBendRadiusMicrometers, AllowedBendRadii);
+            var smoother = new PathSmoother(PathfindingGrid, bendRadius, AllowedRadiiIncluding(bendRadius));
             var smoothedPath = smoother.ConvertToSegments(gridPath, startPin, endPin);
 
             path.Segments.AddRange(smoothedPath.Segments);
@@ -394,6 +476,22 @@ public class WaveguideRouter
             PathfindingGrid.RestoreCells(clearedEndApproach);
             PathfindingGrid.RestoreCells(clearedEndTerminal);
         }
+    }
+
+    /// <summary>
+    /// The allowed bend radii extended with the current attempt's radius, so the smoother
+    /// builds arcs of exactly that radius instead of snapping up to the next foundry value
+    /// (which would not match the setbacks the grid path was planned with).
+    /// </summary>
+    private List<double> AllowedRadiiIncluding(double bendRadius)
+    {
+        if (AllowedBendRadii.Count == 0 ||
+            AllowedBendRadii.Any(r => Math.Abs(r - bendRadius) < RadiusToleranceMicrometers))
+            return AllowedBendRadii;
+
+        var radii = new List<double>(AllowedBendRadii) { bendRadius };
+        radii.Sort();
+        return radii;
     }
 
     /// <summary>

--- a/UnitTests/Helpers/TestComponentFactory.cs
+++ b/UnitTests/Helpers/TestComponentFactory.cs
@@ -135,6 +135,38 @@ namespace UnitTests
         }
 
         /// <summary>
+        /// Creates a 250×250 µm component with four physical pins (two per side), mimicking
+        /// a directional coupler: west0/east0 in the upper row, west1/east1 in the lower row.
+        /// </summary>
+        public static Component CreateFourPinCouplerWithPhysicalPins(string idSuffix)
+        {
+            var component = CreateStraightWaveGuide();
+            component.Identifier = $"coupler_{idSuffix}";
+            component.WidthMicrometers = 250;
+            component.HeightMicrometers = 250;
+
+            AddPhysicalPin(component, "west0", 0, 80, 180);
+            AddPhysicalPin(component, "west1", 0, 180, 180);
+            AddPhysicalPin(component, "east0", 250, 80, 0);
+            AddPhysicalPin(component, "east1", 250, 180, 0);
+            return component;
+        }
+
+        /// <summary>Adds a physical pin at the given component-relative offset and angle.</summary>
+        private static void AddPhysicalPin(
+            Component component, string name, double offsetX, double offsetY, double angleDegrees)
+        {
+            component.PhysicalPins.Add(new PhysicalPin
+            {
+                Name = name,
+                ParentComponent = component,
+                OffsetXMicrometers = offsetX,
+                OffsetYMicrometers = offsetY,
+                AngleDegrees = angleDegrees,
+            });
+        }
+
+        /// <summary>
         /// Creates a basic component for testing (uses CreateStraightWaveGuide).
         /// </summary>
         public static Component CreateBasicComponent()

--- a/UnitTests/Routing/InterconnectRouting/ProcessMinBendRadiusFloorTests.cs
+++ b/UnitTests/Routing/InterconnectRouting/ProcessMinBendRadiusFloorTests.cs
@@ -16,7 +16,9 @@ namespace UnitTests.Routing.InterconnectRouting;
 /// (<see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>, e.g. 30 µm for the
 /// Cornerstone SiN process) floors the effective bend radius everywhere: the AUTO (A*)
 /// route, the Manhattan fallback, and the styled Bend/S geometry. The per-connection
-/// radius and the process minimum combine via max — the larger one governs.
+/// radius and the process minimum combine via max — the larger one governs. When the
+/// floor cannot be realized geometrically, the router degrades to the connection radius
+/// and flags the route (see <c>ProcessMinRadiusDegradationTests</c>).
 /// </summary>
 public class ProcessMinBendRadiusFloorTests
 {
@@ -30,10 +32,11 @@ public class ProcessMinBendRadiusFloorTests
 
         connection.RecalculateTransmission(router);
 
-        router.MinBendRadiusMicrometers.ShouldBe(CornerstoneSinMinRadius);
+        // With enough room the router must realize the floor — no degradation flag.
         var bends = connection.GetPathSegments().OfType<BendSegment>().ToList();
         bends.ShouldNotBeEmpty();
         bends.ShouldAllBe(b => b.RadiusMicrometers >= CornerstoneSinMinRadius - 1e-6);
+        connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse();
     }
 
     [Fact]

--- a/UnitTests/Routing/PathIntersectionDetectorTests.cs
+++ b/UnitTests/Routing/PathIntersectionDetectorTests.cs
@@ -1,0 +1,86 @@
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Tests for <see cref="PathIntersectionDetector"/>: self-intersection of a single routed
+/// path and minimum clearance between two routed paths.
+/// </summary>
+public class PathIntersectionDetectorTests
+{
+    [Fact]
+    public void HasSelfIntersection_SimpleLShape_ReturnsFalse()
+    {
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+        path.Segments.Add(new StraightSegment(100, 0, 100, 100, 90));
+
+        PathIntersectionDetector.HasSelfIntersection(path).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasSelfIntersection_PathCrossingItself_ReturnsTrue()
+    {
+        // The last segment cuts back through the first one.
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+        path.Segments.Add(new StraightSegment(100, 0, 50, 50, 135));
+        path.Segments.Add(new StraightSegment(50, 50, 50, -50, 270));
+
+        PathIntersectionDetector.HasSelfIntersection(path).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HasSelfIntersection_LoopOfArcAndExit_ReturnsTrue()
+    {
+        // Straight lead-in, 300° arc, and an exit straight that cuts back through the
+        // lead-in — the teardrop loop shape the CSC fallback produced at tight spacing.
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, 50, 0, 0));
+        var loop = new BendSegment(50, 30, 30, 0, 300);
+        path.Segments.Add(loop);
+        double exitRad = 300 * Math.PI / 180.0;
+        path.Segments.Add(new StraightSegment(
+            loop.EndPoint.X, loop.EndPoint.Y,
+            loop.EndPoint.X + 40 * Math.Cos(exitRad), loop.EndPoint.Y + 40 * Math.Sin(exitRad),
+            300));
+
+        PathIntersectionDetector.HasSelfIntersection(path).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MinimumDistance_ParallelStraights_ReturnsTheirSpacing()
+    {
+        var first = new RoutedPath();
+        first.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+        var second = new RoutedPath();
+        second.Segments.Add(new StraightSegment(0, 5, 100, 5, 0));
+
+        PathIntersectionDetector.MinimumDistance(first, second).ShouldBe(5.0, 1e-9);
+    }
+
+    [Fact]
+    public void MinimumDistance_CrossingPaths_ReturnsZero()
+    {
+        var first = new RoutedPath();
+        first.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+        var second = new RoutedPath();
+        second.Segments.Add(new StraightSegment(50, -50, 50, 50, 90));
+
+        PathIntersectionDetector.MinimumDistance(first, second).ShouldBe(0.0);
+    }
+
+    [Fact]
+    public void MinimumDistance_OverlappingCollinearPaths_ReturnsZero()
+    {
+        // Two routes lying on top of each other (the CSC-fallback symptom).
+        var first = new RoutedPath();
+        first.Segments.Add(new StraightSegment(0, 0, 100, 0, 0));
+        var second = new RoutedPath();
+        second.Segments.Add(new StraightSegment(20, 0, 80, 0, 0));
+
+        PathIntersectionDetector.MinimumDistance(first, second).ShouldBe(0.0);
+    }
+}

--- a/UnitTests/Routing/ProcessMinRadiusDegradationTests.cs
+++ b/UnitTests/Routing/ProcessMinRadiusDegradationTests.cs
@@ -1,0 +1,161 @@
+using CAP_Core.Analysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Regression tests for AUTO routing under a process bend-radius floor (e.g. Cornerstone
+/// SiN, 30 µm). After PR #756 the floor fed the router but not its A* cost model, so every
+/// route silently fell back to the Manhattan (CSC) router: parallel connections overlapped
+/// and crossed, and close pins produced full-circle self-intersecting loops. The router now
+/// genuinely attempts A* at the floor and, when no clean path exists, degrades in a
+/// controlled way to the connection radius while flagging the route
+/// (<see cref="RoutedPath.ViolatesProcessMinBendRadius"/>) for the design checks.
+/// </summary>
+public class ProcessMinRadiusDegradationTests
+{
+    private const double CornerstoneSinMinRadius = 30.0;
+
+    /// <summary>Minimum clearance (µm) two distinct routes must keep (waveguide spacing).</summary>
+    private const double MinRouteClearance = 2.0;
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(CornerstoneSinMinRadius)]
+    public void ParallelCouplerConnections_NeverCrossEachOther(double processFloor)
+    {
+        var (manager, inner, outer) = RouteParallelCouplers(processFloor);
+
+        inner.IsPathValid.ShouldBeTrue();
+        outer.IsPathValid.ShouldBeTrue();
+        inner.IsBlockedFallback.ShouldBeFalse();
+        outer.IsBlockedFallback.ShouldBeFalse();
+
+        PathIntersectionDetector.HasSelfIntersection(inner.RoutedPath!).ShouldBeFalse();
+        PathIntersectionDetector.HasSelfIntersection(outer.RoutedPath!).ShouldBeFalse();
+        PathIntersectionDetector.MinimumDistance(inner.RoutedPath!, outer.RoutedPath!)
+            .ShouldBeGreaterThan(MinRouteClearance);
+
+        manager.Connections.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ParallelCouplers_WithRoomForTheFloor_AllBendsHonorTheProcessMinimum()
+    {
+        var (_, inner, outer) = RouteParallelCouplers(CornerstoneSinMinRadius);
+
+        foreach (var connection in new[] { inner, outer })
+        {
+            var bends = connection.GetPathSegments().OfType<BendSegment>().ToList();
+            bends.ShouldNotBeEmpty();
+            bends.ShouldAllBe(b => b.RadiusMicrometers >= CornerstoneSinMinRadius - 1e-6);
+            connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse();
+        }
+    }
+
+    [Fact]
+    public void TightNeighbors_FloorFindsNoPath_DegradesToConnectionRadiusWithViolationFlag()
+    {
+        var connection = RouteTightNeighbors(CornerstoneSinMinRadius);
+
+        connection.IsPathValid.ShouldBeTrue();
+        connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeTrue();
+        PathIntersectionDetector.HasSelfIntersection(connection.RoutedPath).ShouldBeFalse();
+
+        // The degraded route still honors the connection's own 10 µm radius.
+        var bends = connection.GetPathSegments().OfType<BendSegment>().ToList();
+        bends.ShouldNotBeEmpty();
+        bends.ShouldAllBe(b => b.RadiusMicrometers >= connection.BendRadiusMicrometers - 1e-6);
+    }
+
+    [Fact]
+    public void TightNeighbors_NoFloor_RoutesCleanWithoutViolationFlag()
+    {
+        var connection = RouteTightNeighbors(processFloor: 0.0);
+
+        connection.IsPathValid.ShouldBeTrue();
+        connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse();
+        PathIntersectionDetector.HasSelfIntersection(connection.RoutedPath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DesignValidator_SurfacesTheProcessMinimumViolation()
+    {
+        var connection = RouteTightNeighbors(CornerstoneSinMinRadius);
+
+        var issues = new DesignValidator().Validate(new[] { connection });
+
+        var issue = issues.ShouldHaveSingleItem();
+        issue.Type.ShouldBe(DesignIssueType.BendRadiusBelowProcessMinimum);
+        issue.Connection.ShouldBe(connection);
+        issue.Description.ShouldContain("below process minimum");
+    }
+
+    /// <summary>
+    /// Two stacked 4-pin couplers with two nested connections on the right side
+    /// (inner pins together, outer pins together) — the layout from the bug report.
+    /// </summary>
+    private static (WaveguideConnectionManager Manager, WaveguideConnection Inner, WaveguideConnection Outer)
+        RouteParallelCouplers(double processFloor)
+    {
+        var top = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("top");
+        top.PhysicalX = 60;
+        top.PhysicalY = 60;
+        var bottom = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("bottom");
+        bottom.PhysicalX = 60;
+        bottom.PhysicalY = 420;
+
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = processFloor };
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, new[] { top, bottom });
+
+        var manager = new WaveguideConnectionManager(router);
+        var inner = new WaveguideConnection
+        {
+            StartPin = Pin(top, "east1"),
+            EndPin = Pin(bottom, "east0"),
+        };
+        var outer = new WaveguideConnection
+        {
+            StartPin = Pin(top, "east0"),
+            EndPin = Pin(bottom, "east1"),
+        };
+        manager.AddExistingConnection(inner);
+        manager.AddExistingConnection(outer);
+        manager.RecalculateAllTransmissions();
+        return (manager, inner, outer);
+    }
+
+    /// <summary>
+    /// Two components whose facing pins are only ~40 µm apart in X and Y — too tight for a
+    /// 30 µm bend radius, the layout that historically produced full-circle loops.
+    /// </summary>
+    private static WaveguideConnection RouteTightNeighbors(double processFloor)
+    {
+        var left = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        right.PhysicalX = 350;
+        right.PhysicalY = 100;
+
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = processFloor };
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, new[] { left, right });
+
+        var manager = new WaveguideConnectionManager(router);
+        var connection = new WaveguideConnection
+        {
+            StartPin = Pin(left, "out"),
+            EndPin = Pin(right, "in"),
+        };
+        manager.AddExistingConnection(connection);
+        manager.RecalculateAllTransmissions();
+        return connection;
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+}

--- a/UnitTests/UI/ProcessMinRadiusRoutingDiagnosticTests.cs
+++ b/UnitTests/UI/ProcessMinRadiusRoutingDiagnosticTests.cs
@@ -1,0 +1,173 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CAP.Avalonia.Controls;
+using CAP.Avalonia.Views;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.UI;
+
+/// <summary>
+/// Visual diagnostic for AUTO routing under a fabrication-process bend-radius floor
+/// (e.g. Cornerstone SiN, 30 µm). Renders the REAL design canvas for two layouts that
+/// degenerated after the floor started feeding the A* router:
+/// (a) two stacked 4-pin couplers with two nested "parallel" connections on the right
+///     side (inner pins and outer pins) — the routes must never cross each other;
+/// (b) two components whose facing pins sit only a few tens of µm apart — the route
+///     must not loop through itself or its own component.
+/// One PNG per layout × floor value is written to
+/// <c>UI_SHOT_DIR/process-min-radius-routing/{layout}-floor{floor}.png</c>.
+/// </summary>
+[Trait("Category", "UiScreenshots")]
+public class ProcessMinRadiusRoutingDiagnosticTests
+{
+    private const int CanvasWidth = 1100;
+    private const int CanvasHeight = 800;
+
+    /// <summary>Headless renders occasionally miss a frame; retrying the capture makes the PNGs reliable.</summary>
+    private const int CaptureAttempts = 3;
+
+    private static readonly double[] Floors = { 10.0, 30.0 };
+
+    /// <summary>Captures both layouts under every process bend-radius floor.</summary>
+    [AvaloniaFact]
+    public async Task CaptureAutoRoutingUnderProcessFloor()
+    {
+        var shotRoot = Environment.GetEnvironmentVariable("UI_SHOT_DIR");
+        if (string.IsNullOrEmpty(shotRoot))
+            return;
+        var outputDir = Path.Combine(shotRoot, "process-min-radius-routing");
+        Directory.CreateDirectory(outputDir);
+        foreach (var stale in Directory.GetFiles(outputDir, "*.png"))
+            File.Delete(stale);
+
+        foreach (var floor in Floors)
+        {
+            await CaptureParallelCouplers(outputDir, floor);
+            await CaptureTightNeighbors(outputDir, floor);
+        }
+
+        Directory.GetFiles(outputDir, "*.png").Length.ShouldBe(Floors.Length * 2,
+            "every layout × floor must yield a PNG");
+    }
+
+    /// <summary>
+    /// Layout (a): two stacked 4-pin couplers; inner right pins connected to each other and
+    /// outer right pins connected to each other — two nested U-turns on the right side.
+    /// </summary>
+    private static async Task CaptureParallelCouplers(string outputDir, double floor)
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Router.ProcessMinBendRadiusMicrometers = floor;
+
+        var top = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("top");
+        top.PhysicalX = 60;
+        top.PhysicalY = 60;
+        var bottom = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("bottom");
+        bottom.PhysicalX = 60;
+        bottom.PhysicalY = 420;
+        canvas.AddComponent(top);
+        canvas.AddComponent(bottom);
+
+        await Capture(canvas, outputDir, $"parallel-couplers-floor{floor:F0}", async () =>
+        {
+            (await canvas.ConnectPinsAsync(Pin(top, "east1"), Pin(bottom, "east0")))
+                .ShouldNotBeNull("inner connection must be created");
+            (await canvas.ConnectPinsAsync(Pin(top, "east0"), Pin(bottom, "east1")))
+                .ShouldNotBeNull("outer connection must be created");
+        });
+    }
+
+    /// <summary>
+    /// Layout (b): two components whose facing pins are only ~40 µm apart in X — with a
+    /// 30 µm floor this historically produced full-circle loops through the component.
+    /// </summary>
+    private static async Task CaptureTightNeighbors(string outputDir, double floor)
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Router.ProcessMinBendRadiusMicrometers = floor;
+
+        var left = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        right.PhysicalX = 350;
+        right.PhysicalY = 100;
+        canvas.AddComponent(left);
+        canvas.AddComponent(right);
+
+        await Capture(canvas, outputDir, $"tight-neighbors-floor{floor:F0}", async () =>
+        {
+            (await canvas.ConnectPinsAsync(Pin(left, "out"), Pin(right, "in")))
+                .ShouldNotBeNull("tight connection must be created");
+        });
+    }
+
+    /// <summary>Connects the pins, pumps the dispatcher, and captures the canvas to a PNG.</summary>
+    private static async Task Capture(
+        DesignCanvasViewModel canvas, string outputDir, string name, Func<Task> connect)
+    {
+        var vm = MainViewModelTestHelper.CreateMainViewModel(canvas: canvas);
+        // MainViewModel rewires the floor provider to the process resolver; this test
+        // dictates the floor explicitly, so re-pin the provider to the test value.
+        double floor = canvas.Router.ProcessMinBendRadiusMicrometers;
+        canvas.Routing.GetProcessMinBendRadiusMicrometers = () => floor;
+        var window = new Window
+        {
+            Width = CanvasWidth,
+            Height = CanvasHeight,
+            Content = new MainView { DataContext = vm },
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            await connect();
+            await canvas.RecalculateRoutesAsync();
+
+            Dispatcher.UIThread.RunJobs();
+            foreach (var designCanvas in window.GetVisualDescendants().OfType<DesignCanvas>())
+                designCanvas.InvalidateVisual();
+            Dispatcher.UIThread.RunJobs();
+
+            CaptureWithRetry(window, Path.Combine(outputDir, $"{name}.png"));
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+
+    /// <summary>Captures the window with dispatcher pumping between attempts (headless flake guard).</summary>
+    private static void CaptureWithRetry(Window window, string path)
+    {
+        WriteableBitmap? bitmap = null;
+        for (int attempt = 0; attempt < CaptureAttempts; attempt++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            var frame = window.CaptureRenderedFrame();
+            if (frame == null)
+                continue;
+            bitmap?.Dispose();
+            bitmap = frame;
+        }
+
+        bitmap.ShouldNotBeNull($"CaptureRenderedFrame stayed null after {CaptureAttempts} attempts for {path}");
+        using (bitmap)
+        {
+            ScreenshotArtifacts.SavePng(bitmap, path);
+        }
+    }
+}


### PR DESCRIPTION
## A* honors the process bend-radius floor — controlled degradation instead of loops and crossings

After #756 raised the router's minimum bend radius to the process value (Cornerstone: 30 µm), auto-routing visibly degenerated: parallel connections between two couplers crossed each other, and tight layouts produced full-circle self-intersecting loops through the component. The user's instinct ("A* isn't used anymore") was literally true.

**Root cause (instrumented):** the A* cost model was never re-synchronized with the raised radius — `CostCalculator.MinStraightRunCells` kept the 10 µm value from grid init, `BendBuilder.SelectRadius(30)` snapped up to the 50 µm entry of `AllowedBendRadii`, and the path smoother computed setbacks for 30 µm — so every A* attempt failed geometry validation and **everything** fell through to the Manhattan (CSC/Dubins) fallback, which ignores obstacles: full-circle loops at close range, both "parallel" routes on the same tangent line.

**Fix:**
- `TryRouteAStar` synchronizes cost model, pin corridors and smoother to the radius **of the attempt**; the exact radius joins the allowed set (no 30→50 snapping).
- `Route()` tries the process floor first; if no clean path exists, it **retries with the connection radius (10 µm)** and marks the result `ViolatesProcessMinBendRadius` — surfaced as a new `BendRadiusBelowProcessMinimum` design issue in the Design Checks panel. Honest warning instead of garbage geometry.
- New `PathIntersectionDetector` (self-intersection + minimum route distance) rejects self-crossing fallback geometry across all paths.

**Verified visually** (headless canvas renders, before/after committed in the diagnostic test): floor 30 now yields two cleanly nested parallel routes with exact 30 µm arcs and no crossing; the tight layout routes as a clean small S-bend with the design-rule flag instead of a loop.

Tests: crossing-freedom at 10 AND 30, no self-intersections, arcs ≥ 30 when space allows, retry sets flag + design issue; full default suite **3675 passed / 0 failed / 14 skipped**. Build 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6xGFNsXL1ntWmGzKFJhrU
