### PR TITLE
Agent: Demo PDK directional coupler: coupling % value unreadable behind spinner buttons

### DIFF
--- a/CAP.Avalonia/Views/Panels/SelectedComponentPropertiesPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/SelectedComponentPropertiesPanel.axaml
@@ -82,6 +82,7 @@
                                            Minimum="{Binding Min}" Maximum="{Binding Max}"
                                            Increment="1" FormatString="F2"
                                            ShowButtonSpinner="False"
+                                           VerticalAlignment="Center"
                                            Margin="6,0,0,0"/>
                         </Grid>
                     </StackPanel>

--- a/CAP.Avalonia/Views/Panels/SelectedComponentPropertiesPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/SelectedComponentPropertiesPanel.axaml
@@ -74,10 +74,14 @@
                             <Slider Grid.Column="0"
                                     Minimum="{Binding Min}" Maximum="{Binding Max}"
                                     Value="{Binding Value, Mode=TwoWay}"/>
+                            <!-- No spinner buttons (#779): in the 80px column Fluent's two
+                                 spinners would cover the value entirely. The slider handles
+                                 stepping; this stays a validated numeric text input. -->
                             <NumericUpDown Grid.Column="1"
                                            Value="{Binding Value, Mode=TwoWay}"
                                            Minimum="{Binding Min}" Maximum="{Binding Max}"
                                            Increment="1" FormatString="F2"
+                                           ShowButtonSpinner="False"
                                            Margin="6,0,0,0"/>
                         </Grid>
                     </StackPanel>

--- a/UnitTests/ViewModels/Properties/PropertiesPanelDeduplicationTests.cs
+++ b/UnitTests/ViewModels/Properties/PropertiesPanelDeduplicationTests.cs
@@ -73,6 +73,16 @@ namespace UnitTests.ViewModels.Properties
             content.ShouldContain("{Binding Value, Mode=TwoWay}");
         }
 
+        [Fact]
+        public void PropertiesPanel_SliderNumericInput_HasNoSpinnerButtons()
+        {
+            // Issue #779: in the 80px editor column the Fluent spinner buttons
+            // covered the numeric value (e.g. directional-coupler coupling %).
+            // The slider provides stepping, so the NumericUpDown must stay a
+            // plain validated text input without spinner buttons.
+            PropertiesPanelAxaml.ShouldContain("ShowButtonSpinner=\"False\"");
+        }
+
         private static string FindRepoRoot()
         {
             var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
Automated implementation for #779

- SliderTpl NumericUpDown: `ShowButtonSpinner="False"` — spinners covered the value in the 80px column
- Affects phase shifter, tunable coupler, Demo PDK directional coupler (coupling %)
- Kept NumericUpDown (validation, Min/Max clamp, keyboard/scroll stepping) over plain TextBox
- Rejected widening the column: right panel is narrow; slider already steps
- Audited all other NumericUpDowns: 100–135px+ layouts, not affected
- Regression test pins the attribute in PropertiesPanelDeduplicationTests
- Build clean; full suite 4322/1 (sole failure = known headless-screenshot flake, passes isolated)


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 68,085
- **Estimated cost:** $0.0381 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*