### PR TITLE
GDS import: ghost-label filter in auto-discovery + editable metal layers (#841, #842)

### DIFF
--- a/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.PinFallback.cs
+++ b/CAP-DataAccess/Import/Gds/GdsHierarchyImportSession.PinFallback.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace CAP_DataAccess.Import.Gds;
 
 /// <summary>
@@ -14,6 +16,41 @@ internal sealed partial class GdsHierarchyImportSession
     private static bool IsSingleLineLabel(GdsText text) => !text.Text.Contains('\n');
 
     /// <summary>
+    /// nazca's bounding-box anchor labels (top-left, bottom-center, …): placement
+    /// anchors every nazca cell carries, never ports. Only the guessing fallback
+    /// filters them — a user who configures a port layer explicitly keeps every
+    /// label on it, unlucky names included.
+    /// </summary>
+    private static readonly HashSet<string> NazcaAnchorNames = new(StringComparer.Ordinal)
+    {
+        "tl", "tc", "tr", "lt", "ct", "rt",
+        "lc", "cc", "rc",
+        "lb", "cb", "rb", "bl", "bc", "br",
+        "cl", "cr",
+    };
+
+    /// <summary>
+    /// Parameter annotations like <c>R:0.0001</c> or <c>n=1.0</c>: a name/value
+    /// pair with a numeric tail is cell metadata, not a port.
+    /// </summary>
+    private static readonly Regex ParameterLabelPattern = new(
+        @"^[A-Za-z_][A-Za-z0-9_]*\s*[:=]\s*[-+]?[0-9][0-9.eE+-]*$", RegexOptions.Compiled);
+
+    /// <summary>True for labels the auto-discovery must never turn into pins.</summary>
+    private static bool IsFallbackGhostLabel(GdsText text)
+    {
+        var name = text.Text.Trim();
+        return NazcaAnchorNames.Contains(name) || ParameterLabelPattern.IsMatch(name);
+    }
+
+    /// <summary>
+    /// True once any cell's pins came from the any-layer fallback — the signal
+    /// that this file does not follow our own export conventions, so layer-number
+    /// defaults (e.g. the metal layers) may not apply either.
+    /// </summary>
+    internal bool LabelFallbackUsed { get; private set; }
+
+    /// <summary>
     /// Runs <see cref="GdsPinDetector"/> with the configured port layers. When
     /// that yields ZERO label pins although the cell carries text labels on
     /// OTHER layers, retries once with every text label treated as a pin label:
@@ -21,9 +58,12 @@ internal sealed partial class GdsHierarchyImportSession
     /// production design places device pins on (56,0)/(59,0)/(233,0)/(235,0)),
     /// so a configured-only pass finds nothing and the whole import would
     /// silently drop the cell. Configured layers always win; the fallback never
-    /// mixes (a single configured label pin skips it). A used fallback emits ONE
-    /// info note per cell listing the layer(s) pins were found on, so the user
-    /// can add them to the port-layer list. Deterministic: layers reported sorted.
+    /// mixes (a single configured label pin skips it). Anchor/parameter helper
+    /// labels (<see cref="IsFallbackGhostLabel"/>) are excluded from the retry —
+    /// they otherwise become ghost pins on every nazca-produced cell. A used
+    /// fallback emits ONE info note per cell listing the layer(s) pins were
+    /// found on, so the user can add them to the port-layer list.
+    /// Deterministic: layers reported sorted.
     /// </summary>
     private IReadOnlyList<DetectedPin> DetectWithAnyLayerFallback(
         FlattenedGdsCell detectionCell, GdsBoundingBox bbox, string cellName)
@@ -32,7 +72,8 @@ internal sealed partial class GdsHierarchyImportSession
         if (pins.Any(p => p.Source == DetectedPinSource.Label))
             return pins;
 
-        var fallbackLayers = detectionCell.Texts
+        var fallbackCell = BuildGhostFilteredCopy(detectionCell, cellName);
+        var fallbackLayers = fallbackCell.Texts
             .Select(t => (t.Layer, t.TextType))
             .Where(pair => !_options.PinDetection.PortLayers.Contains(pair))
             .Distinct()
@@ -45,13 +86,14 @@ internal sealed partial class GdsHierarchyImportSession
         // Re-run with the discovered layers unioned in: label pins on those
         // layers plus the (unchanged) edge heuristic — label anchors now also
         // suppress the heuristic touches they cover.
-        var fallbackPins = GdsPinDetector.Detect(detectionCell, bbox, _options.PinDetection with
+        var fallbackPins = GdsPinDetector.Detect(fallbackCell, bbox, _options.PinDetection with
         {
             PortLayers = [.. _options.PinDetection.PortLayers, .. fallbackLayers],
         });
         if (!fallbackPins.Any(p => p.Source == DetectedPinSource.Label))
             return pins;
 
+        LabelFallbackUsed = true;
         var layerList = string.Join(", ", fallbackLayers.Select(l => $"({l.Layer},{l.TextType})"));
         Infos.Add(fallbackLayers.Count == 1
             ? $"Cell '{cellName}': pins detected on non-standard layer {layerList} — " +
@@ -59,5 +101,36 @@ internal sealed partial class GdsHierarchyImportSession
             : $"Cell '{cellName}': pins detected on non-standard layers {layerList} — " +
               "add them to the port-layer list to silence this note.");
         return fallbackPins;
+    }
+
+    /// <summary>
+    /// The detection cell without anchor/parameter helper labels, with
+    /// <see cref="FlattenedGdsCell.TextOrigins"/> kept index-aligned. Emits one
+    /// info note naming what was ignored (real ports with unlucky names stay
+    /// diagnosable). Returns the original instance when nothing was filtered.
+    /// </summary>
+    private FlattenedGdsCell BuildGhostFilteredCopy(FlattenedGdsCell detectionCell, string cellName)
+    {
+        var ghosts = detectionCell.Texts.Where(IsFallbackGhostLabel).ToList();
+        if (ghosts.Count == 0)
+            return detectionCell;
+
+        var filtered = new FlattenedGdsCell { CellName = detectionCell.CellName };
+        filtered.Polygons.AddRange(detectionCell.Polygons);
+        bool hasOrigins = detectionCell.TextOrigins.Count == detectionCell.Texts.Count;
+        for (int i = 0; i < detectionCell.Texts.Count; i++)
+        {
+            if (IsFallbackGhostLabel(detectionCell.Texts[i]))
+                continue;
+            filtered.Texts.Add(detectionCell.Texts[i]);
+            if (hasOrigins)
+                filtered.TextOrigins.Add(detectionCell.TextOrigins[i]);
+        }
+
+        var ignored = string.Join(", ", ghosts.Select(g => $"'{g.Text.Trim()}'").Distinct().Take(8));
+        Infos.Add(
+            $"Cell '{cellName}': {ghosts.Count} helper label(s) ignored by pin auto-discovery " +
+            $"(bounding-box anchors / parameter annotations: {ignored}).");
+        return filtered;
     }
 }

--- a/CAP-DataAccess/Import/Gds/GdsHierarchyImporter.cs
+++ b/CAP-DataAccess/Import/Gds/GdsHierarchyImporter.cs
@@ -290,6 +290,20 @@ public static class GdsHierarchyImporter
         // (>2 pins, noted as info) stay frozen paths on the group.
         var waveguidePolygons = session.GetTopCellWaveguidePolygons();
         var metalPolygons = session.GetTopCellMetalPolygons();
+        if (session.LabelFallbackUsed && metalPolygons.Count > 0)
+        {
+            // The fallback firing means this file does not follow our export
+            // conventions — then our metal layer NUMBERS are guesses too, and a
+            // foundry that assigns them differently gets every optical route
+            // reconstructed as electrical (straight metal traces, no bends).
+            var metalLayerList = string.Join(", ",
+                session.Options.MetalRouteLayers.Select(l => $"({l.Layer},{l.Datatype})"));
+            session.Warnings.Add(
+                $"Metal-layer defaults {metalLayerList} matched {metalPolygons.Count} top-cell " +
+                "polygon(s) in a file whose pin labels needed auto-discovery — if this foundry " +
+                "assigns those layers differently, connections import as electrical: correct the " +
+                "metal layers in the import dialog.");
+        }
         var waveguideRoutes = GdsRouteConnectivityMatcher.Match(
             waveguidePolygons, pinsPerInstance, topPorts,
             session.Options.PinTouchToleranceUm, session.Options.PolygonChainToleranceUm, session.Infos);

--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -394,6 +394,7 @@
   "GdsImport.ModeBlackBox": "Als einzelne Black-Box-Komponente importieren",
   "GdsImport.ModeExplode": "Hierarchie in Komponenten auflösen (empfohlen)",
   "GdsImport.ModeLabel": "Hierarchiemodus:",
+  "GdsImport.MetalLayersLabel": "Metall-Layer (elektrisch)",
   "GdsImport.OpenFileTitle": "GDS-Layout importieren",
   "GdsImport.OpenTip": "GDS-Layout als Canvas-Komponenten importieren…",
   "GdsImport.PlacedNextToExistingContentFormat": "Die Zeichenfläche enthielt bereits Inhalte — der Import wurde daneben platziert (+{0:0.#} µm nach rechts verschoben).",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -394,6 +394,7 @@
   "GdsImport.ModeBlackBox": "Import as single black-box component",
   "GdsImport.ModeExplode": "Explode hierarchy into components (recommended)",
   "GdsImport.ModeLabel": "Hierarchy mode:",
+  "GdsImport.MetalLayersLabel": "Metal layers (electrical)",
   "GdsImport.OpenFileTitle": "Import GDS layout",
   "GdsImport.OpenTip": "Import a GDS layout as canvas components…",
   "GdsImport.PlacedNextToExistingContentFormat": "Canvas already had content — the import was placed next to it (shifted +{0:0.#} µm to the right).",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -394,6 +394,7 @@
   "GdsImport.ModeBlackBox": "Importar como un único componente de caja negra",
   "GdsImport.ModeExplode": "Expandir la jerarquía en componentes (recomendado)",
   "GdsImport.ModeLabel": "Modo de jerarquía:",
+  "GdsImport.MetalLayersLabel": "Capas metálicas (eléctricas)",
   "GdsImport.OpenFileTitle": "Importar diseño GDS",
   "GdsImport.OpenTip": "Importar un diseño GDS como componentes del lienzo…",
   "GdsImport.PlacedNextToExistingContentFormat": "El lienzo ya tenía contenido — la importación se colocó a su lado (desplazada +{0:0.#} µm a la derecha).",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -394,6 +394,7 @@
   "GdsImport.ModeBlackBox": "単一のブラックボックスコンポーネントとしてインポート",
   "GdsImport.ModeExplode": "階層をコンポーネントに展開（推奨）",
   "GdsImport.ModeLabel": "階層モード:",
+  "GdsImport.MetalLayersLabel": "メタルレイヤー（電気）",
   "GdsImport.OpenFileTitle": "GDSレイアウトをインポート",
   "GdsImport.OpenTip": "GDSレイアウトをキャンバスコンポーネントとしてインポート…",
   "GdsImport.PlacedNextToExistingContentFormat": "キャンバスに既存のコンテンツがあったため、インポートはその右側に配置されました（+{0:0.#} µm シフト）。",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -394,6 +394,7 @@
   "GdsImport.ModeBlackBox": "作为单个黑盒组件导入",
   "GdsImport.ModeExplode": "将层级展开为组件（推荐）",
   "GdsImport.ModeLabel": "层级模式：",
+  "GdsImport.MetalLayersLabel": "金属层（电学）",
   "GdsImport.OpenFileTitle": "导入 GDS 版图",
   "GdsImport.OpenTip": "将 GDS 版图导入为画布组件…",
   "GdsImport.PlacedNextToExistingContentFormat": "画布已有内容 — 导入内容已放置在其旁边（向右偏移 +{0:0.#} µm）。",

--- a/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.Options.cs
+++ b/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.Options.cs
@@ -41,9 +41,11 @@ public partial class GdsImportDialogViewModel
         options = options with
         {
             Mode = IsExplodeMode ? GdsHierarchyImportMode.ExplodeHierarchy : GdsHierarchyImportMode.BlackBox,
-            // One field drives both metal roles: route reconstruction and the
-            // electrical pin-kind inference — split semantics would only invite
-            // half-corrected foundry imports.
+            // Each layer field drives BOTH of its roles — pin detection and route
+            // reconstruction. Split semantics would invite half-corrected foundry
+            // imports: metal cleared but the optical routes still invisible to the
+            // route matcher (field finding).
+            RouteLayers = waveguideLayers,
             MetalRouteLayers = metalLayers,
             PinDetection = new GdsPinDetectionOptions
             {

--- a/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.Options.cs
+++ b/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.Options.cs
@@ -30,14 +30,26 @@ public partial class GdsImportDialogViewModel
                 LocalizationService.Instance.Translate("GdsImport.ErrorLayerSyntax"), WaveguideLayersText);
             return false;
         }
+        var metalLayers = ParseLayerPairs(MetalLayersText);
+        if (metalLayers is null)
+        {
+            error = string.Format(
+                LocalizationService.Instance.Translate("GdsImport.ErrorLayerSyntax"), MetalLayersText);
+            return false;
+        }
 
         options = options with
         {
             Mode = IsExplodeMode ? GdsHierarchyImportMode.ExplodeHierarchy : GdsHierarchyImportMode.BlackBox,
+            // One field drives both metal roles: route reconstruction and the
+            // electrical pin-kind inference — split semantics would only invite
+            // half-corrected foundry imports.
+            MetalRouteLayers = metalLayers,
             PinDetection = new GdsPinDetectionOptions
             {
                 PortLayers = portLayers,
                 WaveguideLayers = waveguideLayers,
+                ElectricalLayers = metalLayers,
             },
         };
         return true;

--- a/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.cs
@@ -88,6 +88,17 @@ public partial class GdsImportDialogViewModel : ObservableObject
     private string _waveguideLayersText = "1,0";
 
     /// <summary>
+    /// METAL layers as "layer,datatype" pairs, ';'-separated. Polygons on these
+    /// layers count as electrical: top-cell routes on them reconstruct as metal
+    /// connections, and label pins touching them classify electrical. Defaults
+    /// to our own exporter's trace/bridge layers plus SiEPIC's pad opening —
+    /// foundry files that assign these numbers differently import their optical
+    /// routing as electrical until corrected here.
+    /// </summary>
+    [ObservableProperty]
+    private string _metalLayersText = "11,0; 12,0; 13,0";
+
+    /// <summary>
     /// Recreate the detected connections with Lunima's own routing (default: on).
     /// The flag flows into <see cref="GdsPlacementExecutor.ExecuteAsync"/>: the
     /// route-derived connections become real router-generated waveguides/metal

--- a/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.cs
@@ -83,9 +83,16 @@ public partial class GdsImportDialogViewModel : ObservableObject
     [ObservableProperty]
     private string _portLayersText = "1,10;501,1";
 
-    /// <summary>Waveguide-core layers as "layer,datatype" pairs, ';'-separated (gdsfactory default: 1,0).</summary>
+    /// <summary>
+    /// Waveguide-core layers as "layer,datatype" pairs, ';'-separated. One field,
+    /// two roles: pin detection (edge heuristic, direction rule) AND optical
+    /// route reconstruction of the top cell's drawn routes — a foundry whose
+    /// optical routing lives on its own layer needs it entered here to get
+    /// optical connections back. Default: gdsfactory's core (1,0) plus nazca's
+    /// interconnect layer (1111,0), mirroring the importer defaults.
+    /// </summary>
     [ObservableProperty]
-    private string _waveguideLayersText = "1,0";
+    private string _waveguideLayersText = "1,0; 1111,0";
 
     /// <summary>
     /// METAL layers as "layer,datatype" pairs, ';'-separated. Polygons on these

--- a/CAP.Avalonia/Views/Dialogs/GdsImportDialog.axaml
+++ b/CAP.Avalonia/Views/Dialogs/GdsImportDialog.axaml
@@ -110,6 +110,17 @@
                     </StackPanel>
                 </Grid>
 
+                <!-- Metal layers: drives route reconstruction as electrical AND the
+                     electrical pin-kind inference — foundry files often assign these
+                     numbers differently than our exporter defaults. -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="{loc:Localize GdsImport.MetalLayersLabel}" Foreground="LightGray"
+                               FontSize="11" TextWrapping="Wrap"/>
+                    <TextBox Text="{Binding MetalLayersText}"
+                             Background="#2d2d2d" Foreground="White" FontSize="11"
+                             ToolTip.Tip="{loc:Localize GdsImport.LayerSyntaxTip}"/>
+                </StackPanel>
+
                 <!-- Recreate detected connections with Lunima routing -->
                 <CheckBox IsChecked="{Binding RerouteConnectionsRequested}"
                           Content="{loc:Localize GdsImport.RerouteConnections}"

--- a/UnitTests/Import/Gds/GdsLabelLayerFallbackTests.cs
+++ b/UnitTests/Import/Gds/GdsLabelLayerFallbackTests.cs
@@ -191,4 +191,96 @@ public class GdsLabelLayerFallbackTests
             "the multi-line metadata blob is filtered — only the real port label remains");
         port.Name.ShouldBe("in0");
     }
+
+    [Fact]
+    public async Task Explode_FallbackIgnoresAnchorAndParameterLabels()
+    {
+        // nazca stamps bbox anchors (tl/tr/bc/…) and parameter annotations
+        // (R:0.0001) on its cells; the any-layer fallback must not turn them
+        // into ghost pins next to the real ports.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("edge", 0, 0)
+            .EndCell()
+            .BeginCell("edge")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(235, 0, "in", 0, 2000)
+                .Text(235, 0, "out", 10000, 2000)
+                .Text(235, 0, "tl", 0, 4000)
+                .Text(235, 0, "tr", 10000, 4000)
+                .Text(235, 0, "bc", 5000, 0)
+                .Text(235, 0, "R:0.0001", 5000, 3000)
+                .Text(235, 0, "n=1.0", 5000, 1000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        var draft = result.ImportedCellDrafts.ShouldHaveSingleItem();
+        draft.Pins.Select(p => p.Name).Where(n => !n.StartsWith("heur_", StringComparison.Ordinal))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ShouldBe(new[] { "in", "out" });
+        var note = result.Infos.Where(i => i.Contains("helper label(s) ignored")).ShouldHaveSingleItem();
+        note.ShouldContain("'edge'");
+        note.ShouldContain("'tl'");
+        note.ShouldContain("'R:0.0001'");
+    }
+
+    [Fact]
+    public async Task Explode_AnchorOnlyLabels_TriggerNoFallback()
+    {
+        // A cell whose only texts are anchors has nothing port-like: the fallback
+        // must stay silent instead of inventing pins from placement anchors.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("plate", 0, 0)
+            .EndCell()
+            .BeginCell("plate")
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(235, 0, "tl", 0, 4000)
+                .Text(235, 0, "br", 10000, 0)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        var draft = result.ImportedCellDrafts.ShouldHaveSingleItem();
+        draft.Pins.Where(p => !p.Name.StartsWith("heur_", StringComparison.Ordinal))
+            .ShouldBeEmpty("anchors alone yield no label pins");
+        result.Infos.Where(i => i.Contains("non-standard layer"))
+            .ShouldBeEmpty("no fallback note when nothing port-like was discovered");
+    }
+
+    [Fact]
+    public async Task Explode_ForeignFileWithMetalLayerPolygons_WarnsAboutLayerCollision()
+    {
+        // Foreign file (labels need auto-discovery) whose top cell carries
+        // polygons on our metal default (12,0): the numbers may mean something
+        // optical at that foundry, so the import must say so out loud.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("soa", 0, 0)
+                .Boundary(12, 0, (0, 6000), (10000, 6000), (10000, 6500), (0, 6500), (0, 6000))
+            .EndCell()
+            .BeginCell("soa")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(235, 0, "in", 0, 2000)
+                .Text(235, 0, "out", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        var warning = result.Warnings.Where(w => w.Contains("Metal-layer defaults")).ShouldHaveSingleItem();
+        warning.ShouldContain("(12,0)");
+        warning.ShouldContain("import dialog");
+    }
 }

--- a/UnitTests/Services/GdsImport/GdsImportDialogViewModelTests.cs
+++ b/UnitTests/Services/GdsImport/GdsImportDialogViewModelTests.cs
@@ -415,6 +415,38 @@ public class GdsImportDialogViewModelTests : IDisposable
                 customMessage: "frozen mode hands nothing to the router");
     }
 
+    [Fact]
+    public async Task ImportAsync_WaveguideLayersField_DrivesRouteReconstruction()
+    {
+        // Foundry files draw optical routes on their own layer numbers; the
+        // dialog's waveguide field must reach the ROUTE matcher, not only pin
+        // detection — otherwise clearing the metal layers just makes the
+        // connections vanish instead of turning optical (field finding).
+        var gds = GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("wgA", 0, 0)
+                .SRef("wgB", 15000, 0)
+                .Boundary(77, 0, (10000, 1750), (15000, 1750), (15000, 2250), (10000, 2250), (10000, 1750))
+            .EndCell()
+            .WaveguideCell("wgA")
+            .WaveguideCell("wgB")
+            .EndLibrary()
+            .ToArray();
+        var (vm, canvas, _) = CreateDialog(WriteGds(gds));
+        await vm.StartAnalysisAsync();
+        vm.WaveguideLayersText = "1,0; 77,0";
+
+        await vm.ImportCommand.ExecuteAsync(null);
+
+        vm.HasError.ShouldBeFalse(vm.ErrorText);
+        var group = canvas.Components.ShouldHaveSingleItem().Component
+            .ShouldBeOfType<CAP_Core.Components.Core.ComponentGroup>();
+        var path = group.InternalPaths.ShouldHaveSingleItem(
+            "the foreign-layer route stripe is consumed by route derivation once its layer is listed");
+        path.StartPin.ShouldNotBeNull("the reconstructed connection is optical and pinned");
+    }
+
     // ── Error-console mirroring ──────────────────────────────────────────────
 
     [Fact]

--- a/UnitTests/Services/GdsImport/GdsImportDialogViewModelTests.cs
+++ b/UnitTests/Services/GdsImport/GdsImportDialogViewModelTests.cs
@@ -301,6 +301,21 @@ public class GdsImportDialogViewModelTests : IDisposable
         pairs[1].ShouldBe((501, 1));
     }
 
+    [Fact]
+    public void MetalLayersText_Default_CoversExporterAndSiepicPadLayers()
+    {
+        var (vm, _, _) = CreateDialog(WriteGds(TwoWaveguideLibrary()));
+
+        // Our exporter's trace/bridge layers plus SiEPIC's pad opening — the dialog
+        // default mirrors the detector defaults so an unchanged dialog changes nothing.
+        var pairs = GdsImportDialogViewModel.ParseLayerPairs(vm.MetalLayersText)
+            .ShouldNotBeNull("the default text must stay valid layer syntax");
+        pairs.Count.ShouldBe(3);
+        pairs[0].ShouldBe((11, 0));
+        pairs[1].ShouldBe((12, 0));
+        pairs[2].ShouldBe((13, 0));
+    }
+
     // ── End-to-end: analyze → import → place on canvas ───────────────────────
 
     [Fact]


### PR DESCRIPTION
Fixes #842 and delivers the quick lever from #841 (dialog-editable metal layers + foreign-file warning); the per-PDK layer tables stay tracked in #841/#822.

Field-tested findings behind this: after #839 unblocked connection detection on a real foundry file, every connection imported as electrical (layer-number collision) and edge couplers grew ~10 ghost pins (nazca anchors + parameter labels via the any-layer fallback).

- Fallback-only ghost filter: nazca bbox anchor names + parameter-shaped labels (`R:0.0001`, `n=1.0`) never become pins; one info note lists what was ignored. Explicitly configured port layers are untouched (user intent wins).
- Import dialog: new metal-layers field (default `11,0; 12,0; 13,0` mirroring detector defaults) driving both route reconstruction and electrical pin-kind inference; localized in all 5 languages.
- Importer warning when the label fallback fired AND metal defaults matched top-cell polygons — the exact signature of the foundry-file misclassification.
- Tests: ghost-filter fixtures (real ports + anchors + parameter labels; anchor-only cells trigger no fallback), foreign-file collision warning, dialog default mapping. 94 affected tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)