### PR TITLE
Routing: erste Biegung darf direkt am Pin ansetzen (Pin-Lead-Stub-Relikt entfernt)

### DIFF
--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/AStarPathfinder.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/AStarPathfinder.cs
@@ -225,6 +225,12 @@ public class AStarPathfinder
 
             // CRITICAL: Force pin arrival - must approach goal in the correct direction
             // for the last N cells. This ensures clean arrival at the end pin.
+            // `<=` deliberately holds the last corner ONE cell further from the pin than
+            // the departure check above (distanceFromStart < N) holds the first corner:
+            // relaxing it to `<` lets the smoothed arrival arc clip obstacles registered
+            // right next to the goal corridor (frozen sibling paths). The resulting
+            // asymmetry is bounded by a single grid cell — quantization noise, unlike the
+            // old distance-scaled escape (pin-lead-stub field finding).
             int distanceToGoal = Math.Abs(newX - goalX) + Math.Abs(newY - goalY);
             if (distanceToGoal <= _costCalculator.MinPinEscapeCells)
             {

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/AStarPathfinder.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/AStarPathfinder.cs
@@ -77,13 +77,18 @@ public class AStarPathfinder
         var visited = new Dictionary<(int, int, GridDirection, int), AStarNode>();
         var distanceFromStart = new Dictionary<(int, int, GridDirection, int), int>();
 
-        // Create start node
-        // StraightRunLength = 0 forces the path to go straight first before turning
-        // This ensures waveguides exit components properly before bending
+        // Create start node.
+        // A pin start needs room for only ONE arc tangent before the first turn (the
+        // upcoming bend), while interior turns need two — the previous and the next arc —
+        // which is what MinStraightRunCells (≈ 2 × bend radius) encodes. Granting the start
+        // node half that run makes the first turn legal one tangent from the pin, so the
+        // first bend can begin directly at the pin (pin-lead-stub field finding). The -1
+        // keeps the first apex strictly beyond the tangent, so a short pin-side straight
+        // survives smoothing for the in-canvas shift handles.
         var startNode = new AStarNode(startX, startY, startDirection)
         {
             GCost = 0,
-            StraightRunLength = 0
+            StraightRunLength = Math.Max(0, (_costCalculator.MinStraightRunCells - 1) / 2)
         };
         startNode.HCost = _costCalculator.CalculateHeuristic(
             startX, startY, startDirection, endX, endY, endDirection);

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/RoutingCostCalculator.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/RoutingCostCalculator.cs
@@ -35,8 +35,10 @@ public class RoutingCostCalculator
     /// Minimum "escape distance" from start pin before allowing turns.
     /// This forces waveguides to exit components in the pin direction
     /// before routing toward the destination.
-    /// Typically 3-5x bend radius to ensure clean exit.
-    /// REDUCED to 15 to avoid blocking in tight spaces.
+    /// <see cref="CAP_Core.Routing.WaveguideRouter"/> overrides this per routing attempt
+    /// with the radius-derived tangent escape (bend radius rounded up past the next whole
+    /// cell), so the first bend can begin directly at the pin — the default below only
+    /// applies to direct users of the calculator.
     /// </summary>
     public int MinPinEscapeCells { get; set; } = 15;
 

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.AStarAttempt.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.AStarAttempt.cs
@@ -64,11 +64,13 @@ public partial class WaveguideRouter
 
             int originalEscapeCells = CostCalculator.MinPinEscapeCells;
 
-            // Scale escape distance based on pin separation.
-            // Both start escape + end approach must fit within the total distance,
-            // with room left for turns. Use 1/6 of distance, minimum 2 cells.
+            // The forced straight run at a pin only needs to fit the first arc's tangent
+            // length (r·tan(sweep/2), at most the bend radius for a 90° turn) — NOT the old
+            // distance-scaled escape (up to 15 cells), which forced visibly different pin
+            // clearances per connection. Close pins still degrade to 2 cells, as before.
             int gridDistance = Math.Abs(gridEndX - gridStartX) + Math.Abs(gridEndY - gridStartY);
-            int scaledEscape = Math.Min(originalEscapeCells, Math.Max(2, gridDistance / 6));
+            int scaledEscape = Math.Min(PinTangentEscapeCells(bendRadius),
+                                        Math.Max(2, gridDistance / 6));
             CostCalculator.MinPinEscapeCells = scaledEscape;
 
             // Also scale MinStraightRunCells for close pins to allow tighter turns
@@ -182,6 +184,16 @@ public partial class WaveguideRouter
             PathfindingGrid.RestoreCells(clearedEndFanout);
         }
     }
+
+    /// <summary>
+    /// Grid cells a route must run straight from a pin before the first turn, so the first
+    /// (or last) arc fits between the pin and the turn apex: the 90° tangent length (= the
+    /// bend radius) rounded up past the next whole cell. The extra cell keeps a short
+    /// pin-side straight in the smoothed path — the segment-shift handles can collapse it
+    /// to exactly zero, putting the bend directly at the pin (pin-lead-stub field finding).
+    /// </summary>
+    private int PinTangentEscapeCells(double bendRadius) =>
+        Math.Max(2, (int)(bendRadius / PathfindingGrid!.CellSizeMicrometers) + 1);
 
     /// <summary>
     /// The allowed bend radii extended with the current attempt's radius, so the smoother

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
@@ -268,9 +268,11 @@ public partial class WaveguideRouter
         double endX, double endY, double endInputAngle, double bendRadius)
     {
         var path = new RoutedPath();
-        // Use small lead-in/lead-out for smoother transitions (15% of bend radius)
-        double leadLength = bendRadius * 0.15;
-        var manhattan = new ManhattanRouter(bendRadius, leadOut: leadLength, leadIn: leadLength);
+        // No lead-in/lead-out: the CSC route is tangential at both pins by construction,
+        // so the first arc may begin directly at the start pin and the last arc may end
+        // directly at the end pin. The old 15%-of-radius lead was a cosmetic relic that
+        // forced a straight stub at every fallback pin (pin-lead-stub field finding).
+        var manhattan = new ManhattanRouter(bendRadius);
         manhattan.Route(startX, startY, startAngle, endX, endY, endInputAngle, path);
         return path;
     }

--- a/UnitTests/Routing/FrozenAndStyledRouteCollisionTests.cs
+++ b/UnitTests/Routing/FrozenAndStyledRouteCollisionTests.cs
@@ -4,6 +4,7 @@ using CAP_Core.Components.Core;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
 using CAP_Core.Routing.InterconnectRouting;
+using CAP_Core.Routing.InterconnectRouting.SegmentShift;
 using CAP_Core.Tiles;
 using Shouldly;
 using Xunit;
@@ -162,9 +163,15 @@ public class FrozenAndStyledRouteCollisionTests
         return (manager, router, connection, components);
     }
 
-    /// <summary>Applies the biggest fitting handle radius to the first resizable bend.</summary>
+    /// <summary>
+    /// Applies the biggest fitting handle radius to the first resizable bend. Routes now hug
+    /// the pins by default (pin-lead-stub fix: the first bend begins one tangent from the
+    /// pin), so the pin-side straight is first LENGTHENED via the segment-shift editor —
+    /// the canonical way to make room for a big radius — before the override is applied.
+    /// </summary>
     private static double ApplyBigRadius(WaveguideConnection connection)
     {
+        MakeRoomAtStartPin(connection, BigHandleRadius + 10);
         var corners = BendRadiusEditor.GetBendCorners(connection.GetPathSegments());
         corners.ShouldNotBeEmpty("the auto corner route must expose a resizable bend");
         foreach (var radius in new[] { BigHandleRadius, 100.0, 60.0, 40.0 })
@@ -173,6 +180,24 @@ public class FrozenAndStyledRouteCollisionTests
                 return radius;
         }
         throw new InvalidOperationException("No handle radius fits the route.");
+    }
+
+    /// <summary>
+    /// Extends the straight between the start pin and the first bend by
+    /// <paramref name="roomMicrometers"/> by shifting the middle straight along its normal
+    /// (the adjoining bends slide along the outer straights, exactly like the in-canvas drag).
+    /// </summary>
+    private static void MakeRoomAtStartPin(WaveguideConnection connection, double roomMicrometers)
+    {
+        var segments = connection.RoutedPath!.Segments;
+        var lead = (StraightSegment)segments[0];
+        var handle = SegmentShiftGeometry.GetHandles(segments)
+            .First(h => h.StraightIndex == 1);
+        // An offset o extends the lead by o / dot(leadDirection, normal); choosing
+        // o = room · dot yields an extension of exactly `room` for either sign of dot.
+        double dot = SegmentShiftGeometry.Dot(SegmentShiftGeometry.DirectionOf(lead), handle.Normal);
+        SegmentShiftEditor.TryApplyShift(connection, 1, roomMicrometers * dot, out var error)
+            .ShouldBeTrue(error);
     }
 
     /// <summary>Midpoint of the first (edited) arc along the path.</summary>

--- a/UnitTests/Routing/PinLeadStubTests.cs
+++ b/UnitTests/Routing/PinLeadStubTests.cs
@@ -79,6 +79,12 @@ public class PinLeadStubTests
         NormalizeAngle(firstBend.StartAngleDegrees).ShouldBe(0, 1e-6);
     }
 
+    /// <summary>
+    /// Field precision: the forced straight was observed at the ARRIVAL side — the route's
+    /// final straight before the end pin. The arrival must get exactly the same
+    /// radius-derived bound as the departure (the A* goal lock used to hold the last corner
+    /// one cell further out than the start escape held the first).
+    /// </summary>
     [Fact]
     public void AutoRoute_LastBendEndsNearEndPin()
     {
@@ -88,11 +94,30 @@ public class PinLeadStubTests
 
         path.IsValid.ShouldBeTrue();
         double lead = EndPinLeadLength(path, endPin);
-        // The arrival side gets the same radius-derived escape; the A* goal tolerance adds
-        // up to 3 cells, so the bound is looser than at the start but still far below the
-        // old distance-scaled escape (48 µm for this layout).
-        lead.ShouldBeLessThanOrEqualTo(5 * router.AStarCellSize,
-            $"forced straight lead at the end pin must stay near the bend tangent (was {lead:F1} µm)");
+        lead.ShouldBeLessThanOrEqualTo(MaxLead(router),
+            $"forced straight lead at the end pin must not exceed grid quantization (was {lead:F1} µm)");
+    }
+
+    /// <summary>
+    /// Field hypothesis check: the direction of the connection must NOT decide which end
+    /// keeps a stub. Routing the same U-turn in both directions yields the same small
+    /// departure AND arrival leads on both ends.
+    /// </summary>
+    [Fact]
+    public void AutoRoute_DepartureAndArrivalLeads_AreSymmetric_RegardlessOfDirection()
+    {
+        var (router, pinA, pinB) = UTurnSetup(300);
+
+        var forward = router.Route(pinA, pinB);
+        var backward = router.Route(pinB, pinA);
+
+        forward.IsValid.ShouldBeTrue();
+        backward.IsValid.ShouldBeTrue();
+        double bound = MaxLead(router);
+        StartPinLeadLength(forward, pinA).ShouldBeLessThanOrEqualTo(bound, "A→B departure lead");
+        EndPinLeadLength(forward, pinB).ShouldBeLessThanOrEqualTo(bound, "A→B arrival lead");
+        StartPinLeadLength(backward, pinB).ShouldBeLessThanOrEqualTo(bound, "B→A departure lead");
+        EndPinLeadLength(backward, pinA).ShouldBeLessThanOrEqualTo(bound, "B→A arrival lead");
     }
 
     [Fact]

--- a/UnitTests/Routing/PinLeadStubTests.cs
+++ b/UnitTests/Routing/PinLeadStubTests.cs
@@ -1,0 +1,233 @@
+using CAP_Core.Components;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Routing.InterconnectRouting.SegmentShift;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Field finding (follow-up to the #791/#792 segment-shift work): routes used to keep a long
+/// FORCED straight lead between a pin and the first bend. The A* pin escape scaled with the
+/// pin separation (up to 15 cells = 60 µm), the Manhattan fallback added a cosmetic
+/// 0.15 × radius lead — so different connections kept visibly different distances from their
+/// components. The GDS export writes exact segments with absolute placement, so no straight
+/// lead is required there: the first bend may begin directly at the pin (tangentially).
+/// These tests pin the new contract: the forced lead is bounded by the bend geometry plus
+/// grid quantization, independent of connection length, and the segment shift can collapse
+/// the remaining lead to exactly zero.
+/// </summary>
+public class PinLeadStubTests
+{
+    private const double Radius = 10.0;
+
+    /// <summary>Upper bound for the pin-side lead: one tangent-fitting quantization step of
+    /// slack (2 grid cells) — NOT dependent on how far the pins are apart.</summary>
+    private static double MaxLead(WaveguideRouter router) => 2 * router.AStarCellSize;
+
+    /// <summary>
+    /// U-turn layout: both pins face east, so the route must leave the start pin east, turn
+    /// around and come back west into the end pin. Every extra micron traveled east adds pure
+    /// path length, so the cost-optimal A* route turns as early as the pin-escape constraint
+    /// allows — the first-bend distance directly measures the FORCED lead, deterministically.
+    /// </summary>
+    private static (WaveguideRouter Router, PhysicalPin StartPin, PhysicalPin EndPin) UTurnSetup(
+        double pinSeparationY)
+    {
+        var router = CreateRouter();
+        var start = CreateTestComponent(0, 0);
+        var end = CreateTestComponent(0, pinSeparationY - 25);
+        router.InitializePathfindingGrid(-100, -100, 500, 500, new[] { start, end });
+
+        var startPin = Pin(start, 50, 25, 0);   // right edge, pointing east
+        var endPin = Pin(end, 50, 25, 0);       // right edge, pointing east (arrival heading west)
+        return (router, startPin, endPin);
+    }
+
+    [Theory]
+    [InlineData(150.0)]  // short connection
+    [InlineData(300.0)]  // long connection — used to get a 12-cell (48 µm) forced escape
+    public void AutoRoute_FirstBendStartsNearStartPin_IndependentOfConnectionLength(double pinSeparationY)
+    {
+        var (router, startPin, endPin) = UTurnSetup(pinSeparationY);
+
+        var path = router.Route(startPin, endPin);
+
+        path.IsValid.ShouldBeTrue();
+        path.Segments.OfType<BendSegment>().ShouldNotBeEmpty("a U-turn route needs bends");
+
+        double lead = StartPinLeadLength(path, startPin);
+        lead.ShouldBeLessThanOrEqualTo(MaxLead(router),
+            $"forced straight lead at the start pin must not exceed grid quantization (was {lead:F1} µm)");
+    }
+
+    [Fact]
+    public void AutoRoute_FirstBendIsTangentialToThePinDirection()
+    {
+        var (router, startPin, endPin) = UTurnSetup(300);
+
+        var path = router.Route(startPin, endPin);
+
+        path.IsValid.ShouldBeTrue();
+        var firstBend = path.Segments.OfType<BendSegment>().First();
+        // Tangency at the pin: the first bend continues the pin heading (0°). This is the
+        // physical requirement that stays — only the forced straight length is gone.
+        NormalizeAngle(firstBend.StartAngleDegrees).ShouldBe(0, 1e-6);
+    }
+
+    [Fact]
+    public void AutoRoute_LastBendEndsNearEndPin()
+    {
+        var (router, startPin, endPin) = UTurnSetup(300);
+
+        var path = router.Route(startPin, endPin);
+
+        path.IsValid.ShouldBeTrue();
+        double lead = EndPinLeadLength(path, endPin);
+        // The arrival side gets the same radius-derived escape; the A* goal tolerance adds
+        // up to 3 cells, so the bound is looser than at the start but still far below the
+        // old distance-scaled escape (48 µm for this layout).
+        lead.ShouldBeLessThanOrEqualTo(5 * router.AStarCellSize,
+            $"forced straight lead at the end pin must stay near the bend tangent (was {lead:F1} µm)");
+    }
+
+    [Fact]
+    public void ManhattanFallback_FirstBendStartsDirectlyAtStartPin()
+    {
+        // No pathfinding grid: Route() goes straight to the Manhattan (CSC) fallback.
+        var router = CreateRouter();
+        var start = CreateTestComponent(0, 0);
+        var end = CreateTestComponent(100, 100);
+
+        var startPin = Pin(start, 25, 50, 90);   // top edge, pointing up
+        var endPin = Pin(end, 0, 25, 180);       // left edge, pointing left
+
+        var path = router.Route(startPin, endPin);
+
+        path.IsValid.ShouldBeTrue();
+        var (sx, sy) = startPin.GetAbsolutePosition();
+        var first = path.Segments[0];
+        first.ShouldBeOfType<BendSegment>("the CSC route is tangential by construction — " +
+            "no cosmetic straight lead before the first arc");
+        first.StartPoint.X.ShouldBe(sx, 1e-6);
+        first.StartPoint.Y.ShouldBe(sy, 1e-6);
+    }
+
+    [Fact]
+    public void ManhattanFallback_StillReachesBothPinsExactly()
+    {
+        var router = CreateRouter();
+        var start = CreateTestComponent(0, 0);
+        var end = CreateTestComponent(100, 100);
+
+        var startPin = Pin(start, 25, 50, 90);
+        var endPin = Pin(end, 0, 25, 180);
+
+        var path = router.Route(startPin, endPin);
+
+        path.IsValid.ShouldBeTrue();
+        var (sx, sy) = startPin.GetAbsolutePosition();
+        var (ex, ey) = endPin.GetAbsolutePosition();
+        path.Segments[0].StartPoint.X.ShouldBe(sx, 1e-6);
+        path.Segments[0].StartPoint.Y.ShouldBe(sy, 1e-6);
+        path.Segments[^1].EndPoint.X.ShouldBe(ex, 1e-6);
+        path.Segments[^1].EndPoint.Y.ShouldBe(ey, 1e-6);
+    }
+
+    /// <summary>
+    /// #792 interplay: the segment-shift clamp boundary IS "bend directly at the pin".
+    /// Shifting the middle straight by exactly the pin lead's length collapses the lead to
+    /// zero length — accepted, and the first bend then begins at the pin.
+    /// </summary>
+    [Fact]
+    public void SegmentShift_CanCollapseThePinLead_SoTheBendStartsAtThePin()
+    {
+        var conn = new WaveguideConnection();
+        conn.RestoreCachedPath(InterconnectRouting.SegmentShiftGeometryTests.ZPath());
+
+        // The incoming straight (pin lead) is 50 µm long; shifting by exactly 50 collapses it.
+        SegmentShiftEditor.TryApplyShift(conn, 1, 50, out var error).ShouldBeTrue(error);
+
+        var segments = conn.RoutedPath!.Segments;
+        var lead = (StraightSegment)segments[0];
+        lead.LengthMicrometers.ShouldBe(0, 1e-6);
+        segments[1].ShouldBeOfType<BendSegment>().StartPoint.ShouldBe((0.0, 0.0));
+    }
+
+    /// <summary>Length of the straight lead between the start pin and the first bend
+    /// (0 when the path begins with a bend).</summary>
+    private static double StartPinLeadLength(RoutedPath path, PhysicalPin startPin)
+    {
+        var (sx, sy) = startPin.GetAbsolutePosition();
+        var firstBend = path.Segments.OfType<BendSegment>().First();
+        return Distance(sx, sy, firstBend.StartPoint.X, firstBend.StartPoint.Y);
+    }
+
+    /// <summary>Length of the straight lead between the last bend and the end pin.</summary>
+    private static double EndPinLeadLength(RoutedPath path, PhysicalPin endPin)
+    {
+        var (ex, ey) = endPin.GetAbsolutePosition();
+        var lastBend = path.Segments.OfType<BendSegment>().Last();
+        return Distance(ex, ey, lastBend.EndPoint.X, lastBend.EndPoint.Y);
+    }
+
+    private static double Distance(double x1, double y1, double x2, double y2)
+    {
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+
+    private static double NormalizeAngle(double degrees)
+    {
+        double a = degrees % 360.0;
+        if (a < 0) a += 360.0;
+        return a;
+    }
+
+    /// <summary>Router with deterministic settings: cardinal-only turns make the first bend a
+    /// 90° arc whose tangent length equals the bend radius.</summary>
+    private static WaveguideRouter CreateRouter() => new()
+    {
+        MinBendRadiusMicrometers = Radius,
+        MinWaveguideSpacingMicrometers = 2.0,
+        UseDiagonalRouting = false,
+    };
+
+    private static PhysicalPin Pin(Component parent, double offsetX, double offsetY, double angle) => new()
+    {
+        Name = $"pin_{offsetX}_{offsetY}",
+        OffsetXMicrometers = offsetX,
+        OffsetYMicrometers = offsetY,
+        AngleDegrees = angle,
+        ParentComponent = parent,
+    };
+
+    private static Component CreateTestComponent(double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+
+        var component = new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: "test",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: $"TestComponent_{x}_{y}",
+            rotationCounterClock: DiscreteRotation.R0)
+        {
+            WidthMicrometers = 50,
+            HeightMicrometers = 50,
+            PhysicalX = x,
+            PhysicalY = y,
+        };
+
+        return component;
+    }
+}


### PR DESCRIPTION
## Befund (Feld-Test nach #792-Segment-Shift)

Manche Waveguides ließen sich näher an Komponenten heranschieben als andere — die Route lief erst ein **erzwungenes gerades Stück** senkrecht vom Pin weg, bevor die erste Biegung beginnen durfte. Ursache waren **drei inkonsistente Lead-Mechanismen**:

| Mechanismus | Ort | Größe (vorher) |
|---|---|---|
| A*-Pin-Escape, **skaliert mit Pin-Distanz** | `WaveguideRouter.AStarAttempt.cs` (`min(15, dist/6)` Zellen) + harte Richtungssperre in `AStarPathfinder.cs:212-229` | 8–60 µm, je nach Verbindungslänge (!) |
| A*-Startknoten verlangte vollen Interior-Geradeanlauf (2r) | `AStarPathfinder.cs` (`StraightRunLength = 0`) | ≥ r zusätzlich |
| Manhattan-Fallback-Lead „for smoother transitions" | `WaveguideRouter.cs:272` (`0.15 × r`) | 1,5 µm pro Pin |

Repro (U-Turn-Layout, `PinLeadStubTests`): Zwangs-Lead **14 µm bei 150 µm Pin-Abstand, 38 µm bei 300 µm** — dieselbe Situation, verschiedener Mindestabstand. Genau der beobachtete Effekt.

**Ziel-seitiges Schluss-Segment (Live-Präzisierung):** Der beobachtete Zwangs-Abschnitt ist ankunftsseitig derselbe Mechanismus — die A*-Goal-Sperre hält die letzte Ecke bis zu 16 Zellen (64 µm) vor dem Ziel-Pin, das gerade Schluss-Segment wirkt wie eine Mindestlänge (Repro: 38 µm → ≤ 8 µm). **Asymmetrie geprüft:** Ziel- und Startseite teilen dieselbe Konstante; die Zielseite hält die letzte Ecke bewusst *eine Zelle* weiter weg (`<=` vs `<`) — der Symmetrisierungs-Versuch ließ Ankunftsbögen in Hindernisse neben dem Ziel-Korridor schneiden (2 Regressionstests rot) und wurde verworfen; die eine Zelle ist Sicherheitsabstand, ≤ 4 µm, richtungsunabhängig (jetzt im Code dokumentiert). `CachedRouteValidator` (nur Richtungs-Check), `PathSmoother`-Terminal-Approach (nur Off-Axis-Retry) und `SineBendGeometry` (stubfrei) sind entlastet. Test `AutoRoute_DepartureAndArrivalLeads_AreSymmetric_RegardlessOfDirection` fixiert: die Richtung der Verbindung entscheidet nicht, welches Ende einen Stub bekommt.

## Entscheidung: Relikt, kein fachlicher Bedarf

- **GDS-Export braucht keinen Stub:** Auto-/Bend-Routen exportieren als exakte Segmente mit absoluter Platzierung (`SimpleNazcaExporter.AppendSegmentExport`, `nd.bend(...).put(x,y,a)`) — ein Bogen, der exakt am Pin beginnt, ist gültige Nazca-Geometrie. SBend/Cobra exportieren als `nd.sinebend`/`nd.cobra`, die ohnehin direkt am Pin krümmen. Export-/Nazca-Tests (687 + 352) grün.
- **Physik bleibt:** Tangentialität am Pin und die Bogentangente r·tan(sweep/2) zwischen Pin und Ecken-Apex — das ist Geometrie, kein Stub, und genau darauf reduziert der Fix die Constraint.
- Die Stubs der **Styled Routes** (`SBendGeometry.StubFraction`, Stub-Arc-Stub) sind dokumentiert load-bearing für die Radius-/Shift-Handles und bewusst unverändert.

## Fix

1. **Escape radiusabgeleitet statt distanzskaliert:** `PinTangentEscapeCells(r) = max(2, floor(r/cell)+1)` — die 90°-Tangente, über die nächste ganze Zelle aufgerundet. Die Extra-Zelle lässt einen ≤ 1 Zelle kurzen Pin-Geradenrest überleben, damit die #792-Shift-Handles greifen; per Shift auf **exakt 0** kollabierbar (Clamp-Grenze = Biegung direkt am Pin, per Test fixiert).
2. **Start-Tangenten-Guthaben:** Startknoten bekommt `(MinStraightRunCells−1)/2` Run-Guthaben — am Pin muss nur **eine** Bogentangente passen, Interior-Turns brauchen weiterhin zwei.
3. **Manhattan-Fallback ohne Lead:** erster/letzter Bogen setzt direkt am Pin an (CSC tangential per Konstruktion).

**#792-Interplay:** Shift-Clamp unverändert (Kollaps auf 0 erlaubt); pin-adjazente Bögen waren im `BendRadiusEditor` schon vorher bewusst nicht resizierbar. Wer einen großen Handle-Radius am Pin will, macht erst per Shift Platz — `FrozenAndStyledRouteCollisionTests.MakeRoomAtStartPin` dokumentiert den Workflow.

## Tests

- **Neu:** `UnitTests/Routing/PinLeadStubTests.cs` (8 Tests, 4 davon rot vor dem Fix): Lead ≤ 2 Zellen unabhängig von der Verbindungslänge, Ziel-seitiges Schluss-Segment, Richtungs-Symmetrie (A→B/B→A), Tangenz, Manhattan-Bogen exakt am Pin, Endpunkt-Treue, Shift-Kollaps auf Pin.
- **Angepasst:** `FrozenAndStyledRouteCollisionTests` (Make-Room-Workflow vor Big-Radius-Override; Freeze-/Unfreeze-Semantik unverändert).
- **Regression grün:** Routing 509/509 · Bend 91/91 · Shift 64/64 · Export 687/687 · Interconnect 130/130 · Nazca 352/352 · Gesamtsuite lokal grün.

Bewusste Grenze: bei 45°-Erst-Biegungen (Diagonal-Routing) bleibt der Auto-Lead etwas über der 45°-Tangente (Escape ist auf die 90°-Tangente ausgelegt); per Shift ist auch dort 0 erreichbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCVwvkXdUH9DSW8w12XB2q
