### PR TITLE
Verwundbare Pakete gepatcht: NCalc 5.7.0 -> 6.1.1, Tmds.DBus.Protocol 0.20.0 -> 0.21.3

### DIFF
--- a/CAP.Desktop/CAP.Desktop.csproj
+++ b/CAP.Desktop/CAP.Desktop.csproj
@@ -21,6 +21,11 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="11.2.1" />
     <PackageReference Include="Avalonia.Diagnostics" Version="11.2.1" Condition="'$(Configuration)' == 'Debug'" />
+    <!-- Explicit pin: Avalonia.FreeDesktop (via Avalonia.Desktop) still requests
+         Tmds.DBus.Protocol 0.20.0, which carries GHSA-xrw6-gwf8-vvr9 (high severity).
+         0.21.3 is the first patched version; pin it directly until Avalonia bumps
+         its own floor. -->
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Connect-A-Pic-Core/CAP-Core.csproj
+++ b/Connect-A-Pic-Core/CAP-Core.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="NCalcSync" Version="5.7.0" />
+    <PackageReference Include="NCalcSync" Version="6.1.1" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.7" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>

--- a/Connect-A-Pic-Core/Components/FormulaReading/ComplexMath.cs
+++ b/Connect-A-Pic-Core/Components/FormulaReading/ComplexMath.cs
@@ -19,52 +19,52 @@ namespace CAP_Core.Grid.FormulaReading
             public static Expression CreateExpressionWithCustomFunctions(string expressionString)
             {
                 var e = new Expression(expressionString);
-                e.EvaluateFunction += delegate (string name, FunctionArgs args)
+                e.EvaluateFunction += delegate (string name, FunctionEventArgs args)
                 {
                     if (name.ToLower() == nameof(ComplexMath.Add).ToLower())
                     {
-                        var a = ConvertToComplex(args.Parameters[0].Evaluate());
-                        var b = ConvertToComplex(args.Parameters[1].Evaluate());
+                        var a = ConvertToComplex(args.Parameters.Evaluate(0));
+                        var b = ConvertToComplex(args.Parameters.Evaluate(1));
                         args.Result = ComplexMath.Add(a, b);
                     }
                     if (name.ToLower() == nameof(ComplexMath.Sub).ToLower())
                     {
-                        var a = ConvertToComplex(args.Parameters[0].Evaluate());
-                        var b = ConvertToComplex(args.Parameters[1].Evaluate());
+                        var a = ConvertToComplex(args.Parameters.Evaluate(0));
+                        var b = ConvertToComplex(args.Parameters.Evaluate(1));
                         args.Result = ComplexMath.Sub(a, b);
                     }
                     if (name.ToLower() == nameof(ComplexMath.Div).ToLower())
                     {
-                        var a = ConvertToComplex(args.Parameters[0].Evaluate());
-                        var b = ConvertToComplex(args.Parameters[1].Evaluate());
+                        var a = ConvertToComplex(args.Parameters.Evaluate(0));
+                        var b = ConvertToComplex(args.Parameters.Evaluate(1));
                         args.Result = ComplexMath.Div(a, b);
                     }
                     if (name.ToLower() == nameof(ComplexMath.Mul).ToLower())
                     {
-                        var a = ConvertToComplex(args.Parameters[0].Evaluate());
-                        var b = ConvertToComplex(args.Parameters[1].Evaluate());
+                        var a = ConvertToComplex(args.Parameters.Evaluate(0));
+                        var b = ConvertToComplex(args.Parameters.Evaluate(1));
                         args.Result = ComplexMath.Mul(a, b);
                     }
                     if (name.ToLower() == nameof(ComplexMath.ToComplex).ToLower())
                     {
-                        var real = ConvertToComplex(args.Parameters[0].Evaluate());
-                        var imaginary = ConvertToComplex(args.Parameters[1].Evaluate());
+                        var real = ConvertToComplex(args.Parameters.Evaluate(0));
+                        var imaginary = ConvertToComplex(args.Parameters.Evaluate(1));
                         args.Result = ComplexMath.ToComplex(real.Real, imaginary.Real); // if the value was a double, then the phase is 0 so real=magnitude= doubleValue
                     }
                     if (name.ToLower() == nameof(ComplexMath.ToComplexFromPolar).ToLower())
                     {
-                        var magnitude = ConvertToComplex(args.Parameters[0].Evaluate());
-                        var phase = ConvertToComplex(args.Parameters[1].Evaluate());
+                        var magnitude = ConvertToComplex(args.Parameters.Evaluate(0));
+                        var phase = ConvertToComplex(args.Parameters.Evaluate(1));
                         args.Result = ComplexMath.ToComplexFromPolar(magnitude.Real, phase.Real);
                     }
                     if (name.ToLower() == nameof(ComplexMath.PhaseShiftFromWGLength).ToLower())
                     {
-                        var wireLength = ConvertToComplex(args.Parameters[0].Evaluate());
-                        var lightWaveLength = ConvertToComplex(args.Parameters[1].Evaluate());
+                        var wireLength = ConvertToComplex(args.Parameters.Evaluate(0));
+                        var lightWaveLength = ConvertToComplex(args.Parameters.Evaluate(1));
                         args.Result = ComplexMath.PhaseShiftFromWGLength(wireLength.Real, lightWaveLength.Real);
                     }
                 };
-                e.EvaluateParameter += (string name, ParameterArgs args) =>
+                e.EvaluateParameter += (string name, ParameterEventArgs args) =>
                 {
                     if (name == "Pi")
                         args.Result = Math.PI;

--- a/Connect-A-Pic-Core/Components/Parametric/FormulaEvaluator.cs
+++ b/Connect-A-Pic-Core/Components/Parametric/FormulaEvaluator.cs
@@ -33,7 +33,7 @@ namespace CAP_Core.Components.Parametric
             // identically regardless of where the app runs.
             var expression = new Expression(formula, ExpressionOptions.None, CultureInfo.InvariantCulture);
 
-            expression.EvaluateParameter += (string name, ParameterArgs args) =>
+            expression.EvaluateParameter += (string name, ParameterEventArgs args) =>
             {
                 if (name.Equals(PiConstantName, StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
## Summary

Fixes two known package vulnerabilities the build was warning about:

- **NU1902 (moderate)** — [GHSA-3w5p-95mh-gq75](https://github.com/advisories/GHSA-3w5p-95mh-gq75): `NCalc.Core` / `NCalcSync` 5.7.0, unbounded/non-terminating factorial evaluation (DoS). First patched version: **6.1.1**. Bumped the direct `NCalcSync` `PackageReference` in `Connect-A-Pic-Core/CAP-Core.csproj` from `5.7.0` to `6.1.1` (smallest jump that closes the advisory; newer 6.x/7.x exist but weren't needed). `NCalc.Core` comes in transitively via `NCalcSync` and follows automatically. `CAP-DataAccess`, `CAP.Avalonia`, `CAP.Desktop`, and `UnitTests` all pick it up transitively through the `CAP-Core` project reference — no direct references there.
- **NU1903 (high)** — [GHSA-xrw6-gwf8-vvr9](https://github.com/advisories/GHSA-xrw6-gwf8-vvr9): `Tmds.DBus.Protocol` 0.20.0, malicious D-Bus peers can spoof signals / exhaust file descriptors (DoS). First patched version: **0.21.3**. It's a transitive dependency of `Avalonia.Desktop` → `Avalonia.FreeDesktop` (Linux D-Bus integration for tray/DnD), confirmed via `CAP.Desktop/obj/project.assets.json`. Pinned an **explicit** `PackageReference` to `Tmds.DBus.Protocol` `0.21.3` in `CAP.Desktop/CAP.Desktop.csproj` — standard NuGet practice for closing a transitive vulnerability without touching the parent package. **No Avalonia version was changed.**

## Breaking changes

**Yes, one — NCalc's 6.0.0 callback API restructuring** (Connect-A-Pic-Core is the only place NCalc's programmatic API is used; two files needed changes):

- `NCalc.Handlers.FunctionArgs` → `FunctionEventArgs`, `ParameterArgs` → `ParameterEventArgs` (renamed, same role).
- `args.Parameters[i].Evaluate()` no longer compiles: function-callback parameters are now typed `LogicalExpression` (not `Expression`) and don't expose an instance `.Evaluate()`. Replaced with `args.Parameters.Evaluate(i)`, the new `FunctionData` helper for evaluating argument `i` against the current context.

Adjusted:
- `Connect-A-Pic-Core/Components/FormulaReading/ComplexMath.cs` — `EvaluateFunction`/`EvaluateParameter` handlers for the complex-number formula functions (`Add`/`Sub`/`Div`/`Mul`/`ToComplex`/`ToComplexFromPolar`/`PhaseShiftFromWGLength`) used by S-matrix parametric formulas.
- `Connect-A-Pic-Core/Components/Parametric/FormulaEvaluator.cs` — `EvaluateParameter` handler for named-parameter formula evaluation.

No behavior change — same evaluation semantics, just the renamed types/API surface. `Component.cs` and `SMatrix.cs` only mention NCalc in comments (no API usage there).

## Verification

`dotnet list <project> package --vulnerable --include-transitive` is now empty for all 5 projects (previously flagged NU1902/NU1903):

```
CAP-Core:        Für das angegebene Projekt "CAP-Core" liegen gemäß den aktuellen Quellen keine anfälligen Pakete vor.
CAP-DataAccess:  Für das angegebene Projekt "CAP-DataAccess" liegen gemäß den aktuellen Quellen keine anfälligen Pakete vor.
CAP.Avalonia:    Für das angegebene Projekt "CAP.Avalonia" liegen gemäß den aktuellen Quellen keine anfälligen Pakete vor.
CAP.Desktop:     Für das angegebene Projekt "CAP.Desktop" liegen gemäß den aktuellen Quellen keine anfälligen Pakete vor.
UnitTests:       Für das angegebene Projekt "UnitTests" liegen gemäß den aktuellen Quellen keine anfälligen Pakete vor.
```

`dotnet build UnitTests/UnitTests.csproj` → 0 errors. `dotnet build CAP.Desktop` → 0 warnings (NU1902/NU1903 gone, confirmed no new warnings vs. baseline in the two touched files — the pre-existing 14 `CS8604` nullability warnings in `ComplexMath.cs` are unchanged in count/location before and after this bump).

## Test plan

Via `smart_test.py` (NCalc-relevant areas + a broad cross-section):

- [x] `FormulaEvaluator` — 16/16 passed
- [x] `PhaseShifter` (S-matrix formulas via NCalc) — 36/36 passed
- [x] `Parametric` — 61/61 passed
- [x] `Simulation` — 234/234 passed
- [x] `Component` — 1655/1656 passed (1 skipped, unrelated)
- [x] `Routing` — 546/546 passed
- [x] `Connection` — 270/270 passed
- [x] `Nazca` — 352/352 passed
- [x] `Analysis` — 306/306 passed
- [x] `Grid` — 161/161 passed
- [x] `Export` — 685/687 passed; the 2 failures (`GdsFactoryScriptExecutionTests.StandaloneScript_RunsAndGdsGeometryLandsOnThePlacementContract`, `...UbcPdkScript_RunsWithRealSiepicCellAndProducesGds`) reproduce identically on unmodified `main` in this environment (missing `ubcpdk`/`gdsfactory` Python packages — `ImportError: cannot import name 'PDK' from 'ubcpdk'`), confirmed by stashing this PR's changes and re-running — pre-existing environment gap, not a regression from this change.

Cross-platform: no OS-specific code touched; `Tmds.DBus.Protocol` pin only affects the Linux D-Bus code path already gated inside Avalonia.FreeDesktop, and the version bump is a drop-in patched release with no API changes for our (indirect) usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCVwvkXdUH9DSW8w12XB2q