### PR TITLE
Fix: Foundry-Preview-Synthese für SiEPIC/nazca-PDKs; kopierbare, einheitliche Fehlermeldungen

### DIFF
--- a/CAP.Avalonia/Services/AddCustomComponent/FoundryEditCodeSynthesis.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/FoundryEditCodeSynthesis.cs
@@ -1,0 +1,81 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
+
+namespace CAP.Avalonia.Services.AddCustomComponent;
+
+/// <summary>
+/// Single resolver that turns a bundled foundry component's function reference into runnable
+/// editor code plus the geometry backend that can execute it ("Edit Component" on a foundry
+/// definition without stored raw code). One rule per bundled-PDK family, derived from how the
+/// cell is REALLY instantiable in the managed Python environment:
+/// <list type="bullet">
+/// <item>gdsfactory-native (cspdk, module-qualified <c>GdsFactoryFunction</c>): cells are PDK
+/// registry entries, not module attributes → <see cref="GdsFactoryPreviewCode.For"/>
+/// (import + PDK.activate() + gf.get_component), the round-4 fix.</item>
+/// <item>SiEPIC (<c>nazcaModuleName</c> "siepic_ebeam_pdk"): the siepic_ebeam_pdk package is
+/// KLayout-based — it has NO cell attributes ("module 'siepic_ebeam_pdk' has no attribute
+/// 'ebeam_adiabatic_te1550'", field round 6) and the canvas renders it via a klayout path the
+/// raw-code editor cannot use. The cells ARE registered in the ubcpdk gdsfactory PDK, so the
+/// editor code resolves them there (<see cref="UbcPdkCellMap"/>, the exporter's mapping).</item>
+/// <item>Nazca PDKs (demo): a real Nazca module call via
+/// <see cref="NazcaCodeTemplateBuilder"/>.</item>
+/// </list>
+/// </summary>
+public static class FoundryEditCodeSynthesis
+{
+    /// <summary>
+    /// Synthesizes (code, backend) for a foundry component reference, or null when no runnable
+    /// editor code exists (no reference at all, or a KLayout-only SiEPIC fixed cell) — callers
+    /// then open an honest empty editor instead of code that can only fail.
+    /// </summary>
+    /// <param name="gdsFactoryFunction">Module-qualified or bare gdsfactory cell reference.</param>
+    /// <param name="nazcaModuleName">The PDK's module name from its JSON (e.g. "siepic_ebeam_pdk").</param>
+    /// <param name="nazcaFunctionName">The component's PDK cell/function name.</param>
+    /// <param name="nazcaParameters">Optional keyword-argument string for the Nazca call.</param>
+    public static (string Code, GeometryBackend Backend)? For(
+        string? gdsFactoryFunction, string? nazcaModuleName,
+        string? nazcaFunctionName, string? nazcaParameters)
+    {
+        if (!string.IsNullOrWhiteSpace(gdsFactoryFunction))
+        {
+            // Bare (dotless) cell names have no PDK module to activate — resolve them
+            // against whatever PDK the render script activates by default.
+            var code = GdsFactoryPreviewCode.For(gdsFactoryFunction)
+                ?? $"import gdsfactory as gf\ncomponent = gf.get_component('{gdsFactoryFunction}')\n";
+            return (code, GeometryBackend.GdsFactory);
+        }
+
+        if (string.IsNullOrWhiteSpace(nazcaFunctionName))
+            return null;
+
+        if (IsSiepicModule(nazcaModuleName))
+            return SynthesizeSiepic(nazcaFunctionName!);
+
+        return (NazcaCodeTemplateBuilder.Build(nazcaModuleName, nazcaFunctionName, nazcaParameters),
+                GeometryBackend.Nazca);
+    }
+
+    /// <summary>
+    /// True for the SiEPIC EBeam PDK module — mirrors the render script's
+    /// <c>_looks_like_siepic</c> predicate so both sides route the same components.
+    /// </summary>
+    private static bool IsSiepicModule(string? module) =>
+        module != null && module.Trim().StartsWith("siepic", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// SiEPIC cells resolve through the ubcpdk gdsfactory registry (the same mapping the GDS
+    /// exporter uses). Cells without a ubcpdk equivalent exist only as KLayout fixed cells —
+    /// there is no runnable editor code for them, so null is returned.
+    /// </summary>
+    private static (string Code, GeometryBackend Backend)? SynthesizeSiepic(string nazcaFunction)
+    {
+        var cell = UbcPdkCellMap.MapToUbcPdkCell(nazcaFunction);
+        if (cell is null)
+            return null;
+
+        var code = "import gdsfactory as gf\n"
+                 + "import ubcpdk\n"
+                 + GdsFactoryPdkContext.UbcPdkActivation + "\n"
+                 + $"component = gf.get_component('{cell}')\n";
+        return (code, GeometryBackend.GdsFactory);
+    }
+}

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.Edit.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using CAP.Avalonia.Services.AddCustomComponent;
 using CAP.Avalonia.Services.Localization;
-using CAP.Avalonia.Services.GdsFactoryExport;
 using CAP.Avalonia.ViewModels.Library;
 using CAP_DataAccess.Components.AddCustomComponent;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
@@ -177,29 +176,13 @@ public partial class NewComponentViewModel
 
     /// <summary>
     /// Turns a foundry component's function reference into equivalent editable code, so a
-    /// bundled component opens with a runnable definition instead of a blank editor.
-    /// gdsfactory-native PDKs register their cells in the PDK registry, NOT as module
-    /// attributes ("cspdk.sin300.coupler_straight()" raises AttributeError), so the code uses
-    /// the same import + PDK.activate() + gf.get_component() pattern as the canvas preview.
+    /// bundled component opens with a runnable definition instead of a blank editor. The
+    /// per-PDK-family rules (gdsfactory registry for cspdk, ubcpdk registry for SiEPIC,
+    /// Nazca call for demo) live in <see cref="FoundryEditCodeSynthesis"/> — field rounds
+    /// 4 (cspdk attribute call) and 6 (siepic attribute call) both came from synthesizing
+    /// module-attribute code for registry-based PDKs.
     /// </summary>
-    private static (string Code, GeometryBackend Backend)? SynthesizeCodeFromReference(ComponentTemplate t)
-    {
-        if (!string.IsNullOrWhiteSpace(t.GdsFactoryFunction))
-        {
-            // Bare (dotless) cell names have no PDK module to activate — resolve them
-            // against whatever PDK the render script activates by default.
-            var code = GdsFactoryPreviewCode.For(t.GdsFactoryFunction)
-                ?? $"import gdsfactory as gf\ncomponent = gf.get_component('{t.GdsFactoryFunction}')\n";
-            return (code, GeometryBackend.GdsFactory);
-        }
-        if (!string.IsNullOrWhiteSpace(t.NazcaFunctionName))
-        {
-            // NazcaCodeTemplateBuilder mirrors the preview script's contract: a def component()
-            // returning the PDK cell, with the demo PDK mapped onto nazca.demofab.
-            return (CAP.Avalonia.Services.NazcaCodeTemplateBuilder.Build(
-                        t.NazcaModuleName, t.NazcaFunctionName, t.NazcaParameters),
-                    GeometryBackend.Nazca);
-        }
-        return null;
-    }
+    private static (string Code, GeometryBackend Backend)? SynthesizeCodeFromReference(ComponentTemplate t) =>
+        FoundryEditCodeSynthesis.For(
+            t.GdsFactoryFunction, t.NazcaModuleName, t.NazcaFunctionName, t.NazcaParameters);
 }

--- a/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Components/AddCustomComponent/NewComponentViewModel.cs
@@ -165,16 +165,19 @@ public partial class NewComponentViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Shows the actionable foundry-package hint in the status bar and keeps the raw Python
-    /// error in the Error Console; unrecognised errors stay verbatim.
+    /// Single source for the preview-failure message (field round 6): the window status shows
+    /// the actionable message (the foundry-package hint when recognised, otherwise the raw
+    /// error) and the Error Console receives the SAME message plus the raw Python detail —
+    /// never two different stories for one failure.
     /// </summary>
     private string DescribeRenderError(string? rawError)
     {
         var hint = CAP_Core.Export.FoundryEnvironmentErrorHint.Describe(rawError);
-        if (hint is null)
-            return rawError ?? "Preview render failed.";
-
-        _errorConsole?.LogError($"Component preview render failed: {rawError}");
-        return hint;
+        var display = hint ?? rawError ?? "Preview render failed.";
+        var detail = hint is not null && !string.IsNullOrWhiteSpace(rawError)
+            ? $"{display}\nPython error detail: {rawError}"
+            : display;
+        _errorConsole?.LogError($"Component preview render failed: {detail}");
+        return display;
     }
 }

--- a/CAP.Avalonia/Views/NewComponentWindow.axaml
+++ b/CAP.Avalonia/Views/NewComponentWindow.axaml
@@ -145,7 +145,9 @@
                             ToolTip.Tip="{loc:Localize NewComponent.ShowStoredSMatricesTip}"/>
                 </StackPanel>
                 <ProgressBar IsIndeterminate="True" IsVisible="{Binding IsBusy}" Height="4" Background="#2d2d2d"/>
-                <TextBlock Text="{Binding StatusText}" Foreground="#dddddd" FontSize="11" TextWrapping="Wrap"/>
+                <!-- SelectableTextBlock so error messages can be copied (field round 6). -->
+                <SelectableTextBlock Text="{Binding StatusText}" Foreground="#dddddd" FontSize="11" TextWrapping="Wrap"
+                                     SelectionBrush="#3d5d8d"/>
 
                 <Expander Header="{loc:Localize NewComponent.SMatrixData}" IsExpanded="False"
                           IsVisible="{Binding HasSMatrix}" Background="#161616">

--- a/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
@@ -383,6 +383,51 @@ public class EditComponentModeTests : IDisposable
     }
 
     [Fact]
+    public void LoadForEdit_siepicComponentWithoutRawCode_synthesizesUbcPdkRegistryCode_notSiepicAttributeCall()
+    {
+        // Field bug round 6: "Edit Component" on the SiEPIC "Adiabatic Coupler TE 1550"
+        // synthesized "import siepic_ebeam_pdk ... siepic_ebeam_pdk.ebeam_adiabatic_te1550()",
+        // failing with "module 'siepic_ebeam_pdk' has no attribute 'ebeam_adiabatic_te1550'".
+        // SiEPIC bundled components carry no GdsFactoryFunction (the round-4 fix never applied);
+        // their cells resolve via the ubcpdk gdsfactory registry.
+        var (vm, _, _) = BuildWithSeededPdk();
+        var template = new ComponentTemplate
+        {
+            Name = "Adiabatic Coupler TE 1550", PdkSource = "Lib",
+            NazcaModuleName = "siepic_ebeam_pdk", NazcaFunctionName = "ebeam_adiabatic_te1550",
+            RawCode = null,
+        };
+
+        vm.LoadForEdit(template);
+
+        vm.SelectedBackend.ShouldBe(GeometryBackend.GdsFactory);
+        vm.Code.ShouldContain("import ubcpdk");
+        vm.Code.ShouldContain("ubcpdk.PDK.activate()");
+        vm.Code.ShouldContain("gf.get_component('ebeam_adiabatic_te1550')");
+        vm.Code.ShouldNotContain("siepic_ebeam_pdk");
+    }
+
+    [Fact]
+    public void LoadForEdit_siepicKlayoutOnlyCell_opensWithEmptyCode_insteadOfBrokenAttributeCode()
+    {
+        // The few SiEPIC cells without a ubcpdk registry equivalent are KLayout fixed cells —
+        // there is no runnable editor code for them. An empty editor with the "no stored code"
+        // status is honest; synthesized attribute code would only reproduce the AttributeError.
+        var (vm, _, _) = BuildWithSeededPdk();
+        var template = new ComponentTemplate
+        {
+            Name = "Contra-Directional Coupler", PdkSource = "Lib",
+            NazcaModuleName = "siepic_ebeam_pdk", NazcaFunctionName = "contra_directional_coupler",
+            RawCode = null,
+        };
+
+        vm.LoadForEdit(template);
+
+        vm.Code.ShouldBe(string.Empty);
+        vm.StatusText.ShouldNotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
     public void LoadForEdit_foundryComponentWithBareCellName_resolvesViaGetComponent()
     {
         // A bare (dotless) gdsfactory cell has no PDK module to import/activate —

--- a/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
+++ b/UnitTests/Components/AddCustomComponent/EditComponentModeTests.cs
@@ -471,6 +471,59 @@ public class EditComponentModeTests : IDisposable
     }
 
     [Fact]
+    public async Task RunPreview_recognisedFoundryError_consoleCarriesTheWindowMessagePlusRawDetail()
+    {
+        // Field wish (round 6): window status and Error Console must tell ONE story.
+        // The window shows the actionable hint; the console carries the SAME message
+        // plus the raw Python detail — not a different, raw-only text.
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        store.CreateNamedPdkWithProcess("Lib", process, "gdsfactory", null);
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(NazcaPreviewResult.Fail(
+               "module 'siepic_ebeam_pdk' has no attribute 'ebeam_adiabatic_te1550'"));
+        var errorConsole = new CAP_Core.ErrorConsoleService();
+        var vm = new NewComponentViewModel(
+            new ComponentGeometryExtractor(nazca.Object, gds.Object), fdtd: null, store,
+            new List<ProcessDefinition> { process }, errorConsole);
+        vm.Code = "component = gf.get_component('ebeam_adiabatic_te1550')";
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+
+        var entry = errorConsole.Entries.ShouldHaveSingleItem();
+        entry.Message.ShouldContain(vm.StatusText);   // same message as the window...
+        entry.Message.ShouldContain(
+            "module 'siepic_ebeam_pdk' has no attribute 'ebeam_adiabatic_te1550'"); // ...plus raw detail
+    }
+
+    [Fact]
+    public async Task RunPreview_unrecognisedError_logsTheSameMessageToWindowAndConsole()
+    {
+        // Unrecognised errors previously reached only the status bar; the console stayed
+        // silent, so window and console diverged. One source: both carry the same text.
+        var store = Store();
+        var process = new ProcessDefinition { Name = "SiN 300" };
+        store.CreateNamedPdkWithProcess("Lib", process, "gdsfactory", null);
+        var nazca = new Mock<IComponentPreviewRenderer>();
+        var gds = new Mock<IComponentPreviewRenderer>();
+        gds.Setup(g => g.RenderRawCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+           .ReturnsAsync(NazcaPreviewResult.Fail("SyntaxError: invalid syntax (line 3)"));
+        var errorConsole = new CAP_Core.ErrorConsoleService();
+        var vm = new NewComponentViewModel(
+            new ComponentGeometryExtractor(nazca.Object, gds.Object), fdtd: null, store,
+            new List<ProcessDefinition> { process }, errorConsole);
+        vm.Code = "def component(:";
+
+        await vm.RunPreviewCommand.ExecuteAsync(null);
+
+        vm.StatusText.ShouldBe("SyntaxError: invalid syntax (line 3)");
+        var entry = errorConsole.Entries.ShouldHaveSingleItem();
+        entry.Message.ShouldContain("SyntaxError: invalid syntax (line 3)");
+    }
+
+    [Fact]
     public void LoadForEdit_withNoStoredCode_setsCodeEmpty_andReportsStatus()
     {
         var (vm, _, _) = BuildWithSeededPdk();

--- a/UnitTests/Components/AddCustomComponent/FoundryEditCodeSynthesisTests.cs
+++ b/UnitTests/Components/AddCustomComponent/FoundryEditCodeSynthesisTests.cs
@@ -1,0 +1,150 @@
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Shouldly;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// Tests for <see cref="FoundryEditCodeSynthesis"/> — the single resolver that turns a bundled
+/// foundry component's function reference into runnable editor code plus the backend that can
+/// execute it. Field round 6: the round-4 fix only covered components carrying a
+/// <c>GdsFactoryFunction</c> (cspdk); SiEPIC components reference their cells via
+/// <c>nazcaModuleName</c>/<c>nazcaFunction</c>, so the synthesis kept emitting the
+/// module-attribute call <c>siepic_ebeam_pdk.ebeam_adiabatic_te1550()</c>, which fails because
+/// siepic_ebeam_pdk is a KLayout package, not a Nazca/gdsfactory module. SiEPIC cells are
+/// instantiable via the ubcpdk gdsfactory registry instead.
+/// </summary>
+public class FoundryEditCodeSynthesisTests
+{
+    // ── cspdk regression (round-4 fix must keep working) ───────────────────
+
+    [Fact]
+    public void For_ModuleQualifiedGdsFactoryFunction_UsesThePdkRegistryPattern()
+    {
+        var result = FoundryEditCodeSynthesis.For(
+            "cspdk.sin300.coupler_straight", null, null, null);
+
+        result.ShouldNotBeNull();
+        result.Value.Backend.ShouldBe(GeometryBackend.GdsFactory);
+        result.Value.Code.ShouldBe(
+            "import gdsfactory as gf\n"
+            + "import cspdk.sin300\n"
+            + "cspdk.sin300.PDK.activate()\n"
+            + "component = gf.get_component('coupler_straight')\n");
+    }
+
+    [Fact]
+    public void For_BareGdsFactoryCellName_ResolvesViaGetComponent()
+    {
+        var result = FoundryEditCodeSynthesis.For("straight", null, null, null);
+
+        result.ShouldNotBeNull();
+        result.Value.Backend.ShouldBe(GeometryBackend.GdsFactory);
+        result.Value.Code.ShouldContain("gf.get_component('straight')");
+        result.Value.Code.ShouldNotContain("import straight");
+    }
+
+    // ── SiEPIC (field round 6) ──────────────────────────────────────────────
+
+    [Fact]
+    public void For_SiepicNazcaReference_SynthesizesUbcPdkRegistryCode_notModuleAttributeCall()
+    {
+        // Field bug: "Edit Component" on "Adiabatic Coupler TE 1550" synthesized
+        // "import siepic_ebeam_pdk ... siepic_ebeam_pdk.ebeam_adiabatic_te1550()" which fails
+        // with "module 'siepic_ebeam_pdk' has no attribute 'ebeam_adiabatic_te1550'" —
+        // siepic_ebeam_pdk is a KLayout package without cell attributes. The cell IS
+        // instantiable via the ubcpdk gdsfactory registry (verified in the managed env).
+        var result = FoundryEditCodeSynthesis.For(
+            null, "siepic_ebeam_pdk", "ebeam_adiabatic_te1550", null);
+
+        result.ShouldNotBeNull();
+        result.Value.Backend.ShouldBe(GeometryBackend.GdsFactory);
+        result.Value.Code.ShouldBe(
+            "import gdsfactory as gf\n"
+            + "import ubcpdk\n"
+            + "ubcpdk.PDK.activate()\n"
+            + "component = gf.get_component('ebeam_adiabatic_te1550')\n");
+    }
+
+    [Fact]
+    public void For_SiepicCellWithUbcPdkRename_UsesTheRenamedRegistryName()
+    {
+        var result = FoundryEditCodeSynthesis.For(
+            null, "siepic_ebeam_pdk", "ebeam_DC_2-1_te895", null);
+
+        result.ShouldNotBeNull();
+        result.Value.Backend.ShouldBe(GeometryBackend.GdsFactory);
+        result.Value.Code.ShouldContain("gf.get_component('ebeam_DC_2m1_te895')");
+    }
+
+    [Fact]
+    public void For_SiepicCellWithoutUbcPdkEquivalent_ReturnsNull_insteadOfBrokenAttributeCode()
+    {
+        // The four KLayout-only cells (no ubcpdk registry entry) have no runnable editor
+        // code — null means "no stored code", which is honest; module-attribute code would
+        // only reproduce the AttributeError.
+        FoundryEditCodeSynthesis.For(null, "siepic_ebeam_pdk", "contra_directional_coupler", null)
+            .ShouldBeNull();
+    }
+
+    // ── demo PDK (nazca) regression ─────────────────────────────────────────
+
+    [Fact]
+    public void For_DemoNazcaReference_SynthesizesNazcaDemofabCode()
+    {
+        var result = FoundryEditCodeSynthesis.For(null, null, "demo.mmi2x2_dp", null);
+
+        result.ShouldNotBeNull();
+        result.Value.Backend.ShouldBe(GeometryBackend.Nazca);
+        result.Value.Code.ShouldContain("import nazca as nd");
+        result.Value.Code.ShouldContain("def component():");
+        result.Value.Code.ShouldContain("nazca.demofab");
+        result.Value.Code.ShouldContain("mmi2x2_dp");
+        result.Value.Code.ShouldNotContain("component = demo");
+    }
+
+    [Fact]
+    public void For_NoReferenceAtAll_ReturnsNull()
+    {
+        FoundryEditCodeSynthesis.For(null, null, null, null).ShouldBeNull();
+        FoundryEditCodeSynthesis.For("", "", "", "").ShouldBeNull();
+    }
+
+    // ── whole bundled SiEPIC PDK: never emit the broken attribute pattern ───
+
+    [Fact]
+    public void For_EveryBundledSiepicComponent_NeverSynthesizesTheSiepicAttributeCall()
+    {
+        var pdkPath = FindBundledPdk("siepic-ebeam-pdk.json");
+        pdkPath.ShouldNotBeNull("bundled siepic-ebeam-pdk.json must exist in CAP-DataAccess/PDKs");
+        var pdk = new PdkLoader().LoadFromFileForEditing(pdkPath!);
+
+        foreach (var comp in pdk.Components.Where(c => !string.IsNullOrWhiteSpace(c.NazcaFunction)))
+        {
+            var result = FoundryEditCodeSynthesis.For(
+                comp.GdsFactoryFunction, pdk.NazcaModuleName, comp.NazcaFunction, comp.NazcaParameters);
+
+            if (result is null)
+                continue; // KLayout-only cell: no runnable editor code, honest empty editor
+
+            result.Value.Backend.ShouldBe(GeometryBackend.GdsFactory,
+                $"'{comp.Name}' must synthesize gdsfactory registry code");
+            result.Value.Code.ShouldNotContain("siepic_ebeam_pdk",
+                customMessage: $"'{comp.Name}' must not reference the KLayout-only siepic module");
+            result.Value.Code.ShouldContain("gf.get_component(");
+        }
+    }
+
+    private static string? FindBundledPdk(string fileName)
+    {
+        var current = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(FoundryEditCodeSynthesisTests).Assembly.Location)!);
+        while (current != null)
+        {
+            var candidate = Path.Combine(current.FullName, "CAP-DataAccess", "PDKs", fileName);
+            if (File.Exists(candidate)) return candidate;
+            current = current.Parent;
+        }
+        return null;
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/NewComponentWindowStatusTextTests.cs
+++ b/UnitTests/Components/AddCustomComponent/NewComponentWindowStatusTextTests.cs
@@ -1,0 +1,44 @@
+using System.Text.RegularExpressions;
+using Shouldly;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// XAML review lock for the field round-6 UX wish: the status/error text in the
+/// "Edit Component" / "New Component" window must be COPYABLE, so users can paste a
+/// failing Python error into a search or a bug report. Avalonia's plain
+/// <c>TextBlock</c> is not selectable; the binding must sit on a
+/// <c>SelectableTextBlock</c>.
+/// </summary>
+public class NewComponentWindowStatusTextTests
+{
+    [Fact]
+    public void StatusText_IsRenderedAsSelectableTextBlock_soErrorsCanBeCopied()
+    {
+        var axaml = File.ReadAllText(FindWindowAxaml());
+
+        var statusBindings = Regex.Matches(
+            axaml, @"<(\w+)[^>]*\{Binding StatusText\}", RegexOptions.Singleline);
+
+        statusBindings.Count.ShouldBeGreaterThan(0, "the window must display StatusText");
+        foreach (Match match in statusBindings)
+        {
+            match.Groups[1].Value.ShouldBe("SelectableTextBlock",
+                "error/status text must be selectable so users can copy it");
+        }
+    }
+
+    private static string FindWindowAxaml()
+    {
+        var current = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(NewComponentWindowStatusTextTests).Assembly.Location)!);
+        while (current != null)
+        {
+            var candidate = Path.Combine(
+                current.FullName, "CAP.Avalonia", "Views", "NewComponentWindow.axaml");
+            if (File.Exists(candidate)) return candidate;
+            current = current.Parent;
+        }
+        throw new FileNotFoundException("NewComponentWindow.axaml not found above test assembly");
+    }
+}

--- a/UnitTests/Components/AddCustomComponent/SiepicEditPreviewE2ETests.cs
+++ b/UnitTests/Components/AddCustomComponent/SiepicEditPreviewE2ETests.cs
@@ -1,0 +1,69 @@
+using CAP.Avalonia.Services.AddCustomComponent;
+using CAP_Core.Export;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+
+namespace UnitTests.Components.AddCustomComponent;
+
+/// <summary>
+/// End-to-end lock for the field round-6 fix: the code the editor synthesizes for a bundled
+/// SiEPIC component ("Edit Component" → Preview) must actually render in a REAL Python
+/// environment via <c>render_gdsfactory_preview.py</c> — the exact pipeline the Preview button
+/// drives. Opt-in like the other env-dependent tests: runs only when LUNIMA_TEST_PYTHON3 is
+/// set; additionally skips when gdsfactory/ubcpdk are not installed in that interpreter
+/// (the CI preview python only carries nazca + klayout + siepic_ebeam_pdk).
+/// </summary>
+[Trait("Category", "Slow")]
+public class SiepicEditPreviewE2ETests
+{
+    [Fact]
+    public async Task SynthesizedEditCode_ForAdiabaticCouplerTe1550_RendersInTheRealEnvironment()
+    {
+        var python = Environment.GetEnvironmentVariable("LUNIMA_TEST_PYTHON3");
+        if (string.IsNullOrWhiteSpace(python)) return;   // env skip
+        var script = FindRepoFile(Path.Combine("scripts", "render_gdsfactory_preview.py"));
+        if (script is null) return;                       // env skip
+
+        var (pdk, draft) = LoadBundledSiepicDraft("Adiabatic Coupler TE 1550");
+        draft.ShouldNotBeNull("'Adiabatic Coupler TE 1550' must exist in the bundled SiEPIC JSON");
+
+        var synthesized = FoundryEditCodeSynthesis.For(
+            draft!.GdsFactoryFunction, pdk!.NazcaModuleName, draft.NazcaFunction, draft.NazcaParameters);
+        synthesized.ShouldNotBeNull();
+        synthesized!.Value.Backend.ShouldBe(GeometryBackend.GdsFactory);
+
+        var service = new GdsFactoryComponentPreviewService(python!, script);
+        var result = await service.RenderRawCodeAsync(synthesized.Value.Code);
+
+        // gdsfactory/ubcpdk not installed → env skip, not a Lunima bug.
+        if (!result.Success && result.Error?.Contains("No module named") == true) return;
+
+        result.Success.ShouldBeTrue($"synthesized editor code failed to render: {result.Error}");
+        result.Polygons.Count.ShouldBeGreaterThan(0, "the rendered cell must carry real geometry");
+        result.Pins.Count.ShouldBe(4, "ebeam_adiabatic_te1550 exposes four optical ports");
+    }
+
+    private static (PdkDraft? Pdk, PdkComponentDraft? Component) LoadBundledSiepicDraft(string componentName)
+    {
+        var path = FindRepoFile(Path.Combine("CAP-DataAccess", "PDKs", "siepic-ebeam-pdk.json"));
+        if (path is null) return (null, null);
+        var pdk = new PdkLoader().LoadFromFileForEditing(path);
+        var component = pdk.Components.FirstOrDefault(c =>
+            string.Equals(c.Name, componentName, StringComparison.Ordinal));
+        return (pdk, component);
+    }
+
+    private static string? FindRepoFile(string relativePath)
+    {
+        var current = new DirectoryInfo(
+            Path.GetDirectoryName(typeof(SiepicEditPreviewE2ETests).Assembly.Location)!);
+        while (current != null)
+        {
+            var candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate)) return candidate;
+            current = current.Parent;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Feld-Bug (Runde 6)

„Edit Component" auf **Adiabatic Coupler TE 1550** (SiEPIC EBeam PDK) → Preview →
`module 'siepic_ebeam_pdk' has no attribute 'ebeam_adiabatic_te1550'`.

**Ursache:** Der Runde-4-Fix (1fc54fce) griff nur für Komponenten mit `GdsFactoryFunction` (cspdk). SiEPIC-Komponenten referenzieren ihre Zellen über `nazcaModuleName`/`nazcaFunction` und liefen weiter durch die Nazca-Synthese → Modul-Attribut-Code. `siepic_ebeam_pdk` ist aber ein KLayout-Paket ohne Zell-Attribute (der Canvas rendert es über einen klayout-Pfad, den der Raw-Code-Editor nicht nutzen kann).

**Fix:** Neuer zentraler Resolver `FoundryEditCodeSynthesis` — Backend + Code pro PDK-Familie aus den PDK-JSON-Daten:
- cspdk (module-qualified `GdsFactoryFunction`) → gdsfactory-Registry-Pattern (Runde-4-Verhalten bleibt)
- SiEPIC → ubcpdk-gdsfactory-Registry via `UbcPdkCellMap` (Mapping des Exporters; 38/42 Bundled-Zellen)
- demo → Nazca-Call via `NazcaCodeTemplateBuilder`
- KLayout-only-SiEPIC-Zellen (kein ubcpdk-Äquivalent) → ehrlicher leerer Editor statt sicher fehlschlagendem Attribut-Code

**E2E-Beleg:** synthetisierter Code für `ebeam_adiabatic_te1550` rendert real in der managed env via `render_gdsfactory_preview.py` → success, 13 Polygone, 4 Pins (env-gated `SiepicEditPreviewE2ETests`).

## Fehler-UX (Feld-Wunsch)

1. **Eine Quelle** für Fenster-Status und Error Console: Fenster zeigt die handlungsleitende Meldung, Console dieselbe Meldung **plus** Python-Rohdetail — auch für unerkannte Fehler (vorher: Console still).
2. Status-/Fehlertext im Edit-Component-Fenster ist jetzt **kopierbar** (`SelectableTextBlock`), per AXAML-Review-Test gelockt.

## Tests

- `FoundryEditCodeSynthesisTests`: cspdk-Regression, SiEPIC (verbatim + Rename + unmapped), demo/nazca, PDK-weiter Lock über alle Bundled-SiEPIC-Komponenten
- `SiepicEditPreviewE2ETests` (Category=Slow, skipt ohne env)
- `EditComponentModeTests`: SiEPIC-LoadForEdit, Fehler-Unification
- `NewComponentWindowStatusTextTests`: SelectableTextBlock-Lock
- Volle Suite: 4273 passed / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCVwvkXdUH9DSW8w12XB2q