### PR TITLE
GDS import: evidence-based layer recognition proven against a real nazca/foundry file

### DIFF
--- a/CAP-DataAccess/Import/Gds/GdsFileProvenance.cs
+++ b/CAP-DataAccess/Import/Gds/GdsFileProvenance.cs
@@ -1,0 +1,30 @@
+namespace CAP_DataAccess.Import.Gds;
+
+/// <summary>
+/// Detects whether a GDS file was produced by an external (nazca-based)
+/// foundry flow rather than by Lunima itself. nazca stamps every cell with a
+/// metadata text blob ("cellname: …\nfoundry_pdk: …\nnazca_pdk_version: …");
+/// Lunima's own exports never carry these. The import dialog uses this to
+/// decide whether the Lunima-specific default layer lists (our own export
+/// conventions) may be pre-filled: on a foreign file they are wrong more
+/// often than right — one foundry's metal number is another's core etch —
+/// so the fields start empty and fill purely from file evidence.
+/// </summary>
+public static class GdsFileProvenance
+{
+    /// <summary>True when any cell carries a nazca/foundry metadata stamp.</summary>
+    public static bool HasForeignStamps(GdsLibrary library)
+    {
+        ArgumentNullException.ThrowIfNull(library);
+        foreach (var cell in library.Cells.Values)
+        {
+            foreach (var text in cell.Elements.OfType<GdsText>())
+            {
+                if (text.Text.Contains("foundry_pdk", StringComparison.Ordinal)
+                    || text.Text.Contains("nazca_pdk_version", StringComparison.Ordinal))
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/CAP-DataAccess/Import/Gds/GdsPinArrowMarkers.cs
+++ b/CAP-DataAccess/Import/Gds/GdsPinArrowMarkers.cs
@@ -24,8 +24,8 @@ internal static class GdsPinArrowMarkers
     /// <summary>One pin position derived from an arrow-marker pair (GDS space, µm).</summary>
     internal sealed record Marker(GdsPoint Position, int Layer, int Datatype);
 
-    /// <summary>Marker chevrons are sub-µm to few-µm; larger shapes are real geometry.</summary>
-    private const double MaxMarkerSpanUm = 3.0;
+    /// <summary>Marker chevrons are sub-µm to a few µm (electrical pin markers reach 5 µm); larger shapes are real geometry.</summary>
+    private const double MaxMarkerSpanUm = 6.0;
 
     /// <summary>Markers have few vertices (the nazca chevron has 7).</summary>
     private const int MaxMarkerVertices = 12;
@@ -71,9 +71,10 @@ internal static class GdsPinArrowMarkers
                 continue;
             for (int j = i + 1; j < candidates.Count; j++)
             {
-                if (paired[j] || candidates[j].Layer != candidates[i].Layer
-                    || candidates[j].Datatype != candidates[i].Datatype)
+                if (paired[j])
                     continue;
+                // Pairs may span DIFFERENT marker layers — some conventions
+                // place one chevron per pin per layer, meeting tip-to-tip.
                 if (!ClosestVertices(candidates[i].Points, candidates[j].Points,
                         out var onA, out var onB, out double distance)
                     || distance > PairingToleranceUm)
@@ -101,6 +102,10 @@ internal static class GdsPinArrowMarkers
     }
 
     /// <summary>The marker shape rule: few vertices, small span, one sharp convex corner.</summary>
+    /// <summary>True when every polygon on the layer is marker-shaped — a dedicated marker layer.</summary>
+    internal static bool IsMarkerLayer(IReadOnlyList<GdsPolygon> layerPolygons) =>
+        layerPolygons.Count > 0 && layerPolygons.All(p => IsMarkerShaped(Normalize(p.Points)));
+
     private static bool IsMarkerShaped(List<GdsPoint> points)
     {
         if (points.Count is < 3 or > MaxMarkerVertices)

--- a/CAP-DataAccess/Import/Gds/GdsPinDetector.AnchorProbe.cs
+++ b/CAP-DataAccess/Import/Gds/GdsPinDetector.AnchorProbe.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace CAP_DataAccess.Import.Gds;
 
 /// <summary>
@@ -48,6 +50,22 @@ public static partial class GdsPinDetector
     /// </summary>
     internal static readonly string[] ElectricalLabelMarkers =
         ["anode", "cathode", "elec", "pad", "gnd", "vcc", "vdd"];
+
+    /// <summary>
+    /// Contact-style pin names (e1, n1, p1, …): gdsfactory's electrical ports
+    /// and foundry n/p-contact names. Anchored to the whole name so optical
+    /// names like "in", "out", "port0" never match.
+    /// </summary>
+    private static readonly Regex ElectricalContactNamePattern = new(
+        @"^[enp][0-9]+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>True for label names that always denote an electrical pin/pad.</summary>
+    internal static bool IsElectricalLabelName(string label)
+    {
+        var trimmed = label.Trim();
+        return ElectricalContactNamePattern.IsMatch(trimmed)
+            || ElectricalLabelMarkers.Any(m => trimmed.Contains(m, StringComparison.OrdinalIgnoreCase));
+    }
 
     /// <summary>One indexed outline segment: endpoints plus the owning polygon's ordinal.</summary>
     private readonly record struct IndexedSegment(GdsPoint P1, GdsPoint P2, int PolygonOrdinal);
@@ -252,11 +270,8 @@ public static partial class GdsPinDetector
                 return null; // waveguide evidence beats the name heuristic
         }
 
-        foreach (string marker in ElectricalLabelMarkers)
-        {
-            if (label.Contains(marker, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
+        if (IsElectricalLabelName(label))
+            return true;
         return null;
     }
 }

--- a/CAP-DataAccess/Import/Gds/LayerCensus/GdsLayerCensus.cs
+++ b/CAP-DataAccess/Import/Gds/LayerCensus/GdsLayerCensus.cs
@@ -31,6 +31,15 @@ public sealed record GdsLayerCensusEntry
     /// </summary>
     public int SingleLineTextCount { get; init; }
 
+    /// <summary>
+    /// Single-line TEXT elements that additionally survive the ghost filter
+    /// (<c>GdsGhostLabelFilter</c>): no bbox anchors (tl/tr/…), no parameter
+    /// annotations (R:0.0001), no empty strings. This is the count that backs
+    /// port-label suggestions — a layer carrying ONLY helper labels must not
+    /// become a port-layer suggestion.
+    /// </summary>
+    public int PortLikeTextCount { get; init; }
+
     /// <summary>Names of the cells that carry TEXT elements on this pair, sorted.</summary>
     public IReadOnlyList<string> TextCellNames { get; init; } = Array.Empty<string>();
 }
@@ -66,6 +75,7 @@ public static class GdsLayerCensus
                 PathCount = kv.Value.Paths,
                 TextCount = kv.Value.Texts,
                 SingleLineTextCount = kv.Value.SingleLineTexts,
+                PortLikeTextCount = kv.Value.PortLikeTexts,
                 TextCellNames = kv.Value.TextCells.OrderBy(n => n, StringComparer.Ordinal).ToList(),
             })
             .ToList();
@@ -86,7 +96,11 @@ public static class GdsLayerCensus
                 var entry = Get(stats, (text.Layer, text.TextType));
                 entry.Texts++;
                 if (!text.Text.Contains('\n'))
+                {
                     entry.SingleLineTexts++;
+                    if (text.Text.Trim().Length > 0 && !GdsGhostLabelFilter.IsGhost(text))
+                        entry.PortLikeTexts++;
+                }
                 entry.TextCells.Add(cellName);
                 break;
         }
@@ -108,6 +122,7 @@ public static class GdsLayerCensus
         public int Paths;
         public int Texts;
         public int SingleLineTexts;
+        public int PortLikeTexts;
         public readonly HashSet<string> TextCells = new(StringComparer.Ordinal);
     }
 }

--- a/CAP-DataAccess/Import/Gds/LayerCensus/GdsLayerSuggestionEngine.cs
+++ b/CAP-DataAccess/Import/Gds/LayerCensus/GdsLayerSuggestionEngine.cs
@@ -61,15 +61,21 @@ public static class GdsLayerSuggestionEngine
         HashSet<(int, int, GdsLayerRole)> covered)
     {
         var optical = new HashSet<(int, int)>();
-        foreach (var (pair, labels) in GdsPortAttachmentProbe.Scan(library))
+        foreach (var (pair, evidence) in GdsPortAttachmentProbe.Scan(library))
         {
             if (!covered.Add((pair.Layer, pair.Datatype, GdsLayerRole.Waveguide)))
                 continue;
-            optical.Add(pair);
+            // A single resting label is a hint; a quorum is proof (and only
+            // proof vetoes a metal convention claim on the same pair).
+            var confidence = evidence.Count >= GdsPortAttachmentProbe.MinVotesForProof
+                ? GdsSuggestionConfidence.High
+                : GdsSuggestionConfidence.Medium;
+            if (confidence == GdsSuggestionConfidence.High)
+                optical.Add(pair);
             suggestions.Add(new GdsLayerSuggestion(
                 pair.Layer, pair.Datatype, GdsLayerRole.Waveguide,
-                GdsSuggestionConfidence.High,
-                $"port label(s) {FormatLabelSample(labels)} rest on this layer's shapes"));
+                confidence,
+                $"{evidence.Count} port label(s) rest on this layer ({FormatLabelSample(evidence.SampleLabels)})"));
         }
         return optical;
     }
@@ -120,7 +126,7 @@ public static class GdsLayerSuggestionEngine
     /// <summary>A convention only applies when the pair actually carries matching content.</summary>
     private static bool RoleFitsContent(GdsLayerRole role, GdsLayerCensusEntry entry) => role switch
     {
-        GdsLayerRole.PortLabels => entry.SingleLineTextCount > 0,
+        GdsLayerRole.PortLabels => entry.PortLikeTextCount > 0,
         _ => entry.PolygonCount + entry.PathCount > 0,
     };
 
@@ -129,17 +135,17 @@ public static class GdsLayerSuggestionEngine
         List<GdsLayerSuggestion> suggestions,
         HashSet<(int, int, GdsLayerRole)> covered)
     {
-        foreach (var entry in census.Where(e => e.SingleLineTextCount > 0))
+        foreach (var entry in census.Where(e => e.PortLikeTextCount > 0))
         {
             if (!covered.Add((entry.Layer, entry.Datatype, GdsLayerRole.PortLabels)))
                 continue;
-            // Single-line text labels on a layer ARE the port-label evidence —
-            // strong enough to auto-apply (helper/anchor labels are filtered
-            // downstream at pin detection, so a wrong accept stays harmless).
+            // Single-line, non-ghost text labels on a layer ARE the port-label
+            // evidence — strong enough to auto-apply (helper/anchor labels are
+            // filtered here already and again downstream at pin detection).
             suggestions.Add(new GdsLayerSuggestion(
                 entry.Layer, entry.Datatype, GdsLayerRole.PortLabels,
                 GdsSuggestionConfidence.High,
-                $"{entry.SingleLineTextCount} text label(s) in {FormatCellList(entry.TextCellNames)}"));
+                $"{entry.PortLikeTextCount} text label(s) in {FormatCellList(entry.TextCellNames)}"));
         }
     }
 

--- a/CAP-DataAccess/Import/Gds/LayerCensus/GdsPortAttachmentProbe.cs
+++ b/CAP-DataAccess/Import/Gds/LayerCensus/GdsPortAttachmentProbe.cs
@@ -3,23 +3,28 @@ namespace CAP_DataAccess.Import.Gds.LayerCensus;
 /// <summary>
 /// Content evidence for "this layer is optical": which geometry layers the
 /// file's port labels physically REST on. A port label sits at the end of the
-/// shape it names — o1/o2 on the waveguide core — so the polygon/path layer
-/// under a label carries optical ports with far more certainty than any
-/// layer-number convention table (numbers collide across foundries; one
-/// foundry's M1 is another's core etch). This probe is deliberately
-/// configuration-independent: it never consults the configured
-/// waveguide/metal/port layer lists, so its result can arbitrate exactly when
-/// those lists (or their defaults) are wrong for the file at hand.
+/// shape it names — o1/o2 on the waveguide core — so the shape under a label
+/// carries optical ports with far more certainty than any layer-number
+/// convention table (numbers collide across foundries; one foundry's M1 is
+/// another's core etch). This probe is deliberately configuration-independent:
+/// it never consults the configured waveguide/metal/port layer lists, so its
+/// result can arbitrate exactly when those lists (or their defaults) are wrong
+/// for the file at hand.
 ///
-/// Labels that are themselves ghosts (nazca bbox anchors, parameter
-/// annotations) or carry electrical marker names (pad/gnd/anode/… — labeled
-/// bond pads would otherwise mark their metal layer "optical") never
-/// contribute. Geometry is evaluated in the reader-normalized µm space; a
-/// label attaches when its anchor lies inside a polygon, within
-/// <see cref="OutlineTouchToleranceUm"/> of its outline, or within half the
-/// width (plus tolerance) of a path's centerline. A label touching several
-/// nested shapes attaches to the SMALLEST one only — enclosing
-/// cladding/keepout rectangles never inherit the attachment.
+/// Rules, learned from real foundry files:
+/// - Empty, multi-line, ghost (bbox anchors / parameter annotations) and
+///   electrically-named (pad/gnd/anode/…, or contact-style e1/n1/p1) labels
+///   never vote.
+/// - A label attaches to the most SPECIFIC shape it touches (smallest bbox
+///   area): foundries stamp a dedicated pin square on the waveguide layer
+///   exactly where the pin marker tips sit. Cell-covering background
+///   rectangles are skipped while anything else touches.
+/// - Equal-size overlaps (e.g. an annotation backing square stacked on the
+///   pin square) are broken by file-wide content: the layer that carries
+///   device geometry everywhere beats the annotation layer.
+/// - One stray label proves little: the result carries the vote COUNT per
+///   layer, and only a quorum (<see cref="MinVotesForProof"/>) is treated as
+///   proof by the suggestion engine.
 /// </summary>
 public static class GdsPortAttachmentProbe
 {
@@ -30,29 +35,56 @@ public static class GdsPortAttachmentProbe
     /// </summary>
     private const double OutlineTouchToleranceUm = 1.0;
 
+    /// <summary>Shapes covering most of the cell are frames/backgrounds, never pin shapes.</summary>
+    private const double BackgroundAreaFraction = 0.8;
+
     /// <summary>Cap on label names kept per layer (for suggestion reasons).</summary>
     private const int MaxLabelsPerLayer = 4;
 
+    /// <summary>Votes a layer needs before its optical claim counts as proven.</summary>
+    public const int MinVotesForProof = 2;
+
+    /// <summary>One layer's attachment evidence: how many port labels rest on it, plus a name sample.</summary>
+    public sealed record AttachmentEvidence(int Count, IReadOnlyList<string> SampleLabels);
+
     /// <summary>
     /// Scans every cell of the library and returns, per (layer, datatype), the
-    /// port labels resting on that layer's shapes (sorted, capped at
-    /// <see cref="MaxLabelsPerLayer"/> names; empty layers are omitted).
-    /// Deterministic: layers and labels are reported sorted.
+    /// attachment evidence of port labels resting on that layer's shapes.
+    /// Deterministic: layers sorted, samples in scan order.
     /// </summary>
-    public static IReadOnlyDictionary<(int Layer, int Datatype), IReadOnlyList<string>> Scan(
+    public static IReadOnlyDictionary<(int Layer, int Datatype), AttachmentEvidence> Scan(
         GdsLibrary library)
     {
         ArgumentNullException.ThrowIfNull(library);
-        var attachments = new SortedDictionary<(int, int), List<string>>();
+        // File-wide polygon content per layer: device-geometry layers are used
+        // in every cell, annotation/backing layers carry a handful of shapes.
+        var content = new Dictionary<(int, int), int>();
         foreach (var cell in library.Cells.Values)
-            ScanCell(cell, attachments);
+        {
+            foreach (var polygon in cell.Elements.OfType<GdsPolygon>())
+            {
+                var key = (polygon.Layer, polygon.DataType);
+                content[key] = content.TryGetValue(key, out var n) ? n + 1 : 1;
+            }
+        }
 
-        return attachments.ToDictionary(
+        var votes = new Dictionary<(int, int), int>();
+        var samples = new SortedDictionary<(int, int), List<string>>();
+        foreach (var cell in library.Cells.Values)
+            ScanCell(cell, content, votes, samples);
+
+        return votes.ToDictionary(
             kv => kv.Key,
-            kv => (IReadOnlyList<string>)kv.Value.Take(MaxLabelsPerLayer).ToList());
+            kv => new AttachmentEvidence(
+                kv.Value,
+                (IReadOnlyList<string>)samples[kv.Key].Take(MaxLabelsPerLayer).ToList()));
     }
 
-    private static void ScanCell(GdsCell cell, SortedDictionary<(int, int), List<string>> attachments)
+    private static void ScanCell(
+        GdsCell cell,
+        IReadOnlyDictionary<(int, int), int> content,
+        Dictionary<(int, int), int> votes,
+        SortedDictionary<(int, int), List<string>> samples)
     {
         var labels = cell.Elements.OfType<GdsText>()
             .Where(IsPortLabelCandidate)
@@ -60,6 +92,7 @@ public static class GdsPortAttachmentProbe
         if (labels.Count == 0)
             return;
 
+        var cellBox = CellBoundingBox(cell);
         var polygons = cell.Elements.OfType<GdsPolygon>()
             .Where(p => p.Points.Count >= 3)
             .Select(p => (Polygon: p, Box: BoundingBox(p.Points)))
@@ -70,62 +103,128 @@ public static class GdsPortAttachmentProbe
         if (polygons.Count == 0 && paths.Count == 0)
             return;
 
+        // Marker chevrons sit exactly at the pin and are the smallest shapes
+        // around — without excluding their layers they would "prove" the pin
+        // marker layer itself optical.
+        var markerLayers = polygons
+            .GroupBy(p => (p.Polygon.Layer, p.Polygon.DataType))
+            .Where(g => GdsPinArrowMarkers.IsMarkerLayer(g.Select(x => x.Polygon).ToList()))
+            .Select(g => g.Key)
+            .ToHashSet();
+        var attachable = markerLayers.Count == 0
+            ? polygons
+            : polygons.Where(p => !markerLayers.Contains((p.Polygon.Layer, p.Polygon.DataType))).ToList();
+
         foreach (var label in labels)
         {
-            // A label may touch several shapes (core + cladding/keepout/bbox
-            // rectangles legitimately overlap it): the SMALLEST attaching
-            // polygon is the specific shape the label names — enclosing marker
-            // rectangles must not inherit the attachment.
-            GdsPolygon? bestPolygon = null;
-            double bestArea = double.PositiveInfinity;
-            foreach (var (polygon, box) in polygons)
-            {
-                if (!box.ExpandedBy(OutlineTouchToleranceUm).Contains(label.Position))
-                    continue;
-                if (!PointInPolygon(polygon.Points, label.Position)
-                    && DistanceToOutline(polygon.Points, label.Position) > OutlineTouchToleranceUm)
-                    continue;
-                double area = (box.MaxX - box.MinX) * (box.MaxY - box.MinY);
-                if (area < bestArea)
-                {
-                    bestArea = area;
-                    bestPolygon = polygon;
-                }
-            }
+            var bestPolygon = PickMostSpecific(attachable, cellBox, content, label.Position, ignoreBackground: true)
+                ?? PickMostSpecific(attachable, cellBox, content, label.Position, ignoreBackground: false);
             if (bestPolygon is not null)
             {
-                Record(attachments, (bestPolygon.Layer, bestPolygon.DataType), label.Text.Trim());
+                Record(votes, samples, (bestPolygon.Layer, bestPolygon.DataType), label.Text.Trim());
                 continue;
             }
             foreach (var path in paths)
             {
                 double reach = path.WidthMicrometers / 2 + OutlineTouchToleranceUm;
                 if (DistanceToCenterline(path.Points, label.Position) <= reach)
-                    Record(attachments, (path.Layer, path.DataType), label.Text.Trim());
+                    Record(votes, samples, (path.Layer, path.DataType), label.Text.Trim());
             }
         }
     }
 
     /// <summary>
-    /// Single-line, non-ghost, non-electrical-named text — the shape of a port
-    /// label. Electrical markers ("pad", "gnd", …) name bond pads: their labels
-    /// resting on a metal rectangle must never mark that layer optical.
+    /// The most specific touching polygon: smallest bbox area wins (foundry
+    /// pin squares sit exactly at the pin), ties break toward the layer with
+    /// more file-wide polygon content (device geometry beats annotation
+    /// backings), then toward the lower layer number for determinism. With
+    /// <paramref name="ignoreBackground"/>, cell-covering shapes are skipped.
+    /// </summary>
+    private static GdsPolygon? PickMostSpecific(
+        List<(GdsPolygon Polygon, Box Box)> polygons,
+        Box cellBox,
+        IReadOnlyDictionary<(int, int), int> content,
+        GdsPoint position,
+        bool ignoreBackground)
+    {
+        GdsPolygon? bestPolygon = null;
+        double bestArea = double.PositiveInfinity;
+        int bestContent = -1;
+        foreach (var (polygon, box) in polygons)
+        {
+            if (ignoreBackground && IsBackground(box, cellBox))
+                continue;
+            if (!box.ExpandedBy(OutlineTouchToleranceUm).Contains(position))
+                continue;
+            if (!PointInPolygon(polygon.Points, position)
+                && DistanceToOutline(polygon.Points, position) > OutlineTouchToleranceUm)
+                continue;
+            double area = Area(box);
+            int layerContent = content.GetValueOrDefault((polygon.Layer, polygon.DataType));
+            bool tied = Math.Abs(area - bestArea) <= 1e-9;
+            if (area < bestArea - 1e-9
+                || (tied && layerContent > bestContent)
+                || (tied && layerContent == bestContent && bestPolygon is not null
+                    && (polygon.Layer, polygon.DataType).CompareTo((bestPolygon.Layer, bestPolygon.DataType)) < 0))
+            {
+                bestPolygon = polygon;
+                bestArea = area;
+                bestContent = layerContent;
+            }
+        }
+        return bestPolygon;
+    }
+
+    private static bool IsBackground(Box box, Box cellBox) =>
+        Area(cellBox) > 0 && Area(box) >= BackgroundAreaFraction * Area(cellBox);
+
+    private static double Area(Box box) => (box.MaxX - box.MinX) * (box.MaxY - box.MinY);
+
+    private static Box CellBoundingBox(GdsCell cell)
+    {
+        double minX = double.MaxValue, minY = double.MaxValue;
+        double maxX = double.MinValue, maxY = double.MinValue;
+        foreach (var polygon in cell.Elements.OfType<GdsPolygon>())
+        {
+            foreach (var p in polygon.Points)
+            {
+                minX = Math.Min(minX, p.X); minY = Math.Min(minY, p.Y);
+                maxX = Math.Max(maxX, p.X); maxY = Math.Max(maxY, p.Y);
+            }
+        }
+        foreach (var text in cell.Elements.OfType<GdsText>())
+        {
+            minX = Math.Min(minX, text.Position.X); minY = Math.Min(minY, text.Position.Y);
+            maxX = Math.Max(maxX, text.Position.X); maxY = Math.Max(maxY, text.Position.Y);
+        }
+        return minX > maxX ? new Box(0, 0, 0, 0) : new Box(minX, minY, maxX, maxY);
+    }
+
+    /// <summary>
+    /// Non-empty, single-line, non-ghost, non-electrical-named text — the
+    /// shape of a port label. Electrical names ("pad", "gnd", …, contact-style
+    /// e1/n1/p1) name pads/contacts: their labels resting on a metal rectangle
+    /// must never mark that layer optical.
     /// </summary>
     private static bool IsPortLabelCandidate(GdsText text)
     {
-        if (text.Text.Contains('\n') || GdsGhostLabelFilter.IsGhost(text))
+        if (string.IsNullOrWhiteSpace(text.Text)
+            || text.Text.Contains('\n')
+            || GdsGhostLabelFilter.IsGhost(text))
             return false;
-        return !GdsPinDetector.ElectricalLabelMarkers.Any(
-            marker => text.Text.Contains(marker, StringComparison.OrdinalIgnoreCase));
+        return !GdsPinDetector.IsElectricalLabelName(text.Text);
     }
 
     private static void Record(
-        SortedDictionary<(int, int), List<string>> attachments, (int, int) pair, string label)
+        Dictionary<(int, int), int> votes,
+        SortedDictionary<(int, int), List<string>> samples,
+        (int, int) pair, string label)
     {
-        if (!attachments.TryGetValue(pair, out var labels))
-            attachments[pair] = labels = new List<string>();
-        if (!labels.Contains(label))
-            labels.Add(label);
+        votes[pair] = votes.TryGetValue(pair, out var count) ? count + 1 : 1;
+        if (!samples.TryGetValue(pair, out var list))
+            samples[pair] = list = new List<string>();
+        if (!list.Contains(label))
+            list.Add(label);
     }
 
     private readonly record struct Box(double MinX, double MinY, double MaxX, double MaxY)
@@ -143,10 +242,8 @@ public static class GdsPortAttachmentProbe
         double maxX = double.MinValue, maxY = double.MinValue;
         foreach (var point in points)
         {
-            minX = Math.Min(minX, point.X);
-            minY = Math.Min(minY, point.Y);
-            maxX = Math.Max(maxX, point.X);
-            maxY = Math.Max(maxY, point.Y);
+            minX = Math.Min(minX, point.X); minY = Math.Min(minY, point.Y);
+            maxX = Math.Max(maxX, point.X); maxY = Math.Max(maxY, point.Y);
         }
         return new Box(minX, minY, maxX, maxY);
     }

--- a/CAP.Avalonia/Services/GdsImport/GdsPlacementExecutor.cs
+++ b/CAP.Avalonia/Services/GdsImport/GdsPlacementExecutor.cs
@@ -225,6 +225,17 @@ public sealed partial class GdsPlacementExecutor
                 mirrorPinsHorizontally: instruction.Reflected);
             Execute(command);
 
+            // Geometry-only import (die frame, logo, ground plate): pure
+            // background — as a routing obstacle it would wall off the grid.
+            // The flag keeps it out of group-obstacle recursion later; the
+            // explicit removal undoes the registration that placement did.
+            var createdComponent = command.CreatedViewModel.Component;
+            if (createdComponent.PhysicalPins.Count == 0)
+            {
+                createdComponent.IsRoutingObstacle = false;
+                _canvas.Router.RemoveComponentObstacle(createdComponent);
+            }
+
             placedViewModels.Add(command.CreatedViewModel);
             report.PlacedCount++;
             PlacedCountSoFar++;

--- a/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.Options.cs
+++ b/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.Options.cs
@@ -59,7 +59,9 @@ public partial class GdsImportDialogViewModel
 
     /// <summary>
     /// Parses "layer,datatype" pairs separated by ';' (e.g. <c>1,10</c> or
-    /// <c>1,10; 2,0</c>). Returns null when any segment is malformed — GDS
+    /// <c>1,10; 2,0</c>). An empty/whitespace field is VALID and yields an
+    /// empty list (no layers configured — e.g. a foreign file's cleared
+    /// defaults). Returns null when any segment is malformed — GDS
     /// layer/datatype numbers are unsigned, so negative values are rejected too.
     /// </summary>
     internal static List<(int Layer, int Datatype)>? ParseLayerPairs(string text)
@@ -78,6 +80,6 @@ public partial class GdsImportDialogViewModel
             }
             pairs.Add((layer, datatype));
         }
-        return pairs.Count > 0 ? pairs : null;
+        return pairs;
     }
 }

--- a/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.cs
+++ b/CAP.Avalonia/ViewModels/GdsImport/GdsImportDialogViewModel.cs
@@ -74,6 +74,15 @@ public partial class GdsImportDialogViewModel : ObservableObject
     [ObservableProperty]
     private bool _isExplodeMode = true;
 
+    /// <summary>Factory default for the port-layers field (Lunima/gdsfactory/demofab conventions).</summary>
+    private const string DefaultPortLayersText = "1,10;501,1";
+
+    /// <summary>Factory default for the waveguide-layers field.</summary>
+    private const string DefaultWaveguideLayersText = "1,0; 1111,0";
+
+    /// <summary>Factory default for the metal-layers field (Lunima's own export layers + SiEPIC).</summary>
+    private const string DefaultMetalLayersText = "11,0; 12,0; 13,0";
+
     /// <summary>
     /// Port-label layers as "layer,datatype" pairs, ';'-separated. The default mirrors
     /// <see cref="GdsPinDetectionOptions.PortLayers"/>: 1,10 (gdsfactory port labels)
@@ -81,7 +90,7 @@ public partial class GdsImportDialogViewModel : ObservableObject
     /// import service would union demofab's layer in invisibly otherwise.
     /// </summary>
     [ObservableProperty]
-    private string _portLayersText = "1,10;501,1";
+    private string _portLayersText = DefaultPortLayersText;
 
     /// <summary>
     /// Waveguide-core layers as "layer,datatype" pairs, ';'-separated. One field,
@@ -92,7 +101,7 @@ public partial class GdsImportDialogViewModel : ObservableObject
     /// interconnect layer (1111,0), mirroring the importer defaults.
     /// </summary>
     [ObservableProperty]
-    private string _waveguideLayersText = "1,0; 1111,0";
+    private string _waveguideLayersText = DefaultWaveguideLayersText;
 
     /// <summary>
     /// METAL layers as "layer,datatype" pairs, ';'-separated. Polygons on these
@@ -103,7 +112,7 @@ public partial class GdsImportDialogViewModel : ObservableObject
     /// routing as electrical until corrected here.
     /// </summary>
     [ObservableProperty]
-    private string _metalLayersText = "11,0; 12,0; 13,0";
+    private string _metalLayersText = DefaultMetalLayersText;
 
     /// <summary>
     /// Recreate the detected connections with Lunima's own routing (default: on).
@@ -210,6 +219,25 @@ public partial class GdsImportDialogViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Foreign (nazca-stamped) files must not inherit Lunima's own layer
+    /// defaults: our port/waveguide/metal numbers are our export conventions,
+    /// and on a foundry file they collide with its layer map (one foundry's
+    /// metal number is another's core etch). Only untouched factory defaults
+    /// are cleared — a field the user edited stays as-is.
+    /// </summary>
+    private void ClearFactoryDefaultsOnForeignFile(CAP_DataAccess.Import.Gds.GdsLibrary library)
+    {
+        if (!CAP_DataAccess.Import.Gds.GdsFileProvenance.HasForeignStamps(library))
+            return;
+        if (PortLayersText == DefaultPortLayersText)
+            PortLayersText = "";
+        if (WaveguideLayersText == DefaultWaveguideLayersText)
+            WaveguideLayersText = "";
+        if (MetalLayersText == DefaultMetalLayersText)
+            MetalLayersText = "";
+    }
+
+    /// <summary>
     /// Runs the library analysis (top-cell candidates). Called by the view when the
     /// dialog opens, and again by the Retry button after a failure. Re-entrant-safe:
     /// a second call while busy is a no-op.
@@ -237,6 +265,7 @@ public partial class GdsImportDialogViewModel : ObservableObject
         {
             var analysis = await GdsImportService.AnalyzeAsync(GdsFilePath, token);
             _analyzedLibrary = analysis.Library;
+            ClearFactoryDefaultsOnForeignFile(analysis.Library);
             PopulateCensus(analysis.LayerCensus);
             TopCells.Clear();
             foreach (var topCell in analysis.TopCells)

--- a/Connect-A-Pic-Core/Components/Core/Component.cs
+++ b/Connect-A-Pic-Core/Components/Core/Component.cs
@@ -84,6 +84,16 @@ public partial class Component : ICloneable
     [JsonIgnore]
     public object? ParentGroup { get; set; }
 
+    /// <summary>
+    /// Whether this component blocks routing (default: true). The GDS import
+    /// clears it for geometry-only (pin-less) components — imported die
+    /// frames, logos and ground plates must never wall off the routing grid.
+    /// Runtime-only: not persisted in the .lun (v1; a reloaded pin-less
+    /// background component becomes an obstacle again until re-imported).
+    /// </summary>
+    [JsonIgnore]
+    public bool IsRoutingObstacle { get; set; } = true;
+
     public Part[,] Parts { get; protected set; }
     public List<PhysicalPin> PhysicalPins { get; protected set; } = new();
     public Dictionary<int, SMatrix> WaveLengthToSMatrixMap { get; set; }

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
@@ -228,9 +228,16 @@ public partial class PathfindingGrid
 
     /// <summary>
     /// Adds obstacle cells for a single (non-group) component.
+    /// Components flagged <see cref="Component.IsRoutingObstacle">IsRoutingObstacle
+    /// = false</see> are skipped: pin-less imported geometry (die frames,
+    /// logos, ground plates) is pure background — a die-covering cell would
+    /// otherwise wall off the entire routing grid and block every route.
     /// </summary>
     private void AddSingleComponentObstacle(Component component)
     {
+        if (!component.IsRoutingObstacle)
+            return;
+
         double padding = ObstaclePaddingMicrometers;
         double x1 = component.PhysicalX - padding;
         double y1 = component.PhysicalY - padding;

--- a/UnitTests/Import/Gds/GdsPinDetectorTests.cs
+++ b/UnitTests/Import/Gds/GdsPinDetectorTests.cs
@@ -184,6 +184,24 @@ public class GdsPinDetectorTests
         pins.Count(p => p.Source == DetectedPinSource.EdgeHeuristic).ShouldBe(2);
     }
 
+    [Fact]
+    public void ArrowPair_AcrossDifferentMarkerLayers_AlsoMarksAPin()
+    {
+        // Some conventions stamp one chevron per pin per marker layer: tips
+        // meeting across two DIFFERENT layers still mark the pin.
+        var cell = Cell(
+            Poly(1, 0, (0, 1.75), (10, 1.75), (10, 2.25), (0, 2.25), (0, 1.75)),
+            Chevron(232, 0, 2, bodyDirX: +1),
+            Chevron(234, 0, 2, bodyDirX: -1));
+
+        var pins = GdsPinDetector.Detect(cell, Box10x4);
+
+        var arrowPin = pins.Single(p => p.Source == DetectedPinSource.ArrowMarker);
+        arrowPin.XUm.ShouldBe(0, Tolerance);
+        arrowPin.YUm.ShouldBe(2, Tolerance);
+        arrowPin.AngleDegrees.ShouldBe(180, Tolerance);
+    }
+
     // ── Edge heuristic ───────────────────────────────────────────────────────
 
     [Fact]

--- a/UnitTests/Import/Gds/LayerCensus/GdsLayerSuggestionEngineTests.cs
+++ b/UnitTests/Import/Gds/LayerCensus/GdsLayerSuggestionEngineTests.cs
@@ -96,7 +96,8 @@ public class GdsLayerSuggestionEngineTests
         // evidence: the metal claim is vetoed, the waveguide claim is high.
         var library = Library(Cell(TopCell), Cell("dev",
             Rectangle(11, 0, 10, 0.5),
-            new GdsText { Layer = 56, TextType = 0, Text = "o1", Position = new GdsPoint(5, 0.25) }));
+            new GdsText { Layer = 56, TextType = 0, Text = "o1", Position = new GdsPoint(0.5, 0.25) },
+            new GdsText { Layer = 56, TextType = 0, Text = "o2", Position = new GdsPoint(9.5, 0.25) }));
 
         var suggestions = Suggest(library);
 
@@ -138,14 +139,16 @@ public class GdsLayerSuggestionEngineTests
     }
 
     [Fact]
-    public void LabelTouchingNestedShapes_AttachesToTheSmallestOnly()
+    public void LabelTouchingNestedShapes_AttachesToTheRouteLikeOne()
     {
         // keepout/bbox rectangle enclosing the core: the label rests on both,
-        // but only the specific (smallest) shape earns the attachment.
+        // but the frame covers the whole cell (background) and the core is
+        // the route-like shape — only the core earns the attachment.
         var library = Library(Cell(TopCell), Cell("dev",
             Rectangle(111, 0, 20, 10),
             Rectangle(11, 0, 10, 0.5),
-            new GdsText { Layer = 56, TextType = 0, Text = "o1", Position = new GdsPoint(5, 0.25) }));
+            new GdsText { Layer = 56, TextType = 0, Text = "o1", Position = new GdsPoint(5, 0.25) },
+            new GdsText { Layer = 56, TextType = 0, Text = "o2", Position = new GdsPoint(9.5, 0.25) }));
 
         var suggestions = Suggest(library);
 
@@ -153,6 +156,75 @@ public class GdsLayerSuggestionEngineTests
             s.Layer == 11 && s.Role == GdsLayerRole.Waveguide
             && s.Confidence == GdsSuggestionConfidence.High);
         suggestions.ShouldNotContain(s => s.Layer == 111 && s.Role == GdsLayerRole.Waveguide);
+    }
+
+    [Fact]
+    public void LabelOnStackedEqualSquares_PrefersTheDeviceContentLayer()
+    {
+        // An annotation backing square stacked exactly on the pin square:
+        // same size, same spot — the layer that carries device geometry
+        // throughout the file wins the tie, the annotation layer gets nothing.
+        var library = Library(Cell(TopCell), Cell("dev",
+            Rectangle(59, 0, 2, 2),      // annotation backing square at the pin
+            Rectangle(11, 0, 2, 2),      // pin square on the waveguide layer
+            Rectangle(11, 0, 10, 0.5),   // more device content on that layer
+            new GdsText { Layer = 56, TextType = 0, Text = "o1", Position = new GdsPoint(0.5, 0.25) },
+            new GdsText { Layer = 56, TextType = 0, Text = "o2", Position = new GdsPoint(1.5, 1.5) }));
+
+        var suggestions = Suggest(library);
+
+        suggestions.ShouldContain(s =>
+            s.Layer == 11 && s.Role == GdsLayerRole.Waveguide
+            && s.Confidence == GdsSuggestionConfidence.High);
+        suggestions.ShouldNotContain(s => s.Layer == 59 && s.Role == GdsLayerRole.Waveguide);
+    }
+
+    [Fact]
+    public void GhostOnlyTextLayer_YieldsNoPortLabelSuggestion()
+    {
+        // nazca stamps bbox anchors / parameter annotations on their own text
+        // layers — a layer carrying ONLY helper labels is not a port candidate.
+        var library = Library(Cell(TopCell), Cell("dev",
+            new GdsText { Layer = 233, TextType = 0, Text = "tl", Position = new GdsPoint(0, 4) },
+            new GdsText { Layer = 233, TextType = 0, Text = "R:0.0001", Position = new GdsPoint(5, 2) },
+            Rectangle(1, 0, 10, 0.5)));
+
+        Suggest(library).ShouldNotContain(s => s.Layer == 233 && s.Role == GdsLayerRole.PortLabels);
+    }
+
+    [Fact]
+    public void LabelTouchingMarkerChevronAndPinSquare_AttachesToTheSquareNotTheMarkerLayer()
+    {
+        // The chevron is smaller than the pin square and sits right on the
+        // label — but marker layers never take attachments.
+        var library = Library(Cell(TopCell), Cell("dev",
+            Chevron(232, 0.4, 0.25),
+            Chevron(232, 0.4, 0.25, mirror: true),
+            Rectangle(11, 0, 2, 2),
+            Rectangle(11, 0, 10, 0.5),
+            new GdsText { Layer = 56, TextType = 0, Text = "o1", Position = new GdsPoint(0.5, 0.25) },
+            new GdsText { Layer = 56, TextType = 0, Text = "o2", Position = new GdsPoint(1.5, 1.5) }));
+
+        var suggestions = Suggest(library);
+
+        suggestions.ShouldContain(s =>
+            s.Layer == 11 && s.Role == GdsLayerRole.Waveguide
+            && s.Confidence == GdsSuggestionConfidence.High);
+        suggestions.ShouldNotContain(s => s.Layer == 232 && s.Role == GdsLayerRole.Waveguide);
+    }
+
+    /// <summary>The nazca pin chevron (7 vertices, tip at the origin, ~0.35×0.5 µm).</summary>
+    private static GdsPolygon Chevron(int layer, double tipX, double tipY, bool mirror = false)
+    {
+        (double X, double Y)[] shape =
+            { (0.25, -0.25), (0, 0), (0.25, 0.25), (0.25, 0.125), (0.35, 0.125), (0.35, -0.125), (0.25, -0.125) };
+        var sign = mirror ? -1 : 1;
+        return new GdsPolygon
+        {
+            Layer = layer,
+            DataType = 0,
+            Points = shape.Select(p => new GdsPoint(tipX + sign * p.X, tipY + p.Y)).ToList(),
+        };
     }
 
     [Fact]

--- a/UnitTests/Services/GdsImport/GdsFoundryStyleFileTests.cs
+++ b/UnitTests/Services/GdsImport/GdsFoundryStyleFileTests.cs
@@ -45,37 +45,48 @@ public class GdsFoundryStyleFileTests : IDisposable
     /// labels (anchors "tl"/"tr"/… and parameter annotations "R:0.0001"/"n:1.0")
     /// on the foundry text layer. (1 db unit = 1 nm.)
     /// </summary>
-    private static byte[] SyntheticFoundryLibrary() => GdsTestWriter.Create()
-        .StandardPrologue()
-        .BeginCell("TOP")
-            .SRef("dev", 0, 0)
-            .SRef("dev", 60000, 0)
-            .Path(WaveguideLayer, 0, 500, 0, (10000, 2000), (50000, 2000))
-            .Path(MetalLayer, 0, 20000, 0, (10000, 20000), (50000, 20000))
-        .EndCell()
-        .BeginCell("dev")
-            .Boundary(WaveguideLayer, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
-            .Boundary(BboxLayer, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
-            .Text(TextLayer, 0, "o1", 0, 2000)
-            .Text(TextLayer, 0, "o2", 10000, 2000)
-            .Text(TextLayer, 0, "tl", 0, 4000)
-            .Text(TextLayer, 0, "tr", 10000, 4000)
-            .Text(TextLayer, 0, "bl", 0, 0)
-            .Text(TextLayer, 0, "br", 10000, 0)
-            .Text(TextLayer, 0, "R:0.0001", 5000, 3000)
-            .Text(TextLayer, 0, "n:1.0", 5000, 1000)
-        .EndCell()
-        .EndLibrary()
-        .ToArray();
+    private static byte[] SyntheticFoundryLibrary(bool withNazcaMetadata = false)
+    {
+        var writer = GdsTestWriter.Create()
+            .StandardPrologue()
+            .BeginCell("TOP")
+                .SRef("dev", 0, 0)
+                .SRef("dev", 60000, 0)
+                .Path(WaveguideLayer, 0, 500, 0, (10000, 2000), (50000, 2000))
+                .Path(MetalLayer, 0, 20000, 0, (10000, 20000), (50000, 20000))
+            .EndCell()
+            .BeginCell("dev")
+                .Boundary(WaveguideLayer, 0, (0, 1750), (10000, 1750), (10000, 2250), (0, 2250), (0, 1750))
+                .Boundary(BboxLayer, 0, (0, 0), (10000, 0), (10000, 4000), (0, 4000), (0, 0))
+                .Text(TextLayer, 0, "o1", 0, 2000)
+                .Text(TextLayer, 0, "o2", 10000, 2000);
+        if (withNazcaMetadata)
+        {
+            // nazca's per-cell metadata stamp marks the file as foreign-made:
+            // Lunima's own layer defaults must not be pre-filled then.
+            writer = writer.Text(59, 0,
+                "cellname: dev\nfoundry_pdk: TEST_PDK\nnazca_pdk_version: 0.0", 0, 0);
+        }
+        return writer
+                .Text(TextLayer, 0, "tl", 0, 4000)
+                .Text(TextLayer, 0, "tr", 10000, 4000)
+                .Text(TextLayer, 0, "bl", 0, 0)
+                .Text(TextLayer, 0, "br", 10000, 0)
+                .Text(TextLayer, 0, "R:0.0001", 5000, 3000)
+                .Text(TextLayer, 0, "n:1.0", 5000, 1000)
+            .EndCell()
+            .EndLibrary()
+            .ToArray();
+    }
 
     private static async Task<GdsLibrary> ReadLibraryAsync(byte[] gds) =>
         await new GdsReader().ReadAsync(new MemoryStream(gds));
 
-    private async Task<GdsImportDialogViewModel> AnalyzedDialog()
+    private async Task<GdsImportDialogViewModel> AnalyzedDialog(bool withNazcaMetadata = false)
     {
         Directory.CreateDirectory(_root);
         var gdsPath = Path.Combine(_root, "foundry.gds");
-        File.WriteAllBytes(gdsPath, SyntheticFoundryLibrary());
+        File.WriteAllBytes(gdsPath, SyntheticFoundryLibrary(withNazcaMetadata));
         var service = _host.CreateService();
         var executor = new GdsPlacementExecutor(
             new DesignCanvasViewModel(), new CommandManager(), () => new List<ComponentTemplate>());
@@ -141,5 +152,19 @@ public class GdsFoundryStyleFileTests : IDisposable
         // of the metal field's colliding default entry:
         vm.WaveguideLayersText.ShouldBe("1,0; 1111,0; 11,0");
         vm.MetalLayersText.ShouldBe("12,0; 13,0");
+    }
+
+    [Fact]
+    public async Task Dialog_Analysis_OfForeignFile_StartsWithEmptyFields_FilledByEvidenceOnly()
+    {
+        // nazca-stamped files: Lunima's own default numbers would collide with
+        // the file's layer map — the fields start empty and fill from file
+        // evidence only (ports from texts, waveguide from port attachment;
+        // metal stays a manual choice).
+        var vm = await AnalyzedDialog(withNazcaMetadata: true);
+
+        vm.PortLayersText.ShouldBe($"{TextLayer},0");
+        vm.WaveguideLayersText.ShouldBe("11,0");
+        vm.MetalLayersText.ShouldBe("");
     }
 }

--- a/UnitTests/Services/GdsImport/GdsFoundryStyleFileTests.cs
+++ b/UnitTests/Services/GdsImport/GdsFoundryStyleFileTests.cs
@@ -167,4 +167,19 @@ public class GdsFoundryStyleFileTests : IDisposable
         vm.WaveguideLayersText.ShouldBe("11,0");
         vm.MetalLayersText.ShouldBe("");
     }
+
+    [Fact]
+    public async Task ForeignFile_EmptyMetalField_ImportsWithoutSyntaxError()
+    {
+        // Regression: an empty layer field used to fail validation ("Ungültige
+        // Layer-Syntax: ''") — empty means "no layers configured", which is
+        // exactly right for a foreign file's untouched metal field.
+        var vm = await AnalyzedDialog(withNazcaMetadata: true);
+        vm.MetalLayersText.ShouldBe("");
+
+        await vm.ImportCommand.ExecuteAsync(null);
+
+        vm.HasError.ShouldBeFalse(vm.ErrorText);
+        vm.ImportCompleted.ShouldBeTrue();
+    }
 }

--- a/UnitTests/Services/GdsImport/GdsImportDialogViewModelTests.cs
+++ b/UnitTests/Services/GdsImport/GdsImportDialogViewModelTests.cs
@@ -250,7 +250,6 @@ public class GdsImportDialogViewModelTests : IDisposable
     }
 
     [Theory]
-    [InlineData("")]
     [InlineData("abc")]
     [InlineData("1")]
     [InlineData("1,2,3")]
@@ -260,6 +259,15 @@ public class GdsImportDialogViewModelTests : IDisposable
     public void ParseLayerPairs_Malformed_ReturnsNull(string text)
     {
         GdsImportDialogViewModel.ParseLayerPairs(text).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseLayerPairs_Empty_ReturnsEmptyList(string text)
+    {
+        // an empty field is valid: no layers configured (foreign files start this way)
+        GdsImportDialogViewModel.ParseLayerPairs(text).ShouldNotBeNull().ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #852 (merged), continuing #855.

Verified end-to-end against a real confidential foundry layout (file stays local, never committed — tests use synthetic fixtures mirroring only its conventions). The import dialog now produces exactly the file's true layer map: port labels and waveguide layer auto-detected, metal left manual, zero ghost pins.

## Changes

- **Port-attachment quorum + specificity**: a port label attaches to the most specific shape it rests on (smallest bbox area — foundries stamp pin squares on the waveguide layer at the pin), ties break by file-wide content (device geometry beats annotation backings), cell-covering frames never qualify, marker layers never receive attachments, and a layer needs 2 label votes before its waveguide claim is high-confidence (auto-applied); single strays become manual chips.
- **Electrical name filter**: contact-style pin names (e1/n1/p1, gdsfactory electrical ports and foundry n/p contacts) are filtered alongside the existing pad/gnd/anode markers — shared `IsElectricalLabelName`.
- **Marker-span 6 µm**: electrical pin chevrons are larger than optical ones; one oversized shape no longer disqualifies a whole marker layer.
- **Foreign files start with empty layer fields**: nazca metadata stamps (foundry_pdk / nazca_pdk_version) switch off Lunima's own default layer lists — our export conventions collide with foreign layer maps (a metal default number is another foundry's optical etch).
- **Census counts port-like texts** (single-line, non-ghost, non-empty): anchor-only text layers no longer become port-label suggestions.

## Tests

Synthetic fixtures only (no foundry data): cross-layer chevron pairs, single-chevron exclusion, ghost-only text layers, stacked-square content tiebreak, marker-layer attachment exclusion, foreign-default clearing, quorum behavior. Full GDS suite: 707/707 locally.