### PR TITLE
Time-domain simulation: evaluate slider-driven formula connections instead of rejecting the design

### DIFF
--- a/Connect-A-Pic-Core/Components/FormulaReading/MathExpressionReader.cs
+++ b/Connect-A-Pic-Core/Components/FormulaReading/MathExpressionReader.cs
@@ -1,4 +1,4 @@
-﻿using CAP_Core.Components;
+using CAP_Core.Components;
 using CAP_Core.Components.Core;
 using CAP_Core.Components.FormulaReading;
 using MathNet.Numerics;
@@ -68,6 +68,7 @@ namespace CAP_Core.Grid.FormulaReading
             var matches = regex.Matches(expressionDraft);
 
             Dictionary<string, Guid> usedParameterGuids = new();
+            IsPinsInvolved = false;
             foreach (Match match in matches)
             {
                 string parameterName = match.Value;
@@ -79,14 +80,12 @@ namespace CAP_Core.Grid.FormulaReading
                 else if (sliderParameterNameToGuidMap.TryGetValue(parameterName, out parameterGuid))
                 {
                     usedParameterGuids.TryAdd(parameterName, parameterGuid);
-                    IsPinsInvolved = false;
                 }
                 else
                 {
                     throw new InvalidOperationException($"Parameter name '{parameterName}' could not be found in any provided parameter name to Guid map.");
                 }
             }
-            IsPinsInvolved = false;
             return usedParameterGuids;
         }
         public static ConnectionFunction ConvertToDelegate(string expressionDraft,

--- a/Connect-A-Pic-Core/LightCalculation/SMatrix.cs
+++ b/Connect-A-Pic-Core/LightCalculation/SMatrix.cs
@@ -200,7 +200,7 @@ namespace CAP_Core.LightCalculation
             // error-handling layer can log and surface it.
         }
 
-        private List<object> GetWeightParameters(IEnumerable<Guid> parameterGuids, MathNet.Numerics.LinearAlgebra.Vector<Complex> inputVector)
+        private List<object> GetWeightParameters(IEnumerable<Guid> parameterGuids, MathNet.Numerics.LinearAlgebra.Vector<Complex>? inputVector)
         {
             List<object> usedParameterValues = new();
             foreach (var paramGuid in parameterGuids)
@@ -208,6 +208,10 @@ namespace CAP_Core.LightCalculation
                 // first check if the parameterGuid is in the pin-Dict
                 if (PinReference.TryGetValue(paramGuid, out int pinNumber))
                 {
+                    if (inputVector == null)
+                        throw new InvalidOperationException(
+                            "Field-dependent formula connection needs the current field vector; " +
+                            "only parameter-only connections may be evaluated without one.");
                     usedParameterValues.Add(inputVector[pinNumber]);
                 }
                 // check if parameterGuid is in the slider Dict
@@ -218,6 +222,26 @@ namespace CAP_Core.LightCalculation
             }
 
             return usedParameterValues;
+        }
+
+        /// <summary>
+        /// Evaluates every parameter-only (slider-driven) formula connection once and writes
+        /// the resulting constant into the linear matrix. Such connections depend on design
+        /// parameters, not on the optical field, so the circuit stays linear for a fixed
+        /// parameter set — callers that require a purely linear system (e.g. the time-domain
+        /// simulation) can use this to resolve them instead of rejecting the design.
+        /// Field-dependent (inner-loop) connections are left untouched.
+        /// </summary>
+        public void EvaluateParameterOnlyConnections()
+        {
+            foreach (var connection in NonLinearConnections)
+            {
+                if (connection.Value.IsInnerLoopFunction)
+                    continue;
+                var weightParameters = GetWeightParameters(connection.Value.UsedParameterGuids, inputVector: null);
+                var calculatedWeight = connection.Value.CalcConnectionWeightAsync(weightParameters);
+                SMat[PinReference[connection.Key.PinIdEnd], PinReference[connection.Key.PinIdStart]] = calculatedWeight;
+            }
         }
         private async Task RecomputeSMatNonLinearPartsAsync(MathNet.Numerics.LinearAlgebra.Vector<Complex> inputVector, bool SkipOuterLoopFunctions = true)
         {

--- a/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilder.cs
+++ b/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilder.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using MathNet.Numerics.IntegralTransforms;
 
@@ -53,8 +54,10 @@ public class ImpulseResponseBuilder
     /// in per closure call.
     /// </param>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when any nonlinear connection is found (Phase 1 gate) or the closure's
-    /// pair count exceeds the memory gate.
+    /// Thrown when a field-dependent (truly nonlinear) connection is found (Phase 1 gate)
+    /// or the closure's pair count exceeds the memory gate. Parameter-only (slider-driven)
+    /// formula connections are constant for a fixed parameter set and are evaluated into
+    /// the linear matrix instead of being rejected.
     /// </exception>
     /// <exception cref="NonConvergentCircuitException">
     /// A component's S-matrix data is non-passive, a lossless feedback loop sits exactly
@@ -72,14 +75,17 @@ public class ImpulseResponseBuilder
 
         var (freqGrid, dt) = BuildFrequencyGrid(centerWavelengthNm, spanNm, nPoints);
 
-        // Check for nonlinear connections — Phase 1 only supports linear circuits.
+        // Parameter-only (slider-driven) formula connections are constant for a fixed
+        // parameter set — evaluate them once into the linear matrix instead of rejecting
+        // the design. Only field-dependent (inner-loop) connections are truly nonlinear.
         int referenceNm = FreqToWavelengthNmInt(freqGrid[nPoints / 2]);
         var referenceMatrix = _matrixBuilder.GetSystemSMatrix(referenceNm);
-        if (referenceMatrix.NonLinearConnections.Count > 0)
+        referenceMatrix.EvaluateParameterOnlyConnections();
+        if (referenceMatrix.NonLinearConnections.Any(c => c.Value.IsInnerLoopFunction))
         {
             throw new InvalidOperationException(
                 "Time-domain simulation (Phase 1) supports linear circuits only. " +
-                "The design contains nonlinear connections. Remove or linearize them before running transient analysis.");
+                "The design contains field-dependent (nonlinear) connections. Remove or linearize them before running transient analysis.");
         }
 
         // Cache S-matrix results by rounded wavelength nm to avoid duplicate calls.
@@ -115,6 +121,9 @@ public class ImpulseResponseBuilder
                 // pair must include the transitive multi-hop closure, otherwise light
                 // never crosses a component boundary in the transient simulation.
                 var sMatrix = _matrixBuilder.GetSystemSMatrix(wavelengthNm);
+                // Same parameter-only evaluation as for the reference matrix (see Build):
+                // fresh matrices from the builder carry the formula connections again.
+                sMatrix.EvaluateParameterOnlyConnections();
                 values = ComputeTransitiveValues(sMatrix, activeInputPinIds, circuitContext, wavelengthNm);
                 matrixCache[wavelengthNm] = values;
             }

--- a/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilder.cs
+++ b/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilder.cs
@@ -80,13 +80,7 @@ public class ImpulseResponseBuilder
         // the design. Only field-dependent (inner-loop) connections are truly nonlinear.
         int referenceNm = FreqToWavelengthNmInt(freqGrid[nPoints / 2]);
         var referenceMatrix = _matrixBuilder.GetSystemSMatrix(referenceNm);
-        referenceMatrix.EvaluateParameterOnlyConnections();
-        if (referenceMatrix.NonLinearConnections.Any(c => c.Value.IsInnerLoopFunction))
-        {
-            throw new InvalidOperationException(
-                "Time-domain simulation (Phase 1) supports linear circuits only. " +
-                "The design contains field-dependent (nonlinear) connections. Remove or linearize them before running transient analysis.");
-        }
+        EvaluateParameterOnlyAndThrowIfFieldDependent(referenceMatrix);
 
         // Cache S-matrix results by rounded wavelength nm to avoid duplicate calls.
         // Seeding with the reference wavelength keeps its matrix from being built twice.
@@ -101,6 +95,22 @@ public class ImpulseResponseBuilder
 
         var hFreq = CollectFrequencyResponses(freqGrid, nPoints, matrixCache, activeInputPinIds, circuitContext);
         return InverseTransform(hFreq, nPoints, dt);
+    }
+
+    /// <summary>
+    /// Evaluates parameter-only (slider-driven) formula connections into the linear matrix
+    /// and enforces the Phase-1 gate: any remaining field-dependent (inner-loop) connection
+    /// makes the circuit truly nonlinear and is rejected.
+    /// </summary>
+    private static void EvaluateParameterOnlyAndThrowIfFieldDependent(SMatrix sMatrix)
+    {
+        sMatrix.EvaluateParameterOnlyConnections();
+        if (sMatrix.NonLinearConnections.Any(c => c.Value.IsInnerLoopFunction))
+        {
+            throw new InvalidOperationException(
+                "Time-domain simulation (Phase 1) supports linear circuits only. " +
+                "The design contains field-dependent (nonlinear) connections. Remove or linearize them before running transient analysis.");
+        }
     }
 
     /// <summary>Fills H[k] for each frequency point; new pairs re-check the memory gate.</summary>
@@ -121,9 +131,12 @@ public class ImpulseResponseBuilder
                 // pair must include the transitive multi-hop closure, otherwise light
                 // never crosses a component boundary in the transient simulation.
                 var sMatrix = _matrixBuilder.GetSystemSMatrix(wavelengthNm);
-                // Same parameter-only evaluation as for the reference matrix (see Build):
-                // fresh matrices from the builder carry the formula connections again.
-                sMatrix.EvaluateParameterOnlyConnections();
+                // Fresh matrices from the builder carry the formula connections again, so the
+                // same evaluation + gate as for the reference matrix applies. In practice the
+                // connection set is wavelength-invariant (interpolators copy it over), but if
+                // that invariant ever breaks, a field-dependent connection must throw here
+                // rather than silently stay 0 in the linear matrix.
+                EvaluateParameterOnlyAndThrowIfFieldDependent(sMatrix);
                 values = ComputeTransitiveValues(sMatrix, activeInputPinIds, circuitContext, wavelengthNm);
                 matrixCache[wavelengthNm] = values;
             }

--- a/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/TimeDomainSimulator.cs
+++ b/Connect-A-Pic-Core/LightCalculation/TimeDomainSimulation/TimeDomainSimulator.cs
@@ -4,7 +4,9 @@ namespace CAP_Core.LightCalculation.TimeDomainSimulation;
 
 /// <summary>
 /// Orchestrates circuit-level time-domain simulation via IFFT of S-parameters.
-/// Phase 1: linear circuits only (nonlinear connections cause an exception).
+/// Phase 1: linear circuits only. Parameter-only (slider-driven) formula connections are
+/// evaluated once into the linear matrix; only field-dependent (truly nonlinear)
+/// connections cause an exception.
 /// Implements <see cref="ILightCalculator"/> for polymorphic registration alongside
 /// <see cref="GridLightCalculator"/>; steady-state field propagation is not applicable
 /// for time-domain mode — use <see cref="Run"/> instead.

--- a/UnitTests/Components/FormulaReading/MathExpressionReaderTests.cs
+++ b/UnitTests/Components/FormulaReading/MathExpressionReaderTests.cs
@@ -1,0 +1,68 @@
+using CAP_Core.Components.FormulaReading;
+using CAP_Core.Grid.FormulaReading;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.FormulaReading;
+
+public class MathExpressionReaderTests
+{
+    private static ConnectionFunction Convert(
+        string expression,
+        Dictionary<string, Guid>? pinMap = null,
+        Dictionary<string, Guid>? sliderMap = null)
+    {
+        return MathExpressionReader.ConvertToDelegate(
+            expression,
+            pinMap ?? new Dictionary<string, Guid>(),
+            sliderMap ?? new Dictionary<string, Guid>());
+    }
+
+    [Fact]
+    public void ConvertToDelegate_SliderOnlyFormula_IsNotInnerLoop()
+    {
+        var sliderId = Guid.NewGuid();
+
+        var fn = Convert("SLIDER1 * 0.5", sliderMap: new() { ["SLIDER1"] = sliderId });
+
+        fn.IsInnerLoopFunction.ShouldBeFalse();
+        fn.UsedParameterGuids.ShouldBe(new[] { sliderId });
+    }
+
+    [Fact]
+    public void ConvertToDelegate_PinDependentFormula_IsInnerLoop()
+    {
+        var pinId = Guid.NewGuid();
+
+        var fn = Convert("PIN1 * 2", pinMap: new() { ["PIN1"] = pinId });
+
+        fn.IsInnerLoopFunction.ShouldBeTrue();
+        fn.UsedParameterGuids.ShouldBe(new[] { pinId });
+    }
+
+    [Fact]
+    public void ConvertToDelegate_MixedPinAndSliderFormula_IsInnerLoop()
+    {
+        var pinId = Guid.NewGuid();
+        var sliderId = Guid.NewGuid();
+
+        var fn = Convert("PIN1 * SLIDER1",
+            pinMap: new() { ["PIN1"] = pinId },
+            sliderMap: new() { ["SLIDER1"] = sliderId });
+
+        // any pin involvement makes the connection field-dependent, no matter
+        // whether a slider appears before or after the pin in the expression
+        fn.IsInnerLoopFunction.ShouldBeTrue();
+        fn.UsedParameterGuids.ShouldContain(pinId);
+        fn.UsedParameterGuids.ShouldContain(sliderId);
+    }
+
+    [Fact]
+    public void ConvertToDelegate_ConstantExpression_IsNotInnerLoop()
+    {
+        var fn = Convert("0.707");
+
+        fn.IsInnerLoopFunction.ShouldBeFalse();
+        fn.UsedParameterGuids.ShouldBeEmpty();
+    }
+}

--- a/UnitTests/LightCalculation/InnerLoopFormulaEvaluationTests.cs
+++ b/UnitTests/LightCalculation/InnerLoopFormulaEvaluationTests.cs
@@ -1,0 +1,71 @@
+using System.Numerics;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.FormulaReading;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
+using MathNetVector = MathNet.Numerics.LinearAlgebra.Vector<System.Numerics.Complex>;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.LightCalculation;
+
+/// <summary>
+/// Pins the steady-state behaviour of field-dependent (inner-loop) formula connections:
+/// they are re-evaluated on every Neumann-series iteration because they depend on the
+/// current field (e.g. logic gates switching on optical power), unlike parameter-only
+/// (slider-driven) connections which are evaluated once before the iteration.
+/// This only works when IsInnerLoopFunction is classified correctly (MathExpressionReader).
+/// </summary>
+public class InnerLoopFormulaEvaluationTests
+{
+    [Fact]
+    public async Task InnerLoopConnection_IsReevaluatedDuringIteration()
+    {
+        var pin = new Pin("p", 0, MatterType.Light, RectSide.Left);
+        var sMatrix = new SMatrix(new List<Guid> { pin.IDInFlow, pin.IDOutFlow }, new());
+
+        int evaluationCount = 0;
+        var innerLoopFn = new ConnectionFunction(
+            weights => { evaluationCount++; return Complex.Zero; },
+            "PIN1 * 0",
+            new List<Guid> { pin.IDInFlow },
+            IsInnerLoopFunction: true);
+        sMatrix.NonLinearConnections.Add((pin.IDInFlow, pin.IDOutFlow), innerLoopFn);
+
+        var input = MathNetVector.Build.Dense(2);
+        input[sMatrix.PinReference[pin.IDInFlow]] = Complex.One;
+
+        await sMatrix.CalcFieldAtPinsAfterStepsAsync(input, maxIterations: 5, new CancellationTokenSource());
+
+        // Once before the iteration (all functions are evaluated there) plus at least
+        // once inside it (inner-loop only). With the old classification bug the flag was
+        // always false, so the in-loop evaluation never happened and the count stayed 1.
+        evaluationCount.ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task ParameterOnlyConnection_IsEvaluatedOnceBeforeIteration()
+    {
+        var pin = new Pin("p", 0, MatterType.Light, RectSide.Left);
+        var sliderId = Guid.NewGuid();
+        var sMatrix = new SMatrix(
+            new List<Guid> { pin.IDInFlow, pin.IDOutFlow },
+            new List<(Guid sliderID, double value)> { (sliderId, 0.5) });
+
+        int evaluationCount = 0;
+        var parameterOnlyFn = new ConnectionFunction(
+            weights => { evaluationCount++; return Complex.Zero; },
+            "SLIDER1 * 0",
+            new List<Guid> { sliderId },
+            IsInnerLoopFunction: false);
+        sMatrix.NonLinearConnections.Add((pin.IDInFlow, pin.IDOutFlow), parameterOnlyFn);
+
+        var input = MathNetVector.Build.Dense(2);
+        input[sMatrix.PinReference[pin.IDInFlow]] = Complex.One;
+
+        await sMatrix.CalcFieldAtPinsAfterStepsAsync(input, maxIterations: 5, new CancellationTokenSource());
+
+        // Evaluated exactly once before the iteration; skipped inside the loop.
+        evaluationCount.ShouldBe(1);
+    }
+}

--- a/UnitTests/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilderTests.cs
+++ b/UnitTests/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilderTests.cs
@@ -99,9 +99,9 @@ public class ImpulseResponseBuilderTests
     }
 
     [Fact]
-    public void Build_WithNonlinearConnections_ThrowsInvalidOperationException()
+    public void Build_WithFieldDependentConnection_ThrowsInvalidOperationException()
     {
-        // Arrange: system matrix has a nonlinear connection
+        // Arrange: system matrix has a truly nonlinear (field-dependent) connection
         var inputPinId = Guid.NewGuid();
         var outputPinId = Guid.NewGuid();
         var allPins = new List<Guid> { inputPinId, outputPinId };
@@ -113,10 +113,10 @@ public class ImpulseResponseBuilderTests
                 var matrix = new SMatrix(allPins, new());
                 var key = (inputPinId, outputPinId);
                 var nonLinFn = new ConnectionFunction(
-                    _ => Complex.One,
-                    "1",
-                    new List<Guid>(),
-                    IsInnerLoopFunction: false);
+                    weights => (Complex)weights[0],
+                    "PIN1 * 2",
+                    new List<Guid> { inputPinId },
+                    IsInnerLoopFunction: true);
                 matrix.NonLinearConnections.Add(key, nonLinFn);
                 return matrix;
             });
@@ -124,8 +124,51 @@ public class ImpulseResponseBuilderTests
         var builder = new ImpulseResponseBuilder(mockBuilder.Object);
 
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() =>
+        var ex = Should.Throw<InvalidOperationException>(() =>
             builder.Build(CenterWavelengthNm, SpanNm, NPoints));
+        ex.Message.ShouldContain("linear circuits only");
+    }
+
+    [Fact]
+    public void Build_WithParameterOnlyConnection_EvaluatesSliderValueIntoLinearMatrix()
+    {
+        // Arrange: a slider-driven formula connection is constant for a fixed slider
+        // value, so it must be evaluated into the linear matrix instead of rejected.
+        var inputPinId = Guid.NewGuid();
+        var outputPinId = Guid.NewGuid();
+        var sliderId = Guid.NewGuid();
+        const double sliderValue = 0.5;
+        var allPins = new List<Guid> { inputPinId, outputPinId };
+
+        var mockBuilder = new Mock<ISystemMatrixBuilder>();
+        mockBuilder.Setup(b => b.GetSystemSMatrix(It.IsAny<int>()))
+            .Returns((int _) =>
+            {
+                // fresh matrix per call, like the real builder — the connection must be
+                // evaluated on every wavelength's matrix, not just the reference one.
+                var matrix = new SMatrix(allPins, new List<(Guid sliderID, double value)> { (sliderId, sliderValue) });
+                var key = (inputPinId, outputPinId);
+                var formulaFn = new ConnectionFunction(
+                    weights => new Complex((double)weights[0], 0),
+                    "SLIDER1",
+                    new List<Guid> { sliderId },
+                    IsInnerLoopFunction: false);
+                matrix.NonLinearConnections.Add(key, formulaFn);
+                return matrix;
+            });
+
+        var builder = new ImpulseResponseBuilder(mockBuilder.Object);
+
+        // Act: must not throw, and the evaluated S_21 = sliderValue at all frequencies
+        // gives an impulse response peaked at t=0 with that magnitude.
+        var impulseResponses = builder.Build(CenterWavelengthNm, SpanNm, NPoints);
+
+        // Assert
+        impulseResponses.Count.ShouldBe(1);
+        var h = impulseResponses[0].Samples;
+        int peakIdx = h.Select((v, i) => (Mag: v.Magnitude, Idx: i)).MaxBy(x => x.Mag).Idx;
+        peakIdx.ShouldBe(0);
+        h[0].Magnitude.ShouldBe(sliderValue, tolerance: 0.05);
     }
 
     [Fact]

--- a/UnitTests/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilderTests.cs
+++ b/UnitTests/LightCalculation/TimeDomainSimulation/ImpulseResponseBuilderTests.cs
@@ -165,6 +165,8 @@ public class ImpulseResponseBuilderTests
 
         // Assert
         impulseResponses.Count.ShouldBe(1);
+        impulseResponses[0].InputPinId.ShouldBe(inputPinId);
+        impulseResponses[0].OutputPinId.ShouldBe(outputPinId);
         var h = impulseResponses[0].Samples;
         int peakIdx = h.Select((v, i) => (Mag: v.Magnitude, Idx: i)).MaxBy(x => x.Mag).Idx;
         peakIdx.ShouldBe(0);

--- a/UnitTests/LightCalculation/TimeDomainSimulation/TimeDomainSimulatorTests.cs
+++ b/UnitTests/LightCalculation/TimeDomainSimulation/TimeDomainSimulatorTests.cs
@@ -136,8 +136,9 @@ public class TimeDomainSimulatorTests
             .Returns((int _) =>
             {
                 var matrix = new SMatrix(allPins, new());
+                // truly nonlinear: the transfer depends on the pin's field amplitude
                 var nonLinFn = new ConnectionFunction(
-                    _ => Complex.One, "1", new List<Guid>(), IsInnerLoopFunction: false);
+                    weights => (Complex)weights[0], "PIN1 * 2", new List<Guid> { inputPin }, IsInnerLoopFunction: true);
                 matrix.NonLinearConnections.Add((inputPin, outputPin), nonLinFn);
                 return matrix;
             });


### PR DESCRIPTION
## Problem

Clicking **eye diagram** on a design with slider-parametrized components (e.g. the bundled Mach-Zehnder example with MMI splitters / phase shifter) failed with:

> Time-domain simulation (Phase 1) supports linear circuits only. The design contains nonlinear connections.

Physically wrong: an MMI whose transfer is a formula over a **slider** (`splitting_ratio`, `phase_shift`) is *linear* for a fixed parameter set — no nonlinear material involved. The steady-state solver already treats them that way.

## Root causes (two bugs)

1. **`MathExpressionReader.ExtractParameterGuids`** unconditionally reset `IsPinsInvolved = false` at the end, discarding the pin-involvement detection done in the loop. Every formula connection was mis-classified as non-field-dependent, making the `IsInnerLoopFunction` flag useless.

2. **`ImpulseResponseBuilder`** rejected *any* design whose system matrix contained formula connections, instead of evaluating the constant (slider-driven) ones into the linear matrix like `SMatrix.CalcFieldAtPinsAfterStepsAsync` already does for steady state.

## Fix

- `IsPinsInvolved` is now aggregated correctly (any `PIN<n>` placeholder ⇒ field-dependent / inner-loop).
- New `SMatrix.EvaluateParameterOnlyConnections()` evaluates slider-driven formula connections once into the linear matrix; the Phase-1 gate now only rejects truly field-dependent (inner-loop) connections, with a clearer error message. The gate runs on the reference matrix *and* on every freshly built wavelength matrix in the sweep.
- No bundled PDK uses pin-dependent formulas, so existing designs see no behaviour change in steady-state simulation — they only gain working transient/eye analysis.

### Side effect of the classification fix (intended)

With `IsPinsInvolved` now working, steady-state simulation (`CalcFieldAtPinsAfterStepsAsync`) re-evaluates pin-dependent (inner-loop) formulas **on every Neumann-series iteration** instead of freezing them after the pre-loop pass. That is exactly the behaviour the existing code comment documents ("logic gates that switch based on optical power") — it was dead code before because the flag was always `false`. New tests pin both behaviours (inner-loop re-evaluated, parameter-only evaluated once).

## Tests

- 4 new `MathExpressionReader` tests (slider-only / pin-only / mixed / constant)
- 2 new steady-state tests pinning inner-loop vs. parameter-only evaluation cadence
- Gate tests on builder + simulator level switched to genuinely field-dependent connections
- New test: slider-formula connection is evaluated into the matrix (impulse peak ≈ slider value, correct pin direction)
- **Full suite: 5477 passed, 0 failed** (before the 2 additional steady-state tests)
