### PR TITLE
Routing: joint move, copy-paste & live-drag all keep the waveguide's manual geometry (#805, supersedes #806)

### DIFF
--- a/CAP.Avalonia/Gestures/ComponentDragGestureRecognizer.cs
+++ b/CAP.Avalonia/Gestures/ComponentDragGestureRecognizer.cs
@@ -185,7 +185,13 @@ public class ComponentDragGestureRecognizer : IGestureRecognizer
         if (_state.DraggingComponent == null) return;
         double dx = delta.X / _getZoom(), dy = delta.Y / _getZoom();
         bool isGroup = canvas.Selection.SelectedComponents.Count > 1;
-        if (isGroup) foreach (var c in canvas.Selection.SelectedComponents) canvas.MoveComponent(c, dx, dy);
+        if (isGroup)
+        {
+            foreach (var c in canvas.Selection.SelectedComponents) canvas.MoveComponent(c, dx, dy);
+            // Both dragged together = pure translation: shift internal waveguides with the
+            // components so they follow the pointer instead of snapping back only on drop.
+            canvas.TranslateInternalConnectionRoutes(canvas.Selection.SelectedComponents, dx, dy);
+        }
         else canvas.MoveComponent(_state.DraggingComponent!, dx, dy);
         if (canvas.AlignmentGuide.IsEnabled) canvas.AlignmentGuide.UpdateAlignments(_state.DraggingComponent!, canvas.Components);
         UpdateDragPreview(canvas, isGroup);

--- a/CAP.Avalonia/Selection/ComponentClipboard.cs
+++ b/CAP.Avalonia/Selection/ComponentClipboard.cs
@@ -5,6 +5,7 @@ using CAP_Core.Components;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Creation;
+using CAP_Core.LightCalculation.MaterialDispersion;
 using CAP_Core.Routing;
 
 namespace CAP.Avalonia.Selection;
@@ -95,7 +96,7 @@ public class ComponentClipboard
                     conn.Connection.StartPin.Name,
                     endIdx,
                     conn.Connection.EndPin.Name,
-                    conn.Connection));
+                    Snapshot(conn.Connection)));
             }
         }
     }
@@ -236,7 +237,7 @@ public class ComponentClipboard
 
             if (startPin != null && endPin != null)
             {
-                var connVm = PasteConnection(canvas, conn.Source, startPin, endPin, offsetX, offsetY);
+                var connVm = PasteConnection(canvas, conn.Snapshot, startPin, endPin, offsetX, offsetY);
                 if (connVm != null)
                     newConnections.Add(connVm);
             }
@@ -246,35 +247,51 @@ public class ComponentClipboard
     }
 
     /// <summary>
-    /// Recreates a copied connection between the pasted pins, carrying its routing settings
-    /// and its exact geometry. The source route is translated by the paste offset so its
+    /// Snapshots the user-editable routing/loss settings, manual bend/segment edits and a deep
+    /// copy of the routed geometry at COPY time, so later edits or re-routes of the source do
+    /// not leak into a paste. A clipboard entry is an immutable copy, not a live reference.
+    /// </summary>
+    private static ConnectionSnapshot Snapshot(WaveguideConnection source) => new(
+        source.Type,
+        source.BendRadiusMicrometers,
+        source.WidthMicrometers,
+        source.PropagationLossDbPerCm,
+        source.BendLossDbPer90Deg,
+        source.DispersionModel,
+        new Dictionary<int, double>(source.BendRadiusOverrides),
+        new Dictionary<int, double>(source.StraightShiftOffsets),
+        source.IsRouteFrozen,
+        source.RoutedPath is { Segments.Count: > 0 } ? source.RoutedPath.DeepCopy() : null);
+
+    /// <summary>
+    /// Recreates a copied connection between the pasted pins, carrying its snapshotted routing
+    /// settings and exact geometry. The snapshot route is translated by the paste offset so its
     /// endpoints land on the pasted pins — matching the group-paste behaviour and preserving
     /// hand-tuned bends that a from-scratch re-route would otherwise discard.
     /// </summary>
     private static WaveguideConnectionViewModel? PasteConnection(
         DesignCanvasViewModel canvas,
-        WaveguideConnection source,
+        ConnectionSnapshot snapshot,
         PhysicalPin startPin,
         PhysicalPin endPin,
         double offsetX,
         double offsetY)
     {
-        var sourcePath = source.RoutedPath;
-        var connVm = sourcePath is { Segments.Count: > 0 }
-            ? canvas.ConnectPinsWithCachedRoute(startPin, endPin, sourcePath.TranslatedCopy(offsetX, offsetY))
+        var connVm = snapshot.Route is { Segments.Count: > 0 }
+            ? canvas.ConnectPinsWithCachedRoute(startPin, endPin, snapshot.Route.TranslatedCopy(offsetX, offsetY))
             : canvas.ConnectPins(startPin, endPin);
         if (connVm == null)
             return null;
 
-        CopyConnectionSettings(source, connVm.Connection);
+        CopyConnectionSettings(snapshot, connVm.Connection);
         return connVm;
     }
 
     /// <summary>
-    /// Copies the user-editable routing and loss settings — plus any manual per-bend/segment
-    /// edits and the freeze flag — from a source connection onto a freshly pasted one.
+    /// Applies the snapshotted routing/loss settings — plus any manual per-bend/segment edits
+    /// and the freeze flag — onto a freshly pasted connection.
     /// </summary>
-    private static void CopyConnectionSettings(WaveguideConnection source, WaveguideConnection target)
+    private static void CopyConnectionSettings(ConnectionSnapshot source, WaveguideConnection target)
     {
         target.Type = source.Type;
         target.BendRadiusMicrometers = source.BendRadiusMicrometers;
@@ -428,7 +445,24 @@ public class ComponentClipboard
         string StartPinName,
         int EndComponentIndex,
         string EndPinName,
-        WaveguideConnection Source);
+        ConnectionSnapshot Snapshot);
+
+    /// <summary>
+    /// Immutable copy-time snapshot of a connection's user-editable settings and geometry.
+    /// The route is a deep copy; the override maps are fresh copies — nothing aliases the
+    /// live source connection.
+    /// </summary>
+    private sealed record ConnectionSnapshot(
+        WaveguideType Type,
+        double BendRadiusMicrometers,
+        double WidthMicrometers,
+        double PropagationLossDbPerCm,
+        double BendLossDbPer90Deg,
+        IDispersionModel? DispersionModel,
+        Dictionary<int, double> BendRadiusOverrides,
+        Dictionary<int, double> StraightShiftOffsets,
+        bool IsRouteFrozen,
+        RoutedPath? Route);
 }
 
 /// <summary>

--- a/CAP.Avalonia/Selection/ComponentClipboard.cs
+++ b/CAP.Avalonia/Selection/ComponentClipboard.cs
@@ -2,8 +2,10 @@ using System.Linq;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Library;
 using CAP_Core.Components;
+using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.Creation;
+using CAP_Core.Routing;
 
 namespace CAP.Avalonia.Selection;
 
@@ -92,7 +94,8 @@ public class ComponentClipboard
                     startIdx,
                     conn.Connection.StartPin.Name,
                     endIdx,
-                    conn.Connection.EndPin.Name));
+                    conn.Connection.EndPin.Name,
+                    conn.Connection));
             }
         }
     }
@@ -233,13 +236,62 @@ public class ComponentClipboard
 
             if (startPin != null && endPin != null)
             {
-                var connVm = canvas.ConnectPins(startPin, endPin);
+                var connVm = PasteConnection(canvas, conn.Source, startPin, endPin, offsetX, offsetY);
                 if (connVm != null)
                     newConnections.Add(connVm);
             }
         }
 
         return new PasteResult(newComponents, newConnections, pastedIdentifierMap);
+    }
+
+    /// <summary>
+    /// Recreates a copied connection between the pasted pins, carrying its routing settings
+    /// and its exact geometry. The source route is translated by the paste offset so its
+    /// endpoints land on the pasted pins — matching the group-paste behaviour and preserving
+    /// hand-tuned bends that a from-scratch re-route would otherwise discard.
+    /// </summary>
+    private static WaveguideConnectionViewModel? PasteConnection(
+        DesignCanvasViewModel canvas,
+        WaveguideConnection source,
+        PhysicalPin startPin,
+        PhysicalPin endPin,
+        double offsetX,
+        double offsetY)
+    {
+        var sourcePath = source.RoutedPath;
+        var connVm = sourcePath is { Segments.Count: > 0 }
+            ? canvas.ConnectPinsWithCachedRoute(startPin, endPin, sourcePath.TranslatedCopy(offsetX, offsetY))
+            : canvas.ConnectPins(startPin, endPin);
+        if (connVm == null)
+            return null;
+
+        CopyConnectionSettings(source, connVm.Connection);
+        return connVm;
+    }
+
+    /// <summary>
+    /// Copies the user-editable routing and loss settings — plus any manual per-bend/segment
+    /// edits and the freeze flag — from a source connection onto a freshly pasted one.
+    /// </summary>
+    private static void CopyConnectionSettings(WaveguideConnection source, WaveguideConnection target)
+    {
+        target.Type = source.Type;
+        target.BendRadiusMicrometers = source.BendRadiusMicrometers;
+        target.WidthMicrometers = source.WidthMicrometers;
+        target.PropagationLossDbPerCm = source.PropagationLossDbPerCm;
+        target.BendLossDbPer90Deg = source.BendLossDbPer90Deg;
+        target.DispersionModel = source.DispersionModel;
+
+        target.BendRadiusOverrides.Clear();
+        foreach (var (bendIndex, radius) in source.BendRadiusOverrides)
+            target.BendRadiusOverrides[bendIndex] = radius;
+
+        target.StraightShiftOffsets.Clear();
+        foreach (var (straightIndex, shift) in source.StraightShiftOffsets)
+            target.StraightShiftOffsets[straightIndex] = shift;
+
+        target.IsRouteFrozen = source.IsRouteFrozen;
     }
 
     /// <summary>
@@ -375,7 +427,8 @@ public class ComponentClipboard
         int StartComponentIndex,
         string StartPinName,
         int EndComponentIndex,
-        string EndPinName);
+        string EndPinName,
+        WaveguideConnection Source);
 }
 
 /// <summary>

--- a/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/DesignCanvasViewModel.cs
@@ -237,6 +237,14 @@ public partial class DesignCanvasViewModel : ObservableObject
             Groups.IsInGroupEditMode, Groups.CurrentEditGroup,
             Groups.UpdateExternalPinPositions, Routing.RecalculateRoutesAsync);
 
+    /// <summary>
+    /// Shifts the routed geometry of connections internal to <paramref name="selection"/> by
+    /// the given delta, so waveguides follow a live joint drag of both their components.
+    /// </summary>
+    public void TranslateInternalConnectionRoutes(
+        IEnumerable<ComponentViewModel> selection, double deltaX, double deltaY)
+        => Placement.TranslateInternalConnectionRoutes(selection, deltaX, deltaY);
+
     public bool CanPlaceComponent(double x, double y, double width, double height,
         ComponentViewModel? excludeComponent = null)
         => Placement.CanPlaceComponent(x, y, width, height, excludeComponent);

--- a/CAP.Avalonia/ViewModels/Canvas/Services/ComponentPlacementService.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/Services/ComponentPlacementService.cs
@@ -107,6 +107,32 @@ public class ComponentPlacementService
     }
 
     /// <summary>
+    /// Translates the routed path of every connection whose BOTH endpoints sit on components
+    /// in <paramref name="selection"/> by (<paramref name="deltaX"/>, <paramref name="deltaY"/>),
+    /// so an internal waveguide follows a joint drag of both its components in real time.
+    /// Connections with only one selected endpoint are left untouched — their geometry
+    /// genuinely changes and is re-routed on drop.
+    /// </summary>
+    public void TranslateInternalConnectionRoutes(
+        IEnumerable<ComponentViewModel> selection, double deltaX, double deltaY)
+    {
+        var selected = new HashSet<Component>(
+            selection.Select(c => c.Component).Where(c => !c.IsLocked));
+        foreach (var conn in _connections)
+        {
+            var connection = conn.Connection;
+            if (connection.RoutedPath is not { Segments.Count: > 0 })
+                continue;
+            if (!selected.Contains(connection.StartPin.ParentComponent) ||
+                !selected.Contains(connection.EndPin.ParentComponent))
+                continue;
+
+            connection.ReplaceRoutedPath(connection.RoutedPath.TranslatedCopy(deltaX, deltaY));
+            conn.NotifyPathChanged();
+        }
+    }
+
+    /// <summary>
     /// Checks if a component can be placed without overlapping others and within chip boundaries.
     /// </summary>
     public bool CanPlaceComponent(double x, double y, double width, double height,

--- a/CAP.Browser/CAP.Browser.csproj
+++ b/CAP.Browser/CAP.Browser.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- The BlazorWebAssembly SDK injects this implicit using, but no referenced
+         package provides the Microsoft.Extensions.Configuration assembly. -->
+    <Using Remove="Microsoft.Extensions.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Avalonia.Browser" Version="11.2.1" />
   </ItemGroup>
 

--- a/Connect-A-Pic-Core/Components/Connections/JointMoveRouteTranslator.cs
+++ b/Connect-A-Pic-Core/Components/Connections/JointMoveRouteTranslator.cs
@@ -1,0 +1,75 @@
+using CAP_Core.Routing;
+
+namespace CAP_Core.Components.Connections;
+
+/// <summary>
+/// Detects that BOTH endpoints of a routed connection moved by the same delta — the user
+/// dragged both connected components together — and translates the existing route to the
+/// new pin positions instead of letting it be re-routed. A joint move does not change the
+/// relative constellation of the pins, so a pure translation preserves the exact geometry,
+/// including manually edited bend radii and segment shifts.
+/// </summary>
+public static class JointMoveRouteTranslator
+{
+    /// <summary>
+    /// Maximum difference in micrometers between the start-pin delta and the end-pin delta
+    /// for the move to count as one uniform translation. Matches the endpoint tolerance
+    /// used by <see cref="WaveguideConnection.FrozenPathStillMatchesPins"/>.
+    /// </summary>
+    public const double DeltaMatchToleranceMicrometers =
+        WaveguideConnection.FrozenEndpointToleranceMicrometers;
+
+    /// <summary>
+    /// Translates the connection's routed path so its endpoints match the current pin
+    /// positions, when — and only when — both pins moved by the same delta. Returns false
+    /// (leaving the path untouched) when the endpoints already match, moved by different
+    /// deltas (only one component moved, or a component was resized), or a pin's direction
+    /// changed (a rotation can coincidentally produce equal deltas). Collision checks are
+    /// the caller's responsibility: the translated path may overlap a third component and
+    /// must still go through the normal validity pipeline.
+    /// </summary>
+    /// <param name="connection">The connection whose route may be translated in place.</param>
+    /// <returns>True when the path was replaced by a translated copy matching the pins.</returns>
+    public static bool TryTranslateToPins(WaveguideConnection connection)
+    {
+        var path = connection.RoutedPath;
+        if (path == null || path.Segments.Count == 0 ||
+            connection.StartPin == null || connection.EndPin == null)
+            return false;
+        if (path.IsBlockedFallback || path.IsInvalidGeometry || path.IsPlaceholderGeometry)
+            return false;
+
+        var (startX, startY) = connection.StartPin.GetAbsolutePosition();
+        var (endX, endY) = connection.EndPin.GetAbsolutePosition();
+        var first = path.Segments[0];
+        var last = path.Segments[^1];
+
+        double startDx = startX - first.StartPoint.X;
+        double startDy = startY - first.StartPoint.Y;
+        double endDx = endX - last.EndPoint.X;
+        double endDy = endY - last.EndPoint.Y;
+
+        // Endpoints already match: nothing moved, keep the live path untouched.
+        if (Length(startDx, startDy) <= DeltaMatchToleranceMicrometers &&
+            Length(endDx, endDy) <= DeltaMatchToleranceMicrometers)
+            return false;
+
+        // Different deltas: only one component moved (or one was resized) — genuine re-route.
+        if (Length(startDx - endDx, startDy - endDy) > DeltaMatchToleranceMicrometers)
+            return false;
+
+        // A rotation can coincidentally move both pins by the same delta; the pins'
+        // directions then no longer match the path's launch/entry directions.
+        var (startDirectionOk, endDirectionOk) = CachedRouteValidator.CheckPinDirections(
+            connection.StartPin, connection.EndPin, path);
+        if (!startDirectionOk || !endDirectionOk)
+            return false;
+
+        // Publish the finished copy through the single reference assignment so the UI
+        // thread never observes half-translated segments (see ReplaceRoutedPath).
+        connection.ReplaceRoutedPath(path.TranslatedCopy(startDx, startDy));
+        return true;
+    }
+
+    private static double Length(double dx, double dy) => Math.Sqrt(dx * dx + dy * dy);
+}

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -158,8 +158,10 @@ namespace CAP_Core.Components.Connections
                 // A styled route the user has hand-edited (bend radius via the canvas handles,
                 // recorded in BendRadiusOverrides) is sacred: keep it as long as its endpoints
                 // still match the pins, only refreshing the losses. Rebuilding here would
-                // silently wipe the manual edit on every unrelated recalculation.
-                if (HasManualPathEdits && FrozenPathStillMatchesPins())
+                // silently wipe the manual edit on every unrelated recalculation. A joint move
+                // of both components is a pure translation and keeps the edits too.
+                if (HasManualPathEdits &&
+                    (FrozenPathStillMatchesPins() || JointMoveRouteTranslator.TryTranslateToPins(this)))
                 {
                     UpdateLossFromPath(wavelengthNm);
                     return;
@@ -191,7 +193,9 @@ namespace CAP_Core.Components.Connections
 
             if (IsRouteFrozen)
             {
-                if (FrozenPathStillMatchesPins())
+                // Both endpoints moved by the same delta (joint drag of both components):
+                // translate the frozen geometry instead of unfreezing it.
+                if (FrozenPathStillMatchesPins() || JointMoveRouteTranslator.TryTranslateToPins(this))
                 {
                     // Keep manually edited geometry; just refresh the loss values.
                     UpdateLossFromPath(wavelengthNm);

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.cs
@@ -468,6 +468,12 @@ public partial class WaveguideConnectionManager
             if (cancellationToken.IsCancellationRequested)
                 return (false, 0);
 
+            // A joint drag of BOTH connected components is a pure translation: shift the
+            // existing route (with all manual bend edits) to the new pin positions BEFORE
+            // the validity checks, so collision handling below runs on the translated
+            // geometry and can still force a re-route.
+            JointMoveRouteTranslator.TryTranslateToPins(connection);
+
             if (TryUnfreezeCollidedAutoRoute(connection, router))
             {
                 // A component overlaps the manually edited geometry: treat it like an

--- a/Connect-A-Pic-Core/Routing/RoutedPath.cs
+++ b/Connect-A-Pic-Core/Routing/RoutedPath.cs
@@ -76,7 +76,16 @@ public class RoutedPath
     /// (bend-radius handles mutate segments in place) silently corrupt the stored
     /// original. <c>DebugGridPath</c> is not copied — it is diagnostic-only.
     /// </summary>
-    public RoutedPath DeepCopy()
+    public RoutedPath DeepCopy() => TranslatedCopy(0, 0);
+
+    /// <summary>
+    /// Creates an independent deep copy with every segment shifted by (dx, dy).
+    /// A pure translation leaves angles, radii and sweeps untouched, so the exact
+    /// shape — including manually edited bend radii — is preserved.
+    /// </summary>
+    /// <param name="dx">Shift along X in micrometers.</param>
+    /// <param name="dy">Shift along Y in micrometers.</param>
+    public RoutedPath TranslatedCopy(double dx, double dy)
     {
         var copy = new RoutedPath
         {
@@ -93,18 +102,18 @@ public class RoutedPath
             {
                 case BendSegment bend:
                     copy.Segments.Add(new BendSegment(
-                        bend.Center.X,
-                        bend.Center.Y,
+                        bend.Center.X + dx,
+                        bend.Center.Y + dy,
                         bend.RadiusMicrometers,
                         bend.StartAngleDegrees,
                         bend.SweepAngleDegrees));
                     break;
                 case StraightSegment straight:
                     copy.Segments.Add(new StraightSegment(
-                        straight.StartPoint.X,
-                        straight.StartPoint.Y,
-                        straight.EndPoint.X,
-                        straight.EndPoint.Y,
+                        straight.StartPoint.X + dx,
+                        straight.StartPoint.Y + dy,
+                        straight.EndPoint.X + dx,
+                        straight.EndPoint.Y + dy,
                         straight.StartAngleDegrees));
                     break;
             }

--- a/UnitTests/Commands/CopyPasteWorkflowTests.cs
+++ b/UnitTests/Commands/CopyPasteWorkflowTests.cs
@@ -3,6 +3,7 @@ using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
+using CAP_Core.Routing;
 using CAP_Core.Components.ComponentHelpers;
 using CAP_Core.Tiles;
 using Shouldly;
@@ -179,6 +180,44 @@ public class CopyPasteWorkflowTests
         pasted.Type.ShouldBe(WaveguideType.Bend, "Connection type must survive paste");
         pasted.BendRadiusMicrometers.ShouldBe(35.0, "Manual bend radius must survive paste");
         pasted.WidthMicrometers.ShouldBe(1.25, "Waveguide width must survive paste");
+    }
+
+    /// <summary>
+    /// The clipboard must snapshot a connection's geometry at copy time. If the source is
+    /// re-routed after the copy, paste must still reproduce the copied route (translated onto
+    /// the pasted pins) — a live reference would translate the source's newer, mismatched
+    /// geometry and quietly fall back to a re-route on the next recalc.
+    /// </summary>
+    [Fact]
+    public void Paste_ConnectedComponents_UsesRouteSnapshotFromCopyTime()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        var comp1 = CreateComponentWithPins(100, 50, 100, 100);
+        var comp2 = CreateComponentWithPins(100, 50, 300, 100);
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        var copyTimeRoute = new RoutedPath();
+        copyTimeRoute.Segments.Add(new StraightSegment(200, 125, 300, 125, 0));
+        var sourceVm = canvas.ConnectPinsWithCachedRoute(
+            comp1.PhysicalPins[1], comp2.PhysicalPins[0], copyTimeRoute);
+        sourceVm.ShouldNotBeNull();
+
+        canvas.Clipboard.Copy(new[] { vm1, vm2 }, canvas.Connections);
+
+        // Source is re-routed to a very different geometry AFTER the copy.
+        var laterRoute = new RoutedPath();
+        laterRoute.Segments.Add(new StraightSegment(200, 900, 300, 900, 0));
+        sourceVm.Connection.RestoreCachedPath(laterRoute);
+
+        var cmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        cmd.Execute();
+
+        var pasted = cmd.Result!.Connections[0].Connection;
+        // 50 µm is the fixed paste offset; the copy-time Y was 125, the later one 900.
+        pasted.RoutedPath!.Segments[0].StartPoint.Y.ShouldBe(175.0, 1e-9,
+            "paste must reproduce the route captured at copy time, not the source's later geometry");
     }
 
     /// <summary>

--- a/UnitTests/Commands/CopyPasteWorkflowTests.cs
+++ b/UnitTests/Commands/CopyPasteWorkflowTests.cs
@@ -1,6 +1,7 @@
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP_Core.Components;
+using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.ComponentHelpers;
 using CAP_Core.Tiles;
@@ -144,6 +145,40 @@ public class CopyPasteWorkflowTests
 
         canvas.Connections.Count.ShouldBe(initialConnectionCount + 1,
             "Total connections should increase by 1");
+    }
+
+    /// <summary>
+    /// Verifies that pasting a connection carries its routing settings — the connection
+    /// type and the manually chosen bend radius — instead of resetting them to defaults
+    /// (field report: copy/paste of an Auto connection with a 35 µm radius dropped it).
+    /// </summary>
+    [Fact]
+    public void Paste_ConnectedComponents_PreservesConnectionSettings()
+    {
+        var canvas = new DesignCanvasViewModel();
+
+        var comp1 = CreateComponentWithPins(100, 50, 100, 100);
+        var comp2 = CreateComponentWithPins(100, 50, 300, 100);
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        var sourceVm = canvas.ConnectPins(comp1.PhysicalPins[1], comp2.PhysicalPins[0]);
+        sourceVm.ShouldNotBeNull();
+        sourceVm.Connection.Type = WaveguideType.Bend;
+        sourceVm.Connection.BendRadiusMicrometers = 35.0;
+        sourceVm.Connection.WidthMicrometers = 1.25;
+
+        canvas.Clipboard.Copy(new[] { vm1, vm2 }, canvas.Connections);
+        var cmd = new PasteComponentsCommand(canvas, canvas.Clipboard);
+        cmd.Execute();
+
+        cmd.Result.ShouldNotBeNull();
+        cmd.Result.Connections.Count.ShouldBe(1, "Should paste the internal connection");
+
+        var pasted = cmd.Result.Connections[0].Connection;
+        pasted.Type.ShouldBe(WaveguideType.Bend, "Connection type must survive paste");
+        pasted.BendRadiusMicrometers.ShouldBe(35.0, "Manual bend radius must survive paste");
+        pasted.WidthMicrometers.ShouldBe(1.25, "Waveguide width must survive paste");
     }
 
     /// <summary>

--- a/UnitTests/Routing/JointMoveRouteTranslationIntegrationTests.cs
+++ b/UnitTests/Routing/JointMoveRouteTranslationIntegrationTests.cs
@@ -1,0 +1,223 @@
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Routing.InterconnectRouting;
+using CAP_Core.Routing.InterconnectRouting.SegmentShift;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// End-to-end tests for issue #805 through <see cref="WaveguideConnectionManager"/>:
+/// dragging BOTH connected components together must translate the frozen route (manual
+/// bend radii survive), while single moves and collisions with a third component still
+/// fall back to the normal re-route path. The undo round-trip is the same joint move in
+/// reverse, so validity must hold in both directions.
+/// </summary>
+public class JointMoveRouteTranslationIntegrationTests
+{
+    private static readonly double[] RadiusCandidates = { 40.0, 25.0, 15.0, 12.0 };
+    private const double JointMoveDelta = 60.0;
+    private const double CoordinateTolerance = 1e-9;
+
+    [Fact]
+    public void JointMove_FrozenRouteWithEditedRadius_IsTranslatedNotRerouted()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        double appliedRadius = ApplyRadiusOverride(connection);
+        var originalPoints = SegmentPointsOf(connection);
+
+        MoveBothComponents(components, JointMoveDelta, JointMoveDelta);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeTrue("a joint move must not unfreeze the route");
+        connection.BendRadiusOverrides.ShouldContainKeyAndValue(0, appliedRadius);
+        AssertTranslatedBy(connection, originalPoints, JointMoveDelta, JointMoveDelta);
+    }
+
+    [Fact]
+    public void SingleMove_FrozenRouteWithEditedRadius_StillReroutesAndDropsEdit()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        ApplyRadiusOverride(connection);
+
+        components[1].PhysicalX += JointMoveDelta;
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeFalse("moving one component genuinely changes the geometry");
+        connection.BendRadiusOverrides.ShouldBeEmpty();
+        connection.IsPathValid.ShouldBeTrue();
+        connection.FrozenPathStillMatchesPins().ShouldBeTrue("the re-route must reach the moved pin");
+    }
+
+    [Fact]
+    public void JointMove_TranslatedRouteCollidesWithThirdComponent_FallsBackToReroute()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        ApplyRadiusOverride(connection);
+
+        // Place a blocker where the translated route WILL land after the joint move.
+        var mid = connection.GetPathSegments()[connection.GetPathSegments().Count / 2].StartPoint;
+        var blocker = CreateBlocker(mid.X + JointMoveDelta, mid.Y + JointMoveDelta);
+        components.Add(blocker);
+
+        MoveBothComponents(new List<Component> { components[0], components[1] },
+            JointMoveDelta, JointMoveDelta);
+        router.PathfindingGrid!.RebuildFromComponents(components);
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeFalse(
+            "a translated route through a third component must be re-routed, not kept");
+        connection.BendRadiusOverrides.ShouldBeEmpty();
+        connection.IsPathValid.ShouldBeTrue();
+        PathIntersectionDetector.IntersectsRectangle(
+                connection.RoutedPath!,
+                blocker.PhysicalX + 0.5, blocker.PhysicalY + 0.5,
+                blocker.PhysicalX + blocker.WidthMicrometers - 0.5,
+                blocker.PhysicalY + blocker.HeightMicrometers - 0.5)
+            .ShouldBeFalse("the fallback re-route must avoid the third component");
+    }
+
+    [Fact]
+    public void JointMoveUndoRedo_RoundTrip_RestoresGeometryAndKeepsRadii()
+    {
+        var (manager, router, connection, components) = RouteAcrossCorner();
+        double appliedRadius = ApplyRadiusOverride(connection);
+        var originalPoints = SegmentPointsOf(connection);
+
+        // Drag both components (the move command), then undo (move back), then redo.
+        foreach (var (dx, dy) in new[]
+                 { (JointMoveDelta, JointMoveDelta), (-JointMoveDelta, -JointMoveDelta),
+                   (JointMoveDelta, JointMoveDelta) })
+        {
+            MoveBothComponents(components, dx, dy);
+            router.PathfindingGrid!.RebuildFromComponents(components);
+            manager.RecalculateAllTransmissions();
+            connection.IsRouteFrozen.ShouldBeTrue($"move by ({dx},{dy}) must keep the route frozen");
+        }
+
+        connection.BendRadiusOverrides.ShouldContainKeyAndValue(0, appliedRadius);
+        AssertTranslatedBy(connection, originalPoints, JointMoveDelta, JointMoveDelta);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void MoveBothComponents(List<Component> components, double dx, double dy)
+    {
+        foreach (var component in components)
+        {
+            component.PhysicalX += dx;
+            component.PhysicalY += dy;
+        }
+    }
+
+    /// <summary>
+    /// Applies the largest fitting radius override to the first bend; returns it. Routes hug
+    /// the pins by default, so the pin-side straight is lengthened first via the segment-shift
+    /// editor — the canonical in-canvas way to make room for a bigger radius.
+    /// </summary>
+    private static double ApplyRadiusOverride(WaveguideConnection connection)
+    {
+        MakeRoomAtStartPin(connection, RadiusCandidates[0] + 10);
+        var corners = BendRadiusEditor.GetBendCorners(connection.GetPathSegments());
+        corners.ShouldNotBeEmpty("the corner route must expose a resizable bend");
+        foreach (var radius in RadiusCandidates)
+        {
+            if (BendRadiusEditor.TryApplyOverride(connection, corners[0].BendIndex, radius, out _))
+            {
+                connection.IsRouteFrozen.ShouldBeTrue();
+                return radius;
+            }
+        }
+        throw new InvalidOperationException("No candidate radius fits the route.");
+    }
+
+    /// <summary>
+    /// Extends the straight between the start pin and the first bend by shifting the middle
+    /// straight along its normal (same technique as FrozenAndStyledRouteCollisionTests).
+    /// </summary>
+    private static void MakeRoomAtStartPin(WaveguideConnection connection, double roomMicrometers)
+    {
+        var segments = connection.RoutedPath!.Segments;
+        var lead = (StraightSegment)segments[0];
+        var handle = SegmentShiftGeometry.GetHandles(segments)
+            .First(h => h.StraightIndex == 1);
+        double dot = SegmentShiftGeometry.Dot(SegmentShiftGeometry.DirectionOf(lead), handle.Normal);
+        SegmentShiftEditor.TryApplyShift(connection, 1, roomMicrometers * dot, out var error)
+            .ShouldBeTrue(error);
+    }
+
+    private static List<(double X, double Y)> SegmentPointsOf(WaveguideConnection connection) =>
+        connection.RoutedPath!.Segments
+            .SelectMany(s => new[] { s.StartPoint, s.EndPoint })
+            .ToList();
+
+    private static void AssertTranslatedBy(
+        WaveguideConnection connection,
+        List<(double X, double Y)> originalPoints,
+        double dx, double dy)
+    {
+        var points = SegmentPointsOf(connection);
+        points.Count.ShouldBe(originalPoints.Count, "translation must not change the segment structure");
+        for (int i = 0; i < points.Count; i++)
+        {
+            points[i].X.ShouldBe(originalPoints[i].X + dx, CoordinateTolerance);
+            points[i].Y.ShouldBe(originalPoints[i].Y + dy, CoordinateTolerance);
+        }
+    }
+
+    /// <summary>
+    /// Two couplers offset so the connection turns a corner, routed through the manager
+    /// so the grid state matches the app (same layout as FrozenAndStyledRouteCollisionTests).
+    /// </summary>
+    private static (WaveguideConnectionManager Manager, WaveguideRouter Router,
+        WaveguideConnection Connection, List<Component> Components) RouteAcrossCorner()
+    {
+        var left = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("left");
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("right");
+        right.PhysicalX = 560;
+        right.PhysicalY = 360;
+        var components = new List<Component> { left, right };
+
+        var router = new WaveguideRouter();
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, components);
+        var manager = new WaveguideConnectionManager(router);
+        var connection = new WaveguideConnection
+        {
+            StartPin = Pin(left, "east0"),
+            EndPin = Pin(right, "west0"),
+        };
+        manager.AddExistingConnection(connection);
+        manager.RecalculateAllTransmissions();
+        connection.IsPathValid.ShouldBeTrue("the corner route must route in the empty layout");
+        return (manager, router, connection, components);
+    }
+
+    private static Component CreateBlocker(double centerX, double centerY)
+    {
+        const double BlockerSize = 50.0;
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+        return new Component(
+            new Dictionary<int, SMatrix>(), new List<Slider>(), "blocker", "",
+            parts, 0, "Blocker", DiscreteRotation.R0)
+        {
+            WidthMicrometers = BlockerSize,
+            HeightMicrometers = BlockerSize,
+            PhysicalX = centerX - BlockerSize / 2,
+            PhysicalY = centerY - BlockerSize / 2,
+        };
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+}

--- a/UnitTests/Routing/JointMoveRouteTranslatorTests.cs
+++ b/UnitTests/Routing/JointMoveRouteTranslatorTests.cs
@@ -1,0 +1,191 @@
+using CAP_Core.Components;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Unit tests for <see cref="JointMoveRouteTranslator"/> (issue #805): moving BOTH
+/// connected components by the same delta must translate the existing route instead of
+/// invalidating it; any other change (single move, rotation) must leave it untouched so
+/// the normal re-route path runs.
+/// </summary>
+public class JointMoveRouteTranslatorTests
+{
+    private const double JointMoveDeltaX = 120.0;
+    private const double JointMoveDeltaY = -35.0;
+    private const double CoordinateTolerance = 1e-9;
+
+    [Fact]
+    public void TryTranslateToPins_BothComponentsMovedEqually_TranslatesPathExactly()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection();
+        var originalPoints = SegmentPointsOf(conn);
+
+        startComponent.PhysicalX += JointMoveDeltaX;
+        startComponent.PhysicalY += JointMoveDeltaY;
+        endComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalY += JointMoveDeltaY;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeTrue();
+
+        conn.FrozenPathStillMatchesPins().ShouldBeTrue("translated path must match the moved pins");
+        var translatedPoints = SegmentPointsOf(conn);
+        translatedPoints.Count.ShouldBe(originalPoints.Count);
+        for (int i = 0; i < originalPoints.Count; i++)
+        {
+            translatedPoints[i].X.ShouldBe(originalPoints[i].X + JointMoveDeltaX, CoordinateTolerance);
+            translatedPoints[i].Y.ShouldBe(originalPoints[i].Y + JointMoveDeltaY, CoordinateTolerance);
+        }
+    }
+
+    [Fact]
+    public void TryTranslateToPins_TranslationPreservesBendGeometry()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection(offsetEndY: 200);
+        var originalBends = conn.RoutedPath!.Segments.OfType<BendSegment>().ToList();
+        originalBends.ShouldNotBeEmpty("the offset layout must contain bends");
+        var originalRadii = originalBends.Select(b => b.RadiusMicrometers).ToList();
+        var originalSweeps = originalBends.Select(b => b.SweepAngleDegrees).ToList();
+
+        startComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalX += JointMoveDeltaX;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeTrue();
+
+        var translatedBends = conn.RoutedPath!.Segments.OfType<BendSegment>().ToList();
+        translatedBends.Select(b => b.RadiusMicrometers).ShouldBe(originalRadii);
+        translatedBends.Select(b => b.SweepAngleDegrees).ShouldBe(originalSweeps);
+        for (int i = 0; i < originalBends.Count; i++)
+        {
+            translatedBends[i].Center.X.ShouldBe(originalBends[i].Center.X + JointMoveDeltaX, CoordinateTolerance);
+            translatedBends[i].Center.Y.ShouldBe(originalBends[i].Center.Y, CoordinateTolerance);
+        }
+    }
+
+    [Fact]
+    public void TryTranslateToPins_OnlyOneComponentMoved_ReturnsFalseAndKeepsPath()
+    {
+        var (conn, _, endComponent) = CreateRoutedConnection();
+        var originalPath = conn.RoutedPath;
+
+        endComponent.PhysicalX += JointMoveDeltaX;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse();
+        conn.RoutedPath.ShouldBeSameAs(originalPath, "an unequal-delta move must not touch the path");
+    }
+
+    [Fact]
+    public void TryTranslateToPins_NothingMoved_ReturnsFalse()
+    {
+        var (conn, _, _) = CreateRoutedConnection();
+        var originalPath = conn.RoutedPath;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse();
+        conn.RoutedPath.ShouldBeSameAs(originalPath);
+    }
+
+    [Fact]
+    public void TryTranslateToPins_EqualDeltasButPinDirectionChanged_ReturnsFalse()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection();
+
+        // Simulate a rotation that coincidentally moves both pins by the same delta:
+        // the pins' angles flip while the absolute positions shift uniformly.
+        startComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalX += JointMoveDeltaX;
+        conn.StartPin.AngleDegrees += 90;
+        conn.EndPin.AngleDegrees += 90;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse(
+            "a direction change is a rotation, not a translation");
+    }
+
+    [Fact]
+    public void TryTranslateToPins_BlockedFallbackPath_ReturnsFalse()
+    {
+        var (conn, startComponent, endComponent) = CreateRoutedConnection();
+        conn.RoutedPath!.IsBlockedFallback = true;
+
+        startComponent.PhysicalX += JointMoveDeltaX;
+        endComponent.PhysicalX += JointMoveDeltaX;
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse(
+            "emergency geometry must be re-routed, never carried along");
+    }
+
+    [Fact]
+    public void TryTranslateToPins_NoPath_ReturnsFalse()
+    {
+        var conn = new WaveguideConnection();
+
+        JointMoveRouteTranslator.TryTranslateToPins(conn).ShouldBeFalse();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static List<(double X, double Y)> SegmentPointsOf(WaveguideConnection conn) =>
+        conn.RoutedPath!.Segments
+            .SelectMany(s => new[] { s.StartPoint, s.EndPoint })
+            .ToList();
+
+    private static (WaveguideConnection Connection, Component StartComponent, Component EndComponent)
+        CreateRoutedConnection(double offsetEndY = 0)
+    {
+        var startComponent = CreateTestComponent(0, 0);
+        var endComponent = CreateTestComponent(400, offsetEndY);
+
+        var conn = new WaveguideConnection
+        {
+            StartPin = new PhysicalPin
+            {
+                Name = "output",
+                OffsetXMicrometers = 50,
+                OffsetYMicrometers = 25,
+                AngleDegrees = 0,
+                ParentComponent = startComponent,
+            },
+            EndPin = new PhysicalPin
+            {
+                Name = "input",
+                OffsetXMicrometers = 0,
+                OffsetYMicrometers = 25,
+                AngleDegrees = 180,
+                ParentComponent = endComponent,
+            },
+        };
+
+        conn.RecalculateTransmission(new WaveguideRouter());
+        conn.RoutedPath.ShouldNotBeNull();
+        return (conn, startComponent, endComponent);
+    }
+
+    private static Component CreateTestComponent(double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+
+        return new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: "test",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: $"TestComponent_{x}_{y}",
+            rotationCounterClock: DiscreteRotation.R0)
+        {
+            WidthMicrometers = 50,
+            HeightMicrometers = 50,
+            PhysicalX = x,
+            PhysicalY = y,
+        };
+    }
+}

--- a/UnitTests/UI/Flows/UiFlowMultiSelectDragTests.cs
+++ b/UnitTests/UI/Flows/UiFlowMultiSelectDragTests.cs
@@ -3,6 +3,8 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using CAP.Avalonia.Controls;
 using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
 using Shouldly;
 using Xunit;
 
@@ -77,5 +79,69 @@ public class UiFlowMultiSelectDragTests
             deltas[i].Dx.ShouldBe(deltas[0].Dx, 0.01, $"component {i} must move with the group");
             deltas[i].Dy.ShouldBe(deltas[0].Dy, 0.01, $"component {i} must move with the group");
         }
+    }
+
+    /// <summary>
+    /// Issue #805, through the real input pipeline: dragging BOTH connected components
+    /// together must keep the waveguide glued to the pins and preserve the connection's bend
+    /// radius. Before the fix the route stayed pinned to its old grid spot during the drag and
+    /// was re-routed from scratch on drop, discarding the manual radius.
+    /// </summary>
+    [AvaloniaFact]
+    public void DraggingBothConnectedComponents_KeepsWaveguideOnPinsAndBendRadius()
+    {
+        using var host = new UiFlowTestHost();
+        var vm = host.Vm;
+        var win = host.Window;
+
+        var template = vm.LeftPanel.AllTemplates.Single(t => t.PdkSource == PdkName && t.Name == ComponentName);
+        var library = host.LibraryListBox;
+        library.ScrollIntoView(template);
+        UiInput.RunJobs();
+        var libRow = (Avalonia.Controls.ListBoxItem)library.ContainerFromItem(template)!;
+        UiInput.Click(win, libRow, relX: 0.35);
+
+        var canvasControl = UiInput.Descendants<DesignCanvas>(win).First();
+        Point CanvasPoint(double x, double y) =>
+            canvasControl.TranslatePoint(
+                new Point(x * canvasControl.Zoom + vm.Canvas.PanX, y * canvasControl.Zoom + vm.Canvas.PanY), win)!.Value;
+
+        UiInput.ClickAt(win, CanvasPoint(150, 150));
+        UiInput.ClickAt(win, CanvasPoint(600, 150));
+        vm.Canvas.Components.Count.ShouldBe(2);
+
+        // Connect a right-facing pin of the left component to a left-facing pin of the right
+        // one, with a straight cached route so the geometry is deterministic, then give the
+        // connection a distinctive bend radius the way a user would.
+        var left = vm.Canvas.Components[0].Component;
+        var right = vm.Canvas.Components[1].Component;
+        var startPin = left.PhysicalPins.OrderByDescending(p => p.GetAbsolutePosition().Item1).First();
+        var endPin = right.PhysicalPins.OrderBy(p => p.GetAbsolutePosition().Item1).First();
+        var (sx, sy) = startPin.GetAbsolutePosition();
+        var (ex, ey) = endPin.GetAbsolutePosition();
+        var route = new RoutedPath();
+        route.Segments.Add(new StraightSegment(sx, sy, ex, ey, 0));
+        var connVm = vm.Canvas.ConnectPinsWithCachedRoute(startPin, endPin, route);
+        connVm.ShouldNotBeNull();
+        connVm.Connection.Type = WaveguideType.Bend;
+        connVm.Connection.BendRadiusMicrometers = 35.0;
+
+        UiInput.PressKey(win, Key.S);
+        UiInput.DragMouse(win, CanvasPoint(40, 40), CanvasPoint(720, 260));
+        vm.Canvas.Selection.SelectedComponents.Count.ShouldBe(2, "box select must grab both components");
+
+        UiInput.DragMouse(win, CanvasPoint(150, 150), CanvasPoint(210, 190));
+        UiInput.RunJobs();
+
+        // The waveguide's endpoints must still sit on the (moved) pins — the route followed the
+        // joint move instead of being left behind — and the manual radius must survive.
+        var path = connVm.Connection.RoutedPath!;
+        var (newSx, newSy) = startPin.GetAbsolutePosition();
+        var (newEx, newEy) = endPin.GetAbsolutePosition();
+        path.Segments[0].StartPoint.X.ShouldBe(newSx, 1.0, "waveguide start must stay on the moved start pin");
+        path.Segments[0].StartPoint.Y.ShouldBe(newSy, 1.0);
+        path.Segments[^1].EndPoint.X.ShouldBe(newEx, 1.0, "waveguide end must stay on the moved end pin");
+        path.Segments[^1].EndPoint.Y.ShouldBe(newEy, 1.0);
+        connVm.Connection.BendRadiusMicrometers.ShouldBe(35.0, "the manual bend radius must survive the joint move");
     }
 }

--- a/UnitTests/UI/Flows/UiFlowMultiSelectDragTests.cs
+++ b/UnitTests/UI/Flows/UiFlowMultiSelectDragTests.cs
@@ -82,10 +82,10 @@ public class UiFlowMultiSelectDragTests
     }
 
     /// <summary>
-    /// Issue #805, through the real input pipeline: dragging BOTH connected components
-    /// together must keep the waveguide glued to the pins and preserve the connection's bend
-    /// radius. Before the fix the route stayed pinned to its old grid spot during the drag and
-    /// was re-routed from scratch on drop, discarding the manual radius.
+    /// Through the real input pipeline: dragging BOTH connected components together must keep
+    /// the waveguide glued to the pins and preserve the connection's bend radius. Before the
+    /// fix the route stayed pinned to its old grid spot during the drag and was re-routed from
+    /// scratch on drop, discarding the manual radius.
     /// </summary>
     [AvaloniaFact]
     public void DraggingBothConnectedComponents_KeepsWaveguideOnPinsAndBendRadius()

--- a/UnitTests/ViewModels/Canvas/LiveDragRouteTranslationTests.cs
+++ b/UnitTests/ViewModels/Canvas/LiveDragRouteTranslationTests.cs
@@ -1,0 +1,108 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels.Canvas;
+
+/// <summary>
+/// Tests for issue #805 (live-drag half): while BOTH connected components are dragged
+/// together, the waveguide between them must follow the pointer instead of staying pinned
+/// to its old grid position until drop. A joint drag is a pure translation, so the route is
+/// shifted by the same per-frame delta — the same behaviour a Ctrl+G group already has.
+/// Connections that only have ONE endpoint in the selection are left for the drop-time
+/// re-route (their geometry genuinely changes).
+/// </summary>
+public class LiveDragRouteTranslationTests
+{
+    private const double DeltaX = 40.0;
+    private const double DeltaY = -25.0;
+    private const double Tolerance = 1e-9;
+
+    [Fact]
+    public void TranslateInternalConnectionRoutes_BothEndpointsSelected_ShiftsRouteByDelta()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins(100, 100);
+        var comp2 = CreateComponentWithPins(300, 100);
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        var connVm = canvas.ConnectPinsWithCachedRoute(
+            comp1.PhysicalPins[1], comp2.PhysicalPins[0], StraightRoute(150, 125, 300, 125));
+        connVm.ShouldNotBeNull();
+        var originalStart = connVm.Connection.RoutedPath!.Segments[0].StartPoint;
+        var originalEnd = connVm.Connection.RoutedPath!.Segments[0].EndPoint;
+
+        canvas.TranslateInternalConnectionRoutes(new[] { vm1, vm2 }, DeltaX, DeltaY);
+
+        var seg = connVm.Connection.RoutedPath!.Segments[0];
+        seg.StartPoint.X.ShouldBe(originalStart.X + DeltaX, Tolerance);
+        seg.StartPoint.Y.ShouldBe(originalStart.Y + DeltaY, Tolerance);
+        seg.EndPoint.X.ShouldBe(originalEnd.X + DeltaX, Tolerance);
+        seg.EndPoint.Y.ShouldBe(originalEnd.Y + DeltaY, Tolerance);
+    }
+
+    [Fact]
+    public void TranslateInternalConnectionRoutes_OnlyOneEndpointSelected_LeavesRouteUntouched()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var comp1 = CreateComponentWithPins(100, 100);
+        var comp2 = CreateComponentWithPins(300, 100);
+        var vm1 = canvas.AddComponent(comp1);
+        var vm2 = canvas.AddComponent(comp2);
+
+        var connVm = canvas.ConnectPinsWithCachedRoute(
+            comp1.PhysicalPins[1], comp2.PhysicalPins[0], StraightRoute(150, 125, 300, 125));
+        connVm.ShouldNotBeNull();
+        var originalPath = connVm.Connection.RoutedPath;
+
+        canvas.TranslateInternalConnectionRoutes(new[] { vm2 }, DeltaX, DeltaY);
+
+        connVm.Connection.RoutedPath.ShouldBeSameAs(originalPath,
+            "a connection with only one moved endpoint must re-route on drop, not translate");
+    }
+
+    private static RoutedPath StraightRoute(double x1, double y1, double x2, double y2)
+    {
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, 0));
+        return path;
+    }
+
+    private static Component CreateComponentWithPins(double x, double y)
+    {
+        const double width = 100, height = 50;
+        var physicalPins = new List<PhysicalPin>
+        {
+            new() { Name = "west0", OffsetXMicrometers = 0, OffsetYMicrometers = height / 2 },
+            new() { Name = "east0", OffsetXMicrometers = width, OffsetYMicrometers = height / 2 },
+        };
+
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>
+        {
+            new("west0", 0, MatterType.Light, RectSide.Left),
+            new("east0", 1, MatterType.Light, RectSide.Right),
+        });
+
+        return new Component(
+            new Dictionary<int, CAP_Core.LightCalculation.SMatrix>(),
+            new List<Slider>(),
+            "test_component",
+            "",
+            parts,
+            0,
+            "TestComp",
+            DiscreteRotation.R0,
+            physicalPins)
+        {
+            WidthMicrometers = width,
+            HeightMicrometers = height,
+            PhysicalX = x,
+            PhysicalY = y,
+        };
+    }
+}

--- a/UnitTests/ViewModels/Canvas/LiveDragRouteTranslationTests.cs
+++ b/UnitTests/ViewModels/Canvas/LiveDragRouteTranslationTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace UnitTests.ViewModels.Canvas;
 
 /// <summary>
-/// Tests for issue #805 (live-drag half): while BOTH connected components are dragged
+/// Live-drag half of the joint-move fix: while BOTH connected components are dragged
 /// together, the waveguide between them must follow the pointer instead of staying pinned
 /// to its old grid position until drop. A joint drag is a pure translation, so the route is
 /// shifted by the same per-frame delta — the same behaviour a Ctrl+G group already has.


### PR DESCRIPTION
Closes #805. **Supersedes #806** (its joint-move fix is merged into this branch and extended).

Field report: a connection in **Auto** with a manually set **35 µm** radius loses that radius when you (a) select both connected components and drag them, (b) copy-paste the pair, or (c) even during the drag the waveguide "sticks to the grid" and only reappears (re-routed, radius gone) on drop. The Ctrl+G-group workaround preserved it — because a group translates its geometry as a rigid body while loose selections re-routed from scratch.

Root cause is one theme in three code paths: **a pure translation of both endpoints was treated as an endpoint change and re-routed**, discarding hand-tuned geometry. The fix gives all three paths the group's translate-don't-reroute behaviour, built on one shared primitive: `RoutedPath.TranslatedCopy(dx, dy)`.

## What changed

**#1 — Joint move (from #806, absorbed)**
`JointMoveRouteTranslator.TryTranslateToPins` shifts the existing route to the moved pins inside the incremental router when both pins moved by the same delta (guarded against rotation/resize/single-move); collision with a third component still falls back to a re-route.

**#2 — Copy-paste** (`ComponentClipboard`)
The clipboard captured only the pin identity of an internal connection, so paste rebuilt it with defaults (Auto, 10 µm). It now snapshots the connection at **copy time** — `Type`, `BendRadiusMicrometers`, width, loss params, manual bend/segment edits and a `DeepCopy` of the route — and lays that route onto the pasted pins via `TranslatedCopy(offset)`. Snapshot (not a live reference) so editing/re-routing the source between Copy and Paste can't leak into the paste.

**#3 — Live multi-select drag** (`ComponentPlacementService` + `ComponentDragGestureRecognizer`)
While both components were dragged, only `NotifyPathChanged` ran, so the waveguide stayed at its old position until drop. `TranslateInternalConnectionRoutes` now shifts every route internal to the selection by the per-frame delta so it follows the pointer. Locked members are excluded; drop and undo/redo still finalize through the #806 translator.

## Testing
- Paste-settings + copy-time-snapshot preservation unit tests (`CopyPasteWorkflowTests`)
- Live-drag translate unit tests, incl. the negative single-endpoint case (`LiveDragRouteTranslationTests`)
- End-to-end UI flow test driving the **real pointer pipeline**: dragging both connected components keeps the waveguide on the pins and the bend radius (`UiFlowMultiSelectDragTests`, `Category=Slow`)
- #806's translator/integration tests (11) carried along
- Full **non-Slow** suite green: 4409 passed / 0 failed / 6 skipped

## Notes
- Persona fit: this is core GDS-layout-editing fidelity — Peter (Figma-precision) and Priya expect manual geometry to survive a move/copy.
- Cross-platform: no launching/paths/formatting/build/packaging touched; pure in-memory geometry + gesture logic, identical on all three OSes.
- **`CAP.Browser.csproj`** carries one line inherited from #806 (`<Using Remove="Microsoft.Extensions.Configuration" />`): the BlazorWebAssembly SDK injects that implicit using but no referenced package provides the assembly, so the WASM project fails to build without it. Kept because this branch supersedes #806; not part of the geometry change.
- An independent code review of the first push flagged the clipboard live-reference staleness (now fixed via the copy-time snapshot) and this csproj note; no correctness issues remained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCVwvkXdUH9DSW8w12XB2q
