### PR TITLE
Landing page: fix hard-coded v0.12.0, auto-sync to latest release

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -268,10 +268,10 @@
 
 <header>
   <div class="wrap nav">
-    <a class="wordmark" href="#top">LUNIMA<span class="v">v0.12.0</span></a>
+    <a class="wordmark" href="#top">LUNIMA<span class="v" data-release-version>v0.13.0</span></a>
     <nav class="nav-links" aria-label="Main">
       <a class="gh-txt" href="https://github.com/aignermax/Lunima">GitHub</a>
-      <a class="gh-txt" href="https://github.com/aignermax/Lunima/releases/tag/v0.12.0">Release notes</a>
+      <a class="gh-txt" data-release-notes href="https://github.com/aignermax/Lunima/releases/tag/v0.13.0">Release notes</a>
       <a class="btn-sm" href="#download">Download</a>
     </nav>
   </div>
@@ -291,7 +291,7 @@
         with you in open formats.
       </p>
       <div class="cta-row">
-        <a class="btn btn-primary" href="https://github.com/aignermax/Lunima/releases/tag/v0.12.0">Download v0.12.0</a>
+        <a class="btn btn-primary" data-release-cta href="https://github.com/aignermax/Lunima/releases/tag/v0.13.0">Download v0.13.0</a>
         <a class="btn btn-ghost" href="https://github.com/aignermax/Lunima">View on GitHub</a>
       </div>
       <p class="platforms">Windows · Linux · macOS — MIT licensed</p>
@@ -576,7 +576,7 @@
   <!-- ================= DOWNLOAD ================= -->
   <section class="download wrap" id="download">
     <p class="eyebrow">Get Lunima</p>
-    <h2>Download v0.12.0</h2>
+    <h2 data-release-heading>Download v0.13.0</h2>
     <p class="sub">
       Free and MIT-licensed. Once installed, Lunima updates itself in place —
       download, swap, relaunch — on all three platforms.
@@ -585,21 +585,21 @@
       <div class="dl-card">
         <h3>Windows</h3>
         <p class="arch">x64</p>
-        <a class="asset" href="https://github.com/aignermax/Lunima/releases/download/v0.12.0/Lunima-Setup-0.12.0.msi">Lunima-Setup-0.12.0.msi</a>
-        <a class="asset" href="https://github.com/aignermax/Lunima/releases/download/v0.12.0/Lunima-0.12.0-win-x64.zip">Lunima-0.12.0-win-x64.zip</a>
+        <a class="asset" data-release-asset="msi" href="https://github.com/aignermax/Lunima/releases/download/v0.13.0/Lunima-Setup-0.13.0.msi">Lunima-Setup-0.13.0.msi</a>
+        <a class="asset" data-release-asset="win-zip" href="https://github.com/aignermax/Lunima/releases/download/v0.13.0/Lunima-0.13.0-win-x64.zip">Lunima-0.13.0-win-x64.zip</a>
         <p class="note">Installer, or portable zip — unzip and run.</p>
       </div>
       <div class="dl-card">
         <h3>Linux</h3>
         <p class="arch">x64</p>
-        <a class="asset" href="https://github.com/aignermax/Lunima/releases/download/v0.12.0/Lunima-0.12.0-linux-x64.tar.gz">Lunima-0.12.0-linux-x64.tar.gz</a>
+        <a class="asset" data-release-asset="linux-tar" href="https://github.com/aignermax/Lunima/releases/download/v0.13.0/Lunima-0.13.0-linux-x64.tar.gz">Lunima-0.13.0-linux-x64.tar.gz</a>
         <p class="note">Extract into its own folder and run.</p>
       </div>
       <div class="dl-card">
         <h3>macOS</h3>
         <p class="arch">Apple Silicon · Intel</p>
-        <a class="asset" href="https://github.com/aignermax/Lunima/releases/download/v0.12.0/Lunima-0.12.0-osx-arm64.dmg">Lunima-0.12.0-osx-arm64.dmg</a>
-        <a class="asset" href="https://github.com/aignermax/Lunima/releases/download/v0.12.0/Lunima-0.12.0-osx-x64.dmg">Lunima-0.12.0-osx-x64.dmg</a>
+        <a class="asset" data-release-asset="osx-arm" href="https://github.com/aignermax/Lunima/releases/download/v0.13.0/Lunima-0.13.0-osx-arm64.dmg">Lunima-0.13.0-osx-arm64.dmg</a>
+        <a class="asset" data-release-asset="osx-x64" href="https://github.com/aignermax/Lunima/releases/download/v0.13.0/Lunima-0.13.0-osx-x64.dmg">Lunima-0.13.0-osx-x64.dmg</a>
         <p class="note">Unsigned build — see the first-launch note below.</p>
       </div>
     </div>
@@ -618,7 +618,7 @@
       <a class="wordmark" href="#top">LUNIMA</a>
       <nav class="foot-links" aria-label="Footer">
         <a href="https://github.com/aignermax/Lunima">GitHub</a>
-        <a href="https://github.com/aignermax/Lunima/releases/tag/v0.12.0">Release notes</a>
+        <a data-release-notes href="https://github.com/aignermax/Lunima/releases/tag/v0.13.0">Release notes</a>
         <a href="https://github.com/aignermax/Lunima/blob/main/docs/PDK_JSON_FORMAT.md">PDK format</a>
         <a href="https://www.akhetonics.com/">Akhetonics</a>
         <a href="https://akhetonics.com/impressum">Imprint</a>
@@ -647,6 +647,79 @@
     the page; see the <a href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement">GitHub Privacy Statement</a> for details.
   </p>
 </section>
+
+<!-- ================= DYNAMIC RELEASE INFO ================= -->
+<!-- Keeps the static v0.13.0 fallback above in sync with the latest GitHub
+     release. Anonymous, unauthenticated API read only — no tracking, no
+     storage, matching the privacy promise above. Any failure (offline, rate
+     limit, missing asset) leaves the static markup exactly as it is. -->
+<script>
+(function () {
+  "use strict";
+
+  var API_URL = "https://api.github.com/repos/aignermax/Lunima/releases/latest";
+
+  var ASSET_SUFFIXES = {
+    "msi": ".msi",
+    "win-zip": "-win-x64.zip",
+    "linux-tar": "-linux-x64.tar.gz",
+    "osx-arm": "-osx-arm64.dmg",
+    "osx-x64": "-osx-x64.dmg"
+  };
+
+  function setText(selector, text) {
+    document.querySelectorAll(selector).forEach(function (el) {
+      el.textContent = text;
+    });
+  }
+
+  function setHref(selector, href) {
+    document.querySelectorAll(selector).forEach(function (el) {
+      el.setAttribute("href", href);
+    });
+  }
+
+  function applyVersionLabels(tagName) {
+    setText("[data-release-version]", tagName);
+    setText("[data-release-heading]", "Download " + tagName);
+    setText("[data-release-cta]", "Download " + tagName);
+
+    var notesUrl = "https://github.com/aignermax/Lunima/releases/tag/" + tagName;
+    setHref("[data-release-notes]", notesUrl);
+    setHref("[data-release-cta]", notesUrl);
+  }
+
+  function applyAsset(kind, asset) {
+    var selector = '[data-release-asset="' + kind + '"]';
+    setHref(selector, asset.browser_download_url);
+    setText(selector, asset.name);
+  }
+
+  function applyAssets(assets) {
+    Object.keys(ASSET_SUFFIXES).forEach(function (kind) {
+      var suffix = ASSET_SUFFIXES[kind];
+      var match = assets.find(function (asset) {
+        return typeof asset.name === "string" && asset.name.endsWith(suffix);
+      });
+      if (match) applyAsset(kind, match);
+    });
+  }
+
+  function applyRelease(release) {
+    if (!release || typeof release.tag_name !== "string") return;
+    applyVersionLabels(release.tag_name);
+    if (Array.isArray(release.assets)) applyAssets(release.assets);
+  }
+
+  fetch(API_URL, { headers: { "Accept": "application/vnd.github+json" } })
+    .then(function (response) { return response.ok ? response.json() : null; })
+    .then(applyRelease)
+    .catch(function () {
+      // Offline, rate-limited, or malformed response — the static v0.13.0
+      // fallback markup above stays exactly as authored.
+    });
+})();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Was / Warum

Die Landing-Page (https://aignermax.github.io/Lunima/, deployt aus `main:/docs/index.html`) verlinkte an 10 Stellen hart auf **v0.12.0** — das neueste Release ist aber **v0.13.0** (Wordmark, Nav-/Footer-Release-Notes-Links, Hero-Button, Download-Überschrift, 5 Asset-Links).

Damit das bei künftigen Releases nicht wieder passiert:

1. **Statischer Fallback auf v0.13.0 gebracht** — alle 10 Stellen aktualisiert, Asset-Namen/URLs 1:1 aus `gh release view v0.13.0 --json assets` übernommen (Namensschema unverändert: `Lunima-Setup-<ver>.msi`, `Lunima-<ver>-win-x64.zip`, `Lunima-<ver>-linux-x64.tar.gz`, `Lunima-<ver>-osx-arm64.dmg`, `Lunima-<ver>-osx-x64.dmg`).
2. **Dynamisches Inline-Script** (vanilla JS, vor `</body>`): lädt beim Seitenaufruf anonym `GET /repos/aignermax/Lunima/releases/latest` von der GitHub-API und schreibt `tag_name` + die 5 Asset-hrefs/-Texte per Suffix-Matching in die Seite. Zielelemente sind über `data-release-version` / `data-release-notes` / `data-release-cta` / `data-release-heading` / `data-release-asset="msi|win-zip|linux-tar|osx-arm|osx-x64"` markiert statt über fragile Selektoren.
3. **Fail-safe:** fetch-Fehler, Rate-Limit oder ein fehlendes Asset lassen den statischen v0.13.0-Stand einfach stehen (try/catch via `.catch`, kein `console`-Spam, ein Asset-Miss verhindert die anderen Updates nicht). Kein externes Framework, kein Storage/Cookies — passt zum „no tracking"-Versprechen im Privacy-Abschnitt der Seite.

Media-Pfade (`docs/media/v0.12/...`) bewusst NICHT angefasst — die Screenshots liegen dort physisch und referenzieren keine Release-Version.

## Verifikation

- `gh release view v0.13.0 --json assets --jq '.assets[].name'` → Asset-Namen exakt wie im Diff verwendet.
- `curl -s https://api.github.com/repos/aignermax/Lunima/releases/latest` → `tag_name: v0.13.0`; Suffix-Matching (`.msi`, `-win-x64.zip`, `-linux-x64.tar.gz`, `-osx-arm64.dmg`, `-osx-x64.dmg`) in Python nachgebaut und gegen die echte API-Antwort verifiziert — alle 5 Assets matchen genau einmal.
- Alle 5 statischen Asset-Download-URLs per `curl -sI -o /dev/null -w '%{http_code}' -L <url>` → **200** für alle fünf.
- HTML-Sanity: `html.parser`-Durchlauf ohne Fehler; Tag-Balance (`div`/`section`/`header`/`footer`/`main`/`script`/`html`/`body`) geprüft — alle ausgeglichen.
- Keine Unit-Tests für `docs/` vorhanden, kein `dotnet build` nötig — nur `docs/index.html` geändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)