### PR TITLE
Agent: Transient blocked for every parametric component since #825 — the linearity gate counts slider formulas as nonlinear

### DIFF
--- a/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilder.cs
+++ b/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilder.cs
@@ -72,10 +72,12 @@ public class ImpulseResponseBuilder
 
         var (freqGrid, dt) = BuildFrequencyGrid(centerWavelengthNm, spanNm, nPoints);
 
-        // Check for nonlinear connections — Phase 1 only supports linear circuits.
+        // Check for TRULY nonlinear connections — Phase 1 only supports linear circuits.
+        // Parametric (slider-only) formulas are constants during a run and stay eligible;
+        // they are pre-evaluated into concrete weights in ComputeTransitiveValues.
         int referenceNm = FreqToWavelengthNmInt(freqGrid[nPoints / 2]);
         var referenceMatrix = _matrixBuilder.GetSystemSMatrix(referenceNm);
-        if (referenceMatrix.NonLinearConnections.Count > 0)
+        if (ParametricConnectionEvaluator.CountTrulyNonLinear(referenceMatrix) > 0)
         {
             throw new InvalidOperationException(
                 "Time-domain simulation (Phase 1) supports linear circuits only. " +
@@ -143,6 +145,9 @@ public class ImpulseResponseBuilder
         SMatrix sMatrix, IReadOnlyCollection<Guid>? activeInputPinIds,
         TransitiveClosureContext? circuitContext, int wavelengthNm)
     {
+        // Slider-bound formulas are constants at simulation time: bake them into
+        // the S-matrix so the closure (and reachability) sees their transfers.
+        ParametricConnectionEvaluator.EvaluateParametricConnections(sMatrix);
         var scoped = activeInputPinIds == null
             ? sMatrix
             : ReachableSubMatrixExtractor.ExtractReachable(sMatrix, activeInputPinIds);

--- a/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ParametricConnectionEvaluator.cs
+++ b/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ParametricConnectionEvaluator.cs
@@ -1,0 +1,52 @@
+using System.Numerics;
+using CAP_Core.Components.FormulaReading;
+
+namespace CAP_Core.LightCalculation.TimeDomainSimulation;
+
+/// <summary>
+/// Distinguishes truly nonlinear connection formulas (those depending on live pin
+/// fields) from merely parametric ones (slider-bound only) and pre-evaluates the
+/// parametric formulas into concrete complex weights.
+///
+/// A slider-bound formula is a constant at simulation time — parameters do not
+/// change during a run — so a circuit containing only such formulas is still
+/// linear and eligible for the Phase-1 time-domain path.
+/// </summary>
+public static class ParametricConnectionEvaluator
+{
+    /// <summary>
+    /// True when the formula depends on the live field vector: it is flagged as an
+    /// inner-loop function or references at least one pin of the matrix. Slider-only
+    /// formulas return false — they are constants for the duration of a run.
+    /// </summary>
+    public static bool IsTrulyNonLinear(SMatrix matrix, ConnectionFunction function) =>
+        function.IsInnerLoopFunction
+        || function.UsedParameterGuids.Any(matrix.PinReference.ContainsKey);
+
+    /// <summary>Counts the connections whose formulas depend on live pin inputs.</summary>
+    public static int CountTrulyNonLinear(SMatrix matrix) =>
+        matrix.NonLinearConnections.Count(kv => IsTrulyNonLinear(matrix, kv.Value));
+
+    /// <summary>
+    /// Evaluates every parametric (slider-only) connection formula with the matrix's
+    /// current slider values and writes the resulting constant weight into the
+    /// S-matrix. Mirrors what the CW path does on its first recompute pass, so the
+    /// impulse-response closure sees the same transfer values.
+    /// </summary>
+    /// <param name="matrix">System or component S-matrix to update in place.</param>
+    public static void EvaluateParametricConnections(SMatrix matrix)
+    {
+        var transfers = new Dictionary<(Guid PinIdInflow, Guid PinIdOutflow), Complex>();
+        foreach (var (key, function) in matrix.NonLinearConnections)
+        {
+            if (IsTrulyNonLinear(matrix, function))
+                continue;
+            var sliderValues = function.UsedParameterGuids
+                .Where(matrix.SliderReference.ContainsKey)
+                .Select(guid => (object)matrix.SliderReference[guid])
+                .ToList();
+            transfers[key] = function.CalcConnectionWeightAsync(sliderValues);
+        }
+        matrix.SetValues(transfers);
+    }
+}

--- a/UnitTests/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilderTests.cs
+++ b/UnitTests/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilderTests.cs
@@ -99,9 +99,10 @@ public class ImpulseResponseBuilderTests
     }
 
     [Fact]
-    public void Build_WithNonlinearConnections_ThrowsInvalidOperationException()
+    public void Build_WithPinDependentConnection_ThrowsInvalidOperationException()
     {
-        // Arrange: system matrix has a nonlinear connection
+        // Arrange: the formula references a pin, so it depends on the live field
+        // vector — genuinely nonlinear and blocked by the Phase-1 gate.
         var inputPinId = Guid.NewGuid();
         var outputPinId = Guid.NewGuid();
         var allPins = new List<Guid> { inputPinId, outputPinId };
@@ -114,8 +115,8 @@ public class ImpulseResponseBuilderTests
                 var key = (inputPinId, outputPinId);
                 var nonLinFn = new ConnectionFunction(
                     _ => Complex.One,
-                    "1",
-                    new List<Guid>(),
+                    "abs(P1)",
+                    new List<Guid> { inputPinId },
                     IsInnerLoopFunction: false);
                 matrix.NonLinearConnections.Add(key, nonLinFn);
                 return matrix;
@@ -124,8 +125,80 @@ public class ImpulseResponseBuilderTests
         var builder = new ImpulseResponseBuilder(mockBuilder.Object);
 
         // Act & Assert
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            builder.Build(CenterWavelengthNm, SpanNm, NPoints));
+        ex.Message.ShouldContain("linear circuits only");
+    }
+
+    [Fact]
+    public void Build_WithInnerLoopConnection_ThrowsInvalidOperationException()
+    {
+        var inputPinId = Guid.NewGuid();
+        var outputPinId = Guid.NewGuid();
+        var allPins = new List<Guid> { inputPinId, outputPinId };
+
+        var mockBuilder = new Mock<ISystemMatrixBuilder>();
+        mockBuilder.Setup(b => b.GetSystemSMatrix(It.IsAny<int>()))
+            .Returns((int _) =>
+            {
+                var matrix = new SMatrix(allPins, new());
+                var nonLinFn = new ConnectionFunction(
+                    _ => Complex.One, "1", new List<Guid>(), IsInnerLoopFunction: true);
+                matrix.NonLinearConnections.Add((inputPinId, outputPinId), nonLinFn);
+                return matrix;
+            });
+
+        var builder = new ImpulseResponseBuilder(mockBuilder.Object);
+
         Should.Throw<InvalidOperationException>(() =>
             builder.Build(CenterWavelengthNm, SpanNm, NPoints));
+    }
+
+    [Fact]
+    public void Build_ParametricSliderFormula_MatchesFixedValueDesignBitExactly()
+    {
+        // Arrange: one design carries the transfer as a slider-bound formula,
+        // the other as a fixed value — the impulse responses must be identical.
+        var inputPinId = Guid.NewGuid();
+        var outputPinId = Guid.NewGuid();
+        var sliderId = Guid.NewGuid();
+        const double splitRatioPercent = 65.0;
+        var expectedWeight = new Complex(Math.Sqrt(splitRatioPercent / 100.0), 0);
+
+        var parametricBuilder = new Mock<ISystemMatrixBuilder>();
+        parametricBuilder.Setup(b => b.GetSystemSMatrix(It.IsAny<int>()))
+            .Returns((int _) =>
+            {
+                var matrix = new SMatrix(
+                    new List<Guid> { inputPinId, outputPinId },
+                    new() { (sliderId, splitRatioPercent) });
+                var parametricFn = new ConnectionFunction(
+                    parameters => new Complex(Math.Sqrt((double)parameters[0] / 100.0), 0),
+                    "sqrt(SR/100)",
+                    new List<Guid> { sliderId },
+                    IsInnerLoopFunction: false);
+                matrix.NonLinearConnections.Add((inputPinId, outputPinId), parametricFn);
+                return matrix;
+            });
+
+        var fixedBuilder = new Mock<ISystemMatrixBuilder>();
+        fixedBuilder.Setup(b => b.GetSystemSMatrix(It.IsAny<int>()))
+            .Returns((int _) => CreateTwoPortMatrix(inputPinId, outputPinId, expectedWeight));
+
+        // Act
+        var parametricResult = new ImpulseResponseBuilder(parametricBuilder.Object)
+            .Build(CenterWavelengthNm, SpanNm, NPoints);
+        var fixedResult = new ImpulseResponseBuilder(fixedBuilder.Object)
+            .Build(CenterWavelengthNm, SpanNm, NPoints);
+
+        // Assert: same connection set, bit-exact samples
+        parametricResult.Count.ShouldBe(fixedResult.Count);
+        var parametric = parametricResult.Single(
+            r => r.InputPinId == inputPinId && r.OutputPinId == outputPinId);
+        var fixedResponse = fixedResult.Single(
+            r => r.InputPinId == inputPinId && r.OutputPinId == outputPinId);
+        for (int i = 0; i < parametric.Samples.Length; i++)
+            parametric.Samples[i].ShouldBe(fixedResponse.Samples[i]);
     }
 
     [Fact]

--- a/UnitTests/LightCalculation/TimeDomainSimulation/ParametricConnectionEvaluatorTests.cs
+++ b/UnitTests/LightCalculation/TimeDomainSimulation/ParametricConnectionEvaluatorTests.cs
@@ -1,0 +1,93 @@
+using CAP_Core.Components.FormulaReading;
+using CAP_Core.LightCalculation;
+using CAP_Core.LightCalculation.TimeDomainSimulation;
+using Shouldly;
+using System.Numerics;
+using Xunit;
+
+namespace UnitTests.LightCalculation.TimeDomainSimulation;
+
+public class ParametricConnectionEvaluatorTests
+{
+    private static readonly Guid InputPinId = Guid.NewGuid();
+    private static readonly Guid OutputPinId = Guid.NewGuid();
+    private static readonly Guid SliderId = Guid.NewGuid();
+    private const double SliderValue = 65.0;
+
+    private static SMatrix CreateMatrixWithSlider() =>
+        new(new List<Guid> { InputPinId, OutputPinId }, new() { (SliderId, SliderValue) });
+
+    private static ConnectionFunction SliderOnlyFunction() => new(
+        parameters => new Complex((double)parameters[0] / 100.0, 0),
+        "SR/100",
+        new List<Guid> { SliderId },
+        IsInnerLoopFunction: false);
+
+    [Fact]
+    public void IsTrulyNonLinear_SliderOnlyFormula_ReturnsFalse()
+    {
+        var matrix = CreateMatrixWithSlider();
+
+        ParametricConnectionEvaluator.IsTrulyNonLinear(matrix, SliderOnlyFunction())
+            .ShouldBeFalse("a slider-bound formula is a constant at simulation time");
+    }
+
+    [Fact]
+    public void IsTrulyNonLinear_PinReferencingFormula_ReturnsTrue()
+    {
+        var matrix = CreateMatrixWithSlider();
+        var pinDependent = new ConnectionFunction(
+            _ => Complex.One, "abs(P1)", new List<Guid> { InputPinId },
+            IsInnerLoopFunction: false);
+
+        ParametricConnectionEvaluator.IsTrulyNonLinear(matrix, pinDependent).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsTrulyNonLinear_InnerLoopFlag_ReturnsTrue()
+    {
+        var matrix = CreateMatrixWithSlider();
+        var innerLoop = new ConnectionFunction(
+            _ => Complex.One, "1", new List<Guid>(), IsInnerLoopFunction: true);
+
+        ParametricConnectionEvaluator.IsTrulyNonLinear(matrix, innerLoop).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CountTrulyNonLinear_MixedConnections_CountsOnlyPinDependentOnes()
+    {
+        var matrix = CreateMatrixWithSlider();
+        matrix.NonLinearConnections.Add((InputPinId, OutputPinId), SliderOnlyFunction());
+        matrix.NonLinearConnections.Add((OutputPinId, InputPinId), new ConnectionFunction(
+            _ => Complex.One, "abs(P1)", new List<Guid> { InputPinId },
+            IsInnerLoopFunction: false));
+
+        ParametricConnectionEvaluator.CountTrulyNonLinear(matrix).ShouldBe(1);
+    }
+
+    [Fact]
+    public void EvaluateParametricConnections_WritesSliderEvaluatedWeightIntoMatrix()
+    {
+        var matrix = CreateMatrixWithSlider();
+        matrix.NonLinearConnections.Add((InputPinId, OutputPinId), SliderOnlyFunction());
+
+        ParametricConnectionEvaluator.EvaluateParametricConnections(matrix);
+
+        var values = matrix.GetNonNullValues();
+        values[(InputPinId, OutputPinId)].ShouldBe(new Complex(SliderValue / 100.0, 0));
+    }
+
+    [Fact]
+    public void EvaluateParametricConnections_LeavesTrulyNonLinearUntouched()
+    {
+        var matrix = CreateMatrixWithSlider();
+        matrix.NonLinearConnections.Add((InputPinId, OutputPinId), new ConnectionFunction(
+            _ => Complex.One, "abs(P1)", new List<Guid> { InputPinId },
+            IsInnerLoopFunction: false));
+
+        ParametricConnectionEvaluator.EvaluateParametricConnections(matrix);
+
+        matrix.GetNonNullValues().ShouldBeEmpty(
+            "pin-dependent formulas must not be baked in as constants");
+    }
+}

--- a/UnitTests/LightCalculation/TimeDomainSimulation/TimeDomainSimulatorTests.cs
+++ b/UnitTests/LightCalculation/TimeDomainSimulation/TimeDomainSimulatorTests.cs
@@ -137,7 +137,8 @@ public class TimeDomainSimulatorTests
             {
                 var matrix = new SMatrix(allPins, new());
                 var nonLinFn = new ConnectionFunction(
-                    _ => Complex.One, "1", new List<Guid>(), IsInnerLoopFunction: false);
+                    _ => Complex.One, "abs(P1)", new List<Guid> { inputPin },
+                    IsInnerLoopFunction: false);
                 matrix.NonLinearConnections.Add((inputPin, outputPin), nonLinFn);
                 return matrix;
             });
@@ -152,6 +153,70 @@ public class TimeDomainSimulatorTests
 
         Should.Throw<InvalidOperationException>(() =>
             simulator.Run(inputSignals, timeDef, CenterWavelengthNm, SpanNm, NPoints));
+    }
+
+    [Fact]
+    public void Run_ParametricSplitter_MatchesFixedValueDesignBitExactly()
+    {
+        // Arrange: a slider-bound MMI-style splitter (parametric like the demo PDK
+        // since #825) vs. the same splitter with fixed values — transient traces
+        // must be identical because slider parameters are constants during a run.
+        var inputPin = Guid.NewGuid();
+        var outputPin1 = Guid.NewGuid();
+        var outputPin2 = Guid.NewGuid();
+        var sliderId = Guid.NewGuid();
+        const double splittingRatioPercent = 65.0;
+        var allPins = new List<Guid> { inputPin, outputPin1, outputPin2 };
+
+        var parametricBuilder = new Mock<ISystemMatrixBuilder>();
+        parametricBuilder.Setup(b => b.GetSystemSMatrix(It.IsAny<int>()))
+            .Returns((int _) =>
+            {
+                var matrix = new SMatrix(allPins, new() { (sliderId, splittingRatioPercent) });
+                var toOut1 = new ConnectionFunction(
+                    p => new Complex(Math.Sqrt((double)p[0] / 100.0), 0),
+                    "sqrt(SR/100)", new List<Guid> { sliderId }, IsInnerLoopFunction: false);
+                var toOut2 = new ConnectionFunction(
+                    p => new Complex(Math.Sqrt(1.0 - (double)p[0] / 100.0), 0),
+                    "sqrt(1-SR/100)", new List<Guid> { sliderId }, IsInnerLoopFunction: false);
+                matrix.NonLinearConnections.Add((inputPin, outputPin1), toOut1);
+                matrix.NonLinearConnections.Add((inputPin, outputPin2), toOut2);
+                return matrix;
+            });
+
+        var fixedBuilder = new Mock<ISystemMatrixBuilder>();
+        fixedBuilder.Setup(b => b.GetSystemSMatrix(It.IsAny<int>()))
+            .Returns((int _) =>
+            {
+                var matrix = new SMatrix(allPins, new());
+                matrix.SetValues(new Dictionary<(Guid, Guid), Complex>
+                {
+                    { (inputPin, outputPin1), new Complex(Math.Sqrt(splittingRatioPercent / 100.0), 0) },
+                    { (inputPin, outputPin2), new Complex(Math.Sqrt(1.0 - splittingRatioPercent / 100.0), 0) },
+                });
+                return matrix;
+            });
+
+        var timeDef = TimeSignalDefinition.FromWavelengthSweep(CenterWavelengthNm, SpanNm, NPoints);
+        var inputSignal = timeDef.CreateGaussianPulse(
+            20 * timeDef.TimeStepSeconds, 3 * timeDef.TimeStepSeconds);
+        var inputSignals = new Dictionary<Guid, double[]> { { inputPin, inputSignal } };
+
+        // Act
+        var parametricResult = new TimeDomainSimulator(parametricBuilder.Object)
+            .Run(inputSignals, timeDef, CenterWavelengthNm, SpanNm, NPoints);
+        var fixedResult = new TimeDomainSimulator(fixedBuilder.Object)
+            .Run(inputSignals, timeDef, CenterWavelengthNm, SpanNm, NPoints);
+
+        // Assert: bit-exact traces at both outputs
+        foreach (var outputPin in new[] { outputPin1, outputPin2 })
+        {
+            parametricResult.PinTraces.ShouldContainKey(outputPin);
+            var parametricTrace = parametricResult.PinTraces[outputPin];
+            var fixedTrace = fixedResult.PinTraces[outputPin];
+            for (int i = 0; i < parametricTrace.Length; i++)
+                parametricTrace[i].ShouldBe(fixedTrace[i]);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Automated implementation for #844

That's the earlier full-suite background run finishing — its output was the known smart_test.py 5-minute timeout message (the suite itself takes ~8 min), which is why I verified via batched area runs instead. All 726 affected tests passed and the work is already committed; nothing further to do.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 107,562
- **Estimated cost:** $0.0602 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*