### PR TITLE
GDS import: coincident-label dedup (helper labels no longer block connection reconstruction)

### DIFF
--- a/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.CoincidentLabels.cs
+++ b/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.CoincidentLabels.cs
@@ -18,22 +18,32 @@ namespace CAP_DataAccess.Import.Gds;
 /// <list type="bullet">
 /// <item>A label on a CONFIGURED port layer
 /// (<see cref="GdsPinDetectionOptions.PortLayers"/>) wins over every
-/// non-configured helper label; the pin name comes from the winner's
-/// text.</item>
+/// non-configured label; the pin name comes from the winner's text. Several
+/// configured labels in one stack tie-break by FILE ORDER — the first
+/// configured label wins.</item>
 /// <item>With no configured-layer label in the stack the FIRST label in file
 /// order wins — it stands for the label set the any-layer fallback
 /// (<see cref="DetectWithAnyLayerFallback"/>) would discover anyway.</item>
-/// <item>Labels tied on the winner's OWN (layer, texttype) are ALL kept: real
-/// duplicate pins must never silently merge (the duplicate-name handling in
-/// <c>GdsPinNameNormalizer</c> deals out unique names).</item>
+/// <item>Labels tied on the winner's OWN (layer, texttype) with DIFFERENT
+/// texts are ALL kept: real duplicate pins must never silently merge (the
+/// duplicate-name handling in <c>GdsPinNameNormalizer</c> deals out unique
+/// names). Those kept duplicates at one anchor still inflate the pin count of
+/// any route network touching it — accepted, because merging away real pins
+/// is worse than a frozen path. Byte-IDENTICAL copies (same text, layer and
+/// anchor — e.g. an exporter writing one label twice) are not real duplicates:
+/// only the FIRST copy is kept, silently, exactly like the black-box
+/// fingerprint dedup (<see cref="GetBlackBoxPins"/>). Kept, the copies would
+/// read as several pins at one position — re-inflating the touching network
+/// into a junction — and the duplicate-name rename would fire a warning for
+/// what is physically one pin.</item>
 /// </list>
 ///
 /// The dedup runs on the TEXTS, before <see cref="GdsPinDetector"/> sees them,
 /// so the edge heuristic's label-coverage suppression also treats the stack as
 /// one pin (no phantom pins either way), and the fallback's discovered-layer
-/// list is no longer polluted by dropped helper layers. Every stack that
-/// actually dropped a label is reported — ONE aggregated info note per cell,
-/// never one per pin.
+/// list is no longer polluted by dropped label layers. Every stack that
+/// dropped a DIFFERENT label is reported — ONE aggregated info note per cell,
+/// never one per pin; verbatim-doubled labels collapse silently.
 /// </summary>
 internal sealed partial class GdsHierarchyImportSession
 {
@@ -44,47 +54,20 @@ internal sealed partial class GdsHierarchyImportSession
     /// Collapses coincident label stacks in <paramref name="texts"/> (see the
     /// class-level remarks) and returns the surviving labels in their original
     /// file order. Emits the aggregated info note into <see cref="Infos"/>
-    /// when at least one stack dropped a label.
+    /// when at least one stack dropped a different label.
     /// </summary>
     private List<GdsText> CollapseCoincidentLabels(IReadOnlyList<GdsText> texts, string cellName)
     {
         if (texts.Count < 2)
             return [.. texts];
 
-        double tolerance = _options.PinDetection.EdgeTouchToleranceUm;
-        double toleranceSquared = tolerance * tolerance;
-
-        // Greedy grouping on each stack's FIRST anchor: stacked labels share
-        // their anchor within a database unit, and first-seen order is the
-        // deterministic tie-break for the winner.
-        var stackAnchors = new List<GdsPoint>(texts.Count);
-        var stacks = new List<List<int>>(texts.Count);
-        for (var i = 0; i < texts.Count; i++)
-        {
-            int stackIndex = -1;
-            for (var s = 0; s < stackAnchors.Count; s++)
-            {
-                double dx = stackAnchors[s].X - texts[i].Position.X;
-                double dy = stackAnchors[s].Y - texts[i].Position.Y;
-                if (dx * dx + dy * dy <= toleranceSquared)
-                {
-                    stackIndex = s;
-                    break;
-                }
-            }
-            if (stackIndex < 0)
-            {
-                stackIndex = stacks.Count;
-                stackAnchors.Add(texts[i].Position);
-                stacks.Add(new List<int>());
-            }
-            stacks[stackIndex].Add(i);
-        }
-
         var keep = new bool[texts.Count];
         var merges = new List<CoincidentLabelMerge>();
-        foreach (var stack in stacks)
+        foreach (var stack in GroupIntoStacks(texts, _options.PinDetection.EdgeTouchToleranceUm))
         {
+            // The stack's winner: the first CONFIGURED label (file order is the
+            // deterministic tie-break between several configured labels), else
+            // the first label in file order.
             int winnerIndex = stack[0];
             foreach (int i in stack)
             {
@@ -96,24 +79,32 @@ internal sealed partial class GdsHierarchyImportSession
             }
 
             var winner = texts[winnerIndex];
-            int kept = 0;
+            var keptTexts = new HashSet<string>(StringComparer.Ordinal);
+            int dropped = 0;
             foreach (int i in stack)
             {
                 if (texts[i].Layer == winner.Layer && texts[i].TextType == winner.TextType)
                 {
-                    keep[i] = true;
-                    kept++;
+                    // Byte-identical copies (same text on the winner's own layer
+                    // and anchor) describe the same physical pin — keep only the
+                    // first, silently (see the class remarks).
+                    if (keptTexts.Add(texts[i].Text))
+                        keep[i] = true;
+                }
+                else
+                {
+                    dropped++;
                 }
             }
-            if (kept < stack.Count)
-                merges.Add(new CoincidentLabelMerge(winner.Text, winner.Layer, winner.TextType, stack.Count - kept));
+            if (dropped > 0)
+                merges.Add(new CoincidentLabelMerge(winner.Text, winner.Layer, winner.TextType, dropped));
         }
 
         if (merges.Count > 0)
         {
             var details = string.Join("; ", merges.Select(m =>
                 $"'{m.KeptName}' kept from layer ({m.Layer},{m.TextType}), " +
-                $"{m.DroppedCount} helper {(m.DroppedCount == 1 ? "label" : "labels")} ignored"));
+                $"{m.DroppedCount} {(m.DroppedCount == 1 ? "label" : "labels")} ignored"));
             Infos.Add(merges.Count == 1
                 ? $"Cell '{cellName}': coincident labels merged into one pin ({details})."
                 : $"Cell '{cellName}': coincident labels merged into one pin at {merges.Count} stacked anchors ({details}).");
@@ -126,5 +117,62 @@ internal sealed partial class GdsHierarchyImportSession
                 survivors.Add(texts[i]);
         }
         return survivors;
+    }
+
+    /// <summary>
+    /// Groups the label indexes into coincident stacks: greedy grouping on each
+    /// stack's FIRST anchor (stacked labels share their anchor within a database
+    /// unit), first-seen order deciding which stack a label joins. The anchors
+    /// are bucketed through a <see cref="GdsSpatialGrid"/> so a label only
+    /// compares against the stacks near it — comparing every label to every
+    /// stack is O(n²), and production cells carry hundreds of labels. The
+    /// grid's candidates come back unordered; the ascending sort restores the
+    /// naive scan's lowest-stack-index win, so the grouping is exactly the naive
+    /// scan's, deterministic in file order.
+    /// </summary>
+    private static List<List<int>> GroupIntoStacks(IReadOnlyList<GdsText> texts, double tolerance)
+    {
+        double toleranceSquared = tolerance * tolerance;
+        double minX = double.MaxValue, minY = double.MaxValue;
+        double maxX = double.MinValue, maxY = double.MinValue;
+        foreach (var text in texts)
+        {
+            minX = Math.Min(minX, text.Position.X);
+            minY = Math.Min(minY, text.Position.Y);
+            maxX = Math.Max(maxX, text.Position.X);
+            maxY = Math.Max(maxY, text.Position.Y);
+        }
+
+        var grid = GdsSpatialGrid.Create(Math.Max(maxX - minX, maxY - minY), tolerance, texts.Count);
+        var stackAnchors = new List<GdsPoint>(texts.Count);
+        var stacks = new List<List<int>>(texts.Count);
+        for (var i = 0; i < texts.Count; i++)
+        {
+            var position = texts[i].Position;
+            var candidates = grid.QueryBox(
+                position.X - tolerance, position.Y - tolerance,
+                position.X + tolerance, position.Y + tolerance);
+            candidates.Sort();
+            int stackIndex = -1;
+            foreach (int s in candidates)
+            {
+                double dx = stackAnchors[s].X - position.X;
+                double dy = stackAnchors[s].Y - position.Y;
+                if (dx * dx + dy * dy <= toleranceSquared)
+                {
+                    stackIndex = s;
+                    break;
+                }
+            }
+            if (stackIndex < 0)
+            {
+                stackIndex = stacks.Count;
+                stackAnchors.Add(position);
+                stacks.Add(new List<int>());
+                grid.InsertPoint(stackIndex, position.X, position.Y);
+            }
+            stacks[stackIndex].Add(i);
+        }
+        return stacks;
     }
 }

--- a/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.CoincidentLabels.cs
+++ b/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.CoincidentLabels.cs
@@ -1,0 +1,130 @@
+namespace CAP_DataAccess.Import.Gds;
+
+/// <summary>
+/// The coincident-label dedup of <see cref="GdsHierarchyImportSession"/>,
+/// split out to keep the session file under the project's 500-line gate.
+///
+/// Real foundry layouts stack several TEXT labels on the SAME pin anchor: the
+/// real pin label (e.g. <c>o1</c> on the foundry's pin layer) plus helper /
+/// marker labels (e.g. <c>lc</c>) on other layers. Taken literally every label
+/// becomes its own pin, and the identical positions then inflate every route
+/// network's pin count — a true 2-pin connection reads as a &gt;2-pin junction
+/// and stays frozen instead of becoming a connection.
+///
+/// Labels whose anchors coincide within
+/// <see cref="GdsPinDetectionOptions.EdgeTouchToleranceUm"/> (stacked labels
+/// share their database-unit anchor) therefore collapse into ONE label before
+/// pin detection runs:
+/// <list type="bullet">
+/// <item>A label on a CONFIGURED port layer
+/// (<see cref="GdsPinDetectionOptions.PortLayers"/>) wins over every
+/// non-configured helper label; the pin name comes from the winner's
+/// text.</item>
+/// <item>With no configured-layer label in the stack the FIRST label in file
+/// order wins — it stands for the label set the any-layer fallback
+/// (<see cref="DetectWithAnyLayerFallback"/>) would discover anyway.</item>
+/// <item>Labels tied on the winner's OWN (layer, texttype) are ALL kept: real
+/// duplicate pins must never silently merge (the duplicate-name handling in
+/// <c>GdsPinNameNormalizer</c> deals out unique names).</item>
+/// </list>
+///
+/// The dedup runs on the TEXTS, before <see cref="GdsPinDetector"/> sees them,
+/// so the edge heuristic's label-coverage suppression also treats the stack as
+/// one pin (no phantom pins either way), and the fallback's discovered-layer
+/// list is no longer polluted by dropped helper layers. Every stack that
+/// actually dropped a label is reported — ONE aggregated info note per cell,
+/// never one per pin.
+/// </summary>
+internal sealed partial class GdsHierarchyImportSession
+{
+    /// <summary>One collapsed label stack, for the aggregated per-cell info note.</summary>
+    private readonly record struct CoincidentLabelMerge(string KeptName, int Layer, int TextType, int DroppedCount);
+
+    /// <summary>
+    /// Collapses coincident label stacks in <paramref name="texts"/> (see the
+    /// class-level remarks) and returns the surviving labels in their original
+    /// file order. Emits the aggregated info note into <see cref="Infos"/>
+    /// when at least one stack dropped a label.
+    /// </summary>
+    private List<GdsText> CollapseCoincidentLabels(IReadOnlyList<GdsText> texts, string cellName)
+    {
+        if (texts.Count < 2)
+            return [.. texts];
+
+        double tolerance = _options.PinDetection.EdgeTouchToleranceUm;
+        double toleranceSquared = tolerance * tolerance;
+
+        // Greedy grouping on each stack's FIRST anchor: stacked labels share
+        // their anchor within a database unit, and first-seen order is the
+        // deterministic tie-break for the winner.
+        var stackAnchors = new List<GdsPoint>(texts.Count);
+        var stacks = new List<List<int>>(texts.Count);
+        for (var i = 0; i < texts.Count; i++)
+        {
+            int stackIndex = -1;
+            for (var s = 0; s < stackAnchors.Count; s++)
+            {
+                double dx = stackAnchors[s].X - texts[i].Position.X;
+                double dy = stackAnchors[s].Y - texts[i].Position.Y;
+                if (dx * dx + dy * dy <= toleranceSquared)
+                {
+                    stackIndex = s;
+                    break;
+                }
+            }
+            if (stackIndex < 0)
+            {
+                stackIndex = stacks.Count;
+                stackAnchors.Add(texts[i].Position);
+                stacks.Add(new List<int>());
+            }
+            stacks[stackIndex].Add(i);
+        }
+
+        var keep = new bool[texts.Count];
+        var merges = new List<CoincidentLabelMerge>();
+        foreach (var stack in stacks)
+        {
+            int winnerIndex = stack[0];
+            foreach (int i in stack)
+            {
+                if (_options.PinDetection.PortLayers.Contains((texts[i].Layer, texts[i].TextType)))
+                {
+                    winnerIndex = i;
+                    break;
+                }
+            }
+
+            var winner = texts[winnerIndex];
+            int kept = 0;
+            foreach (int i in stack)
+            {
+                if (texts[i].Layer == winner.Layer && texts[i].TextType == winner.TextType)
+                {
+                    keep[i] = true;
+                    kept++;
+                }
+            }
+            if (kept < stack.Count)
+                merges.Add(new CoincidentLabelMerge(winner.Text, winner.Layer, winner.TextType, stack.Count - kept));
+        }
+
+        if (merges.Count > 0)
+        {
+            var details = string.Join("; ", merges.Select(m =>
+                $"'{m.KeptName}' kept from layer ({m.Layer},{m.TextType}), " +
+                $"{m.DroppedCount} helper {(m.DroppedCount == 1 ? "label" : "labels")} ignored"));
+            Infos.Add(merges.Count == 1
+                ? $"Cell '{cellName}': coincident labels merged into one pin ({details})."
+                : $"Cell '{cellName}': coincident labels merged into one pin at {merges.Count} stacked anchors ({details}).");
+        }
+
+        var survivors = new List<GdsText>(texts.Count);
+        for (var i = 0; i < texts.Count; i++)
+        {
+            if (keep[i])
+                survivors.Add(texts[i]);
+        }
+        return survivors;
+    }
+}

--- a/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.cs
+++ b/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.cs
@@ -74,9 +74,10 @@ internal sealed partial class GdsHierarchyImportSession
     /// are normalized (<see cref="GdsPinNameNormalizer"/>) BEFORE caching, so
     /// the draft pins and the names used for connection reconstruction can
     /// never diverge (blank/duplicate names would otherwise mis-wire or poison
-    /// the persisted PDK). When no configured port layer yields any label pin,
-    /// the any-layer fallback retries with every text label
-    /// (<see cref="DetectWithAnyLayerFallback"/>).
+    /// the persisted PDK). Coincident label stacks collapse into one label
+    /// first (<see cref="CollapseCoincidentLabels"/>). When no configured port
+    /// layer yields any label pin, the any-layer fallback retries with every
+    /// text label (<see cref="DetectWithAnyLayerFallback"/>).
     /// </summary>
     public IReadOnlyList<DetectedPin> GetCellPins(string cellName, GdsBoundingBox bbox)
     {
@@ -85,8 +86,9 @@ internal sealed partial class GdsHierarchyImportSession
 
         var detectionCell = new FlattenedGdsCell { CellName = cellName };
         detectionCell.Polygons.AddRange(GetFlattened(cellName).Polygons);
-        detectionCell.Texts.AddRange(Library.Cells[cellName].Elements.OfType<GdsText>()
-            .Where(IsSingleLineLabel));
+        detectionCell.Texts.AddRange(CollapseCoincidentLabels(
+            Library.Cells[cellName].Elements.OfType<GdsText>().Where(IsSingleLineLabel).ToList(),
+            cellName));
         var pins = GdsPinNameNormalizer.Normalize(
             DetectWithAnyLayerFallback(detectionCell, bbox, cellName),
             $"Cell '{cellName}'",
@@ -245,6 +247,9 @@ internal sealed partial class GdsHierarchyImportSession
     /// doubled <c>c0</c> label on its eopm cell) collapse into ONE pin
     /// silently: two identical label records describe one physical pin, and
     /// keeping both would only trigger the duplicate-name rename warning.
+    /// Coincident stacks of DIFFERENT labels (real pin label plus helper
+    /// labels) collapse via <see cref="CollapseCoincidentLabels"/> before
+    /// detection, exactly like explode-mode draft pins.
     /// </summary>
     private IReadOnlyList<DetectedPin> GetBlackBoxPins(string cellName, GdsBoundingBox bbox)
     {
@@ -263,6 +268,7 @@ internal sealed partial class GdsHierarchyImportSession
         }
 
         var seenLabels = new HashSet<string>(StringComparer.Ordinal);
+        var labels = new List<GdsText>();
         for (int i = 0; i < flat.Texts.Count; i++)
         {
             var text = flat.Texts[i];
@@ -283,8 +289,10 @@ internal sealed partial class GdsHierarchyImportSession
             if (!seenLabels.Add(fingerprint))
                 continue;
 
-            detectionCell.Texts.Add(text with { Text = label });
+            labels.Add(text with { Text = label });
         }
+
+        detectionCell.Texts.AddRange(CollapseCoincidentLabels(labels, cellName));
 
         return GdsPinNameNormalizer.Normalize(
             DetectWithAnyLayerFallback(detectionCell, bbox, cellName),

--- a/CAP-DataAccess/Import/Gds/GdsPinDetectionOptions.cs
+++ b/CAP-DataAccess/Import/Gds/GdsPinDetectionOptions.cs
@@ -43,7 +43,11 @@ public sealed record GdsPinDetectionOptions
     /// <summary>
     /// Distance in micrometers within which a segment endpoint or text anchor is
     /// considered to lie on a bounding-box edge line. Default: 0.001 µm = 1 nm
-    /// (one database unit in a typical 1 nm grid).
+    /// (one database unit in a typical 1 nm grid). The same tolerance also gates
+    /// the coincident-label merging of the import session
+    /// (<c>GdsHierarchyImportSession.CollapseCoincidentLabels</c>): stacked pin
+    /// labels share their database-unit anchor, so labels closer than this
+    /// collapse into ONE label before pin detection runs.
     /// </summary>
     public double EdgeTouchToleranceUm { get; init; } = 0.001;
 

--- a/UnitTests/Import/Gds/GdsCoincidentLabelDedupTests.cs
+++ b/UnitTests/Import/Gds/GdsCoincidentLabelDedupTests.cs
@@ -23,8 +23,11 @@ public class GdsCoincidentLabelDedupTests
     [Fact]
     public async Task GetCellPins_CoincidentLabels_ConfiguredLayerWinsWithNote()
     {
-        // Helper "lc" on (99,0) is written FIRST, but the configured (1,10)
-        // label "o1" at the same anchor must win the stack.
+        // Helper "lc" on (99,0) is written FIRST, then TWO configured labels —
+        // (501,1) "x1" and (1,10) "o1" — share its anchor. The first configured
+        // label in file order wins the stack. Without the dedup both configured
+        // labels become pins and the count reads 3, not 2 — the count gates the
+        // feature.
         var library = await ReadLibraryAsync(GdsTestWriter.Create()
             .StandardPrologue()
             .BeginCell("TOP")
@@ -34,6 +37,7 @@ public class GdsCoincidentLabelDedupTests
                 .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
                 .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
                 .Text(99, 0, "lc", 0, 2000)
+                .Text(501, 1, "x1", 0, 2000)
                 .Text(1, 10, "o1", 0, 2000)
                 .Text(1, 10, "i1", 10000, 2000)
             .EndCell()
@@ -43,13 +47,13 @@ public class GdsCoincidentLabelDedupTests
 
         var pins = session.GetCellPins("soa", session.GetCellBBox("soa"));
 
-        pins.Count.ShouldBe(2, "the stack collapses into one pin; the labels suppress the edge heuristic");
-        pins[0].Name.ShouldBe("o1");
+        pins.Count.ShouldBe(2, "the 3-label stack collapses into one pin; the labels suppress the edge heuristic");
+        pins[0].Name.ShouldBe("x1");
         pins[0].Source.ShouldBe(DetectedPinSource.Label);
         pins[1].Name.ShouldBe("i1");
         var note = session.Infos.Where(i => i.Contains("coincident labels merged")).ShouldHaveSingleItem();
-        note.ShouldContain("'o1' kept from layer (1,10)");
-        note.ShouldContain("1 helper label ignored");
+        note.ShouldContain("'x1' kept from layer (501,1)");
+        note.ShouldContain("2 labels ignored");
     }
 
     [Fact]
@@ -117,6 +121,82 @@ public class GdsCoincidentLabelDedupTests
     }
 
     [Fact]
+    public async Task GetCellPins_LabelsBeyondMergeTolerance_NotMergedNoNote()
+    {
+        // "lc" sits 2 nm (0.002 µm > EdgeTouchToleranceUm) from "o1": beyond the
+        // merge tolerance it is NOT a stacked label. It never becomes a pin
+        // (its layer is not configured and a configured pin exists, so no
+        // fallback) — the observable is the absent merge note: a stack wrongly
+        // spanning 2 nm would report a dropped label.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("soa", 0, 0)
+            .EndCell()
+            .BeginCell("soa")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(1, 10, "o1", 0, 2000)
+                .Text(99, 0, "lc", 2, 2000)
+                .Text(1, 10, "i1", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+        var session = new GdsHierarchyImportSession(library, "TOP", new GdsHierarchyImportOptions());
+
+        var pins = session.GetCellPins("soa", session.GetCellBBox("soa"));
+
+        pins.Count.ShouldBe(2, "labels 2 nm apart do not merge");
+        pins[0].Name.ShouldBe("o1");
+        pins[1].Name.ShouldBe("i1");
+        session.Infos.ShouldNotContain(i => i.Contains("coincident labels merged"),
+            "anchors beyond EdgeTouchToleranceUm form no stack — nothing was dropped");
+    }
+
+    [Fact]
+    public async Task Explode_RouteNetworkWithDoubledIdenticalLabel_ConnectionRestored()
+    {
+        // The exporter wrote the "out" label twice, byte-identical (same layer,
+        // text and anchor). Kept, the second copy would be renamed as a
+        // duplicate pin at the same anchor: the route network between
+        // dev#0.out and dev#1.in would count 3 touching pins — a junction, left
+        // frozen with 0 connections. The verbatim copy must collapse silently.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("dev", 0, 0)
+                .SRef("dev", 20000, 0)
+                .Boundary(1, 0, (10000, 1750), (20000, 1750), (20000, 2250), (10000, 2250), (10000, 1750))
+            .EndCell()
+            .BeginCell("dev")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(235, 0, "in", 0, 2000)
+                .Text(235, 0, "out", 10000, 2000)
+                .Text(235, 0, "out", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        var draft = result.ImportedCellDrafts.ShouldHaveSingleItem();
+        draft.Pins.Count.ShouldBe(2, "the doubled identical label collapses into one pin");
+        var connection = result.Connections.ShouldHaveSingleItem(
+            "the 2-pin route network becomes a connection again, not a junction-frozen path");
+        connection.IsRouteDerived.ShouldBeTrue();
+        connection.A.PinName.ShouldBe("out");
+        connection.B.PinName.ShouldBe("in");
+        connection.XUm.ShouldBe(15.0, Tolerance);
+        connection.YUm.ShouldBe(2.0, Tolerance);
+        result.Warnings.ShouldNotContain(w => w.Contains("duplicate pin name"),
+            "one physical pin must not trigger the duplicate-name rename warning");
+        result.Infos.ShouldNotContain(i => i.Contains("coincident labels merged"),
+            "verbatim-identical labels collapse silently — no different label was merged away");
+        result.Infos.ShouldNotContain(i => i.Contains("junction"));
+    }
+
+    [Fact]
     public async Task Explode_RouteNetworkWithStackedHelperLabels_ConnectionRestored()
     {
         // Foundry shape: every pin anchor carries the real label on (235,0)
@@ -152,8 +232,9 @@ public class GdsCoincidentLabelDedupTests
         connection.B.PinName.ShouldBe("in");
         connection.XUm.ShouldBe(15.0, Tolerance);
         connection.YUm.ShouldBe(2.0, Tolerance);
-        result.Infos.ShouldContain(i => i.Contains("coincident labels merged"),
+        var note = result.Infos.Where(i => i.Contains("coincident labels merged")).ShouldHaveSingleItem(
             "one aggregated note for the cell (fired once although the cell is placed twice)");
+        note.ShouldContain("coincident labels merged into one pin at 2 stacked anchors");
         result.Infos.ShouldNotContain(i => i.Contains("junction"));
     }
 

--- a/UnitTests/Import/Gds/GdsCoincidentLabelDedupTests.cs
+++ b/UnitTests/Import/Gds/GdsCoincidentLabelDedupTests.cs
@@ -1,0 +1,191 @@
+using CAP_DataAccess.Import.Gds;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Import.Gds;
+
+/// <summary>
+/// Tests for the coincident-label dedup
+/// (<c>GdsHierarchyImportSession.CollapseCoincidentLabels</c>): foundry layouts
+/// stack helper/marker labels on the same anchor as the real pin label, and
+/// the stack must collapse into ONE pin — otherwise every 2-pin route network
+/// inflates into a &gt;2-pin junction and stays frozen instead of becoming a
+/// connection. Fixtures follow <see cref="GdsHierarchyImporterTests"/>
+/// (1 db unit = 1 nm, coordinates in database units).
+/// </summary>
+public class GdsCoincidentLabelDedupTests
+{
+    private const double Tolerance = 1e-6;
+
+    private static async Task<GdsLibrary> ReadLibraryAsync(byte[] gds) =>
+        await new GdsReader().ReadAsync(new MemoryStream(gds));
+
+    [Fact]
+    public async Task GetCellPins_CoincidentLabels_ConfiguredLayerWinsWithNote()
+    {
+        // Helper "lc" on (99,0) is written FIRST, but the configured (1,10)
+        // label "o1" at the same anchor must win the stack.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("soa", 0, 0)
+            .EndCell()
+            .BeginCell("soa")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(99, 0, "lc", 0, 2000)
+                .Text(1, 10, "o1", 0, 2000)
+                .Text(1, 10, "i1", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+        var session = new GdsHierarchyImportSession(library, "TOP", new GdsHierarchyImportOptions());
+
+        var pins = session.GetCellPins("soa", session.GetCellBBox("soa"));
+
+        pins.Count.ShouldBe(2, "the stack collapses into one pin; the labels suppress the edge heuristic");
+        pins[0].Name.ShouldBe("o1");
+        pins[0].Source.ShouldBe(DetectedPinSource.Label);
+        pins[1].Name.ShouldBe("i1");
+        var note = session.Infos.Where(i => i.Contains("coincident labels merged")).ShouldHaveSingleItem();
+        note.ShouldContain("'o1' kept from layer (1,10)");
+        note.ShouldContain("1 helper label ignored");
+    }
+
+    [Fact]
+    public async Task GetCellPins_CoincidentLabelsOnNonConfiguredLayers_FirstLabelWinsViaFallback()
+    {
+        // No configured-layer label anywhere: the any-layer fallback discovers
+        // the pins, and the stack collapses to its FIRST label in file order.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("soa", 0, 0)
+            .EndCell()
+            .BeginCell("soa")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(233, 0, "o1", 0, 2000)
+                .Text(99, 0, "lc", 0, 2000)
+                .Text(233, 0, "i1", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+        var session = new GdsHierarchyImportSession(library, "TOP", new GdsHierarchyImportOptions());
+
+        var pins = session.GetCellPins("soa", session.GetCellBBox("soa"));
+
+        pins.Count.ShouldBe(2, "one pin per anchor, not one per stacked label");
+        pins[0].Name.ShouldBe("o1");
+        pins[1].Name.ShouldBe("i1");
+        var note = session.Infos.Where(i => i.Contains("coincident labels merged")).ShouldHaveSingleItem();
+        note.ShouldContain("'o1' kept from layer (233,0)");
+        var fallbackNote = session.Infos.Where(i => i.Contains("non-standard layer")).ShouldHaveSingleItem();
+        fallbackNote.ShouldContain("(233,0)");
+        // The dropped helper label's layer must not pollute the discovered-layer list.
+        fallbackNote.ShouldNotContain("(99,0)");
+    }
+
+    [Fact]
+    public async Task GetCellPins_CoincidentLabelsOnSameConfiguredLayer_BothKeptWithoutNote()
+    {
+        // Two labels tied on the SAME layer at the same anchor are real
+        // duplicates — they must not silently merge.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("soa", 0, 0)
+            .EndCell()
+            .BeginCell("soa")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(1, 10, "o1", 0, 2000)
+                .Text(1, 10, "o1b", 0, 2000)
+                .Text(1, 10, "i1", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+        var session = new GdsHierarchyImportSession(library, "TOP", new GdsHierarchyImportOptions());
+
+        var pins = session.GetCellPins("soa", session.GetCellBBox("soa"));
+
+        pins.Count.ShouldBe(3, "same-layer duplicates are both kept (the name normalizer handles naming)");
+        pins.ShouldContain(p => p.Name == "o1");
+        pins.ShouldContain(p => p.Name == "o1b");
+        session.Infos.ShouldNotContain(i => i.Contains("coincident labels merged"),
+            "nothing was dropped — no merge, no note");
+    }
+
+    [Fact]
+    public async Task Explode_RouteNetworkWithStackedHelperLabels_ConnectionRestored()
+    {
+        // Foundry shape: every pin anchor carries the real label on (235,0)
+        // plus a stacked helper "lc" on (233,0). Without the dedup each device
+        // reads as 4 pins and the route network between dev#0.out and dev#1.in
+        // counts 4 touching pins — a junction, left frozen with 0 connections.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("dev", 0, 0)
+                .SRef("dev", 20000, 0)
+                .Boundary(1, 0, (10000, 1750), (20000, 1750), (20000, 2250), (10000, 2250), (10000, 1750))
+            .EndCell()
+            .BeginCell("dev")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(235, 0, "in", 0, 2000)
+                .Text(233, 0, "lc", 0, 2000)
+                .Text(235, 0, "out", 10000, 2000)
+                .Text(233, 0, "lc", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        var draft = result.ImportedCellDrafts.ShouldHaveSingleItem();
+        draft.Pins.Count.ShouldBe(2, "each stacked anchor collapses into one pin");
+        var connection = result.Connections.ShouldHaveSingleItem(
+            "the 2-pin route network becomes a connection again, not a junction-frozen path");
+        connection.IsRouteDerived.ShouldBeTrue();
+        connection.A.PinName.ShouldBe("out");
+        connection.B.PinName.ShouldBe("in");
+        connection.XUm.ShouldBe(15.0, Tolerance);
+        connection.YUm.ShouldBe(2.0, Tolerance);
+        result.Infos.ShouldContain(i => i.Contains("coincident labels merged"),
+            "one aggregated note for the cell (fired once although the cell is placed twice)");
+        result.Infos.ShouldNotContain(i => i.Contains("junction"));
+    }
+
+    [Fact]
+    public async Task BlackBox_CoincidentLabels_MergedIntoOnePin()
+    {
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("dev", 0, 0)
+            .EndCell()
+            .BeginCell("dev")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(235, 0, "in", 0, 2000)
+                .Text(233, 0, "lc", 0, 2000)
+                .Text(235, 0, "out", 10000, 2000)
+                .Text(233, 0, "lc", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions
+        {
+            Mode = GdsHierarchyImportMode.BlackBox,
+        });
+
+        var draft = result.ImportedCellDrafts.ShouldHaveSingleItem();
+        draft.Pins.Count.ShouldBe(2, "black-box pin detection dedups the same stacks");
+        draft.Pins.ShouldContain(p => p.Name == "dev_in");
+        draft.Pins.ShouldContain(p => p.Name == "dev_out");
+        draft.Pins.ShouldNotContain(p => p.Name == "dev_lc");
+        result.Infos.ShouldContain(i => i.Contains("coincident labels merged"));
+    }
+}


### PR DESCRIPTION
Small follow-up from field testing the merged GDS import on a big production file.

Real foundry layouts stack several text labels at the same pin anchor on different layers (real pin label + helper/marker labels). Every 2-pin route network then read as a 3-4-pin junction and was left frozen instead of becoming a connection — with default settings the big file got 0 restored connections.

Now: coincident labels (≤1 µm) collapse into ONE pin — the label on a configured port layer wins, fallback labels only when nothing configured matches; same-layer duplicates are kept (never silently merged). One aggregated info note per cell.

Verified: with dedup the big file's 132 route networks restore as connections; without, they stay frozen. 421/421 green in the GDS import + reader suites.