### PR TITLE
Arc-true collision handling: components on a bend's belly are detected; Auto avoids styled siblings

### DIFF
--- a/Connect-A-Pic-Core/Analysis/DesignIssue.cs
+++ b/Connect-A-Pic-Core/Analysis/DesignIssue.cs
@@ -42,7 +42,14 @@ public enum DesignIssueType
     /// process' minimum bend radius (the router's controlled degradation). The geometry
     /// is clean, but fabrication rules are violated — free up space or reroute manually.
     /// </summary>
-    BendRadiusBelowProcessMinimum
+    BendRadiusBelowProcessMinimum,
+
+    /// <summary>
+    /// A styled (forced-shape) route passes through a component. Styled routes ignore
+    /// obstacles by design and are never auto-rerouted, so the collision must be resolved
+    /// manually — move the component or pick a different routing style.
+    /// </summary>
+    StyledRouteThroughComponent
 }
 
 /// <summary>

--- a/Connect-A-Pic-Core/Analysis/DesignValidator.cs
+++ b/Connect-A-Pic-Core/Analysis/DesignValidator.cs
@@ -99,6 +99,18 @@ public class DesignValidator
                 midY,
                 $"Bend radius below process minimum: {startName} to {endName}"));
         }
+
+        if (connection.RoutedPath?.PassesThroughComponent == true)
+        {
+            var startName = FormatPinName(connection.StartPin);
+            var endName = FormatPinName(connection.EndPin);
+            issues.Add(new DesignIssue(
+                DesignIssueType.StyledRouteThroughComponent,
+                connection,
+                midX,
+                midY,
+                $"Styled route passes through a component: {startName} to {endName}"));
+        }
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.CollisionHandling.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.CollisionHandling.cs
@@ -1,0 +1,92 @@
+using CAP_Core.Routing;
+
+namespace CAP_Core.Components.Connections;
+
+/// <summary>
+/// Collision handling for frozen and styled routes: unfreezing manually edited AUTO routes
+/// that a component now overlaps, flagging styled routes that pass through components, and
+/// marking unavoidable sibling crossings as blocked instead of leaving them silent.
+/// </summary>
+public partial class WaveguideConnectionManager
+{
+    /// <summary>
+    /// Detects a component collision on a FROZEN AUTO route (manual bend edit) and, when
+    /// found, treats it like an endpoint move: the route is unfrozen and the manual bend
+    /// overrides are discarded so the connection is re-routed around the component.
+    /// Uses the true arc geometry against component obstacles only, so the verdict does
+    /// not depend on which sibling waveguides are currently registered in the grid.
+    /// Styled routes (Type != Auto) are never unfrozen here — their shape is forced and a
+    /// collision is surfaced via <see cref="RoutedPath.PassesThroughComponent"/> instead.
+    /// </summary>
+    /// <returns>True when the connection was unfrozen and must be re-routed.</returns>
+    private static bool TryUnfreezeCollidedAutoRoute(WaveguideConnection connection, WaveguideRouter router)
+    {
+        if (connection.Type != WaveguideType.Auto || !connection.IsRouteFrozen)
+            return false;
+        if (!connection.FrozenPathStillMatchesPins())
+            return false; // Endpoint moved: RecalculateTransmission already unfreezes.
+        if (!router.IsPathBlockedByComponents(connection.RoutedPath!.Segments))
+            return false;
+
+        connection.IsRouteFrozen = false;
+        connection.BendRadiusOverrides.Clear();
+        return true;
+    }
+
+    /// <summary>
+    /// Refreshes <see cref="RoutedPath.PassesThroughComponent"/> on a STYLED route.
+    /// Styled routes ignore obstacles by design, so a component dropped onto the curve
+    /// never triggers a re-route; the flag makes the design checks report the collision.
+    /// No-op for Auto connections and connections without a routed path.
+    /// </summary>
+    private static void RefreshStyledObstacleCollision(WaveguideConnection connection, WaveguideRouter router)
+    {
+        if (connection.Type == WaveguideType.Auto || connection.RoutedPath == null)
+            return;
+        connection.RoutedPath.PassesThroughComponent =
+            router.IsPathBlockedByComponents(connection.RoutedPath.Segments);
+    }
+
+    /// <summary>
+    /// Marks routes that still properly cross a sibling after all routing passes (including
+    /// the ordering cascade and crossing insertion) as blocked fallbacks — the existing
+    /// controlled degradation — instead of leaving a silent crossing on the canvas.
+    /// Only the re-routable side (Auto, not frozen) is flagged: it is re-routed on the next
+    /// pass and rendered as blocked until the crossing is resolved. Forced routes (styled or
+    /// manually frozen) keep their shape; their overlap is reported by the design checks.
+    /// </summary>
+    private void MarkUnresolvedSiblingCrossings()
+    {
+        var routed = Connections
+            .Where(c => c.RoutedPath != null && c.IsPathValid)
+            .ToList();
+
+        for (int i = 0; i < routed.Count; i++)
+        {
+            for (int j = i + 1; j < routed.Count; j++)
+            {
+                if (!PathIntersectionDetector.Crosses(routed[i].RoutedPath!, routed[j].RoutedPath!))
+                    continue;
+                var target = PickReroutableSide(routed[i], routed[j]);
+                if (target != null)
+                    target.RoutedPath!.IsBlockedFallback = true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Picks which side of a crossing pair to degrade: the LATER re-routable Auto route
+    /// (it was routed with the earlier one already registered), the earlier one when only
+    /// that is re-routable, or null when both shapes are forced.
+    /// </summary>
+    private static WaveguideConnection? PickReroutableSide(
+        WaveguideConnection first, WaveguideConnection second)
+    {
+        static bool IsReroutable(WaveguideConnection c) =>
+            c.Type == WaveguideType.Auto && !c.IsRouteFrozen;
+
+        if (IsReroutable(second)) return second;
+        if (IsReroutable(first)) return first;
+        return null;
+    }
+}

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
@@ -5,7 +5,7 @@ using CAP_Core.Components.Core;
 
 namespace CAP_Core.Components.Connections;
 
-public class WaveguideConnectionManager
+public partial class WaveguideConnectionManager
 {
     private readonly WaveguideRouter _router;
 
@@ -255,6 +255,15 @@ public class WaveguideConnectionManager
     {
         RouteAllConnections(progressCallback, cancellationToken);
         RunCrossingInsertionPass(cancellationToken);
+
+        // Any crossing that survived routing, the ordering cascade AND crossing insertion
+        // is unavoidable in the current layout: degrade it visibly instead of drawing a
+        // silent crossing.
+        if (UseSequentialRouting && _router.PathfindingGrid != null &&
+            !cancellationToken.IsCancellationRequested)
+        {
+            MarkUnresolvedSiblingCrossings();
+        }
     }
 
     /// <summary>
@@ -376,8 +385,15 @@ public class WaveguideConnectionManager
             if (cancellationToken.IsCancellationRequested)
                 return (false, 0);
 
-            if (IsRouteStillValid(connection, router))
+            if (TryUnfreezeCollidedAutoRoute(connection, router))
             {
+                // A component overlaps the manually edited geometry: treat it like an
+                // endpoint move — the edit is discarded and the connection re-routed.
+                invalidConnections.Add(connection);
+            }
+            else if (IsRouteStillValid(connection, router))
+            {
+                RefreshStyledObstacleCollision(connection, router);
                 validConnections.Add(connection);
             }
             else
@@ -405,6 +421,7 @@ public class WaveguideConnectionManager
                 return (false, failedCount);
 
             connection.RecalculateTransmission(_router, cancellationToken: cancellationToken);
+            RefreshStyledObstacleCollision(connection, router);
             progressCallback?.Invoke();
 
             // Register ALL paths with valid geometry as obstacles, including blocked fallbacks.
@@ -498,6 +515,7 @@ public class WaveguideConnectionManager
                 return (false, failedCount);
 
             connection.RecalculateTransmission(_router, cancellationToken: cancellationToken);
+            RefreshStyledObstacleCollision(connection, router);
             progressCallback?.Invoke();
 
             // Register ANY path with valid geometry as an obstacle, including blocked fallbacks.

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
@@ -209,23 +209,9 @@ public partial class PathfindingGrid
             }
             else if (segment is BendSegment bend)
             {
-                // Mark cells along arc - sample points along the arc
-                double startRad = bend.StartAngleDegrees * Math.PI / 180;
-                double sweepRad = bend.SweepAngleDegrees * Math.PI / 180;
-                int numSamples = Math.Max(10, (int)(Math.Abs(bend.SweepAngleDegrees) / 5));
-
-                for (int i = 0; i <= numSamples; i++)
+                // Mark cells along the arc, sampled by arc length so large radii stay solid
+                foreach (var (px, py) in ArcSampling.SamplePoints(bend, CellSizeMicrometers))
                 {
-                    double t = (double)i / numSamples;
-                    double angle = startRad + sweepRad * t;
-
-                    // Point on arc
-                    double sign = Math.Sign(bend.SweepAngleDegrees);
-                    if (sign == 0) sign = 1;
-
-                    double px = bend.Center.X + bend.RadiusMicrometers * Math.Cos(angle - Math.PI / 2 * sign);
-                    double py = bend.Center.Y + bend.RadiusMicrometers * Math.Sin(angle - Math.PI / 2 * sign);
-
                     MarkCircleAsCells(px, py, halfWidth, cells);
                 }
             }
@@ -499,6 +485,18 @@ public partial class PathfindingGrid
     }
 
     /// <summary>
+    /// Checks if a cell is blocked by a component or a frozen group path (cell states 1 and 3),
+    /// ignoring waveguide obstacles. Used to judge whether an existing route collides with
+    /// component geometry independently of which sibling routes are currently registered.
+    /// </summary>
+    public bool IsBlockedByComponent(int gridX, int gridY)
+    {
+        if (!IsInBounds(gridX, gridY)) return true;
+        byte state = _cells[gridX, gridY];
+        return state == 1 || state == 3;
+    }
+
+    /// <summary>
     /// Gets the state of a cell.
     /// Returns: 0 = free, 1 = blocked by component, 2 = blocked by waveguide
     /// </summary>
@@ -602,23 +600,9 @@ public partial class PathfindingGrid
             }
             else if (segment is BendSegment bend)
             {
-                // Mark cells along arc - sample points along the arc
-                double startRad = bend.StartAngleDegrees * Math.PI / 180;
-                double sweepRad = bend.SweepAngleDegrees * Math.PI / 180;
-                int numSamples = Math.Max(10, (int)(Math.Abs(bend.SweepAngleDegrees) / 5));
-
-                for (int i = 0; i <= numSamples; i++)
+                // Mark cells along the arc, sampled by arc length so large radii stay solid
+                foreach (var (px, py) in ArcSampling.SamplePoints(bend, CellSizeMicrometers))
                 {
-                    double t = (double)i / numSamples;
-                    double angle = startRad + sweepRad * t;
-
-                    // Point on arc (perpendicular to tangent direction)
-                    double sign = Math.Sign(bend.SweepAngleDegrees);
-                    if (sign == 0) sign = 1;
-
-                    double px = bend.Center.X + bend.RadiusMicrometers * Math.Cos(angle - Math.PI / 2 * sign);
-                    double py = bend.Center.Y + bend.RadiusMicrometers * Math.Sin(angle - Math.PI / 2 * sign);
-
                     MarkCircleAsCells(px, py, halfWidth, cells);
                 }
             }

--- a/Connect-A-Pic-Core/Routing/ArcSampling.cs
+++ b/Connect-A-Pic-Core/Routing/ArcSampling.cs
@@ -1,0 +1,38 @@
+namespace CAP_Core.Routing;
+
+/// <summary>
+/// Samples <see cref="BendSegment"/> arcs into points spaced by ARC LENGTH.
+/// Obstacle rasterization and collision checks must use this instead of angle-based
+/// sampling: a fixed number of samples per degree leaves gaps larger than a grid cell
+/// on large-radius arcs, so the arc reads as a dotted line instead of a solid obstacle.
+/// </summary>
+public static class ArcSampling
+{
+    /// <summary>
+    /// Returns points along the arc, including both endpoints, spaced at most
+    /// <paramref name="maxStepMicrometers"/> apart along the arc.
+    /// </summary>
+    /// <param name="bend">The arc segment to sample.</param>
+    /// <param name="maxStepMicrometers">Maximum arc-length distance between samples (µm).</param>
+    public static IEnumerable<(double X, double Y)> SamplePoints(BendSegment bend, double maxStepMicrometers)
+    {
+        double startRad = bend.StartAngleDegrees * Math.PI / 180.0;
+        double sweepRad = bend.SweepAngleDegrees * Math.PI / 180.0;
+        double arcLength = Math.Abs(sweepRad) * bend.RadiusMicrometers;
+        double step = Math.Max(maxStepMicrometers, 1e-6);
+        int steps = Math.Max(1, (int)Math.Ceiling(arcLength / step));
+
+        double sign = Math.Sign(bend.SweepAngleDegrees);
+        if (sign == 0) sign = 1;
+        // The arc point sits perpendicular to the tangent angle, on the turn side
+        // (same convention as the BendSegment constructor).
+        double perpOffset = Math.PI / 2 * sign;
+
+        for (int i = 0; i <= steps; i++)
+        {
+            double angle = startRad + sweepRad * i / steps;
+            yield return (bend.Center.X + bend.RadiusMicrometers * Math.Cos(angle - perpOffset),
+                          bend.Center.Y + bend.RadiusMicrometers * Math.Sin(angle - perpOffset));
+        }
+    }
+}

--- a/Connect-A-Pic-Core/Routing/RoutedPath.cs
+++ b/Connect-A-Pic-Core/Routing/RoutedPath.cs
@@ -30,6 +30,14 @@ public class RoutedPath
     public bool ViolatesProcessMinBendRadius { get; set; } = false;
 
     /// <summary>
+    /// True when a STYLED (forced-shape) route passes through a component obstacle.
+    /// Styled routes deliberately ignore obstacles and are never auto-rerouted, so a
+    /// collision cannot be resolved by the router; the design checks surface it as a
+    /// <c>StyledRouteThroughComponent</c> issue instead. Refreshed on every routing pass.
+    /// </summary>
+    public bool PassesThroughComponent { get; set; } = false;
+
+    /// <summary>
     /// Debug information: The raw A* grid path used to generate this path.
     /// Only populated when A* routing is used.
     /// </summary>

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
@@ -298,28 +298,45 @@ public partial class WaveguideRouter
     public bool IsPathBlocked(IEnumerable<PathSegment> segments)
     {
         if (PathfindingGrid == null) return false;
+        return IsPathBlocked(segments, PathfindingGrid.IsBlocked);
+    }
 
+    /// <summary>
+    /// Checks if any segment in a path passes through cells blocked by COMPONENTS
+    /// (including frozen group paths), ignoring registered waveguide obstacles.
+    /// Use this to judge component collisions of an existing route regardless of
+    /// which sibling routes are currently in the grid.
+    /// </summary>
+    public bool IsPathBlockedByComponents(IEnumerable<PathSegment> segments)
+    {
+        if (PathfindingGrid == null) return false;
+        return IsPathBlocked(segments, PathfindingGrid.IsBlockedByComponent);
+    }
+
+    /// <summary>Checks all segments against the given cell-blocked predicate.</summary>
+    private bool IsPathBlocked(IEnumerable<PathSegment> segments, Func<int, int, bool> isCellBlocked)
+    {
         foreach (var segment in segments)
         {
             if (segment is StraightSegment)
             {
                 if (IsLineBlocked(segment.StartPoint.X, segment.StartPoint.Y,
-                                  segment.EndPoint.X, segment.EndPoint.Y))
+                                  segment.EndPoint.X, segment.EndPoint.Y, isCellBlocked))
                     return true;
             }
             else if (segment is BendSegment bend)
             {
-                if (IsArcBlocked(bend)) return true;
+                if (IsArcBlocked(bend, isCellBlocked)) return true;
             }
         }
         return false;
     }
 
-
     /// <summary>
     /// Checks if a straight line passes through any blocked cells.
     /// </summary>
-    private bool IsLineBlocked(double x1, double y1, double x2, double y2)
+    private bool IsLineBlocked(double x1, double y1, double x2, double y2,
+                               Func<int, int, bool> isCellBlocked)
     {
         if (PathfindingGrid == null) return false;
 
@@ -339,36 +356,26 @@ public partial class WaveguideRouter
             double px = x1 + dx * t;
             double py = y1 + dy * t;
             var (gx, gy) = PathfindingGrid.PhysicalToGrid(px, py);
-            if (PathfindingGrid.IsBlocked(gx, gy)) return true;
+            if (isCellBlocked(gx, gy)) return true;
         }
         return false;
     }
 
     /// <summary>
     /// Checks if an arc segment passes through blocked cells.
+    /// The arc endpoints themselves are skipped (they legitimately touch pin corridors).
     /// </summary>
-    private bool IsArcBlocked(BendSegment bend)
+    private bool IsArcBlocked(BendSegment bend, Func<int, int, bool> isCellBlocked)
     {
         if (PathfindingGrid == null) return false;
 
-        double startRad = bend.StartAngleDegrees * Math.PI / 180;
-        double sweepRad = bend.SweepAngleDegrees * Math.PI / 180;
-        double arcLength = Math.Abs(sweepRad) * bend.RadiusMicrometers;
         double stepLength = PathfindingGrid.CellSizeMicrometers * 0.5;
-        int numSamples = Math.Max(10, (int)Math.Ceiling(arcLength / stepLength));
+        var samples = ArcSampling.SamplePoints(bend, stepLength).ToList();
 
-        double sign = Math.Sign(bend.SweepAngleDegrees);
-        if (sign == 0) sign = 1;
-
-        for (int i = 1; i < numSamples; i++)
+        for (int i = 1; i < samples.Count - 1; i++)
         {
-            double t = (double)i / numSamples;
-            double angle = startRad + sweepRad * t;
-            double px = bend.Center.X + bend.RadiusMicrometers * Math.Cos(angle - Math.PI / 2 * sign);
-            double py = bend.Center.Y + bend.RadiusMicrometers * Math.Sin(angle - Math.PI / 2 * sign);
-
-            var (gx, gy) = PathfindingGrid.PhysicalToGrid(px, py);
-            if (PathfindingGrid.IsBlocked(gx, gy)) return true;
+            var (gx, gy) = PathfindingGrid.PhysicalToGrid(samples[i].X, samples[i].Y);
+            if (isCellBlocked(gx, gy)) return true;
         }
         return false;
     }

--- a/UnitTests/Routing/ArcObstacleRasterizationTests.cs
+++ b/UnitTests/Routing/ArcObstacleRasterizationTests.cs
@@ -1,0 +1,64 @@
+using CAP_Core.Routing;
+using CAP_Core.Routing.AStarPathfinder;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Waveguide obstacles must rasterize <see cref="BendSegment"/> arcs by ARC LENGTH:
+/// angle-based sampling leaves gaps larger than a grid cell on large-radius arcs, letting
+/// sibling routes thread straight through a registered bend.
+/// </summary>
+public class ArcObstacleRasterizationTests
+{
+    private const double WaveguideWidth = 4.0;
+
+    [Theory]
+    [InlineData(50.0)]
+    [InlineData(140.0)]
+    [InlineData(300.0)]
+    public void AddWaveguideObstacle_LargeRadiusArc_BlocksTheWholeArcWithoutGaps(double radius)
+    {
+        var grid = new PathfindingGrid(0, 0, 1000, 1000, cellSize: 1.0);
+        var bend = new BendSegment(500, 500, radius, startAngle: 0, sweepAngle: 90);
+
+        grid.AddWaveguideObstacle(Guid.NewGuid(), new PathSegment[] { bend }, WaveguideWidth);
+
+        foreach (var (x, y) in ArcSampling.SamplePoints(bend, maxStepMicrometers: 0.5))
+        {
+            var (gx, gy) = grid.PhysicalToGrid(x, y);
+            grid.IsBlocked(gx, gy).ShouldBeTrue(
+                $"arc point ({x:F1}, {y:F1}) of the r={radius} bend must be a solid obstacle");
+        }
+    }
+
+    [Fact]
+    public void ArcSampling_StepNeverExceedsRequestedArcLength()
+    {
+        var bend = new BendSegment(0, 0, 200, startAngle: 0, sweepAngle: 90);
+
+        var points = ArcSampling.SamplePoints(bend, maxStepMicrometers: 1.0).ToList();
+
+        points.Count.ShouldBeGreaterThan(300, "a 90° arc of r=200 is ~314 µm long");
+        for (int i = 1; i < points.Count; i++)
+        {
+            double dx = points[i].X - points[i - 1].X;
+            double dy = points[i].Y - points[i - 1].Y;
+            Math.Sqrt(dx * dx + dy * dy).ShouldBeLessThanOrEqualTo(1.0 + 1e-6);
+        }
+    }
+
+    [Fact]
+    public void ArcSampling_IncludesBothArcEndpoints()
+    {
+        var bend = new BendSegment(100, 100, 40, startAngle: 45, sweepAngle: -120);
+
+        var points = ArcSampling.SamplePoints(bend, maxStepMicrometers: 2.0).ToList();
+
+        points[0].X.ShouldBe(bend.StartPoint.X, 1e-9);
+        points[0].Y.ShouldBe(bend.StartPoint.Y, 1e-9);
+        points[^1].X.ShouldBe(bend.EndPoint.X, 1e-9);
+        points[^1].Y.ShouldBe(bend.EndPoint.Y, 1e-9);
+    }
+}

--- a/UnitTests/Routing/FrozenAndStyledRouteCollisionTests.cs
+++ b/UnitTests/Routing/FrozenAndStyledRouteCollisionTests.cs
@@ -1,0 +1,210 @@
+using CAP_Core.Analysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Routing.InterconnectRouting;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Collision handling for frozen and styled routes (user bug report):
+/// a component dropped onto the arc belly of a manually enlarged bend must unfreeze and
+/// re-route the AUTO connection; a styled route keeps its forced shape but reports the
+/// collision as a design issue; an Auto sibling that cannot avoid a styled route is marked
+/// blocked instead of silently crossing it.
+/// </summary>
+public class FrozenAndStyledRouteCollisionTests
+{
+    private const double BigHandleRadius = 140.0;
+    private const double BlockerSize = 50.0;
+    private const double BoundsTolerance = 0.5;
+
+    [Fact]
+    public void FrozenAutoRoute_HandleEditSurvivesRecalc_WhileNothingCollides()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        ApplyBigRadius(connection);
+
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeTrue("the manual edit must survive a collision-free recalc");
+        connection.BendRadiusOverrides.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void FrozenAutoRoute_UnfreezesAndReroutes_WhenComponentDropsOntoArcBelly()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        double appliedRadius = ApplyBigRadius(connection);
+        var belly = ArcBellyOf(connection);
+
+        var blocker = CreateBlocker(belly.X, belly.Y);
+        components.Add(blocker);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeFalse(
+            $"a component on the r={appliedRadius} arc belly must unfreeze the route");
+        connection.BendRadiusOverrides.ShouldBeEmpty("the manual edit is discarded like on an endpoint move");
+        connection.IsPathValid.ShouldBeTrue();
+        PathIntersectionDetector.IntersectsRectangle(
+                connection.RoutedPath!,
+                blocker.PhysicalX + BoundsTolerance, blocker.PhysicalY + BoundsTolerance,
+                blocker.PhysicalX + blocker.WidthMicrometers - BoundsTolerance,
+                blocker.PhysicalY + blocker.HeightMicrometers - BoundsTolerance)
+            .ShouldBeFalse("the re-routed path must avoid the dropped component");
+    }
+
+    [Fact]
+    public void StyledRoute_ComponentOnCurve_KeepsShapeAndRaisesDesignIssue()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner(WaveguideType.Cobra);
+        connection.RoutedPath!.PassesThroughComponent.ShouldBeFalse("nothing collides yet");
+
+        var mid = PathMidpointOf(connection);
+        var blocker = CreateBlocker(mid.X, mid.Y);
+        components.Add(blocker);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.Type.ShouldBe(WaveguideType.Cobra, "a styled route is never auto-rerouted");
+        connection.RoutedPath!.PassesThroughComponent.ShouldBeTrue(
+            "the collision with the dropped component must be flagged");
+
+        var issues = new DesignValidator().Validate(new[] { connection });
+        issues.ShouldContain(i => i.Type == DesignIssueType.StyledRouteThroughComponent);
+    }
+
+    [Fact]
+    public void StyledRoute_CollisionFlagClears_WhenTheComponentMovesAway()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner(WaveguideType.Cobra);
+        var mid = PathMidpointOf(connection);
+        var blocker = CreateBlocker(mid.X, mid.Y);
+        components.Add(blocker);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+        connection.RoutedPath!.PassesThroughComponent.ShouldBeTrue();
+
+        components.Remove(blocker);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.RoutedPath!.PassesThroughComponent.ShouldBeFalse(
+            "the flag must clear once the collision is gone");
+    }
+
+    [Fact]
+    public void AutoSibling_TrappedByStyledRoute_IsNeverASilentCrossing()
+    {
+        // Flat couplers with a 30 µm floor: the outer Cobra's slim bulge fences in the
+        // inner pins, and the wide Auto U cannot stay inside it (the user's scenario).
+        var top = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("top");
+        top.PhysicalX = 60;
+        top.PhysicalY = 60;
+        var bottom = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("bottom");
+        bottom.PhysicalX = 60;
+        bottom.PhysicalY = top.PhysicalY + top.HeightMicrometers + 80;
+
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = 30.0 };
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, new[] { top, bottom });
+        var manager = new WaveguideConnectionManager(router);
+        var inner = new WaveguideConnection { StartPin = Pin(top, "east1"), EndPin = Pin(bottom, "east0") };
+        var outer = new WaveguideConnection { StartPin = Pin(top, "east0"), EndPin = Pin(bottom, "east1") };
+        manager.AddExistingConnection(inner);
+        manager.AddExistingConnection(outer);
+        manager.RecalculateAllTransmissions();
+
+        outer.Type = WaveguideType.Cobra;
+        outer.InvalidateRoute();
+        manager.RecalculateAllTransmissions();
+
+        bool crosses = PathIntersectionDetector.Crosses(inner.RoutedPath!, outer.RoutedPath!);
+        (crosses && !inner.IsBlockedFallback).ShouldBeFalse(
+            "an Auto route crossing its styled sibling must be marked blocked, never silent");
+        outer.Type.ShouldBe(WaveguideType.Cobra);
+        outer.IsBlockedFallback.ShouldBeFalse("the forced styled route itself is not degraded");
+    }
+
+    /// <summary>
+    /// Two 250 µm couplers offset so the connection turns a corner; the route is calculated
+    /// through the manager so it registers in the grid like in the app.
+    /// </summary>
+    private static (WaveguideConnectionManager Manager, WaveguideRouter Router,
+        WaveguideConnection Connection, List<Component> Components)
+        RouteAcrossCorner(WaveguideType type = WaveguideType.Auto)
+    {
+        var left = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("left");
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("right");
+        right.PhysicalX = 560;
+        right.PhysicalY = 360;
+        var components = new List<Component> { left, right };
+
+        var router = new WaveguideRouter();
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, components);
+        var manager = new WaveguideConnectionManager(router);
+        var connection = new WaveguideConnection
+        {
+            StartPin = Pin(left, "east0"),
+            EndPin = Pin(right, "west0"),
+            Type = type,
+        };
+        manager.AddExistingConnection(connection);
+        manager.RecalculateAllTransmissions();
+        connection.IsPathValid.ShouldBeTrue("the corner route must route in the empty layout");
+        return (manager, router, connection, components);
+    }
+
+    /// <summary>Applies the biggest fitting handle radius to the first resizable bend.</summary>
+    private static double ApplyBigRadius(WaveguideConnection connection)
+    {
+        var corners = BendRadiusEditor.GetBendCorners(connection.GetPathSegments());
+        corners.ShouldNotBeEmpty("the auto corner route must expose a resizable bend");
+        foreach (var radius in new[] { BigHandleRadius, 100.0, 60.0, 40.0 })
+        {
+            if (BendRadiusEditor.TryApplyOverride(connection, corners[0].BendIndex, radius, out _))
+                return radius;
+        }
+        throw new InvalidOperationException("No handle radius fits the route.");
+    }
+
+    /// <summary>Midpoint of the first (edited) arc along the path.</summary>
+    private static (double X, double Y) ArcBellyOf(WaveguideConnection connection)
+    {
+        var bend = connection.GetPathSegments().OfType<BendSegment>().First();
+        return ArcSampling.SamplePoints(bend, bend.LengthMicrometers / 2).Skip(1).First();
+    }
+
+    /// <summary>Point halfway along the path's segment list (blocker drop position).</summary>
+    private static (double X, double Y) PathMidpointOf(WaveguideConnection connection)
+    {
+        var segments = connection.GetPathSegments();
+        return segments[segments.Count / 2].StartPoint;
+    }
+
+    /// <summary>A pinless square component centered on the given point.</summary>
+    private static Component CreateBlocker(double centerX, double centerY)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+        return new Component(
+            new Dictionary<int, SMatrix>(), new List<CAP_Core.Components.Core.Slider>(), "blocker", "",
+            parts, 0, "Blocker", DiscreteRotation.R0)
+        {
+            WidthMicrometers = BlockerSize,
+            HeightMicrometers = BlockerSize,
+            PhysicalX = centerX - BlockerSize / 2,
+            PhysicalY = centerY - BlockerSize / 2,
+        };
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+}

--- a/UnitTests/UI/ArcObstacleCollisionDiagnosticTests.cs
+++ b/UnitTests/UI/ArcObstacleCollisionDiagnosticTests.cs
@@ -1,0 +1,304 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using CAP.Avalonia.Controls;
+using CAP.Avalonia.Views;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components;
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Routing.InterconnectRouting;
+using CAP_Core.Tiles;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.UI;
+
+/// <summary>
+/// Visual diagnostic for arc-aware collision handling (user bug report, two symptoms):
+/// (a) a manually enlarged bend radius freezes the route; dropping a component onto the
+/// arc's belly must unfreeze and re-route instead of leaving the waveguide through the
+/// component; (b) a Cobra-styled connection must act as an obstacle for its Auto sibling,
+/// which has to route around it instead of crossing. PNGs and a findings text file go to
+/// <c>UI_SHOT_DIR/arc-obstacle-collision/</c>.
+/// </summary>
+[Trait("Category", "UiScreenshots")]
+public class ArcObstacleCollisionDiagnosticTests
+{
+    private const int CanvasWidth = 1100;
+    private const int CanvasHeight = 800;
+    private const int CaptureAttempts = 3;
+
+    /// <summary>Radii tried (descending) for the manual handle edit; the first that fits wins.</summary>
+    private static readonly double[] HandleRadiiMicrometers = { 140, 120, 100, 80, 60, 40 };
+
+    /// <summary>Captures both repro scenarios and writes the findings file.</summary>
+    [AvaloniaFact]
+    public async Task CaptureArcCollisionScenarios()
+    {
+        var shotRoot = Environment.GetEnvironmentVariable("UI_SHOT_DIR");
+        if (string.IsNullOrEmpty(shotRoot))
+            return;
+        var outputDir = Path.Combine(shotRoot, "arc-obstacle-collision");
+        Directory.CreateDirectory(outputDir);
+        foreach (var stale in Directory.GetFiles(outputDir, "*"))
+            File.Delete(stale);
+
+        var findings = new List<string>();
+        await CaptureFrozenArcBellyScenario(outputDir, findings);
+        await CaptureCobraSiblingScenario(outputDir, findings);
+        await CaptureFlatCobraSiblingScenario(outputDir, findings);
+        File.WriteAllLines(Path.Combine(outputDir, "findings.txt"), findings);
+    }
+
+    /// <summary>
+    /// Scenario (a): auto route between two couplers, first bend enlarged via the handle
+    /// editor (freezes the route), then a component is dropped onto the arc belly and the
+    /// routes are recalculated. Records whether the route still pierces the component.
+    /// </summary>
+    private static async Task CaptureFrozenArcBellyScenario(string outputDir, List<string> findings)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var left = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("left");
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("right");
+        right.PhysicalX = 560;
+        right.PhysicalY = 360;
+        canvas.AddComponent(left);
+        canvas.AddComponent(right);
+
+        var (window, _) = ShowWindow(canvas);
+        try
+        {
+            var connVm = await canvas.ConnectPinsAsync(Pin(left, "east0"), Pin(right, "west0"));
+            connVm.ShouldNotBeNull();
+            var conn = connVm!.Connection;
+            await canvas.RecalculateRoutesAsync();
+
+            var corners = BendRadiusEditor.GetBendCorners(conn.GetPathSegments());
+            corners.ShouldNotBeEmpty("the auto route must expose a resizable bend");
+            double? applied = null;
+            foreach (var radius in HandleRadiiMicrometers)
+            {
+                if (BendRadiusEditor.TryApplyOverride(conn, corners[0].BendIndex, radius, out _))
+                {
+                    applied = radius;
+                    break;
+                }
+            }
+            applied.ShouldNotBeNull("one of the handle radii must fit the route");
+            findings.Add($"[belly] applied handle radius: {applied} µm; frozen={conn.IsRouteFrozen}");
+            Capture(window, canvas, Path.Combine(outputDir, "belly-1-frozen-big-radius.png"));
+
+            var belly = ArcBellyOf(conn, corners[0].BendIndex);
+            findings.Add($"[belly] arc belly at ({belly.X:F1}, {belly.Y:F1})");
+            var blocker = CreateBlockerComponent(belly.X, belly.Y, sizeMicrometers: 50);
+            canvas.AddComponent(blocker);
+            await canvas.RecalculateRoutesAsync();
+
+            bool pierces = PathIntersectionDetector.IntersectsRectangle(
+                conn.RoutedPath!,
+                blocker.PhysicalX + 0.5, blocker.PhysicalY + 0.5,
+                blocker.PhysicalX + blocker.WidthMicrometers - 0.5,
+                blocker.PhysicalY + blocker.HeightMicrometers - 0.5);
+            findings.Add($"[belly] after drop: frozen={conn.IsRouteFrozen}, overrides={conn.BendRadiusOverrides.Count}, " +
+                         $"blockedFlag={conn.IsBlockedFallback}, routePiercesBlocker={pierces}");
+            Capture(window, canvas, Path.Combine(outputDir, "belly-2-component-on-arc.png"));
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
+    /// Scenario (b): nested parallel connections on the right side of two stacked couplers;
+    /// the inner one is styled Cobra, the outer stays Auto. Records whether the Auto sibling
+    /// crosses the Cobra.
+    /// </summary>
+    private static async Task CaptureCobraSiblingScenario(string outputDir, List<string> findings)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var top = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("top");
+        top.PhysicalX = 60;
+        top.PhysicalY = 60;
+        var bottom = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("bottom");
+        bottom.PhysicalX = 60;
+        bottom.PhysicalY = 460;
+        canvas.AddComponent(top);
+        canvas.AddComponent(bottom);
+
+        var (window, _) = ShowWindow(canvas);
+        try
+        {
+            var inner = await canvas.ConnectPinsAsync(Pin(top, "east1"), Pin(bottom, "east0"));
+            var outer = await canvas.ConnectPinsAsync(Pin(top, "east0"), Pin(bottom, "east1"));
+            inner.ShouldNotBeNull();
+            outer.ShouldNotBeNull();
+            await canvas.RecalculateRoutesAsync();
+            Capture(window, canvas, Path.Combine(outputDir, "cobra-1-both-auto.png"));
+
+            // Mirror ConnectionRoutingViewModel.OnSelectedStyleChanged for a style pick.
+            inner!.Connection.Type = WaveguideType.Cobra;
+            inner.Connection.InvalidateRoute();
+            await canvas.RecalculateRoutesAsync();
+
+            bool crosses = PathIntersectionDetector.Crosses(
+                inner.Connection.RoutedPath!, outer!.Connection.RoutedPath!);
+            findings.Add($"[cobra] after styling: innerType={inner.Connection.Type}, " +
+                         $"outerBlockedFlag={outer.Connection.IsBlockedFallback}, autoCrossesCobra={crosses}");
+            Capture(window, canvas, Path.Combine(outputDir, "cobra-2-auto-sibling.png"));
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
+    /// Scenario (c): the same nested parallel pair on FLAT couplers (Cornerstone SiN footprint,
+    /// 1.436 µm pin pitch — sub-cell, so grid obstacles cannot separate the fan-outs) under a
+    /// 10 µm process floor. The inner connection is styled Cobra, the outer stays Auto.
+    /// </summary>
+    private static async Task CaptureFlatCobraSiblingScenario(string outputDir, List<string> findings)
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Router.ProcessMinBendRadiusMicrometers = 30.0;
+        var top = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("top");
+        top.PhysicalX = 60;
+        top.PhysicalY = 60;
+        var bottom = TestComponentFactory.CreateFlatCouplerWithPhysicalPins("bottom");
+        bottom.PhysicalX = 60;
+        bottom.PhysicalY = top.PhysicalY + top.HeightMicrometers + 80;
+        canvas.AddComponent(top);
+        canvas.AddComponent(bottom);
+
+        var (window, _) = ShowWindow(canvas);
+        double floor = canvas.Router.ProcessMinBendRadiusMicrometers;
+        canvas.Routing.GetProcessMinBendRadiusMicrometers = () => floor;
+        try
+        {
+            var inner = await canvas.ConnectPinsAsync(Pin(top, "east1"), Pin(bottom, "east0"));
+            var outer = await canvas.ConnectPinsAsync(Pin(top, "east0"), Pin(bottom, "east1"));
+            inner.ShouldNotBeNull();
+            outer.ShouldNotBeNull();
+            await canvas.RecalculateRoutesAsync();
+            SetZoom(window, 2.2);
+            Capture(window, canvas, Path.Combine(outputDir, "flat-cobra-1-both-auto.png"));
+
+            // The OUTER pair takes the Cobra: its slim bulge fences in the inner pins, and the
+            // 30 µm process floor makes the inner Auto U too wide to stay inside it.
+            outer!.Connection.Type = WaveguideType.Cobra;
+            outer.Connection.InvalidateRoute();
+            await canvas.RecalculateRoutesAsync();
+
+            bool crosses = PathIntersectionDetector.Crosses(
+                inner!.Connection.RoutedPath!, outer.Connection.RoutedPath!);
+            findings.Add($"[flat-cobra] after styling: outerType={outer.Connection.Type}, " +
+                         $"innerBlockedFlag={inner.Connection.IsBlockedFallback}, autoCrossesCobra={crosses}");
+            Capture(window, canvas, Path.Combine(outputDir, "flat-cobra-2-auto-sibling.png"));
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>Magnifies the design canvas so micrometer-flat components stay visible.</summary>
+    private static void SetZoom(Window window, double zoom)
+    {
+        foreach (var designCanvas in window.GetVisualDescendants().OfType<DesignCanvas>())
+        {
+            designCanvas.Zoom = zoom;
+            designCanvas.InvalidateVisual();
+        }
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    /// <summary>Midpoint of the (edited) arc with the given bend index along the path.</summary>
+    private static (double X, double Y) ArcBellyOf(WaveguideConnection conn, int bendIndex)
+    {
+        int seen = -1;
+        foreach (var segment in conn.GetPathSegments())
+        {
+            if (segment is not BendSegment bend || ++seen != bendIndex)
+                continue;
+            double sign = Math.Sign(bend.SweepAngleDegrees) == 0 ? 1 : Math.Sign(bend.SweepAngleDegrees);
+            double midRad = (bend.StartAngleDegrees + bend.SweepAngleDegrees / 2) * Math.PI / 180;
+            return (bend.Center.X + bend.RadiusMicrometers * Math.Cos(midRad - Math.PI / 2 * sign),
+                    bend.Center.Y + bend.RadiusMicrometers * Math.Sin(midRad - Math.PI / 2 * sign));
+        }
+        throw new InvalidOperationException($"Bend #{bendIndex} not found.");
+    }
+
+    /// <summary>A pinless square component centered on the given point (the dropped obstacle).</summary>
+    private static Component CreateBlockerComponent(double centerX, double centerY, double sizeMicrometers)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+        return new Component(
+            new Dictionary<int, SMatrix>(), new List<CAP_Core.Components.Core.Slider>(), "blocker", "",
+            parts, 0, "Blocker", DiscreteRotation.R0)
+        {
+            WidthMicrometers = sizeMicrometers,
+            HeightMicrometers = sizeMicrometers,
+            PhysicalX = centerX - sizeMicrometers / 2,
+            PhysicalY = centerY - sizeMicrometers / 2,
+        };
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+
+    private static (Window Window, MainView View) ShowWindow(DesignCanvasViewModel canvas)
+    {
+        var vm = MainViewModelTestHelper.CreateMainViewModel(canvas: canvas);
+        var view = new MainView { DataContext = vm };
+        var window = new Window
+        {
+            Width = CanvasWidth,
+            Height = CanvasHeight,
+            Content = view,
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return (window, view);
+    }
+
+    /// <summary>Pumps the dispatcher, forces a repaint and captures the window to a PNG.</summary>
+    private static void Capture(Window window, DesignCanvasViewModel canvas, string path)
+    {
+        Dispatcher.UIThread.RunJobs();
+        foreach (var designCanvas in window.GetVisualDescendants().OfType<DesignCanvas>())
+            designCanvas.InvalidateVisual();
+        Dispatcher.UIThread.RunJobs();
+
+        WriteableBitmap? bitmap = null;
+        for (int attempt = 0; attempt < CaptureAttempts; attempt++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            var frame = window.CaptureRenderedFrame();
+            if (frame == null)
+                continue;
+            bitmap?.Dispose();
+            bitmap = frame;
+        }
+
+        bitmap.ShouldNotBeNull($"CaptureRenderedFrame stayed null after {CaptureAttempts} attempts for {path}");
+        using (bitmap)
+        {
+            ScreenshotArtifacts.SavePng(bitmap, path);
+        }
+    }
+}


### PR DESCRIPTION
User-reported after #760: dragging a component onto the BELLY of a manually enlarged bend did nothing — the route kept running straight through it. And an Auto connection would cross a Cobra-styled sibling instead of avoiding it.

**Root cause (three layers):**
1. Arc obstacle rasterization sampled by ANGLE (sweep°/5) — a 140 µm radius bend registered as a dotted line with ~17 µm holes at 1 µm cell size (neither chord nor solid).
2. `IsRouteStillValid` returned true for frozen routes with matching endpoints BEFORE ever reaching the obstacle check — a component on the arc was structurally invisible.
3. When every ordering permutation failed, the cascade settled on a silent crossing with no flag.

**Fixes:**
- Arc-length-based sampling (step ≤ cell size) for obstacle registration and self-collision checks (`ArcSampling`, 38 lines).
- A frozen, hand-edited AUTO route that now truly collides with a component unfreezes, discards its overrides and reroutes — same semantics as an endpoint move. Collision-free recalcs still keep the manual edit (tested).
- Styled routes stay obstacle-ignorant for their own shape but are solid obstacles for Auto siblings; an unavoidable残 crossing is now marked as blocked (red + design issue) instead of silent. A styled route piercing a component raises the new `StyledRouteThroughComponent` design issue.

Verified visually (before/after renders in the opt-in diagnostic test): the belly collision now detours cleanly; the flat-coupler #760 scenarios remain untouched. Full default suite **3710 / 0 failed / 14 skipped**, build 0/0, file sizes checked in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6xGFNsXL1ntWmGzKFJhrU