### PR TITLE
Agent: Re-import of our own GDS export: routed waveguides come back as a 'waveguide' COMPONENT instead of Lunima connections

### DIFF
--- a/CAP-DataAccess/Import/Gds/GdsHierarchyImporter.cs
+++ b/CAP-DataAccess/Import/Gds/GdsHierarchyImporter.cs
@@ -121,6 +121,13 @@ public static class GdsHierarchyImporter
         // zero-geometry cells (note emitted after the loop, with the count).
         var artifactNoted = new HashSet<string>(StringComparer.Ordinal);
         var zeroGeometrySkips = new Dictionary<string, int>();
+        // Dissolved route/interconnect cells (see GdsRouteCellDissolver): their
+        // flattened polygons join the top cell's route polygon sets below so
+        // the route matcher reconstructs the connections they draw; one info
+        // note per cell (with the instance count) is emitted after the loop.
+        var dissolvedWaveguidePolygons = new List<GdsOutlinePolygon>();
+        var dissolvedMetalPolygons = new List<GdsOutlinePolygon>();
+        var dissolvedRouteCells = new Dictionary<string, int>(StringComparer.Ordinal);
 
         // Work list: the top cell's direct children, plus — appended while
         // walking — the device instances carried by an expanded export-artifact
@@ -175,6 +182,24 @@ public static class GdsHierarchyImporter
             }
 
             var known = session.ResolveKnown(cell);
+
+            // Routed interconnects our exporters emit as REFERENCED cells
+            // (instead of flattened top-cell geometry) dissolve into the route
+            // polygon sets: the geometry IS a connection, not a component —
+            // importing it as a "waveguide" draft would leave the circuit
+            // graph disconnected. A deliberate known-component binding wins
+            // over dissolution.
+            if (known is null
+                && GdsRouteCellDissolver.IsRouteCell(cell, session.GetFlattened(cell), session.Options))
+            {
+                GdsRouteCellDissolver.Dissolve(
+                    gdsInstance, session.GetFlattened(cell), session.Options, session.TopBBox,
+                    dissolvedWaveguidePolygons, dissolvedMetalPolygons);
+                dissolvedRouteCells.TryGetValue(cell, out int dissolved);
+                dissolvedRouteCells[cell] = dissolved + 1;
+                continue;
+            }
+
             var cellBBox = session.GetCellBBox(cell);
 
             // Zero-geometry cells (empty flattened bbox — e.g. the zero-length
@@ -262,6 +287,13 @@ public static class GdsHierarchyImporter
                 $"{skipCount} instance(s) skipped.");
         }
 
+        foreach (var (cell, dissolvedCount) in dissolvedRouteCells)
+        {
+            session.Infos.Add(
+                $"Route cell '{cell}' ({dissolvedCount} instance(s)) dissolved into the top-cell " +
+                "routing geometry — reconstructed as connections/route paths instead of a component.");
+        }
+
         if (gdsInstances.Count == 0)
         {
             session.Warnings.Add(
@@ -288,8 +320,12 @@ public static class GdsHierarchyImporter
         // abutment matcher pairs coincident positions — no double-connect.
         // Networks that connect nothing (0/1 pins) or form a junction
         // (>2 pins, noted as info) stay frozen paths on the group.
-        var waveguidePolygons = session.GetTopCellWaveguidePolygons();
-        var metalPolygons = session.GetTopCellMetalPolygons();
+        var waveguidePolygons = session.GetTopCellWaveguidePolygons()
+            .Concat(dissolvedWaveguidePolygons)
+            .ToList();
+        var metalPolygons = session.GetTopCellMetalPolygons()
+            .Concat(dissolvedMetalPolygons)
+            .ToList();
         if (session.LabelFallbackUsed && metalPolygons.Count > 0)
         {
             // The fallback firing means this file does not follow our export
@@ -333,7 +369,8 @@ public static class GdsHierarchyImporter
         var residualPolygons = session.GetTopCellResidualPolygons();
         GdsImportReporter.ReportTopLevelGeometry(
             session, topCellName, waveguideRoutes, metalRoutes,
-            frozenRoutePolygons.Count, residualPolygons.Count);
+            frozenRoutePolygons.Count, residualPolygons.Count,
+            dissolvedWaveguidePolygons.Count + dissolvedMetalPolygons.Count);
 
         var connections = waveguideRoutes.Pairs
             .Concat(metalRoutes.Pairs)

--- a/CAP-DataAccess/Import/Gds/GdsImportReporter.cs
+++ b/CAP-DataAccess/Import/Gds/GdsImportReporter.cs
@@ -87,7 +87,11 @@ internal static class GdsImportReporter
     /// that is normal, fully-reconstructed behavior → reported as INFO. Background
     /// polygons dropped to satisfy the outline-point cap are already warned about
     /// (with their true count) where they are collected — nothing else is dropped,
-    /// so this reporter emits no warning of its own.
+    /// so this reporter emits no warning of its own. Polygons contributed by
+    /// dissolved route cells (<paramref name="dissolvedRoutePolygonCount"/>, see
+    /// <see cref="GdsRouteCellDissolver"/>) count toward the routing geometry the
+    /// report accounts for: they went through the same matcher as the top cell's
+    /// own polygons.
     /// </summary>
     public static void ReportTopLevelGeometry(
         GdsHierarchyImportSession session,
@@ -95,13 +99,15 @@ internal static class GdsImportReporter
         GdsRouteConnectivityResult waveguideRoutes,
         GdsRouteConnectivityResult metalRoutes,
         int frozenPolygonCount,
-        int backgroundPolygonCount)
+        int backgroundPolygonCount,
+        int dissolvedRoutePolygonCount)
     {
         // Counted in outline-polygon units (a path expands to one quad per
         // segment) — the same units the route matcher and the frozen-path
         // collector work in; counting path ELEMENTS instead would let a
         // multi-segment path drive the remainder negative.
-        int own = GdsPathOutliner.ExpandDrawnGeometry(session.Library.Cells[topCellName].Elements).Count();
+        int own = GdsPathOutliner.ExpandDrawnGeometry(session.Library.Cells[topCellName].Elements).Count()
+            + dissolvedRoutePolygonCount;
         if (own == 0)
             return;
 
@@ -135,8 +141,11 @@ internal static class GdsImportReporter
 
         if (restoredParts.Count > 0)
         {
+            string source = dissolvedRoutePolygonCount > 0
+                ? "of its own or from dissolved route cells"
+                : "of its own";
             session.Infos.Add(
-                $"Top cell '{topCellName}' contains {own} polygon(s)/path(s) of its own (routing " +
+                $"Top cell '{topCellName}' contains {own} polygon(s)/path(s) {source} (routing " +
                 $"geometry): {string.Join("; ", restoredParts)}.");
         }
     }

--- a/CAP-DataAccess/Import/Gds/GdsRouteCellDissolver.cs
+++ b/CAP-DataAccess/Import/Gds/GdsRouteCellDissolver.cs
@@ -1,0 +1,95 @@
+namespace CAP_DataAccess.Import.Gds;
+
+/// <summary>
+/// Recognizes routed-interconnect cells that our own exporters emit as
+/// REFERENCED GDS cells instead of flattened top-cell geometry — nazca with
+/// <c>cfg.instantiate_mask_element = True</c> ("straight_N"/"arc_N"…) and the
+/// gdsfactory backend's <c>straight</c>/<c>bend_circular</c> factory cells —
+/// and dissolves their flattened geometry into the top cell's route polygon
+/// sets. The route-connectivity matcher then reconstructs the connection the
+/// geometry represents; without dissolution the cell would become a bogus
+/// component draft (e.g. "waveguide") and the circuit graph would stay
+/// disconnected. Dissolving degrades gracefully: polygons the matcher cannot
+/// pair between exactly two pins are imported as frozen route paths, never
+/// lost.
+/// </summary>
+internal static class GdsRouteCellDissolver
+{
+    /// <summary>
+    /// Case-insensitive name prefixes of route/interconnect cells: nazca mask
+    /// elements ("straight", "arc", "sinecurve", "cobra", "taper"-free on
+    /// purpose — a taper can be a real device), nazca interconnect cells
+    /// ("ic_strt", "ic_bend", "ic_sbend"), gdsfactory routing factories
+    /// ("straight", "bend", "sbend") and the generic "waveguide" name our own
+    /// exports round-trip through. A matching NAME alone never dissolves —
+    /// the cell must also be label-free with all geometry on route layers.
+    /// </summary>
+    private static readonly string[] RouteCellNamePrefixes =
+    [
+        "waveguide", "straight", "strt", "bend", "sbend", "sinebend",
+        "sinecurve", "cobra", "arc", "ic_strt", "ic_bend", "ic_sbend",
+    ];
+
+    /// <summary>
+    /// Whether the cell is a routed-interconnect cell that should be dissolved
+    /// instead of imported as a component draft. All criteria must hold:
+    /// route-style name prefix, at least one polygon, ALL flattened polygons on
+    /// the configured optical/metal route layers, and no text labels anywhere
+    /// in the subtree (device cells — including gdsfactory's label-free
+    /// <c>stub_*</c> rectangles by name, and every labeled PDK cell by texts —
+    /// never qualify).
+    /// </summary>
+    public static bool IsRouteCell(
+        string cellName, FlattenedGdsCell flattened, GdsHierarchyImportOptions options)
+    {
+        if (!HasRouteCellName(cellName))
+            return false;
+        if (flattened.Texts.Count > 0 || flattened.Polygons.Count == 0)
+            return false;
+
+        var routeLayers = new HashSet<(int, int)>(
+            options.RouteLayers.Concat(options.MetalRouteLayers));
+        return flattened.Polygons.All(p => routeLayers.Contains((p.Layer, p.DataType)));
+    }
+
+    /// <summary>
+    /// Transforms the cell's flattened polygons through the instance's true GDS
+    /// transform into top-cell app space (Y-down, origin at the top bbox
+    /// top-left — the frame the route matcher works in) and appends them to
+    /// <paramref name="waveguideSink"/> or <paramref name="metalSink"/> by
+    /// layer, so optical and metal networks never merge.
+    /// </summary>
+    public static void Dissolve(
+        GdsInstance instance,
+        FlattenedGdsCell flattened,
+        GdsHierarchyImportOptions options,
+        GdsBoundingBox topBBox,
+        List<GdsOutlinePolygon> waveguideSink,
+        List<GdsOutlinePolygon> metalSink)
+    {
+        var metalLayers = new HashSet<(int, int)>(options.MetalRouteLayers);
+        var transform = GdsInstancePinProjector.TrueTransform(instance);
+
+        foreach (var polygon in flattened.Polygons)
+        {
+            var sink = metalLayers.Contains((polygon.Layer, polygon.DataType))
+                ? metalSink
+                : waveguideSink;
+            sink.Add(new GdsOutlinePolygon
+            {
+                Layer = polygon.Layer,
+                DataType = polygon.DataType,
+                Points = polygon.Points
+                    .Select(point => ToAppSpace(transform.Apply(point), topBBox))
+                    .ToList(),
+            });
+        }
+    }
+
+    private static bool HasRouteCellName(string cellName) =>
+        RouteCellNamePrefixes.Any(prefix =>
+            cellName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+    private static GdsOutlinePoint ToAppSpace(GdsPoint placed, GdsBoundingBox topBBox) =>
+        new(placed.X - topBBox.MinX, topBBox.MaxY - placed.Y);
+}

--- a/UnitTests/Import/Gds/GdsRouteCellDissolveTests.cs
+++ b/UnitTests/Import/Gds/GdsRouteCellDissolveTests.cs
@@ -1,0 +1,249 @@
+using CAP_DataAccess.Import.Gds;
+using Shouldly;
+
+namespace UnitTests.Import.Gds;
+
+/// <summary>
+/// Regression tests for route-cell dissolution (<c>GdsRouteCellDissolver</c>):
+/// re-importing an export whose routed interconnects are REFERENCED cells must
+/// restore the connection through the route matcher instead of creating a
+/// bogus component draft. Fixtures: 1 db unit = 1 nm (<see cref="GdsTestWriter"/>).
+/// </summary>
+public class GdsRouteCellDissolveTests
+{
+    [Fact]
+    public async Task Explode_RouteCellBetweenTwoDevices_RestoresConnectionWithoutDraft()
+    {
+        // wgA.out at GDS (10, 2), wgB.in at GDS (20, 2); the label-free route
+        // cell "waveguide" spans exactly the gap on the waveguide layer (1,0).
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("wgA", 0, 0)
+                .SRef("waveguide", 10000, 0)
+                .SRef("wgB", 20000, 0)
+            .EndCell()
+            .DeviceCell("wgA")
+            .DeviceCell("wgB")
+            .RouteStripCell("waveguide")
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        // No "waveguide" component draft and no placed route instance.
+        result.ImportedCellDrafts.Select(d => d.CellName).ShouldBe(new[] { "wgA", "wgB" });
+        result.Instances.Count.ShouldBe(2);
+        result.Instances.ShouldAllBe(i => i.CellName != "waveguide");
+
+        // The dissolved geometry reconstructs the connection between the pins.
+        var connection = result.Connections.ShouldHaveSingleItem();
+        EndpointNames(result, connection).ShouldBe(new[] { "wgA#0.out", "wgB#0.in" }, ignoreOrder: true);
+
+        // The route polygon was consumed by the matcher — nothing froze.
+        result.TopCellWaveguidePolygons.ShouldBeEmpty();
+        result.Warnings.ShouldBeEmpty();
+        result.Infos.ShouldContain(i =>
+            i.Contains("Route cell 'waveguide'") && i.Contains("1 instance(s)") && i.Contains("dissolved"));
+        result.Infos.ShouldContain(i => i.Contains("restored as 1 real connection(s)"));
+    }
+
+    [Fact]
+    public async Task Explode_RotatedRouteCellInstance_StillRestoresConnection()
+    {
+        // The same strip placed rotated 180° at (20, 4): its transformed span is
+        // again GDS x 10..20 at y ≈ 2, so the dissolution transform math must
+        // land it on both pins.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("wgA", 0, 0)
+                .SRef("straight_7", 20000, 4000, angleDegrees: 180)
+                .SRef("wgB", 20000, 0)
+            .EndCell()
+            .DeviceCell("wgA")
+            .DeviceCell("wgB")
+            .RouteStripCell("straight_7")
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        result.ImportedCellDrafts.Select(d => d.CellName).ShouldBe(new[] { "wgA", "wgB" });
+        var connection = result.Connections.ShouldHaveSingleItem();
+        EndpointNames(result, connection).ShouldBe(new[] { "wgA#0.out", "wgB#0.in" }, ignoreOrder: true);
+        result.Warnings.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Explode_MetalRouteCell_RestoresElectricalConnection()
+    {
+        // The route cell's strip lives on the metal layer (11,0): the metal
+        // matcher restores it as an ELECTRICAL connection and the touched draft
+        // pins are inferred electrical.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("wgA", 0, 0)
+                .SRef("waveguide_metal", 10000, 0)
+                .SRef("wgB", 20000, 0)
+            .EndCell()
+            .DeviceCell("wgA")
+            .DeviceCell("wgB")
+            .RouteStripCell("waveguide_metal", layer: 11)
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        result.ImportedCellDrafts.Select(d => d.CellName).ShouldBe(new[] { "wgA", "wgB" });
+        var connection = result.Connections.ShouldHaveSingleItem();
+        EndpointNames(result, connection).ShouldBe(new[] { "wgA#0.out", "wgB#0.in" }, ignoreOrder: true);
+
+        result.ImportedCellDrafts[0].Pins.Single(p => p.Name == "out").IsElectrical.ShouldBe(true);
+        result.ImportedCellDrafts[1].Pins.Single(p => p.Name == "in").IsElectrical.ShouldBe(true);
+        result.Infos.ShouldContain(i => i.Contains("1 electrical connection(s)"));
+    }
+
+    [Fact]
+    public async Task Explode_DanglingRouteCell_DissolvesToFrozenPathWithoutDraft()
+    {
+        // A route cell touching no pins still dissolves (no draft), but its
+        // polygon cannot pair two pins — it degrades to a frozen route path.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("wgA", 0, 0)
+                .SRef("waveguide", 0, 20000)
+            .EndCell()
+            .DeviceCell("wgA")
+            .RouteStripCell("waveguide")
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        result.ImportedCellDrafts.Select(d => d.CellName).ShouldBe(new[] { "wgA" });
+        result.Connections.ShouldBeEmpty();
+        result.TopCellWaveguidePolygons.ShouldHaveSingleItem();
+        result.Infos.ShouldContain(i => i.Contains("Route cell 'waveguide'") && i.Contains("dissolved"));
+    }
+
+    [Fact]
+    public async Task Explode_LabeledCellWithRouteName_IsNotDissolved()
+    {
+        // A label anywhere marks a device cell: route-style name and pure
+        // route-layer geometry notwithstanding, it must stay a component draft.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("straight_1", 0, 0)
+            .EndCell()
+            .BeginCell("straight_1")
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Text(1, 10, "o1", 0, 2000)
+                .Text(1, 10, "o2", 10000, 2000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        result.ImportedCellDrafts.ShouldHaveSingleItem().CellName.ShouldBe("straight_1");
+        result.Instances.ShouldHaveSingleItem().CellName.ShouldBe("straight_1");
+        result.Infos.ShouldNotContain(i => i.Contains("dissolved"));
+    }
+
+    [Fact]
+    public async Task Explode_RouteLayerCellWithNonRouteName_IsNotDissolved()
+    {
+        // Pure route-layer geometry alone must not dissolve: gdsfactory stub
+        // cells ("stub_*") are label-free (1,0) rectangles and remain components.
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("stub_thing", 0, 0)
+            .EndCell()
+            .RouteStripCell("stub_thing")
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(library, "TOP", new GdsHierarchyImportOptions());
+
+        result.ImportedCellDrafts.ShouldHaveSingleItem().CellName.ShouldBe("stub_thing");
+        result.Instances.ShouldHaveSingleItem().CellName.ShouldBe("stub_thing");
+        result.Infos.ShouldNotContain(i => i.Contains("dissolved"));
+    }
+
+    [Fact]
+    public async Task Explode_KnownResolvedRouteNamedCell_IsNotDissolved()
+    {
+        // A deliberate known-component binding wins over dissolution.
+        var known = new KnownComponent(
+            "wg_lib", "testpdk", 10, 0.5,
+            new[]
+            {
+                new DetectedPin { Name = "in", XUm = 0, YUm = 0.25, AngleDegrees = 180, Source = DetectedPinSource.Label },
+                new DetectedPin { Name = "out", XUm = 10, YUm = 0.25, AngleDegrees = 0, Source = DetectedPinSource.Label },
+            });
+
+        var library = await ReadLibraryAsync(GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("waveguide", 0, 0)
+            .EndCell()
+            .RouteStripCell("waveguide")
+            .EndLibrary()
+            .ToArray());
+
+        var result = await GdsHierarchyImporter.ImportAsync(
+            library, "TOP", new GdsHierarchyImportOptions
+            {
+                ResolveKnownComponent = name => name == "waveguide" ? known : null,
+            });
+
+        result.ImportedCellDrafts.ShouldBeEmpty();
+        var instance = result.Instances.ShouldHaveSingleItem();
+        instance.KnownComponentIdentifier.ShouldBe("wg_lib");
+        result.Infos.ShouldNotContain(i => i.Contains("dissolved"));
+    }
+
+    // ── Fixture helpers ──────────────────────────────────────────────────────
+
+    private static async Task<GdsLibrary> ReadLibraryAsync(byte[] gds) =>
+        await new GdsReader().ReadAsync(new MemoryStream(gds));
+
+    /// <summary>Both endpoints of a pair as "instance.pin" strings.</summary>
+    private static string[] EndpointNames(GdsCircuitImport result, GdsPinPair pair) =>
+        new[] { pair.A, pair.B }
+            .Select(e => $"{result.Instances[e.InstanceIndex].InstanceName}.{e.PinName}")
+            .ToArray();
+}
+
+/// <summary>GDS fixture cell builders for the route-cell dissolution tests.</summary>
+file static class GdsRouteCellDissolveTestCells
+{
+    /// <summary>
+    /// 10×4 µm device cell: 0.5 µm core stripe on (1,0), extent rectangle on
+    /// the non-route layer (111,0), in/out port labels on (1,10) at y = 2 µm.
+    /// </summary>
+    public static GdsTestWriter DeviceCell(this GdsTestWriter writer, string name) =>
+        writer
+            .BeginCell(name)
+                .Boundary(1, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(111, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(1, 10, "in", 0, 2000)
+                .Text(1, 10, "out", 10000, 2000)
+            .EndCell();
+
+    /// <summary>
+    /// Label-free routed-interconnect cell: a single 10 × 0.5 µm strip
+    /// (y ∈ [1.75, 2.25]) on the given route layer — the shape our exporters
+    /// emit for an instantiated route segment.
+    /// </summary>
+    public static GdsTestWriter RouteStripCell(this GdsTestWriter writer, string name, int layer = 1) =>
+        writer
+            .BeginCell(name)
+                .Boundary(layer, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+            .EndCell();
+}


### PR DESCRIPTION
Automated implementation for #846

...
gression tests — connection restored without "waveguide" draft, rotated instance, metal/electrical route, dangling cell → frozen path, and three non-dissolution guards (labeled cell, non-route name, known-component binding). Verified `MixedBackendReimportIntegrationTests` unaffected (gdsfactory cells carry a (68,0) devrec layer, so the pure-route-layer criterion excludes them).

✅ Complete! Tools: smart_test.py (6 runs, ~500K saved), build_errors.py (2 runs, ~100K saved); semantic_search.py unavailable (OpenAI quota) — used Grep/Read.

=== PR SUMMARY ===
- Fixes #846: referenced route cells re-imported as bogus "waveguide" component drafts
- New GdsRouteCellDissolver: route-name prefix + label-free + pure route-layer geometry
- Dissolved polygons transformed into top-cell app space, fed to route matcher
- Restored connections are real and re-routable; unmatched polygons freeze gracefully
- Known-component bindings, labeled cells, mixed-layer cells never dissolve
- gdsfactory cells excluded via devrec layer — MixedBackendReimport tests unaffected
- Info notes report dissolved cells and dissolved-polygon accounting
- 7 new regression tests; 324 affected tests pass, build warning-free


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 9,697,682
- **Estimated cost:** $5.4307 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*