### PR TITLE
Flat PDK components (sub-cell pin pitch) route cleanly — no more crossing fallbacks

### DIFF
--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
@@ -398,6 +398,7 @@ public class WaveguideConnectionManager
 
         // Route only the invalid/new connections
         int failedCount = 0;
+        var routedSoFar = new List<WaveguideConnection>(validConnections);
         foreach (var connection in invalidConnections)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -415,9 +416,13 @@ public class WaveguideConnectionManager
                     connection.RoutedPath.Segments,
                     WaveguideWidthMicrometers);
 
-                // NOTE: Blocked fallbacks are NOT counted as failures in incremental routing.
-                // They have valid geometry and are registered as obstacles, but we'll try
-                // to improve them via full re-route ordering strategies later.
+                // A route that geometrically crosses a sibling counts as a failure so the
+                // full re-route with ordering strategies gets a chance to untangle it.
+                // Blocked fallbacks are otherwise NOT counted as failures here: they have
+                // valid geometry and are registered as obstacles.
+                if (CrossesAnyRoutedSibling(connection, routedSoFar))
+                    failedCount++;
+                routedSoFar.Add(connection);
             }
             else
             {
@@ -484,6 +489,7 @@ public class WaveguideConnectionManager
         router.PathfindingGrid!.ClearAllWaveguideObstacles();
 
         int failedCount = 0;
+        var routedSoFar = new List<WaveguideConnection>();
 
         // Route each connection sequentially
         foreach (var connection in orderedConnections)
@@ -506,11 +512,15 @@ public class WaveguideConnectionManager
                     connection.RoutedPath.Segments,
                     WaveguideWidthMicrometers);
 
-                // Count blocked fallbacks as routing failures for ordering optimization
-                if (connection.IsBlockedFallback)
+                // Count blocked fallbacks and routes that geometrically cross a sibling
+                // as routing failures for ordering optimization. Grid obstacles cannot
+                // represent sub-cell pin pitches (flat PDK components), so the geometric
+                // check decides whether an ordering counts as clean.
+                if (connection.IsBlockedFallback || CrossesAnyRoutedSibling(connection, routedSoFar))
                 {
                     failedCount++;
                 }
+                routedSoFar.Add(connection);
             }
             else
             {
@@ -519,6 +529,18 @@ public class WaveguideConnectionManager
         }
 
         return (failedCount == 0, failedCount);
+    }
+
+    /// <summary>
+    /// True when the connection's routed geometry properly crosses any already-routed
+    /// sibling in this pass. Touching endpoints (shared fan-out regions) do not count.
+    /// </summary>
+    private static bool CrossesAnyRoutedSibling(
+        WaveguideConnection connection, List<WaveguideConnection> routedSoFar)
+    {
+        return routedSoFar.Any(other =>
+            other.RoutedPath != null &&
+            PathIntersectionDetector.Crosses(connection.RoutedPath!, other.RoutedPath));
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.PinFanout.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.PinFanout.cs
@@ -1,0 +1,86 @@
+namespace CAP_Core.Routing.AStarPathfinder;
+
+/// <summary>
+/// Pin fan-out handling for <see cref="PathfindingGrid"/>. Flat PDK components (e.g.
+/// Cornerstone SiN "Coupler Straight", 2.636 µm tall with a 1.436 µm pin pitch) place
+/// neighboring pins closer together than one grid cell and one waveguide obstacle width,
+/// so a sibling's registered route buries the neighboring pin in blocked cells and A*
+/// cannot even start. This part clears exactly the single-cell line of cells along the
+/// pin's outward axis — and only cells owned by routes that terminate right next to the
+/// pin (fan-out siblings) — so the pin becomes routable while every other sibling cell
+/// stays blocked and foreign waveguides are never opened up.
+/// </summary>
+public partial class PathfindingGrid
+{
+    /// <summary>Route endpoints per registered waveguide obstacle (fan-out sibling detection).</summary>
+    private readonly Dictionary<Guid, ((double X, double Y) Start, (double X, double Y) End)> _waveguideEndpoints = new();
+
+    /// <summary>
+    /// Maximum distance (µm) between a pin and a sibling route endpoint to count as the
+    /// same fan-out cluster. Covers real PDK pin pitches (1.436–5.2 µm) without reaching
+    /// unrelated routes.
+    /// </summary>
+    private const double FanoutEndpointRadiusMicrometers = 6.0;
+
+    /// <summary>
+    /// Temporarily clears waveguide cells (state=2) on the single-cell-wide line of cells
+    /// along a pin's outward axis, restricted to cells owned by fan-out sibling routes.
+    /// Returns the cleared cells for <see cref="RestoreCells"/>.
+    /// </summary>
+    /// <param name="pinX">Pin X position in micrometers.</param>
+    /// <param name="pinY">Pin Y position in micrometers.</param>
+    /// <param name="outwardAngleDegrees">Direction pointing away from the component.</param>
+    /// <param name="corridorLength">Length of the cleared line in micrometers.</param>
+    public Dictionary<(int x, int y), byte> ClearPinFanoutWaveguideCells(
+        double pinX, double pinY, double outwardAngleDegrees, double corridorLength)
+    {
+        var cleared = new Dictionary<(int, int), byte>();
+        var siblingCells = CollectFanoutSiblingCells(pinX, pinY);
+        if (siblingCells.Count == 0)
+            return cleared;
+
+        double angleRad = outwardAngleDegrees * Math.PI / 180.0;
+        double dx = Math.Cos(angleRad);
+        double dy = Math.Sin(angleRad);
+
+        for (double dist = 0; dist <= corridorLength; dist += CellSizeMicrometers)
+        {
+            var (gx, gy) = PhysicalToGrid(pinX + dx * dist, pinY + dy * dist);
+            if (!IsInBounds(gx, gy) || _cells[gx, gy] != 2) continue;
+            if (!siblingCells.Contains((gx, gy)) || cleared.ContainsKey((gx, gy))) continue;
+
+            cleared[(gx, gy)] = _cells[gx, gy];
+            _cells[gx, gy] = 0;
+        }
+
+        return cleared;
+    }
+
+    /// <summary>
+    /// Collects the grid cells of all registered routes that have an endpoint within
+    /// <see cref="FanoutEndpointRadiusMicrometers"/> of the given pin.
+    /// </summary>
+    private HashSet<(int, int)> CollectFanoutSiblingCells(double pinX, double pinY)
+    {
+        var siblingCells = new HashSet<(int, int)>();
+        lock (_waveguideCellsLock)
+        {
+            foreach (var (connectionId, (start, end)) in _waveguideEndpoints)
+            {
+                if (DistanceTo(start, pinX, pinY) > FanoutEndpointRadiusMicrometers &&
+                    DistanceTo(end, pinX, pinY) > FanoutEndpointRadiusMicrometers)
+                    continue;
+                if (_waveguideCells.TryGetValue(connectionId, out var cells))
+                    siblingCells.UnionWith(cells);
+            }
+        }
+        return siblingCells;
+    }
+
+    private static double DistanceTo((double X, double Y) point, double x, double y)
+    {
+        double dx = point.X - x;
+        double dy = point.Y - y;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+}

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
@@ -8,7 +8,7 @@ namespace CAP_Core.Routing.AStarPathfinder;
 /// Handles coordinate conversion between physical micrometers and grid cells,
 /// and tracks which cells are blocked by component obstacles.
 /// </summary>
-public class PathfindingGrid
+public partial class PathfindingGrid
 {
     /// <summary>
     /// Grid resolution in micrometers per cell.
@@ -540,6 +540,7 @@ public class PathfindingGrid
         lock (_waveguideCellsLock)
         {
             _waveguideCells.Clear();
+            _waveguideEndpoints.Clear();
         }
         lock (_pinZoneLock)
         {
@@ -635,6 +636,9 @@ public class PathfindingGrid
         lock (_waveguideCellsLock)
         {
             _waveguideCells[connectionId] = cells;
+            _waveguideEndpoints[connectionId] = (
+                (segmentList[0].StartPoint.X, segmentList[0].StartPoint.Y),
+                (segmentList[^1].EndPoint.X, segmentList[^1].EndPoint.Y));
         }
         OnWaveguideCellsAdded?.Invoke(cells);
     }
@@ -650,6 +654,7 @@ public class PathfindingGrid
             if (!_waveguideCells.TryGetValue(connectionId, out cells))
                 return;
             _waveguideCells.Remove(connectionId);
+            _waveguideEndpoints.Remove(connectionId);
         }
 
         foreach (var (gx, gy) in cells)

--- a/Connect-A-Pic-Core/Routing/PathIntersectionDetector.cs
+++ b/Connect-A-Pic-Core/Routing/PathIntersectionDetector.cs
@@ -58,6 +58,85 @@ public static class PathIntersectionDetector
     }
 
     /// <summary>
+    /// Returns true when the two paths properly cross each other. Cheaper than
+    /// <see cref="MinimumDistance"/> for the common non-crossing case: disjoint
+    /// bounding boxes are rejected first and no distances are computed. Touching
+    /// endpoints do not count as crossings (only proper intersections do).
+    /// </summary>
+    public static bool Crosses(RoutedPath first, RoutedPath second)
+    {
+        var a = SamplePolyline(first);
+        var b = SamplePolyline(second);
+        if (a.Count < 2 || b.Count < 2 || !BoundsOverlap(a, b))
+            return false;
+
+        for (int i = 0; i < a.Count - 1; i++)
+        {
+            for (int j = 0; j < b.Count - 1; j++)
+            {
+                if (SegmentsIntersect(a[i], a[i + 1], b[j], b[j + 1]))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>True when the axis-aligned bounding boxes of the two polylines overlap.</summary>
+    private static bool BoundsOverlap(
+        List<(double X, double Y)> a, List<(double X, double Y)> b)
+    {
+        double aMinX = a.Min(p => p.X), aMaxX = a.Max(p => p.X);
+        double aMinY = a.Min(p => p.Y), aMaxY = a.Max(p => p.Y);
+        double bMinX = b.Min(p => p.X), bMaxX = b.Max(p => p.X);
+        double bMinY = b.Min(p => p.Y), bMaxY = b.Max(p => p.Y);
+        return aMinX <= bMaxX && bMinX <= aMaxX && aMinY <= bMaxY && bMinY <= aMaxY;
+    }
+
+    /// <summary>
+    /// Returns true when the path enters the given axis-aligned rectangle: a sampled
+    /// point lies strictly inside it or a polyline segment crosses one of its edges.
+    /// Shrink the rectangle by a small tolerance when path endpoints legitimately sit
+    /// on its boundary (pins are placed on component edges).
+    /// </summary>
+    public static bool IntersectsRectangle(
+        RoutedPath path, double minX, double minY, double maxX, double maxY)
+    {
+        var points = SamplePolyline(path);
+        for (int i = 0; i < points.Count - 1; i++)
+        {
+            if (SegmentIntersectsRectangle(points[i], points[i + 1], minX, minY, maxX, maxY))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True when the segment has an endpoint strictly inside the rectangle or
+    /// properly crosses one of its four edges.
+    /// </summary>
+    private static bool SegmentIntersectsRectangle(
+        (double X, double Y) a, (double X, double Y) b,
+        double minX, double minY, double maxX, double maxY)
+    {
+        static bool Inside((double X, double Y) p, double x1, double y1, double x2, double y2)
+            => p.X > x1 && p.X < x2 && p.Y > y1 && p.Y < y2;
+
+        if (Inside(a, minX, minY, maxX, maxY) || Inside(b, minX, minY, maxX, maxY))
+            return true;
+
+        var corners = new (double X, double Y)[]
+        {
+            (minX, minY), (maxX, minY), (maxX, maxY), (minX, maxY),
+        };
+        for (int i = 0; i < 4; i++)
+        {
+            if (SegmentsIntersect(a, b, corners[i], corners[(i + 1) % 4]))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Samples the path's segments (straights and arcs) into one polyline.
     /// Joints closer than <see cref="JointToleranceMicrometers"/> are merged so
     /// touching segment ends never read as intersections.

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.AStarAttempt.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.AStarAttempt.cs
@@ -46,6 +46,14 @@ public partial class WaveguideRouter
         var clearedEndTerminal = PathfindingGrid.ClearPinCorridor(
             endX, endY, endInputAngle, corridorLength, corridorWidth);
 
+        // Flat PDK components place pins closer together than one grid cell, so a sibling
+        // route registered as an obstacle buries this pin. Clear only the single-cell line
+        // of SIBLING cells along each pin's outward axis (foreign waveguides stay blocked).
+        var clearedStartFanout = PathfindingGrid.ClearPinFanoutWaveguideCells(
+            startX, startY, startAngle, corridorLength);
+        var clearedEndFanout = PathfindingGrid.ClearPinFanoutWaveguideCells(
+            endX, endY, endFacingAngle, corridorLength);
+
         try
         {
             var (gridStartX, gridStartY) = PathfindingGrid.PhysicalToGrid(startX, startY);
@@ -170,6 +178,8 @@ public partial class WaveguideRouter
             PathfindingGrid.RestoreCells(clearedStart);
             PathfindingGrid.RestoreCells(clearedEndApproach);
             PathfindingGrid.RestoreCells(clearedEndTerminal);
+            PathfindingGrid.RestoreCells(clearedStartFanout);
+            PathfindingGrid.RestoreCells(clearedEndFanout);
         }
     }
 

--- a/UnitTests/Helpers/TestComponentFactory.cs
+++ b/UnitTests/Helpers/TestComponentFactory.cs
@@ -152,6 +152,41 @@ namespace UnitTests
             return component;
         }
 
+        /// <summary>
+        /// Creates a flat 4-pin coupler with the Cornerstone SiN "Coupler Straight" footprint:
+        /// 20 × 2.636 µm with two pins per side only 1.436 µm apart vertically
+        /// (west0/east0 upper row at y = 0.6, west1/east1 lower row at y = 2.036).
+        /// </summary>
+        public static Component CreateFlatCouplerWithPhysicalPins(string idSuffix)
+        {
+            var component = CreateStraightWaveGuide();
+            component.Identifier = $"flat_coupler_{idSuffix}";
+            component.WidthMicrometers = 20;
+            component.HeightMicrometers = 2.636;
+
+            AddPhysicalPin(component, "west0", 0, 0.6, 180);
+            AddPhysicalPin(component, "west1", 0, 2.036, 180);
+            AddPhysicalPin(component, "east0", 20, 0.6, 0);
+            AddPhysicalPin(component, "east1", 20, 2.036, 0);
+            return component;
+        }
+
+        /// <summary>
+        /// Creates a flat 2-pin straight with the Cornerstone SiN "Straight" footprint:
+        /// 10 × 1.2 µm with pins at mid-height (y = 0.6).
+        /// </summary>
+        public static Component CreateFlatStraightWithPhysicalPins(string idSuffix)
+        {
+            var component = CreateStraightWaveGuide();
+            component.Identifier = $"flat_straight_{idSuffix}";
+            component.WidthMicrometers = 10;
+            component.HeightMicrometers = 1.2;
+
+            AddPhysicalPin(component, "in", 0, 0.6, 180);
+            AddPhysicalPin(component, "out", 10, 0.6, 0);
+            return component;
+        }
+
         /// <summary>Adds a physical pin at the given component-relative offset and angle.</summary>
         private static void AddPhysicalPin(
             Component component, string name, double offsetX, double offsetY, double angleDegrees)

--- a/UnitTests/Routing/FlatComponentProcessMinRadiusTests.cs
+++ b/UnitTests/Routing/FlatComponentProcessMinRadiusTests.cs
@@ -1,0 +1,171 @@
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// AUTO-routing regression tests with realistically FLAT components (Cornerstone SiN:
+/// "Coupler Straight" 20 × 2.636 µm with a 1.436 µm pin pitch, "Straight" 10 × 1.2 µm)
+/// under a process bend-radius floor. Flat components stress the router differently from
+/// the tall test couplers: the pin pitch is far below the grid cell size and the waveguide
+/// obstacle width, and pin corridors are wider than the whole component body. Routes must
+/// never cross their sibling, loop through themselves, or cut through a component body.
+/// </summary>
+public class FlatComponentProcessMinRadiusTests
+{
+    private const double CornerstoneSinMinRadius = 30.0;
+
+    /// <summary>Routes must clear each other by more than sampling noise (µm); the
+    /// 1.436 µm pin pitch makes the classic 2 µm waveguide clearance unreachable near pins.</summary>
+    private const double MinRouteClearance = 0.5;
+
+    /// <summary>Rectangle shrink tolerance (µm) so pins sitting ON the component edge
+    /// do not count as penetration.</summary>
+    private const double BoundsTolerance = 0.3;
+
+    [Theory]
+    [InlineData(200.0, 10.0)]
+    [InlineData(200.0, 30.0)]
+    [InlineData(80.0, 10.0)]
+    [InlineData(80.0, 30.0)]
+    [InlineData(30.0, 10.0)]
+    [InlineData(30.0, 30.0)]
+    public void FlatParallelCouplers_NestedConnectionsStayCleanAndOutsideComponents(
+        double gapMicrometers, double processFloor)
+    {
+        var (top, bottom, inner, outer) = RouteFlatParallelCouplers(gapMicrometers, processFloor);
+
+        inner.IsPathValid.ShouldBeTrue("inner connection must route");
+        outer.IsPathValid.ShouldBeTrue("outer connection must route");
+        inner.IsBlockedFallback.ShouldBeFalse("inner connection must not be a blocked fallback");
+        outer.IsBlockedFallback.ShouldBeFalse("outer connection must not be a blocked fallback");
+
+        PathIntersectionDetector.HasSelfIntersection(inner.RoutedPath!).ShouldBeFalse(
+            "inner route must not loop through itself");
+        PathIntersectionDetector.HasSelfIntersection(outer.RoutedPath!).ShouldBeFalse(
+            "outer route must not loop through itself");
+        PathIntersectionDetector.MinimumDistance(inner.RoutedPath!, outer.RoutedPath!)
+            .ShouldBeGreaterThan(MinRouteClearance, "nested parallel routes must never cross");
+
+        AssertOutsideComponentBounds(inner, top, bottom);
+        AssertOutsideComponentBounds(outer, top, bottom);
+    }
+
+    [Fact]
+    public void FlatParallelCouplers_WideGap_HonorsTheProcessFloorWithoutViolationFlag()
+    {
+        var (_, _, inner, outer) = RouteFlatParallelCouplers(gapMicrometers: 200.0, CornerstoneSinMinRadius);
+
+        foreach (var connection in new[] { inner, outer })
+        {
+            connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse(
+                "200 µm of space leaves room for 30 µm bends");
+            var bends = connection.GetPathSegments().OfType<BendSegment>().ToList();
+            bends.ShouldNotBeEmpty();
+            bends.ShouldAllBe(b => b.RadiusMicrometers >= CornerstoneSinMinRadius - 1e-6);
+        }
+    }
+
+    [Fact]
+    public void FlatStraights_OffsetNeighbors_RouteCleanAtTheFloor()
+    {
+        var connection = RouteFlatStraights(
+            leftX: 60, leftY: 60, rightX: 150, rightY: 100, CornerstoneSinMinRadius,
+            out var left, out var right);
+
+        connection.IsPathValid.ShouldBeTrue();
+        connection.IsBlockedFallback.ShouldBeFalse();
+        PathIntersectionDetector.HasSelfIntersection(connection.RoutedPath!).ShouldBeFalse();
+        AssertOutsideComponentBounds(connection, left, right);
+    }
+
+    [Fact]
+    public void FlatStraights_TightNeighbors_DegradeControlledWithoutLoopsOrPenetration()
+    {
+        var connection = RouteFlatStraights(
+            leftX: 60, leftY: 60, rightX: 100, rightY: 70, CornerstoneSinMinRadius,
+            out var left, out var right);
+
+        connection.IsPathValid.ShouldBeTrue();
+        connection.IsBlockedFallback.ShouldBeFalse();
+        PathIntersectionDetector.HasSelfIntersection(connection.RoutedPath!).ShouldBeFalse(
+            "tight flat neighbors must not produce loops");
+        AssertOutsideComponentBounds(connection, left, right);
+
+        // 30 µm from pin to pin cannot fit 30 µm arcs — a controlled degradation to the
+        // connection radius with the violation flag is the physically honest outcome.
+        var bends = connection.GetPathSegments().OfType<BendSegment>().ToList();
+        bends.ShouldAllBe(b => b.RadiusMicrometers >= connection.BendRadiusMicrometers - 1e-6);
+    }
+
+    /// <summary>Asserts no sampled part of the route enters either component body.</summary>
+    private static void AssertOutsideComponentBounds(
+        WaveguideConnection connection, Component first, Component second)
+    {
+        foreach (var component in new[] { first, second })
+        {
+            PathIntersectionDetector.IntersectsRectangle(
+                    connection.RoutedPath!,
+                    component.PhysicalX + BoundsTolerance,
+                    component.PhysicalY + BoundsTolerance,
+                    component.PhysicalX + component.WidthMicrometers - BoundsTolerance,
+                    component.PhysicalY + component.HeightMicrometers - BoundsTolerance)
+                .ShouldBeFalse($"route must not pass through component '{component.Identifier}'");
+        }
+    }
+
+    /// <summary>
+    /// Two flat couplers stacked vertically with the given free gap between their bodies.
+    /// Nested connections on the right side: the LOWER right pin of the top component to the
+    /// UPPER right pin of the bottom one (inner), and the upper-top to lower-bottom (outer).
+    /// </summary>
+    private static (Component Top, Component Bottom, WaveguideConnection Inner, WaveguideConnection Outer)
+        RouteFlatParallelCouplers(double gapMicrometers, double processFloor)
+    {
+        var top = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("top");
+        top.PhysicalX = 60;
+        top.PhysicalY = 60;
+        var bottom = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("bottom");
+        bottom.PhysicalX = 60;
+        bottom.PhysicalY = top.PhysicalY + top.HeightMicrometers + gapMicrometers;
+
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = processFloor };
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, new[] { top, bottom });
+
+        var manager = new WaveguideConnectionManager(router);
+        var inner = new WaveguideConnection { StartPin = Pin(top, "east1"), EndPin = Pin(bottom, "east0") };
+        var outer = new WaveguideConnection { StartPin = Pin(top, "east0"), EndPin = Pin(bottom, "east1") };
+        manager.AddExistingConnection(inner);
+        manager.AddExistingConnection(outer);
+        manager.RecalculateAllTransmissions();
+        return (top, bottom, inner, outer);
+    }
+
+    /// <summary>Two flat 1.2 µm straights at the given positions, connected out → in.</summary>
+    private static WaveguideConnection RouteFlatStraights(
+        double leftX, double leftY, double rightX, double rightY, double processFloor,
+        out Component left, out Component right)
+    {
+        left = TestComponentFactory.CreateFlatStraightWithPhysicalPins("left");
+        left.PhysicalX = leftX;
+        left.PhysicalY = leftY;
+        right = TestComponentFactory.CreateFlatStraightWithPhysicalPins("right");
+        right.PhysicalX = rightX;
+        right.PhysicalY = rightY;
+
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = processFloor };
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, new[] { left, right });
+
+        var manager = new WaveguideConnectionManager(router);
+        var connection = new WaveguideConnection { StartPin = Pin(left, "out"), EndPin = Pin(right, "in") };
+        manager.AddExistingConnection(connection);
+        manager.RecalculateAllTransmissions();
+        return connection;
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+}

--- a/UnitTests/UI/FlatComponentRoutingDiagnosticTests.cs
+++ b/UnitTests/UI/FlatComponentRoutingDiagnosticTests.cs
@@ -1,0 +1,180 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CAP.Avalonia.Controls;
+using CAP.Avalonia.Views;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.UI;
+
+/// <summary>
+/// Visual diagnostic for AUTO routing with realistically FLAT components under a process
+/// bend-radius floor (Cornerstone SiN). Real PDK footprints: "Coupler Straight" is
+/// 20 × 2.636 µm with a 1.436 µm pin pitch on each side; "Straight" is 10 × 1.2 µm.
+/// Renders the REAL design canvas for (a) two stacked flat couplers with nested parallel
+/// connections on the right side at wide/medium/tight vertical gaps, and (b) two flat
+/// straights placed close together. One PNG per layout × floor is written to
+/// <c>UI_SHOT_DIR/flat-component-routing/{layout}-floor{floor}.png</c>.
+/// </summary>
+[Trait("Category", "UiScreenshots")]
+public class FlatComponentRoutingDiagnosticTests
+{
+    private const int CanvasWidth = 1100;
+    private const int CanvasHeight = 800;
+
+    /// <summary>Magnification so 2.6 µm tall components stay recognizable in the PNG.</summary>
+    private const double RenderZoom = 2.2;
+
+    /// <summary>Headless renders occasionally miss a frame; retrying makes the PNGs reliable.</summary>
+    private const int CaptureAttempts = 3;
+
+    private static readonly double[] Floors = { 10.0, 30.0 };
+    private static readonly double[] CouplerGaps = { 200.0, 80.0, 30.0 };
+
+    /// <summary>Captures every flat layout under every process bend-radius floor.</summary>
+    [AvaloniaFact]
+    public async Task CaptureFlatComponentRoutingUnderProcessFloor()
+    {
+        var shotRoot = Environment.GetEnvironmentVariable("UI_SHOT_DIR");
+        if (string.IsNullOrEmpty(shotRoot))
+            return;
+        var outputDir = Path.Combine(shotRoot, "flat-component-routing");
+        Directory.CreateDirectory(outputDir);
+        foreach (var stale in Directory.GetFiles(outputDir, "*.png"))
+            File.Delete(stale);
+
+        foreach (var floor in Floors)
+        {
+            foreach (var gap in CouplerGaps)
+                await CaptureFlatParallelCouplers(outputDir, gap, floor);
+            await CaptureFlatStraights(outputDir, floor);
+        }
+
+        Directory.GetFiles(outputDir, "*.png").Length.ShouldBe(
+            Floors.Length * (CouplerGaps.Length + 1),
+            "every layout × floor must yield a PNG");
+    }
+
+    /// <summary>
+    /// Layout (a): two stacked flat couplers (20 × 2.636 µm, 1.436 µm pin pitch) with nested
+    /// connections on the right: top lower pin ↔ bottom upper pin and top upper ↔ bottom lower.
+    /// </summary>
+    private static async Task CaptureFlatParallelCouplers(string outputDir, double gap, double floor)
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Router.ProcessMinBendRadiusMicrometers = floor;
+
+        var top = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("top");
+        top.PhysicalX = 60;
+        top.PhysicalY = 60;
+        var bottom = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("bottom");
+        bottom.PhysicalX = 60;
+        bottom.PhysicalY = top.PhysicalY + top.HeightMicrometers + gap;
+        canvas.AddComponent(top);
+        canvas.AddComponent(bottom);
+
+        await Capture(canvas, outputDir, $"flat-couplers-gap{gap:F0}-floor{floor:F0}", async () =>
+        {
+            (await canvas.ConnectPinsAsync(Pin(top, "east1"), Pin(bottom, "east0")))
+                .ShouldNotBeNull("inner connection must be created");
+            (await canvas.ConnectPinsAsync(Pin(top, "east0"), Pin(bottom, "east1")))
+                .ShouldNotBeNull("outer connection must be created");
+        });
+    }
+
+    /// <summary>
+    /// Layout (b): two flat 1.2 µm straights placed with a small diagonal offset — the pins
+    /// face each other only a few tens of µm apart.
+    /// </summary>
+    private static async Task CaptureFlatStraights(string outputDir, double floor)
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Router.ProcessMinBendRadiusMicrometers = floor;
+
+        var left = TestComponentFactory.CreateFlatStraightWithPhysicalPins("left");
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateFlatStraightWithPhysicalPins("right");
+        right.PhysicalX = 150;
+        right.PhysicalY = 100;
+        canvas.AddComponent(left);
+        canvas.AddComponent(right);
+
+        await Capture(canvas, outputDir, $"flat-straights-floor{floor:F0}", async () =>
+        {
+            (await canvas.ConnectPinsAsync(Pin(left, "out"), Pin(right, "in")))
+                .ShouldNotBeNull("flat straight connection must be created");
+        });
+    }
+
+    /// <summary>Connects the pins, pumps the dispatcher, and captures the canvas to a PNG.</summary>
+    private static async Task Capture(
+        DesignCanvasViewModel canvas, string outputDir, string name, Func<Task> connect)
+    {
+        var vm = MainViewModelTestHelper.CreateMainViewModel(canvas: canvas);
+        // MainViewModel rewires the floor provider to the process resolver; this test
+        // dictates the floor explicitly, so re-pin the provider to the test value.
+        double floor = canvas.Router.ProcessMinBendRadiusMicrometers;
+        canvas.Routing.GetProcessMinBendRadiusMicrometers = () => floor;
+        var window = new Window
+        {
+            Width = CanvasWidth,
+            Height = CanvasHeight,
+            Content = new MainView { DataContext = vm },
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            await connect();
+            await canvas.RecalculateRoutesAsync();
+
+            Dispatcher.UIThread.RunJobs();
+            foreach (var designCanvas in window.GetVisualDescendants().OfType<DesignCanvas>())
+            {
+                designCanvas.Zoom = RenderZoom;
+                designCanvas.InvalidateVisual();
+            }
+            Dispatcher.UIThread.RunJobs();
+
+            CaptureWithRetry(window, Path.Combine(outputDir, $"{name}.png"));
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+
+    /// <summary>Captures the window with dispatcher pumping between attempts (headless flake guard).</summary>
+    private static void CaptureWithRetry(Window window, string path)
+    {
+        WriteableBitmap? bitmap = null;
+        for (int attempt = 0; attempt < CaptureAttempts; attempt++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            var frame = window.CaptureRenderedFrame();
+            if (frame == null)
+                continue;
+            bitmap?.Dispose();
+            bitmap = frame;
+        }
+
+        bitmap.ShouldNotBeNull($"CaptureRenderedFrame stayed null after {CaptureAttempts} attempts for {path}");
+        using (bitmap)
+        {
+            ScreenshotArtifacts.SavePng(bitmap, path);
+        }
+    }
+}


### PR DESCRIPTION
User-reported: the parallel-connection crossings hit hardest with extremely flat components — and real PDK parts ARE that flat (Cornerstone 'Coupler Straight': 20 × 2.636 µm with a 1.4 µm pin pitch; straights/tapers 1.2 µm tall).

**Reproduced** with real dimensions: the outer of two nested connections ALWAYS degenerated to a red blocked-fallback line crossing the inner one — even with 200 µm of room and a 10 µm radius, so this predates the process-floor work.

**Root cause:** the sibling route registers as a 4 µm wide waveguide-obstacle band; with a 1.4 µm pin pitch the neighbor pin's start cell lies inside that band (both pins share one 4 µm grid cell), and pin-corridor clearing only ever cleared component cells — A* died instantly at every radius, and the obstacle-blind Manhattan fallback crossed the sibling.

**Fix:** (1) restore-safe pin fan-out clearing of exactly the pin-axis cell row, only for fan-out siblings (routes ending ≤ 6 µm from the pin) — foreign crossing waveguides stay blocked; (2) geometry is the arbiter: after routing, `PathIntersectionDetector.Crosses` checks against already-routed siblings and a crossing counts as failure, feeding the existing ordering-permutation cascade; (3) detector extended with route-vs-rectangle checks so no segment may pierce a 1.2 µm component body.

**Verified visually** (before/after renders in the diagnostic test, 8 scenarios): nested parallel U-turns at gaps 200/80/30 µm under floors 10 and 30, radii honored, no crossings/self-intersections/red fallbacks; flat straights route as clean S-bends.

Tests: 10 new (crossing freedom via minimum distance, no self-intersection, no body piercing, floor honored). Full default suite **3699 / 0 failed / 14 skipped**. Build 0/0. File-size guard verified in the main checkout (new file 86 lines; grandfathered files +5/+21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6xGFNsXL1ntWmGzKFJhrU