### PR TITLE
Agent: Moving both connected components together loses manually edited bend radii — translate route instead of re-routing

### DIFF
--- a/CAP.Browser/CAP.Browser.csproj
+++ b/CAP.Browser/CAP.Browser.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The BlazorWebAssembly SDK injects this implicit using, but no referenced
+         package provides the Microsoft.Extensions.Configuration assembly. -->
+    <Using Remove="Microsoft.Extensions.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Avalonia.Browser" Version="11.2.1" />
   </ItemGroup>
 

--- a/Connect-A-Pic-Core/Components/Connections/JointMoveRouteTranslator.cs
+++ b/Connect-A-Pic-Core/Components/Connections/JointMoveRouteTranslator.cs
@@ -1,0 +1,75 @@
+using CAP_Core.Routing;
+
+namespace CAP_Core.Components.Connections;
+
+/// <summary>
+/// Detects that BOTH endpoints of a routed connection moved by the same delta — the user
+/// dragged both connected components together — and translates the existing route to the
+/// new pin positions instead of letting it be re-routed. A joint move does not change the
+/// relative constellation of the pins, so a pure translation preserves the exact geometry,
+/// including manually edited bend radii and segment shifts.
+/// </summary>
+public static class JointMoveRouteTranslator
+{
+    /// <summary>
+    /// Maximum difference in micrometers between the start-pin delta and the end-pin delta
+    /// for the move to count as one uniform translation. Matches the endpoint tolerance
+    /// used by <see cref="WaveguideConnection.FrozenPathStillMatchesPins"/>.
+    /// </summary>
+    public const double DeltaMatchToleranceMicrometers =
+        WaveguideConnection.FrozenEndpointToleranceMicrometers;
+
+    /// <summary>
+    /// Translates the connection's routed path so its endpoints match the current pin
+    /// positions, when — and only when — both pins moved by the same delta. Returns false
+    /// (leaving the path untouched) when the endpoints already match, moved by different
+    /// deltas (only one component moved, or a component was resized), or a pin's direction
+    /// changed (a rotation can coincidentally produce equal deltas). Collision checks are
+    /// the caller's responsibility: the translated path may overlap a third component and
+    /// must still go through the normal validity pipeline.
+    /// </summary>
+    /// <param name="connection">The connection whose route may be translated in place.</param>
+    /// <returns>True when the path was replaced by a translated copy matching the pins.</returns>
+    public static bool TryTranslateToPins(WaveguideConnection connection)
+    {
+        var path = connection.RoutedPath;
+        if (path == null || path.Segments.Count == 0 ||
+            connection.StartPin == null || connection.EndPin == null)
+            return false;
+        if (path.IsBlockedFallback || path.IsInvalidGeometry || path.IsPlaceholderGeometry)
+            return false;
+
+        var (startX, startY) = connection.StartPin.GetAbsolutePosition();
+        var (endX, endY) = connection.EndPin.GetAbsolutePosition();
+        var first = path.Segments[0];
+        var last = path.Segments[^1];
+
+        double startDx = startX - first.StartPoint.X;
+        double startDy = startY - first.StartPoint.Y;
+        double endDx = endX - last.EndPoint.X;
+        double endDy = endY - last.EndPoint.Y;
+
+        // Endpoints already match: nothing moved, keep the live path untouched.
+        if (Length(startDx, startDy) <= DeltaMatchToleranceMicrometers &&
+            Length(endDx, endDy) <= DeltaMatchToleranceMicrometers)
+            return false;
+
+        // Different deltas: only one component moved (or one was resized) — genuine re-route.
+        if (Length(startDx - endDx, startDy - endDy) > DeltaMatchToleranceMicrometers)
+            return false;
+
+        // A rotation can coincidentally move both pins by the same delta; the pins'
+        // directions then no longer match the path's launch/entry directions.
+        var (startDirectionOk, endDirectionOk) = CachedRouteValidator.CheckPinDirections(
+            connection.StartPin, connection.EndPin, path);
+        if (!startDirectionOk || !endDirectionOk)
+            return false;
+
+        // Publish the finished copy through the single reference assignment so the UI
+        // thread never observes half-translated segments (see ReplaceRoutedPath).
+        connection.ReplaceRoutedPath(path.TranslatedCopy(startDx, startDy));
+        return true;
+    }
+
+    private static double Length(double dx, double dy) => Math.Sqrt(dx * dx + dy * dy);
+}

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -158,8 +158,10 @@ namespace CAP_Core.Components.Connections
                 // A styled route the user has hand-edited (bend radius via the canvas handles,
                 // recorded in BendRadiusOverrides) is sacred: keep it as long as its endpoints
                 // still match the pins, only refreshing the losses. Rebuilding here would
-                // silently wipe the manual edit on every unrelated recalculation.
-                if (HasManualPathEdits && FrozenPathStillMatchesPins())
+                // silently wipe the manual edit on every unrelated recalculation. A joint move
+                // of both components is a pure translation and keeps the edits too.
+                if (HasManualPathEdits &&
+                    (FrozenPathStillMatchesPins() || JointMoveRouteTranslator.TryTranslateToPins(this)))
                 {
                     UpdateLossFromPath(wavelengthNm);
                     return;
@@ -191,7 +193,9 @@ namespace CAP_Core.Components.Connections
 
             if (IsRouteFrozen)
             {
-                if (FrozenPathStillMatchesPins())
+                // Both endpoints moved by the same delta (joint drag of both components):
+                // translate the frozen geometry instead of unfreezing it.
+                if (FrozenPathStillMatchesPins() || JointMoveRouteTranslator.TryTranslateToPins(this))
                 {
                     // Keep manually edited geometry; just refresh the loss values.
                     UpdateLossFromPath(wavelengthNm);

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
@@ -468,6 +468,12 @@ public partial class WaveguideConnectionManager
             if (cancellationToken.IsCancellationRequested)
                 return (false, 0);
 
+            // A joint drag of BOTH connected components is a pure translation: shift the
+            // existing route (with all manual bend edits) to the new pin positions BEFORE
+            // the validity checks, so collision handling below runs on the translated
+            // geometry and can still force a re-route.
+            JointMoveRouteTranslator.TryTranslateToPins(connection);
+
             if (TryUnfreezeCollidedAutoRoute(connection, router))
             {
                 // A component overlaps the manually edited geometry: treat it like an

--- a/Connect-A-Pic-Core/Routing/RoutedPath.cs
+++ b/Connect-A-Pic-Core/Routing/RoutedPath.cs
@@ -76,7 +76,16 @@ public class RoutedPath
     /// (bend-radius handles mutate segments in place) silently corrupt the stored
     /// original. <c>DebugGridPath</c> is not copied — it is diagnostic-only.
     /// </summary>
-    public RoutedPath DeepCopy()
+    public RoutedPath DeepCopy() => TranslatedCopy(0, 0);
+
+    /// <summary>
+    /// Creates an independent deep copy with every segment shifted by (dx, dy).
+    /// A pure translation leaves angles, radii and sweeps untouched, so the exact
+    /// shape — including manually edited bend radii — is preserved.
+    /// </summary>
+    /// <param name="dx">Shift along X in micrometers.</param>
+    /// <param name="dy">Shift along Y in micrometers.</param>
+    public RoutedPath TranslatedCopy(double dx, double dy)
     {
         var copy = new RoutedPath
         {
@@ -93,18 +102,18 @@ public class RoutedPath
             {
                 case BendSegment bend:
                     copy.Segments.Add(new BendSegment(
-                        bend.Center.X,
-                        bend.Center.Y,
+                        bend.Center.X + dx,
+                        bend.Center.Y + dy,
                         bend.RadiusMicrometers,
                         bend.StartAngleDegrees,
                         bend.SweepAngleDegrees));
                     break;
                 case StraightSegment straight:
                     copy.Segments.Add(new StraightSegment(
-                        straight.StartPoint.X,
-                        straight.StartPoint.Y,
-                        straight.EndPoint.X,
-                        straight.EndPoint.Y,
+                        straight.StartPoint.X + dx,
+                        straight.StartPoint.Y + dy,
+                        straight.EndPoint.X + dx,
+                        straight.EndPoint.Y + dy,
                         straight.StartAngleDegrees));
                     break;
             }

--- a/UnitTests/Routing/JointMoveRouteTranslationIntegrationTests.cs
+++ b/UnitTests/Routing/JointMoveRouteTranslationIntegrationTests.cs
@@ -1,0 +1,223 @@
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Routing.InterconnectRouting;
+using CAP_Core.Routing.InterconnectRouting.SegmentShift;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// End-to-end tests for issue #805 through <see cref="WaveguideConnectionManager"/>:
+/// dragging BOTH connected components together must translate the frozen route (manual
+/// bend radii survive), while single moves and collisions with a third component still
+/// fall back to the normal re-route path. The undo round-trip is the same joint move in
+/// reverse, so validity must hold in both directions.
+/// </summary>
+public class JointMoveRouteTranslationIntegrationTests
+{
+    private static readonly double[] RadiusCandidates = { 40.0, 25.0, 15.0, 12.0 };
+    private const double JointMoveDelta = 60.0;
+    private const double CoordinateTolerance = 1e-9;
+
+    [Fact]
+    public void JointMove_FrozenRouteWithEditedRadius_IsTranslatedNotRerouted()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        double appliedRadius = ApplyRadiusOverride(connection);
+        var originalPoints = SegmentPointsOf(connection);
+
+        MoveBothComponents(components, JointMoveDelta, JointMoveDelta);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeTrue("a joint move must not unfreeze the route");
+        connection.BendRadiusOverrides.ShouldContainKeyAndValue(0, appliedRadius);
+        AssertTranslatedBy(connection, originalPoints, JointMoveDelta, JointMoveDelta);
+    }
+
+    [Fact]
+    public void SingleMove_FrozenRouteWithEditedRadius_StillReroutesAndDropsEdit()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        ApplyRadiusOverride(connection);
+
+        components[1].PhysicalX += JointMoveDelta;
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeFalse("moving one component genuinely changes the geometry");
+        connection.BendRadiusOverrides.ShouldBeEmpty();
+        connection.IsPathValid.ShouldBeTrue();
+        connection.FrozenPathStillMatchesPins().ShouldBeTrue("the re-route must reach the moved pin");
+    }
+
+    [Fact]
+    public void JointMove_TranslatedRouteCollidesWithThirdComponent_FallsBackToReroute()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        ApplyRadiusOverride(connection);
+
+        // Place a blocker where the translated route WILL land after the joint move.
+        var mid = connection.GetPathSegments()[connection.GetPathSegments().Count / 2].StartPoint;
+        var blocker = CreateBlocker(mid.X + JointMoveDelta, mid.Y + JointMoveDelta);
+        components.Add(blocker);
+
+        MoveBothComponents(new List<Component> { components[0], components[1] },
+            JointMoveDelta, JointMoveDelta);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeFalse(
+            "a translated route through a third component must be re-routed, not kept");
+        connection.BendRadiusOverrides.ShouldBeEmpty();
+        connection.IsPathValid.ShouldBeTrue();
+        PathIntersectionDetector.IntersectsRectangle(
+                connection.RoutedPath!,
+                blocker.PhysicalX + 0.5, blocker.PhysicalY + 0.5,
+                blocker.PhysicalX + blocker.WidthMicrometers - 0.5,
+                blocker.PhysicalY + blocker.HeightMicrometers - 0.5)
+            .ShouldBeFalse("the fallback re-route must avoid the third component");
+    }
+
+    [Fact]
+    public void JointMoveUndoRedo_RoundTrip_RestoresGeometryAndKeepsRadii()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        double appliedRadius = ApplyRadiusOverride(connection);
+        var originalPoints = SegmentPointsOf(connection);
+
+        // Drag both components (the move command), then undo (move back), then redo.
+        foreach (var (dx, dy) in new[]
+                 { (JointMoveDelta, JointMoveDelta), (-JointMoveDelta, -JointMoveDelta),
+                   (JointMoveDelta, JointMoveDelta) })
+        {
+            MoveBothComponents(components, dx, dy);
+            router.PathfindingGrid!.RebuildFromComponents(components);
+            manager.RecalculateAllTransmissions();
+            connection.IsRouteFrozen.ShouldBeTrue($"move by ({dx},{dy}) must keep the route frozen");
+        }
+
+        connection.BendRadiusOverrides.ShouldContainKeyAndValue(0, appliedRadius);
+        AssertTranslatedBy(connection, originalPoints, JointMoveDelta, JointMoveDelta);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void MoveBothComponents(List<Component> components, double dx, double dy)
+    {
+        foreach (var component in components)
+        {
+            component.PhysicalX += dx;
+            component.PhysicalY += dy;
+        }
+    }
+
+    /// <summary>
+    /// Applies the largest fitting radius override to the first bend; returns it. Routes hug
+    /// the pins by default, so the pin-side straight is lengthened first via the segment-shift
+    /// editor — the canonical in-canvas way to make room for a bigger radius.
+    /// </summary>
+    private static double ApplyRadiusOverride(WaveguideConnection connection)
+    {
+        MakeRoomAtStartPin(connection, RadiusCandidates[0] + 10);
+        var corners = BendRadiusEditor.GetBendCorners(connection.GetPathSegments());
+        corners.ShouldNotBeEmpty("the corner route must expose a resizable bend");
+        foreach (var radius in RadiusCandidates)
+        {
+            if (BendRadiusEditor.TryApplyOverride(connection, corners[0].BendIndex, radius, out _))
+            {
+                connection.IsRouteFrozen.ShouldBeTrue();
+                return radius;
+            }
+        }
+        throw new InvalidOperationException("No candidate radius fits the route.");
+    }
+
+    /// <summary>
+    /// Extends the straight between the start pin and the first bend by shifting the middle
+    /// straight along its normal (same technique as FrozenAndStyledRouteCollisionTests).
+    /// </summary>
+    private static void MakeRoomAtStartPin(WaveguideConnection connection, double roomMicrometers)
+    {
+        var segments = connection.RoutedPath!.Segments;
+        var lead = (StraightSegment)segments[0];
+        var handle = SegmentShiftGeometry.GetHandles(segments)
+            .First(h => h.StraightIndex == 1);
+        double dot = SegmentShiftGeometry.Dot(SegmentShiftGeometry.DirectionOf(lead), handle.Normal);
+        SegmentShiftEditor.TryApplyShift(connection, 1, roomMicrometers * dot, out var error)
+            .ShouldBeTrue(error);
+    }
+
+    private static List<(double X, double Y)> SegmentPointsOf(WaveguideConnection connection) =>
+        connection.RoutedPath!.Segments
+            .SelectMany(s => new[] { s.StartPoint, s.EndPoint })
+            .ToList();
+
+    private static void AssertTranslatedBy(
+        WaveguideConnection connection,
+        List<(double X, double Y)> originalPoints,
+        double dx, double dy)
+    {
+        var points = SegmentPointsOf(connection);
+        points.Count.ShouldBe(originalPoints.Count, "translation must not change the segment structure");
+        for (int i = 0; i < points.Count; i++)
+        {
+            points[i].X.ShouldBe(originalPoints[i].X + dx, CoordinateTolerance);
+            points[i].Y.ShouldBe(originalPoints[i].Y + dy, CoordinateTolerance);
+        }
+    }
+
+    /// <summary>
+    /// Two couplers offset so the connection turns a corner, routed through the manager
+    /// so the grid state matches the app (same layout as FrozenAndStyledRouteCollisionTests).
+    /// </summary>
+    private static (WaveguideConnectionManager Manager, WaveguideRouter Router,
+        WaveguideConnection Connection, List<Component> Components) RouteAcrossCorner()
+    {
+        var left = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("left");
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("right");
+        right.PhysicalX = 560;
+        right.PhysicalY = 360;
+        var components = new List<Component> { left, right };
+
+        var router = new WaveguideRouter();
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, components);
+        var manager = new WaveguideConnectionManager(router);
+        var connection = new WaveguideConnection
+        {
+            StartPin = Pin(left, "east0"),
+            EndPin = Pin(right, "west0"),
+        };
+        manager.AddExistingConnection(connection);
+        manager.RecalculateAllTransmissions();
+        connection.IsPathValid.ShouldBeTrue("the corner route must route in the empty layout");
+        return (manager, router, connection, components);
+    }
+
+    private static Component CreateBlocker(double centerX, double centerY)
+    {
+        const double BlockerSize = 50.0;
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+        return new Component(
+            new Dictionary<int, SMatrix>(), new List<Slider>(), "blocker", "",
+            parts, 0, "Blocker", DiscreteRotation.R0)
+        {
+            WidthMicrometers = BlockerSize,
+            HeightMicrometers = BlockerSize,
+            PhysicalX = centerX - BlockerSize / 2,
+            PhysicalY = centerY - BlockerSize / 2,
+        };
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+}

--- a/UnitTests/Routing/JointMoveRouteTranslatorTests.cs
+++ b/UnitTests/Routing/JointMoveRouteTranslatorTests.cs
@@ -1,0 +1,191 @@
+using CAP_Core.Components;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Unit tests for <see cref="JointMoveRouteTranslator"/> (issue #805): moving BOTH
+/// connected components by the same delta must translate the existing route instead of
+/// invalidating it; any other change (single move, rotation) must leave it untouched so
+/// the normal re-route path runs.
+/// </summary>
+public class JointMoveRouteTranslatorTests
+{
+    private const double JointMoveDeltaX = 120.0;
+    private const double JointMoveDeltaY = -35.0;
+    private const double CoordinateTolerance = 1e-9;
+
+    [Fact]
+    public void TryTranslateToPins_BothComponentsMovedEqually_TranslatesPathExactly()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection();
+        var originalPoints = SegmentPointsOf(conn);
+
+        startComponent.PhysicalX += JointMoveDeltaX;
+        startComponent.PhysicalY += JointMoveDeltaY;
+        endComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalY += JointMoveDeltaY;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeTrue();
+
+        conn.FrozenPathStillMatchesPins().ShouldBeTrue("translated path must match the moved pins");
+        var translatedPoints = SegmentPointsOf(conn);
+        translatedPoints.Count.ShouldBe(originalPoints.Count);
+        for (int i = 0; i < originalPoints.Count; i++)
+        {
+            translatedPoints[i].X.ShouldBe(originalPoints[i].X + JointMoveDeltaX, CoordinateTolerance);
+            translatedPoints[i].Y.ShouldBe(originalPoints[i].Y + JointMoveDeltaY, CoordinateTolerance);
+        }
+    }
+
+    [Fact]
+    public void TryTranslateToPins_TranslationPreservesBendGeometry()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection(offsetEndY: 200);
+        var originalBends = conn.RoutedPath!.Segments.OfType<BendSegment>().ToList();
+        originalBends.ShouldNotBeEmpty("the offset layout must contain bends");
+        var originalRadii = originalBends.Select(b => b.RadiusMicrometers).ToList();
+        var originalSweeps = originalBends.Select(b => b.SweepAngleDegrees).ToList();
+
+        startComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalX += JointMoveDeltaX;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeTrue();
+
+        var translatedBends = conn.RoutedPath!.Segments.OfType<BendSegment>().ToList();
+        translatedBends.Select(b => b.RadiusMicrometers).ShouldBe(originalRadii);
+        translatedBends.Select(b => b.SweepAngleDegrees).ShouldBe(originalSweeps);
+        for (int i = 0; i < originalBends.Count; i++)
+        {
+            translatedBends[i].Center.X.ShouldBe(originalBends[i].Center.X + JointMoveDeltaX, CoordinateTolerance);
+            translatedBends[i].Center.Y.ShouldBe(originalBends[i].Center.Y, CoordinateTolerance);
+        }
+    }
+
+    [Fact]
+    public void TryTranslateToPins_OnlyOneComponentMoved_ReturnsFalseAndKeepsPath()
+    {
+        var (conn, _, endComponent) = CreateRoutedConnection();
+        var originalPath = conn.RoutedPath;
+
+        endComponent.PhysicalX += JointMoveDeltaX;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse();
+        conn.RoutedPath.ShouldBeSameAs(originalPath, "an unequal-delta move must not touch the path");
+    }
+
+    [Fact]
+    public void TryTranslateToPins_NothingMoved_ReturnsFalse()
+    {
+        var (conn, _, _) = CreateRoutedConnection();
+        var originalPath = conn.RoutedPath;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse();
+        conn.RoutedPath.ShouldBeSameAs(originalPath);
+    }
+
+    [Fact]
+    public void TryTranslateToPins_EqualDeltasButPinDirectionChanged_ReturnsFalse()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection();
+
+        // Simulate a rotation that coincidentally moves both pins by the same delta:
+        // the pins' angles flip while the absolute positions shift uniformly.
+        startComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalX += JointMoveDeltaX;
+        conn.StartPin.AngleDegrees += 90;
+        conn.EndPin.AngleDegrees += 90;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse(
+            "a direction change is a rotation, not a translation");
+    }
+
+    [Fact]
+    public void TryTranslateToPins_BlockedFallbackPath_ReturnsFalse()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection();
+        conn.RoutedPath!.IsBlockedFallback = true;
+
+        startComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalX += JointMoveDeltaX;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse(
+            "emergency geometry must be re-routed, never carried along");
+    }
+
+    [Fact]
+    public void TryTranslateToPins_NoPath_ReturnsFalse()
+    {
+        var conn = new WaveguideConnection();
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static List<(double X, double Y)> SegmentPointsOf(WaveguideConnection conn) =>
+        conn.RoutedPath!.Segments
+            .SelectMany(s => new[] { s.StartPoint, s.EndPoint })
+            .ToList();
+
+    private static (WaveguideConnection Connection, Component StartComponent, Component EndComponent)
+        CreateRoutedConnection(double offsetEndY = 0)
+    {
+        var startComponent = CreateTestComponent(0, 0);
+        var endComponent = CreateTestComponent(400, offsetEndY);
+
+        var conn = new WaveguideConnection
+        {
+            StartPin = new PhysicalPin
+            {
+                Name = "output",
+                OffsetXMicrometers = 50,
+                OffsetYMicrometers = 25,
+                AngleDegrees = 0,
+                ParentComponent = startComponent,
+            },
+            EndPin = new PhysicalPin
+            {
+                Name = "input",
+                OffsetXMicrometers = 0,
+                OffsetYMicrometers = 25,
+                AngleDegrees = 180,
+                ParentComponent = endComponent,
+            },
+        };
+
+        conn.RecalculateTransmission(new WaveguideRouter());
+        conn.RoutedPath.ShouldNotBeNull();
+        return (conn, startComponent, endComponent);
+    }
+
+    private static Component CreateTestComponent(double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+
+        return new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: "test",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: $"TestComponent_{x}_{y}",
+            rotationCounterClock: DiscreteRotation.R0)
+        {
+            WidthMicrometers = 50,
+            HeightMicrometers = 50,
+            PhysicalX = x,
+            PhysicalY = y,
+        };
+    }
+}


### PR DESCRIPTION
Automated implementation for #805

That's the full-suite background run completing — result already accounted for: **4396 passed / 0 failed / 15 skipped** (exit code 0). Work is committed and the summary above stands; nothing further needed.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 145,172
- **Estimated cost:** $0.0813 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*