### PR TITLE
Hotfix: Error-Console-Appends auf den UI-Thread marshallen (Transient-Sim crashte bei Passivitäts-Warnung)

### DIFF
--- a/CAP.Avalonia/App.axaml.cs
+++ b/CAP.Avalonia/App.axaml.cs
@@ -57,6 +57,11 @@ public partial class App : Application
         ConfigureServices(services);
         Services = services.BuildServiceProvider();
 
+        // Error-console entries are bound to the UI, but simulations/renders log from
+        // worker threads — marshal every append through the UI dispatcher.
+        Services.GetRequiredService<CAP_Core.ErrorConsoleService>().PostToUiThread =
+            action => global::Avalonia.Threading.Dispatcher.UIThread.Post(action);
+
         // Apply the persisted UI language (or auto-detect the OS display language when
         // set to "system") before any window binds its localized strings (issue #744).
         Services.GetRequiredService<Services.Localization.LocalizationService>()

--- a/Connect-A-Pic-Core/ErrorConsoleService.cs
+++ b/Connect-A-Pic-Core/ErrorConsoleService.cs
@@ -20,6 +20,14 @@ public class ErrorConsoleService
     /// <summary>Raised whenever a new entry is added.</summary>
     public event EventHandler<Log>? EntryAdded;
 
+    /// <summary>
+    /// <see cref="Entries"/> is bound to the UI, so mutations must happen on the UI thread —
+    /// but callers log from worker threads (simulation runs, python renders). The app installs
+    /// its dispatcher here once at startup (Core cannot reference Avalonia); unset (tests,
+    /// headless) logging stays synchronous on the calling thread.
+    /// </summary>
+    public Action<Action>? PostToUiThread { get; set; }
+
     /// <summary>Initializes a new <see cref="ErrorConsoleService"/>.</summary>
     public ErrorConsoleService()
     {
@@ -31,9 +39,6 @@ public class ErrorConsoleService
     /// <param name="message">Human-readable message.</param>
     public void Log(LogLevel level, string message)
     {
-        if (_entries.Count >= MaxEntries)
-            _entries.RemoveAt(0);
-
         var entry = new Log
         {
             Level = level,
@@ -41,6 +46,18 @@ public class ErrorConsoleService
             TimeStamp = DateTime.Now,
             ClassName = ""
         };
+
+        var post = PostToUiThread;
+        if (post != null)
+            post(() => Append(entry));
+        else
+            Append(entry);
+    }
+
+    private void Append(Log entry)
+    {
+        if (_entries.Count >= MaxEntries)
+            _entries.RemoveAt(0);
 
         _entries.Add(entry);
         EntryAdded?.Invoke(this, entry);

--- a/UnitTests/Core/ErrorConsoleThreadMarshalTests.cs
+++ b/UnitTests/Core/ErrorConsoleThreadMarshalTests.cs
@@ -1,0 +1,57 @@
+using CAP_Core;
+using CAP_Contracts.Logger;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Core;
+
+/// <summary>
+/// The error console's <see cref="ErrorConsoleService.Entries"/> is UI-bound; worker threads
+/// (simulation runs, python renders) log through the same service. Every append must therefore
+/// route through <see cref="ErrorConsoleService.PostToUiThread"/> when installed — logging from
+/// a background thread without it crashed the transient simulation ("Call from invalid thread").
+/// </summary>
+public class ErrorConsoleThreadMarshalTests
+{
+    [Fact]
+    public void Log_withDispatcherInstalled_appendsThroughTheDispatcher()
+    {
+        var console = new ErrorConsoleService();
+        var dispatched = new List<Action>();
+        console.PostToUiThread = dispatched.Add;
+
+        console.LogWarning("from a worker thread");
+
+        console.Entries.ShouldBeEmpty("the append must wait for the dispatcher");
+        dispatched.Count.ShouldBe(1);
+        dispatched[0]();
+        console.Entries.Count.ShouldBe(1);
+        console.Entries[0].Level.ShouldBe(LogLevel.Warn);
+    }
+
+    [Fact]
+    public void Log_withoutDispatcher_appendsSynchronously()
+    {
+        var console = new ErrorConsoleService();
+
+        console.LogError("headless/test path");
+
+        console.Entries.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Log_capsEntries_atMaxAlsoWhenDispatched()
+    {
+        var console = new ErrorConsoleService();
+        var dispatched = new List<Action>();
+        console.PostToUiThread = dispatched.Add;
+
+        for (int i = 0; i < ErrorConsoleService.MaxEntries + 5; i++)
+            console.LogInfo($"entry {i}");
+        foreach (var action in dispatched)
+            action();
+
+        console.Entries.Count.ShouldBe(ErrorConsoleService.MaxEntries);
+        console.Entries[^1].Message.ShouldContain($"entry {ErrorConsoleService.MaxEntries + 4}");
+    }
+}


### PR DESCRIPTION
Feld-Befund: Transient-Simulation bricht mit „Call from invalid thread" ab, sobald der Passivitäts-Warnpfad (#762) aus dem Simulations-Worker-Thread in die Error Console loggt — deren `Entries` ist UI-gebunden.

Fix: `ErrorConsoleService.PostToUiThread` (einmalig beim App-Start verdrahtet auf `Dispatcher.UIThread.Post`) — ALLE Hintergrund-Logs sind damit dauerhaft threadsicher, nicht nur diese eine Stelle. Ohne Dispatcher (Tests/headless) bleibt das Verhalten synchron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCVwvkXdUH9DSW8w12XB2q