### PR TITLE
SiEPIC export: distinct stub cell per parameter set (#783)

### DIFF
--- a/CAP.Avalonia/Services/NazcaStubNaming.cs
+++ b/CAP.Avalonia/Services/NazcaStubNaming.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+using System.Text;
+using CAP_Core.Export;
+
+namespace CAP.Avalonia.Services;
+
+/// <summary>
+/// Names the generated Nazca stub cells/functions. The stub generator dedupes by
+/// function name, so two placements of the same PDK function with DIFFERENT parameters
+/// would share one stub cell — the first placement's dimensions win, and the klayout
+/// upgrade (<see cref="SiepicCellUpgradeWriter"/>) would resolve the losing variants
+/// with the wrong parameters, rendering physically wrong silicon (issue #783).
+/// Parameterized components therefore get a short deterministic parameters hash
+/// appended, so each distinct parameter set gets its own cell. Unparameterized
+/// components keep the bare function name — existing exports are unchanged.
+/// The name must be identically computable at every site that names or references
+/// the stub cell (stub generation, placement call sites, the klayout upgrade map),
+/// which is why it lives in this one helper.
+/// </summary>
+internal static class NazcaStubNaming
+{
+    /// <summary>
+    /// Stub cell/function name for one component. The hash is appended only when the
+    /// placement actually calls the generated stub with parameters: dotted names
+    /// (<c>demo.shallow.bend</c>) call the real module function directly (their stub
+    /// is never invoked), and parametric straights embed the length in their runtime
+    /// cell name already — both keep the bare name.
+    /// </summary>
+    public static string StubName(string funcName, string? parameters)
+    {
+        if (string.IsNullOrEmpty(parameters)
+            || funcName.Contains('.', StringComparison.Ordinal)
+            || NazcaCoordinateMapper.IsParametricStraight(funcName, parameters))
+            return funcName;
+        return $"{funcName}_{ParametersHash(parameters)}";
+    }
+
+    /// <summary>
+    /// 6 lowercase hex chars of SHA-256 over the parameter string — deterministic
+    /// across runs and platforms, and collision-safe for the handful of parameter
+    /// sets one design places per function. Keeps GDS cell names short
+    /// (<c>ebeam_dc_te1550_7f986c</c> is 22 chars; even &gt;32 would be safe).
+    /// </summary>
+    public static string ParametersHash(string parameters)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(parameters));
+        return Convert.ToHexString(bytes, 0, 3).ToLowerInvariant();
+    }
+}

--- a/CAP.Avalonia/Services/SiepicCellUpgradeWriter.cs
+++ b/CAP.Avalonia/Services/SiepicCellUpgradeWriter.cs
@@ -16,9 +16,10 @@ namespace CAP.Avalonia.Services;
 /// deep-copies the real geometry into the stub cell, keeping the cell name so
 /// placed instances stay put. Any failure (klayout or PDK missing, cell unknown)
 /// downgrades to a stderr warning and keeps the stub — the export never breaks.
-/// Components sharing a function name with different parameters share one cell
-/// (the stub generator dedupes by name); the script warns on stderr when that
-/// happens rather than silently rendering one variant for all.
+/// Parameterized components get a parameters hash in their stub cell name
+/// (<see cref="NazcaStubNaming"/>, issue #783), so the map keys each variant's
+/// cell to ITS OWN function name + parameters; a residual stderr warning covers
+/// only a hash collision (two parameter sets, same stub name).
 /// </summary>
 public static class SiepicCellUpgradeWriter
 {
@@ -38,8 +39,11 @@ public static class SiepicCellUpgradeWriter
         if (cells.Count == 0)
             return;
 
+        // stub cell name → (real PDK function name, parameters): the GDS cell to
+        // patch is the hash-suffixed stub (#783), the library lookup needs the
+        // original function name with THIS variant's parameters.
         var mapLiteral = string.Join(", ", cells.Select(
-            kv => $"'{Escape(kv.Key)}': '{Escape(kv.Value)}'"));
+            kv => $"'{Escape(kv.Key)}': ('{Escape(kv.Value.FuncName)}', '{Escape(kv.Value.Params)}')"));
 
         sb.AppendLine();
         sb.AppendLine("# --- Lunima: upgrade SiEPIC stub boxes to real foundry geometry (klayout) ---");
@@ -47,15 +51,16 @@ public static class SiepicCellUpgradeWriter
         sb.AppendLine($"_lunima_upgrade_siepic_cells(gds_filename, {{{mapLiteral}}})");
         foreach (var collision in FindParamCollisions(canvas, include))
             sb.AppendLine(
-                $"print(\"[Lunima] WARN: multiple parameter sets for SiEPIC cell '{Escape(collision)}' " +
-                "— one shared cell is used for all instances; check geometry against the PDK.\", file=sys.stderr)");
+                $"print(\"[Lunima] WARN: SiEPIC stub cell '{Escape(collision)}' maps to multiple parameter sets " +
+                "(parameters-hash collision) — one shared cell is used for all instances; check geometry against the PDK.\", file=sys.stderr)");
         sb.AppendLine();
     }
 
     /// <summary>
-    /// Function names placed with more than one parameter set. The stub generator dedupes
-    /// by function name, so such components share one cell — flag it in the script output
-    /// instead of silently rendering one variant for all.
+    /// Stub cell names that more than one parameter set hashes to. Distinct parameter
+    /// sets get distinct cells via the name hash (#783), so this fires only on an
+    /// actual parameters-hash collision — flag it in the script output instead of
+    /// silently rendering one variant for all.
     /// </summary>
     private static IEnumerable<string> FindParamCollisions(
         DesignCanvasViewModel canvas, Func<Component, bool>? include)
@@ -88,25 +93,30 @@ public static class SiepicCellUpgradeWriter
         if (include != null && !include(comp)) return null;
         var funcName = comp.NazcaFunctionName;
         if (string.IsNullOrEmpty(funcName)) return null;
+        if (!NazcaCoordinateMapper.IsPdkFunction(funcName)) return null;
         if (comp.NazcaModuleName?.StartsWith("siepic", StringComparison.OrdinalIgnoreCase) != true) return null;
         var parameters = comp.NazcaFunctionParameters ?? string.Empty;
-        if (seen.TryGetValue(funcName, out var existing))
-            return existing != parameters ? funcName : null;
-        seen[funcName] = parameters;
+        // Key on the stub cell name — the same key the stub generator dedupes by,
+        // so only a genuine parameters-hash collision reports here.
+        var stubName = NazcaStubNaming.StubName(funcName, parameters);
+        if (seen.TryGetValue(stubName, out var existing))
+            return existing != parameters ? stubName : null;
+        seen[stubName] = parameters;
         return null;
     }
 
     /// <summary>
-    /// Unique SiEPIC stub cells of the design: function name → parameter string.
-    /// Same enumeration as the stub generator (groups flattened, analysis tools
-    /// skipped, <paramref name="include"/> honoured). Parametric straights are
+    /// Unique SiEPIC stub cells of the design: stub cell name (parameters-hash
+    /// suffixed, <see cref="NazcaStubNaming"/>) → (real function name, parameter
+    /// string). Same enumeration as the stub generator (groups flattened, analysis
+    /// tools skipped, <paramref name="include"/> honoured). Parametric straights are
     /// excluded — their stub cell name embeds the instance length, so a
     /// per-function content swap cannot target them.
     /// </summary>
-    private static IReadOnlyDictionary<string, string> CollectSiepicStubCells(
+    private static IReadOnlyDictionary<string, (string FuncName, string Params)> CollectSiepicStubCells(
         DesignCanvasViewModel canvas, Func<Component, bool>? include)
     {
-        var cells = new Dictionary<string, string>(StringComparer.Ordinal);
+        var cells = new Dictionary<string, (string FuncName, string Params)>(StringComparer.Ordinal);
         foreach (var compVm in canvas.Components)
         {
             var comp = compVm.Component;
@@ -125,7 +135,7 @@ public static class SiepicCellUpgradeWriter
     }
 
     private static void AddIfSiepic(
-        IDictionary<string, string> cells, Component comp, Func<Component, bool>? include)
+        IDictionary<string, (string FuncName, string Params)> cells, Component comp, Func<Component, bool>? include)
     {
         if (comp.IsAnalysisTool) return;
         if (include != null && !include(comp)) return;
@@ -136,7 +146,10 @@ public static class SiepicCellUpgradeWriter
         // Cheap routing predicate — anything starting with 'siepic' resolves through
         // the EBeam* KLayout libraries (same split as the editor preview).
         if (comp.NazcaModuleName?.StartsWith("siepic", StringComparison.OrdinalIgnoreCase) != true) return;
-        cells.TryAdd(funcName, comp.NazcaFunctionParameters ?? string.Empty);
+        // The GDS cell to patch is the hash-suffixed stub (#783); the EBeam library
+        // lookup still needs the original function name with this variant's parameters.
+        var parameters = comp.NazcaFunctionParameters ?? string.Empty;
+        cells.TryAdd(NazcaStubNaming.StubName(funcName, parameters), (funcName, parameters));
     }
 
     private static string Escape(string value) =>
@@ -196,8 +209,8 @@ def _lunima_upgrade_siepic_cells(gds_path, cells):
         _out = _kdb.Layout()
         _out.read(gds_path)
         _upgraded = 0
-        for _func_name, _params in cells.items():
-            _stub = _out.cell(_func_name)
+        for _stub_name, (_func_name, _params) in cells.items():
+            _stub = _out.cell(_stub_name)
             if _stub is None:
                 continue
             try:

--- a/CAP.Avalonia/Services/SimpleNazcaExporter.cs
+++ b/CAP.Avalonia/Services/SimpleNazcaExporter.cs
@@ -118,8 +118,9 @@ public class SimpleNazcaExporter
 
     /// <summary>
     /// Generates standalone Nazca cell definitions for PDK components.
-    /// Each unique PDK function used in the design gets a stub cell
-    /// with correct dimensions and pin positions — no external PDK install needed.
+    /// Each unique PDK function AND parameter set used in the design gets a stub cell
+    /// with correct dimensions and pin positions — no external PDK install needed
+    /// (parameterized names carry a hash, <see cref="NazcaStubNaming"/>, issue #783).
     /// ComponentGroups are flattened — stubs are generated for all child components.
     /// SiEPIC stubs are placeholders only: after <c>nd.export_gds()</c> the script's
     /// klayout post-pass (<see cref="SiepicCellUpgradeWriter"/>) swaps their content
@@ -154,6 +155,9 @@ public class SimpleNazcaExporter
 
     /// <summary>
     /// Generates a PDK stub for a single component if required.
+    /// Dedupes by STUB name, not function name: parameterized components carry a
+    /// parameters hash in the name (issue #783), so each distinct parameter set
+    /// generates its own stub while identical placements still share one.
     /// </summary>
     private static void AppendComponentStub(
         StringBuilder sb, Component comp, HashSet<string> generated, CultureInfo ci)
@@ -161,13 +165,14 @@ public class SimpleNazcaExporter
         var funcName = comp.NazcaFunctionName;
         if (string.IsNullOrEmpty(funcName) || !RequiresStub(funcName))
             return;
-        if (!generated.Add(funcName))
+        var stubName = NazcaStubNaming.StubName(funcName, comp.NazcaFunctionParameters);
+        if (!generated.Add(stubName))
             return;
 
         if (NazcaCoordinateMapper.IsParametricStraight(funcName, comp.NazcaFunctionParameters))
             AppendParametricStraightStub(sb, funcName, comp, ci);
         else
-            AppendStandardComponentStub(sb, funcName, comp, ci);
+            AppendStandardComponentStub(sb, funcName, stubName, comp, ci);
     }
 
     /// <summary>
@@ -247,18 +252,23 @@ public class SimpleNazcaExporter
     /// (<see cref="SiepicCellUpgradeWriter"/>) fills with real foundry geometry
     /// for SiEPIC cells — same cell name, so instances keep their placement.
     /// </summary>
+    /// <param name="stubName">
+    /// Cell/function name to emit: <paramref name="funcName"/> plus the parameters
+    /// hash for parameterized components (<see cref="NazcaStubNaming"/>, issue #783),
+    /// so two parameter sets never share one cell.
+    /// </param>
     private static void AppendStandardComponentStub(
-        StringBuilder sb, string funcName, Component comp, CultureInfo ci)
+        StringBuilder sb, string funcName, string stubName, Component comp, CultureInfo ci)
     {
         var w = comp.WidthMicrometers;
         var h = comp.HeightMicrometers;
 
-        // Sanitize function name for valid Python identifier (replace non-alphanumeric/underscore chars)
-        var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_]", "_");
+        // Sanitize stub name for valid Python identifier (replace non-alphanumeric/underscore chars)
+        var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(stubName, @"[^a-zA-Z0-9_]", "_");
 
         // Define cell once, return cached instance on each call
-        sb.AppendLine($"with nd.Cell(name='{funcName}') as _{pythonFuncName}_cell:");
-        sb.AppendLine($"    \"\"\"Auto-generated stub for {funcName} ({comp.WidthMicrometers}x{comp.HeightMicrometers} µm).\"\"\"");
+        sb.AppendLine($"with nd.Cell(name='{stubName}') as _{pythonFuncName}_cell:");
+        sb.AppendLine($"    \"\"\"Auto-generated stub for {funcName} ({comp.WidthMicrometers.ToString(ci)}x{comp.HeightMicrometers.ToString(ci)} µm).\"\"\"");
 
         // Stubs are only generated for PDK-named components (see RequiresStub), whose
         // placement always uses the calibrated origin offset — (0,0) means org at the
@@ -913,8 +923,12 @@ public class SimpleNazcaExporter
         var funcName = comp.NazcaFunctionName;
         if (!string.IsNullOrEmpty(funcName) && NazcaCoordinateMapper.IsPdkFunction(funcName))
         {
-            // Keep dots (for module attribute access like demo.mmi2x2_dp), replace other invalid chars
-            var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_.]", "_");
+            // Keep dots (for module attribute access like demo.mmi2x2_dp), replace other invalid chars.
+            // The placement calls the parameter-specific stub (issue #783): StubName appends
+            // the parameters hash exactly when the stub generator did — dotted names bypass
+            // stubs (real module call) and parametric straights embed the length already.
+            var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(
+                NazcaStubNaming.StubName(funcName, comp.NazcaFunctionParameters), @"[^a-zA-Z0-9_.]", "_");
 
             // Forward stored parameters verbatim — the caller (component model)
             // is responsible for ensuring they match the target PDK function's signature.

--- a/UnitTests/Components/SiepicPdkTests.cs
+++ b/UnitTests/Components/SiepicPdkTests.cs
@@ -213,7 +213,9 @@ public class SiepicPdkTests
         );
 
         var result = SimpleNazcaExporter.GetNazcaFunction(component);
-        result.ShouldBe("ebeam_dc_te1550(gap=200e-9)");
+        // Parameterized placements call the parameter-specific stub (parameters hash
+        // in the name, issue #783) so distinct parameter sets get distinct cells.
+        result.ShouldBe("ebeam_dc_te1550_0e52a6(gap=200e-9)");
     }
 
     [Fact]

--- a/UnitTests/Export/GdsFactoryExport/MixedBackend/MixedBackendMergeIntegrationTests.cs
+++ b/UnitTests/Export/GdsFactoryExport/MixedBackend/MixedBackendMergeIntegrationTests.cs
@@ -58,8 +58,10 @@ public class MixedBackendMergeIntegrationTests
             var counts = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, int>>(probe.StdOut.Trim())!;
 
             counts.ShouldContainKey(MixedBackendGdsOrchestrator.NazcaPartialTopCellName);
-            counts.ShouldContainKey("ebeam_dc_te1550");
-            counts["ebeam_dc_te1550"].ShouldBeGreaterThan(1,
+            // Parameterized stub cell name (issue #783): function name + parameters hash.
+            var dcStub = CAP.Avalonia.Services.NazcaStubNaming.StubName("ebeam_dc_te1550", "gap=200E-9");
+            counts.ShouldContainKey(dcStub);
+            counts[dcStub].ShouldBeGreaterThan(1,
                 "the merged GDS must carry the upgraded real SiEPIC cell, not the 1-polygon stub");
             counts.Values.Count(v => v > 0).ShouldBeGreaterThan(1,
                 "geometry from both backend groups must be present in the merged GDS");

--- a/UnitTests/Export/SiepicRealGeometryExportTests.cs
+++ b/UnitTests/Export/SiepicRealGeometryExportTests.cs
@@ -62,10 +62,13 @@ public class SiepicRealGeometryExportTests
     public void NazcaExport_SiepicComponent_EmitsUpgradeBlockWithSafeFallback()
     {
         // Env-independent pins: the post-pass exists, is fully guarded (any failure keeps
-        // the stub and only warns), and writes the GDS atomically.
+        // the stub and only warns), and writes the GDS atomically. The map keys the
+        // hash-suffixed stub cell (#783) to its real function name + parameters.
         var script = new SimpleNazcaExporter().Export(EbeamCanvas());
 
-        script.ShouldContain("_lunima_upgrade_siepic_cells(gds_filename, {'ebeam_dc_te1550': 'gap=200E-9'})");
+        script.ShouldContain(
+            "_lunima_upgrade_siepic_cells(gds_filename, " +
+            "{'ebeam_dc_te1550_7f986c': ('ebeam_dc_te1550', 'gap=200E-9')})");
         script.ShouldContain("try:");
         script.ShouldContain("except Exception");
         script.ShouldContain("[Lunima] WARN: real SiEPIC cell");
@@ -83,10 +86,14 @@ public class SiepicRealGeometryExportTests
     }
 
     [Fact]
-    public void NazcaExport_ParamCollision_WarnsInScript()
+    public void NazcaExport_DistinctParameterSets_GetDistinctStubCells()
     {
-        // Two placements of the same SiEPIC function with different parameters share one
-        // cell (the stub generator dedupes by name) — the script must say so on stderr.
+        // Regression guard for #783: two placements of the same SiEPIC function with
+        // different parameters must NOT share one stub cell — each parameter set gets
+        // its own cell (parameters hash in the name), each placement calls its own
+        // stub, and the klayout upgrade maps each cell to ITS parameters. The old
+        // "multiple parameter sets" stderr warning is gone: the collision it covered
+        // no longer exists.
         var canvas = EbeamCanvas();
         var second = TestComponentFactory.CreateBasicComponent();
         second.Identifier = "DC2";
@@ -101,7 +108,21 @@ public class SiepicRealGeometryExportTests
 
         var script = new SimpleNazcaExporter().Export(canvas);
 
-        script.ShouldContain("multiple parameter sets for SiEPIC cell 'ebeam_dc_te1550'");
+        // Two distinct stub cells, each with its own variant's dimensions (pre-fix the
+        // first placement's 22.02 µm box won for both).
+        script.ShouldContain("with nd.Cell(name='ebeam_dc_te1550_7f986c')");
+        script.ShouldContain("Auto-generated stub for ebeam_dc_te1550 (22.02x6.2 µm)");
+        script.ShouldContain("with nd.Cell(name='ebeam_dc_te1550_200fdc')");
+        script.ShouldContain("Auto-generated stub for ebeam_dc_te1550 (12.02x6.2 µm)");
+
+        // Each placement references its own parameter-specific stub.
+        script.ShouldContain("comp_0 = ebeam_dc_te1550_7f986c(gap=200E-9).put(");
+        script.ShouldContain("comp_1 = ebeam_dc_te1550_200fdc(gap=200E-9,Lc=5E-6).put(");
+
+        // The upgrade block upgrades EACH variant with ITS parameters.
+        script.ShouldContain("'ebeam_dc_te1550_7f986c': ('ebeam_dc_te1550', 'gap=200E-9')");
+        script.ShouldContain("'ebeam_dc_te1550_200fdc': ('ebeam_dc_te1550', 'gap=200E-9,Lc=5E-6')");
+        script.ShouldNotContain("multiple parameter sets");
     }
 
     [SkippableFact]

--- a/UnitTests/Services/NazcaExportAllComponentsTests.cs
+++ b/UnitTests/Services/NazcaExportAllComponentsTests.cs
@@ -88,7 +88,7 @@ public class NazcaExportAllComponentsTests
         pdk.Components.Count.ShouldBeGreaterThan(0, "SiEPIC PDK should have components");
 
         double xOffset = 0;
-        var expectedFunctions = new List<string>();
+        var expectedFunctions = new List<(string FuncName, string? Parameters)>();
 
         foreach (var pdkComp in pdk.Components)
         {
@@ -99,21 +99,25 @@ public class NazcaExportAllComponentsTests
 
             // Track expected function names
             if (!string.IsNullOrEmpty(pdkComp.NazcaFunction))
-                expectedFunctions.Add(pdkComp.NazcaFunction);
+                expectedFunctions.Add((pdkComp.NazcaFunction, pdkComp.NazcaParameters));
         }
 
         var exporter = new SimpleNazcaExporter();
         var result = exporter.Export(canvas);
 
-        // Every PDK function should have a stub definition and be called in the design
-        // Function names are sanitized to valid Python identifiers (non-alphanumeric/underscore chars replaced with _)
-        foreach (var funcName in expectedFunctions)
+        // Every PDK function should have a stub definition and be called in the design.
+        // Function names are sanitized to valid Python identifiers (non-alphanumeric/underscore
+        // chars replaced with _); parameterized components get the parameters hash appended
+        // (issue #783) — the two "Directional Coupler TE 1550" variants of the shipped PDK
+        // must NOT collapse into one stub.
+        foreach (var (funcName, parameters) in expectedFunctions)
         {
-            var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(funcName, @"[^a-zA-Z0-9_.]", "_");
+            var stubName = NazcaStubNaming.StubName(funcName, parameters);
+            var pythonFuncName = System.Text.RegularExpressions.Regex.Replace(stubName, @"[^a-zA-Z0-9_.]", "_");
             result.ShouldContain($"def {pythonFuncName}(**kwargs):",
-                customMessage: $"Stub definition for '{funcName}' (sanitized: '{pythonFuncName}') not found in export");
+                customMessage: $"Stub definition for '{funcName}' (stub: '{pythonFuncName}') not found in export");
             result.ShouldContain($"{pythonFuncName}(",
-                customMessage: $"PDK function call '{funcName}' (sanitized: '{pythonFuncName}') not found in export");
+                customMessage: $"PDK function call '{funcName}' (stub: '{pythonFuncName}') not found in export");
         }
 
         // Every component should have a comp_N variable
@@ -184,8 +188,10 @@ public class NazcaExportAllComponentsTests
         var exporter = new SimpleNazcaExporter();
         var result = exporter.Export(canvas);
 
-        // Function should include parameters
-        result.ShouldContain($"{compWithParams.NazcaFunction}({compWithParams.NazcaParameters})",
+        // Function call should include the parameters — placed on the parameter-specific
+        // stub (parameters hash in the name, issue #783).
+        var stubName = NazcaStubNaming.StubName(compWithParams.NazcaFunction, compWithParams.NazcaParameters);
+        result.ShouldContain($"{stubName}({compWithParams.NazcaParameters})",
             customMessage: $"Parameters missing for {compWithParams.NazcaFunction}");
     }
 

--- a/UnitTests/Services/NazcaStubNamingTests.cs
+++ b/UnitTests/Services/NazcaStubNamingTests.cs
@@ -1,0 +1,60 @@
+using CAP.Avalonia.Services;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Services;
+
+/// <summary>
+/// Pins the stub-naming contract of issue #783: parameterized components get a short
+/// deterministic parameters hash so each parameter set gets its own stub cell;
+/// unparameterized components (and names that bypass stubs) keep the bare name, so
+/// existing exports are unchanged.
+/// </summary>
+public class NazcaStubNamingTests
+{
+    [Fact]
+    public void StubName_NoParameters_KeepsBareFunctionName()
+    {
+        NazcaStubNaming.StubName("ebeam_y_1550", null).ShouldBe("ebeam_y_1550");
+        NazcaStubNaming.StubName("ebeam_y_1550", "").ShouldBe("ebeam_y_1550");
+    }
+
+    [Fact]
+    public void StubName_SameParameters_IsDeterministic()
+    {
+        NazcaStubNaming.StubName("ebeam_dc_te1550", "gap=200E-9")
+            .ShouldBe(NazcaStubNaming.StubName("ebeam_dc_te1550", "gap=200E-9"));
+    }
+
+    [Fact]
+    public void StubName_DifferentParameters_DifferentNames()
+    {
+        NazcaStubNaming.StubName("ebeam_dc_te1550", "gap=200E-9")
+            .ShouldNotBe(NazcaStubNaming.StubName("ebeam_dc_te1550", "gap=200E-9,Lc=5E-6"));
+    }
+
+    [Fact]
+    public void StubName_Parameters_AppendsShortHexHash()
+    {
+        // 6 hex chars: short GDS cell names, pinned scheme (SHA-256, first 3 bytes).
+        NazcaStubNaming.StubName("ebeam_dc_te1550", "gap=200E-9")
+            .ShouldBe("ebeam_dc_te1550_7f986c");
+    }
+
+    [Fact]
+    public void StubName_DottedName_KeepsBareName()
+    {
+        // Dotted names call the real module function directly (demo.shallow.bend) —
+        // their stub is never invoked, so hashing would break the call.
+        NazcaStubNaming.StubName("demo.shallow.bend", "angle=90")
+            .ShouldBe("demo.shallow.bend");
+    }
+
+    [Fact]
+    public void StubName_ParametricStraight_KeepsBareName()
+    {
+        // The straight stub embeds the length in its runtime cell name already.
+        NazcaStubNaming.StubName("demo_pdk_straight", "length=100")
+            .ShouldBe("demo_pdk_straight");
+    }
+}

--- a/UnitTests/Services/SimpleNazcaExporterTests.cs
+++ b/UnitTests/Services/SimpleNazcaExporterTests.cs
@@ -429,7 +429,9 @@ public class SimpleNazcaExporterTests
 
         var result = SimpleNazcaExporter.GetNazcaFunction(comp);
 
-        result.ShouldBe("ebeam_y_1550(wg_width=0.5)");
+        // Parameterized placements call the parameter-specific stub: the parameters
+        // hash in the name gives each parameter set its own cell (issue #783).
+        result.ShouldBe("ebeam_y_1550_712b11(wg_width=0.5)");
     }
 
     [Fact]


### PR DESCRIPTION
## Why

The nazca stub generator deduped by **function name only**: two placements of the same SiEPIC function with different parameters shared one stub cell — the first placement's dimensions won, and the klayout upgrade post-pass resolved the losing variants with the wrong parameters. This is shipped data, not hypothetical: `siepic-ebeam-pdk.json` contains `Directional Coupler TE 1550` (`gap=200E-9`, W=22.02) and `Directional Coupler TE 1550 (Lc=5um)` (`gap=200E-9,Lc=5E-6`, W=12.02) — both `ebeam_dc_te1550`. With real foundry geometry in the export this is physically wrong silicon, and routed waveguides can land off the ports of the losing variant.

PR #780 only mitigated it (stderr warning). This is the real fix.

## What

- **`NazcaStubNaming`** (new shared helper): parameterized components get `funcName + '_' + hash` where hash = first 3 bytes of SHA-256 over the parameter string (6 lowercase hex chars, same idiom as `ComponentGeometryKey`). Unparameterized, dotted (`demo.*`) and parametric-straight names stay exactly as before — no export churn.
- **All three naming sites key off the same helper** so instances, cells and the upgrade map can't drift: stub generation (`AppendComponentStub`/`AppendStandardComponentStub`), placement call sites (`GetNazcaFunction`), and `SiepicCellUpgradeWriter`'s map.
- The upgrade map now maps **stub cell name → (real funcName, params)** and the embedded Python unpacks the tuple — each variant's cell is upgraded with ITS parameters while library resolution still uses the original PDK name.
- The old *multiple parameter sets* stderr warning is kept but re-purposed: it fires only on a genuine parameters-hash collision.
- The stub docstring now formats dimensions with `InvariantCulture` like every other number in the generated script (was locale-dependent — the new regression test caught this on a de-DE box).
- GDS cell-name length stays short (`ebeam_dc_te1550_7f986c` = 22 chars; >32 is verified safe).

## Tests

- New `NazcaStubNamingTests`: determinism, distinctness, bare-name cases, exact pinned hash.
- `NazcaExport_DistinctParameterSets_GetDistinctStubCells` (replaces the old collision-warning guard): builds both shipped PDK variants and asserts two distinct stub cells with their own dimensions, per-variant placement calls, and both tuples in the upgrade block.
- Call-site expectations synced (`SimpleNazcaExporterTests`, `SiepicPdkTests`, `NazcaExportAllComponentsTests`) and the mixed-backend merge integration test computes the upgraded cell name via the helper (runs the real python env end-to-end: both scripts + klayout inspection).
- Verified locally: 146 (naming/siepic/nazca-export) + 238 (exporter/mixed-backend/gds incl. real-python integration) + 424 (services/pdkoffset) — all green, 0 errors.

Closes #783