### PR TITLE
Save/Don't-Save dialog: content-sized window, centered auto-width buttons

### DIFF
--- a/CAP.Avalonia/Services/MessageBoxService.cs
+++ b/CAP.Avalonia/Services/MessageBoxService.cs
@@ -29,7 +29,7 @@ public class MessageBoxService : IMessageBoxService
         {
             Title = title,
             Width = 450,
-            Height = 180,
+            SizeToContent = SizeToContent.Height,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
             CanResize = false,
             Background = new SolidColorBrush(Color.Parse("#2d2d2d"))
@@ -54,15 +54,16 @@ public class MessageBoxService : IMessageBoxService
         var buttonPanel = new StackPanel
         {
             Orientation = Orientation.Horizontal,
-            HorizontalAlignment = HorizontalAlignment.Right,
+            HorizontalAlignment = HorizontalAlignment.Center,
             Spacing = 10
         };
 
         var saveButton = new Button
         {
             Content = LocalizationService.Instance.Translate("Common.Save"),
-            Width = 90,
-            Height = 32,
+            MinWidth = 90,
+            MinHeight = 28,
+            Padding = new Thickness(12, 4),
             Background = new SolidColorBrush(Color.Parse("#0d6efd")),
             Foreground = Brushes.White
         };
@@ -70,8 +71,9 @@ public class MessageBoxService : IMessageBoxService
         var dontSaveButton = new Button
         {
             Content = LocalizationService.Instance.Translate("Dialog.DontSave"),
-            Width = 90,
-            Height = 32,
+            MinWidth = 90,
+            MinHeight = 28,
+            Padding = new Thickness(12, 4),
             Background = new SolidColorBrush(Color.Parse("#6c757d")),
             Foreground = Brushes.White
         };
@@ -79,8 +81,9 @@ public class MessageBoxService : IMessageBoxService
         var cancelButton = new Button
         {
             Content = LocalizationService.Instance.Translate("Common.Cancel"),
-            Width = 90,
-            Height = 32,
+            MinWidth = 90,
+            MinHeight = 28,
+            Padding = new Thickness(12, 4),
             Background = new SolidColorBrush(Color.Parse("#3d3d3d")),
             Foreground = Brushes.White
         };


### PR DESCRIPTION
Field feedback from manual Linux testing: the unsaved-changes prompt (Save / Don't Save / Cancel) had a fixed 450x180 window with dead space, right-aligned buttons at a fixed 90x32 — which clipped the German 'Nicht speichern' label.

- Window height now follows content (`SizeToContent.Height`, same as the sibling choice prompt)
- Buttons auto-size (`MinWidth=90` + padding, 28px min height) so 'Nicht speichern' fits
- Button row centered instead of right-aligned

Verified manually by the owner on Linux/X11.