### PR TITLE
test: mark scratch probe tests as Category=Slow (local suite 6.2 → ~3.5 min)

### DIFF
--- a/UnitTests/Services/GdsImport/GdsMziElectricalProbeTests.cs
+++ b/UnitTests/Services/GdsImport/GdsMziElectricalProbeTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 namespace UnitTests.Services.GdsImport;
 
 /// <summary>SCRATCH probe — dumps the MZI export/GDS structure + import outcome. Will be removed.</summary>
+[Trait("Category", "Slow")] // runs real Python/nazca subprocesses (184 s) — CI covers it, local default runs skip it
 public class GdsMziElectricalProbeTests
 {
     private readonly ITestOutputHelper _output;

--- a/UnitTests/Services/GdsImport/GdsUserDesignProbeTests.cs
+++ b/UnitTests/Services/GdsImport/GdsUserDesignProbeTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 namespace UnitTests.Services.GdsImport;
 
 /// <summary>SCRATCH probe — user-design import numbers after the network-merging change. Will be removed.</summary>
+[Trait("Category", "Slow")] // runs real Python/nazca subprocesses (43 s) — CI covers it, local default runs skip it
 public class GdsUserDesignProbeTests
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
TRX-instrumented full-suite run (5271 tests, 6.2 min wall): two self-described scratch probes dominate the critical path — `GdsMziElectricalProbeTests.Probe_ExportAndDump` (184 s) and `GdsUserDesignProbeTests.Probe` (43 s), both running real Python/nazca subprocesses. They are marked `Category=Slow`: local default runs (`Category!=Slow`, per .agent.toml) skip them; CI runs everything unfiltered, so coverage is unchanged.

## Top slow tests (for the record)

| duration | test |
|---|---|
| 184.2 s | GdsMziElectricalProbeTests.Probe_ExportAndDump |
| 42.7 s | GdsUserDesignProbeTests.Probe |
| 25.6 s | DynamicGdsFilenameIntegrationTests.CompleteExportFlow_WithDifferentFilenames |
| 16.7 s | DynamicGdsFilenameTests.ExportedScript_HandlesPathsWithSpaces |
| 9.7 s | DynamicGdsFilenameIntegrationTests.CompleteExportFlow_GeneratesMatchingPythonAndGdsFiles |

The remaining Python-executing export tests (~85 s combined) stay in the default bucket for now — real regression coverage; can be revisited if the suite needs to get faster still.