### PR TITLE
Agent: GDS import: non-cardinal rotation (and mirrored pin layout) lost on .lun save/load

### DIFF
--- a/CAP-DataAccess/Persistence/ComponentGroupSerializer.cs
+++ b/CAP-DataAccess/Persistence/ComponentGroupSerializer.cs
@@ -32,6 +32,7 @@ public static class ComponentGroupSerializer
             PhysicalX = group.PhysicalX,
             PhysicalY = group.PhysicalY,
             Rotation90CounterClock = (int)group.Rotation90CounterClock,
+            RotationDegrees = ComponentPoseTransform.GetNonCardinalRotationDegrees(group),
             ParentGroupId = group.ParentGroup?.Identifier,
             ParentGroupIdGuid = group.ParentGroup?.Id.ToString()
         };
@@ -121,6 +122,11 @@ public static class ComponentGroupSerializer
             // Null in files that predate background geometry — stays null.
             OutlinePolygons = dto.BackgroundPolygons
         };
+
+        // The exact continuous angle (non-cardinal GDS placements) supersedes the
+        // discrete quarter-turn value the property setter above applied.
+        if (dto.RotationDegrees is double exactRotation)
+            ComponentPoseTransform.ApplyExactRotation(group, exactRotation);
 
         // Add child components - prefer Guid lookup, fall back to name lookup
         var useGuids = guidLookup != null && dto.ChildComponentGuids.Count == dto.ChildComponentIds.Count

--- a/CAP-DataAccess/Persistence/DTOs/ComponentGroupDto.cs
+++ b/CAP-DataAccess/Persistence/DTOs/ComponentGroupDto.cs
@@ -66,6 +66,13 @@ public class ComponentGroupDto
     public int Rotation90CounterClock { get; set; }
 
     /// <summary>
+    /// Exact continuous rotation in degrees for non-cardinal placements (GDS
+    /// import). Null in old files and for cardinal rotations —
+    /// <see cref="Rotation90CounterClock"/> alone restores those.
+    /// </summary>
+    public double? RotationDegrees { get; set; }
+
+    /// <summary>
     /// List of child component identifiers (by Identifier property).
     /// Used to rebuild the parent-child relationships.
     /// </summary>

--- a/CAP-DataAccess/Persistence/GridPersistenceWithGroupsManager.cs
+++ b/CAP-DataAccess/Persistence/GridPersistenceWithGroupsManager.cs
@@ -71,6 +71,8 @@ public class GridPersistenceWithGroupsManager
                             Identifier = component.Identifier,
                             HumanReadableName = component.HumanReadableName,
                             Rotation = (int)component.Rotation90CounterClock,
+                            RotationDegrees = ComponentPoseTransform.GetNonCardinalRotationDegrees(component),
+                            Mirrored = component.IsMirroredHorizontally ? true : null,
                             Sliders = component.GetAllSliders(),
                             X = x,
                             Y = y
@@ -153,7 +155,7 @@ public class GridPersistenceWithGroupsManager
                 // CRITICAL: Restore HumanReadableName if saved (for backward compatibility, fall back to Identifier)
                 component.HumanReadableName = data.HumanReadableName ?? data.Identifier;
 
-                component.Rotation90CounterClock = (DiscreteRotation)data.Rotation;
+                RestorePose(data, component);
                 LoadSliders(data, component);
                 _gridManager.ComponentMover.PlaceComponent(data.X, data.Y, component);
                 componentLookup[component.Identifier] = component;
@@ -175,7 +177,7 @@ public class GridPersistenceWithGroupsManager
                 // CRITICAL: Restore HumanReadableName if saved (for backward compatibility, fall back to Identifier)
                 component.HumanReadableName = data.HumanReadableName ?? data.Identifier;
 
-                component.Rotation90CounterClock = (DiscreteRotation)data.Rotation;
+                RestorePose(data, component);
                 LoadSliders(data, component);
                 // Don't place in grid - they'll be children of groups
                 componentLookup[component.Identifier] = component;
@@ -300,6 +302,8 @@ public class GridPersistenceWithGroupsManager
                     Identifier = child.Identifier,
                     HumanReadableName = child.HumanReadableName,
                     Rotation = (int)child.Rotation90CounterClock,
+                    RotationDegrees = ComponentPoseTransform.GetNonCardinalRotationDegrees(child),
+                    Mirrored = child.IsMirroredHorizontally ? true : null,
                     Sliders = child.GetAllSliders(),
                     X = child.GridXMainTile,
                     Y = child.GridYMainTile
@@ -333,6 +337,23 @@ public class GridPersistenceWithGroupsManager
 
         // No copy suffix found - return as-is
         return identifier;
+    }
+
+    /// <summary>
+    /// Restores a component's saved pose: mirror first (local, unrotated frame),
+    /// then the discrete quarter turns, then the exact continuous angle when the
+    /// file carries one (GDS-imported non-cardinal instance; null in older files
+    /// and for cardinal rotations).
+    /// </summary>
+    private static void RestorePose(ComponentData data, Component component)
+    {
+        if (data.Mirrored == true)
+            ComponentPoseTransform.MirrorPinsHorizontally(component);
+
+        component.Rotation90CounterClock = (DiscreteRotation)data.Rotation;
+
+        if (data.RotationDegrees is double exact)
+            ComponentPoseTransform.ApplyExactRotation(component, exact);
     }
 
     /// <summary>
@@ -381,6 +402,20 @@ public class GridPersistenceWithGroupsManager
         public int X { get; set; }
         public int Y { get; set; }
         public int Rotation { get; set; }
+
+        /// <summary>
+        /// Exact continuous rotation in degrees for non-cardinal placements (GDS
+        /// import). Null in old files and for cardinal rotations — <see cref="Rotation"/>
+        /// alone restores those.
+        /// </summary>
+        public double? RotationDegrees { get; set; }
+
+        /// <summary>
+        /// True when the pins were mirrored across the local horizontal centerline
+        /// (GDS STRANS-reflected instance). Null in old files — no mirror.
+        /// </summary>
+        public bool? Mirrored { get; set; }
+
         public string Identifier { get; set; } = "";
         public string? HumanReadableName { get; set; }
         public List<Slider>? Sliders { get; set; }

--- a/CAP.Avalonia/Commands/PlaceComponentCommand.cs
+++ b/CAP.Avalonia/Commands/PlaceComponentCommand.cs
@@ -42,17 +42,17 @@ public class PlaceComponentCommand : IUndoableCommand
             // component's local, unrotated frame — after the quarter turns the
             // pins land exactly where a true GDS STRANS transform puts them.
             if (mirrorPinsHorizontally)
-                MirrorPinsHorizontally(_component);
+                ComponentPoseTransform.MirrorPinsHorizontally(_component);
             // Rotate at the model level BEFORE the component is added to the canvas:
             // rotation keeps the top-left corner invariant, so (x, y) is the top-left
             // of the already-rotated bounding box. Doing it pre-placement also avoids
             // the canvas collision guard, which enforces a minimum inter-component
             // gap that GDS-abutting neighbours legitimately violate.
             if (exactRotationDegrees.HasValue)
-                RotateComponentCommand.ApplyModelRotation(_component, exactRotationDegrees.Value);
+                ComponentPoseTransform.ApplyExactRotation(_component, exactRotationDegrees.Value);
             else
                 for (var i = 0; i < quarterTurnsCounterClockwise; i++)
-                    RotateComponentCommand.ApplyModelRotation90(_component);
+                    ComponentPoseTransform.Rotate90CounterClockwise(_component);
         }
     }
 
@@ -122,26 +122,6 @@ public class PlaceComponentCommand : IUndoableCommand
 
     /// <summary>The component instance created by this command (null when invalid).</summary>
     public Component? PlacedComponent => _component;
-
-    /// <summary>
-    /// Mirrors the physical pins across the component's horizontal centerline in
-    /// its LOCAL (unrotated) frame: offset Y flips within the box, the angle maps
-    /// θ → −θ (a down-pointing pin becomes up-pointing). This is the app-space
-    /// effect of the GDS STRANS flag (reflection across the GDS x-axis) on pins;
-    /// combined with the placement position — the true reflected bbox top-left —
-    /// and the usual pre-placement rotation, the mirrored pins coincide with the
-    /// true reflected pin positions for every cardinal reference transform.
-    /// Geometry (parts, outlines) is NOT mirrored: the core model has no mirror
-    /// support (v1 limitation, surfaced as a placement warning).
-    /// </summary>
-    internal static void MirrorPinsHorizontally(Component component)
-    {
-        foreach (var pin in component.PhysicalPins)
-        {
-            pin.OffsetYMicrometers = component.HeightMicrometers - pin.OffsetYMicrometers;
-            pin.AngleDegrees = (360.0 - pin.AngleDegrees) % 360.0;
-        }
-    }
 
     /// <summary>The canvas ViewModel created for the component on <see cref="Execute"/> (null until then).</summary>
     public ComponentViewModel? CreatedViewModel => _createdViewModel;

--- a/CAP.Avalonia/Commands/RotateComponentCommand.cs
+++ b/CAP.Avalonia/Commands/RotateComponentCommand.cs
@@ -66,7 +66,7 @@ public class RotateComponentCommand : IUndoableCommand
     private void RotateComponent90()
     {
         var comp = _component.Component;
-        ApplyModelRotation90(comp);
+        ComponentPoseTransform.Rotate90CounterClockwise(comp);
 
         // Notify the view model of dimension changes
         _component.NotifyDimensionsChanged();
@@ -76,118 +76,5 @@ public class RotateComponentCommand : IUndoableCommand
 
         // Recalculate paths asynchronously (pin angles change with rotation)
         _ = _canvas.RecalculateRoutesAsync();
-    }
-
-    /// <summary>
-    /// Model-level 90° counter-clockwise rotation around the component center:
-    /// physical pin offsets, width/height swap, discrete rotation and
-    /// <c>RotationDegrees</c>. The top-left corner (<c>PhysicalX</c>/<c>PhysicalY</c>)
-    /// is deliberately left untouched. No ViewModel/canvas notifications — shared
-    /// with programmatic placement (GDS import), which rotates the component
-    /// before it is added to the canvas.
-    /// </summary>
-    internal static void ApplyModelRotation90(Component comp)
-    {
-        RecordUnrotatedDimensions(comp);
-        var width = comp.WidthMicrometers;
-        var height = comp.HeightMicrometers;
-
-        // Rotate each physical pin's offset around the component center
-        // Pin angles stay relative to the component - GetAbsoluteAngle() adds RotationDegrees
-        foreach (var pin in comp.PhysicalPins)
-        {
-            // Rotate offset 90° counter-clockwise around center
-            // Center is at (width/2, height/2)
-            var cx = width / 2;
-            var cy = height / 2;
-
-            // Translate to origin
-            var x = pin.OffsetXMicrometers - cx;
-            var y = pin.OffsetYMicrometers - cy;
-
-            // Rotate 90° counter-clockwise: (x, y) -> (-y, x)
-            var newX = -y;
-            var newY = x;
-
-            // Translate back (but to new center after dimension swap)
-            pin.OffsetXMicrometers = newX + cy; // cy becomes new cx
-            pin.OffsetYMicrometers = newY + cx; // cx becomes new cy
-
-            // NOTE: Pin angles are stored relative to the component.
-            // GetAbsoluteAngle() adds component.RotationDegrees to get world-space angle.
-            // Do NOT modify pin.AngleDegrees here.
-        }
-
-        // Swap dimensions
-        comp.WidthMicrometers = height;
-        comp.HeightMicrometers = width;
-
-        // Update the component's discrete rotation and RotationDegrees
-        comp.RotateBy90CounterClockwise();
-    }
-
-    /// <summary>
-    /// Model-level rotation around the component center by an ARBITRARY angle, in
-    /// the same convention <see cref="ApplyModelRotation90"/> uses (0° = east,
-    /// positive toward south in the Y-down plane — for θ = 90° the math below
-    /// reduces exactly to <see cref="ApplyModelRotation90"/>). Physical pin
-    /// offsets rotate around the old center; width/height become the axis-aligned
-    /// bounding box of the rotated footprint, so an unchanged top-left corner
-    /// (<c>PhysicalX</c>/<c>PhysicalY</c>) is the rotated AABB's top-left — the
-    /// same frame the GDS projector computes for the true instance transform.
-    /// Pin angles stay relative to the component (<c>GetAbsoluteAngle()</c> adds
-    /// <c>RotationDegrees</c>). The discrete tile matrix (<c>Parts</c>) and
-    /// <c>Rotation90CounterClock</c> cannot represent non-cardinal angles and are
-    /// deliberately left untouched — rendering and absolute pin angles follow the
-    /// continuous <c>RotationDegrees</c>. Used by programmatic placement (GDS
-    /// import), where snapping a non-Manhattan instance angle to a cardinal would
-    /// move its pins off the true joints; interactive rotation stays cardinal.
-    /// </summary>
-    internal static void ApplyModelRotation(Component comp, double degrees)
-    {
-        RecordUnrotatedDimensions(comp);
-        var radians = degrees * Math.PI / 180.0;
-        var cos = Math.Cos(radians);
-        var sin = Math.Sin(radians);
-
-        var width = comp.WidthMicrometers;
-        var height = comp.HeightMicrometers;
-        var cx = width / 2;
-        var cy = height / 2;
-
-        // Axis-aligned bounding box of the rotated footprint
-        var newWidth = width * Math.Abs(cos) + height * Math.Abs(sin);
-        var newHeight = width * Math.Abs(sin) + height * Math.Abs(cos);
-
-        foreach (var pin in comp.PhysicalPins)
-        {
-            var x = pin.OffsetXMicrometers - cx;
-            var y = pin.OffsetYMicrometers - cy;
-            pin.OffsetXMicrometers = x * cos - y * sin + newWidth / 2;
-            pin.OffsetYMicrometers = x * sin + y * cos + newHeight / 2;
-            // NOTE: Pin angles stay relative to the component — see ApplyModelRotation90.
-        }
-
-        comp.WidthMicrometers = newWidth;
-        comp.HeightMicrometers = newHeight;
-
-        comp.RotationDegrees = (comp.RotationDegrees + degrees) % 360;
-        if (comp.RotationDegrees < 0)
-            comp.RotationDegrees += 360;
-    }
-
-    /// <summary>
-    /// Records the pre-rotation footprint dims ONCE as the unrotated outline
-    /// frame (<see cref="Component.UnrotatedWidthMicrometers"/>). Idempotent by
-    /// design: the unrotated frame is invariant under further rotations, and
-    /// undo/redo cycles must never overwrite it with already-rotated dims.
-    /// </summary>
-    private static void RecordUnrotatedDimensions(Component comp)
-    {
-        if (comp.UnrotatedWidthMicrometers <= 0 || comp.UnrotatedHeightMicrometers <= 0)
-        {
-            comp.UnrotatedWidthMicrometers = comp.WidthMicrometers;
-            comp.UnrotatedHeightMicrometers = comp.HeightMicrometers;
-        }
     }
 }

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -1305,11 +1305,18 @@ public class ChildComponentData
     public int Rotation { get; set; }
 
     /// <summary>
-    /// Exact continuous rotation in degrees (GDS imports keep non-cardinal
-    /// angles). Null in old files — falls back to <see cref="Rotation"/>
-    /// quarter-turns. Supersedes <see cref="Rotation"/> when present.
+    /// Exact continuous rotation in degrees for non-cardinal placements (GDS
+    /// import). Null in old files and for cardinal rotations — <see cref="Rotation"/>
+    /// alone restores those.
     /// </summary>
     public double? RotationDegrees { get; set; }
+
+    /// <summary>
+    /// True when the pins were mirrored across the local horizontal centerline
+    /// (GDS STRANS-reflected instance). Null in old files — no mirror.
+    /// </summary>
+    public bool? Mirrored { get; set; }
+
     public double? SliderValue { get; set; }
 
     /// <summary>
@@ -1341,11 +1348,18 @@ public class ComponentData
     public int Rotation { get; set; }
 
     /// <summary>
-    /// Exact continuous rotation in degrees (GDS imports keep non-cardinal
-    /// angles). Null in old files — falls back to <see cref="Rotation"/>
-    /// quarter-turns. Supersedes <see cref="Rotation"/> when present.
+    /// Exact continuous rotation in degrees for non-cardinal placements (GDS
+    /// import). Null in old files and for cardinal rotations — <see cref="Rotation"/>
+    /// alone restores those.
     /// </summary>
     public double? RotationDegrees { get; set; }
+
+    /// <summary>
+    /// True when the pins were mirrored across the local horizontal centerline
+    /// (GDS STRANS-reflected instance). Null in old files — no mirror.
+    /// </summary>
+    public bool? Mirrored { get; set; }
+
     public double? SliderValue { get; set; }
 
     /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -491,7 +491,8 @@ public partial class FileOperationsViewModel : ObservableObject
             Y = c.Y,
             Identifier = c.Component.Identifier,
             Rotation = (int)c.Component.Rotation90CounterClock,
-            RotationDegrees = c.Component.RotationDegrees,
+            RotationDegrees = ComponentPoseTransform.GetNonCardinalRotationDegrees(c.Component),
+            Mirrored = c.Component.IsMirroredHorizontally ? true : null,
             SliderValue = c.HasSliders ? c.SliderValue : null,
             SliderValues = SnapshotSliderValues(c.Component),
             LaserWavelengthNm = c.LaserConfig?.WavelengthNm,
@@ -700,7 +701,8 @@ public partial class FileOperationsViewModel : ObservableObject
                 X = child.PhysicalX,
                 Y = child.PhysicalY,
                 Rotation = (int)child.Rotation90CounterClock,
-                RotationDegrees = child.RotationDegrees,
+                RotationDegrees = ComponentPoseTransform.GetNonCardinalRotationDegrees(child),
+                Mirrored = child.IsMirroredHorizontally ? true : null,
                 SliderValue = child.GetAllSliders().Count > 0
                     ? child.GetSlider(0)?.Value : null,
                 SliderValues = SnapshotSliderValues(child),
@@ -1331,31 +1333,7 @@ public partial class FileOperationsViewModel : ObservableObject
         if (compData.HumanReadableName != null)
             component.HumanReadableName = compData.HumanReadableName;
 
-        // Apply rotation: exact continuous angle when the file carries one
-        // (GDS imports keep non-cardinal rotations); cardinal angles keep the
-        // legacy quarter-turn loop (discrete-rotation sync, numerically exact).
-        if (compData.RotationDegrees is double exactDegrees)
-        {
-            int quarterTurns = (int)Math.Round(exactDegrees / 90.0);
-            if (Math.Abs(exactDegrees - (quarterTurns * 90.0)) < 1e-6)
-            {
-                for (int i = 0; i < ((quarterTurns % 4) + 4) % 4; i++)
-                {
-                    ApplyRotationToComponent(component);
-                }
-            }
-            else
-            {
-                RotateComponentCommand.ApplyModelRotation(component, exactDegrees);
-            }
-        }
-        else
-        {
-            for (int i = 0; i < compData.Rotation; i++)
-            {
-                ApplyRotationToComponent(component);
-            }
-        }
+        RestorePose(component, compData.Mirrored, compData.Rotation, compData.RotationDegrees);
 
         var vm = _canvas.AddComponent(component, template.Name, template.PdkSource);
 
@@ -1434,34 +1412,7 @@ public partial class FileOperationsViewModel : ObservableObject
                 if (childData.HumanReadableName != null)
                     child.HumanReadableName = childData.HumanReadableName;
 
-                // Apply rotation: the exact continuous angle when the file
-                // carries one (GDS imports keep non-cardinal rotations; the
-                // exact path also records the unrotated dims for outline
-                // rendering). Cardinal angles keep the legacy quarter-turn
-                // loop — it keeps the discrete rotation enum in sync and is
-                // numerically exact (no trig noise).
-                if (childData.RotationDegrees is double exactDegrees)
-                {
-                    int quarterTurns = (int)Math.Round(exactDegrees / 90.0);
-                    if (Math.Abs(exactDegrees - (quarterTurns * 90.0)) < 1e-6)
-                    {
-                        for (int i = 0; i < ((quarterTurns % 4) + 4) % 4; i++)
-                        {
-                            ApplyRotationToComponent(child);
-                        }
-                    }
-                    else
-                    {
-                        RotateComponentCommand.ApplyModelRotation(child, exactDegrees);
-                    }
-                }
-                else
-                {
-                    for (int i = 0; i < childData.Rotation; i++)
-                    {
-                        ApplyRotationToComponent(child);
-                    }
-                }
+                RestorePose(child, childData.Mirrored, childData.Rotation, childData.RotationDegrees);
 
                 // Restore slider values (all sliders; legacy single value as fallback)
                 RestoreSliderValues(child, childData.SliderValues, childData.SliderValue);
@@ -1974,28 +1925,24 @@ public partial class FileOperationsViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Applies a 90° counter-clockwise rotation to a component.
+    /// Restores a freshly template-created component's saved pose in placement
+    /// order: mirror first (local, unrotated frame — matching
+    /// <see cref="Commands.PlaceComponentCommand.CreateExact"/>), then the
+    /// discrete quarter turns, then the exact continuous angle when the file
+    /// carries one (GDS-imported non-cardinal instance; null in older files
+    /// and for cardinal rotations).
     /// </summary>
-    private static void ApplyRotationToComponent(Component comp)
+    private static void RestorePose(
+        Component component, bool? mirrored, int quarterTurns, double? exactRotationDegrees)
     {
-        var width = comp.WidthMicrometers;
-        var height = comp.HeightMicrometers;
+        if (mirrored == true)
+            ComponentPoseTransform.MirrorPinsHorizontally(component);
 
-        foreach (var pin in comp.PhysicalPins)
-        {
-            var cx = width / 2;
-            var cy = height / 2;
-            var x = pin.OffsetXMicrometers - cx;
-            var y = pin.OffsetYMicrometers - cy;
-            var newX = -y;
-            var newY = x;
-            pin.OffsetXMicrometers = newX + cy;
-            pin.OffsetYMicrometers = newY + cx;
-        }
+        for (int i = 0; i < quarterTurns; i++)
+            ComponentPoseTransform.Rotate90CounterClockwise(component);
 
-        comp.WidthMicrometers = height;
-        comp.HeightMicrometers = width;
-        comp.RotateBy90CounterClockwise();
+        if (exactRotationDegrees is double exact)
+            ComponentPoseTransform.ApplyExactRotation(component, exact);
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Components/Core/Component.cs
+++ b/Connect-A-Pic-Core/Components/Core/Component.cs
@@ -52,6 +52,14 @@ public partial class Component : ICloneable
     public double PhysicalOffsetX { get; set; }
     public double PhysicalOffsetY { get; set; }
     public double RotationDegrees { get; set; }
+
+    /// <summary>
+    /// True when the physical pins were mirrored across the component's local
+    /// horizontal centerline (GDS STRANS-reflected instance — see
+    /// <see cref="ComponentPoseTransform.MirrorPinsHorizontally"/>). Persisted
+    /// with the design so the mirrored pin layout survives a save/load.
+    /// </summary>
+    public bool IsMirroredHorizontally { get; set; }
     public double NazcaOriginOffsetX { get; set; }
     public double NazcaOriginOffsetY { get; set; }
 
@@ -365,6 +373,7 @@ public partial class Component : ICloneable
         clonedComponent.PhysicalOffsetX = PhysicalOffsetX;
         clonedComponent.PhysicalOffsetY = PhysicalOffsetY;
         clonedComponent.RotationDegrees = RotationDegrees;
+        clonedComponent.IsMirroredHorizontally = IsMirroredHorizontally;
         clonedComponent.NazcaOriginOffsetX = NazcaOriginOffsetX;
         clonedComponent.NazcaOriginOffsetY = NazcaOriginOffsetY;
         // The module is part of the component's geometry identity (it picks the Nazca cell):

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -731,6 +731,12 @@ public class ComponentGroup : Component, INotifyPropertyChanged
             PhysicalY = source.PhysicalY,
             WidthMicrometers = source.WidthMicrometers,
             HeightMicrometers = source.HeightMicrometers,
+            // Pose metadata must survive group cloning, else the next save/load actively
+            // rotates the already-transformed pins back (non-cardinal rotation, mirroring).
+            RotationDegrees = source.RotationDegrees,
+            IsMirroredHorizontally = source.IsMirroredHorizontally,
+            UnrotatedWidthMicrometers = source.UnrotatedWidthMicrometers,
+            UnrotatedHeightMicrometers = source.UnrotatedHeightMicrometers,
             NazcaOriginOffsetX = source.NazcaOriginOffsetX,
             NazcaOriginOffsetY = source.NazcaOriginOffsetY,
             NazcaModuleName = source.NazcaModuleName,

--- a/Connect-A-Pic-Core/Components/Core/ComponentPoseTransform.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentPoseTransform.cs
@@ -1,0 +1,167 @@
+namespace CAP_Core.Components.Core;
+
+/// <summary>
+/// Model-level pose transforms shared by interactive rotation, programmatic
+/// placement (GDS import) and .lun persistence. Lives in the core layer so
+/// both CAP.Avalonia and CAP_DataAccess apply the exact same math — a loaded
+/// design must reproduce the pin layout the import created.
+/// </summary>
+public static class ComponentPoseTransform
+{
+    /// <summary>Tolerance below which two rotation angles count as equal.</summary>
+    public const double AngleEpsilonDegrees = 1e-6;
+
+    /// <summary>
+    /// Model-level 90° counter-clockwise rotation around the component center:
+    /// physical pin offsets, width/height swap, discrete rotation and
+    /// <see cref="Component.RotationDegrees"/>. The top-left corner
+    /// (<see cref="Component.PhysicalX"/>/<see cref="Component.PhysicalY"/>) is
+    /// deliberately left untouched. No ViewModel/canvas notifications — shared
+    /// with programmatic placement (GDS import) and .lun loading, which rotate
+    /// the component before it is added to the canvas.
+    /// </summary>
+    public static void Rotate90CounterClockwise(Component component)
+    {
+        RecordUnrotatedDimensions(component);
+        var width = component.WidthMicrometers;
+        var height = component.HeightMicrometers;
+        var cx = width / 2;
+        var cy = height / 2;
+
+        // Pin angles stay relative to the component — GetAbsoluteAngle() adds
+        // RotationDegrees, so only the offsets are rotated here.
+        foreach (var pin in component.PhysicalPins)
+        {
+            var x = pin.OffsetXMicrometers - cx;
+            var y = pin.OffsetYMicrometers - cy;
+
+            // Rotate 90° counter-clockwise: (x, y) -> (-y, x), then translate
+            // back to the swapped-dimension center (cy becomes the new cx).
+            pin.OffsetXMicrometers = -y + cy;
+            pin.OffsetYMicrometers = x + cx;
+        }
+
+        component.WidthMicrometers = height;
+        component.HeightMicrometers = width;
+        component.RotateBy90CounterClockwise();
+    }
+
+    /// <summary>
+    /// Model-level rotation around the component center by an ARBITRARY angle,
+    /// relative to the current pose, in the same convention
+    /// <see cref="Rotate90CounterClockwise"/> uses (0° = east, positive toward
+    /// south in the Y-down plane — for θ = 90° the math reduces exactly to a
+    /// quarter turn). Physical pin offsets rotate around the old center;
+    /// width/height become the axis-aligned bounding box of the rotated
+    /// footprint, so an unchanged top-left corner
+    /// (<see cref="Component.PhysicalX"/>/<see cref="Component.PhysicalY"/>) is
+    /// the rotated AABB's top-left — the same frame the GDS projector computes
+    /// for the true instance transform. Pin angles stay relative to the
+    /// component (<c>GetAbsoluteAngle()</c> adds
+    /// <see cref="Component.RotationDegrees"/>). The discrete tile matrix
+    /// (<c>Parts</c>) and <c>Rotation90CounterClock</c> cannot represent
+    /// non-cardinal angles and are deliberately left untouched — rendering and
+    /// absolute pin angles follow the continuous rotation.
+    /// </summary>
+    public static void RotateByDegrees(Component component, double degrees)
+    {
+        RecordUnrotatedDimensions(component);
+        var radians = degrees * Math.PI / 180.0;
+        var cos = Math.Cos(radians);
+        var sin = Math.Sin(radians);
+
+        var width = component.WidthMicrometers;
+        var height = component.HeightMicrometers;
+        var cx = width / 2;
+        var cy = height / 2;
+
+        // Axis-aligned bounding box of the rotated footprint.
+        var newWidth = width * Math.Abs(cos) + height * Math.Abs(sin);
+        var newHeight = width * Math.Abs(sin) + height * Math.Abs(cos);
+
+        foreach (var pin in component.PhysicalPins)
+        {
+            var x = pin.OffsetXMicrometers - cx;
+            var y = pin.OffsetYMicrometers - cy;
+            pin.OffsetXMicrometers = x * cos - y * sin + newWidth / 2;
+            pin.OffsetYMicrometers = x * sin + y * cos + newHeight / 2;
+        }
+
+        component.WidthMicrometers = newWidth;
+        component.HeightMicrometers = newHeight;
+        component.RotationDegrees = NormalizeDegrees(component.RotationDegrees + degrees);
+    }
+
+    /// <summary>
+    /// Brings the component from its current (cardinal) rotation to the exact
+    /// continuous angle <paramref name="exactRotationDegrees"/>: the shortest
+    /// signed residual is applied via <see cref="RotateByDegrees"/> (pins
+    /// re-based into the rotated footprint's AABB) and
+    /// <see cref="Component.RotationDegrees"/> takes the exact value. Used by
+    /// GDS placement and on .lun load to restore instances placed at
+    /// non-cardinal angles (e.g. 330°).
+    /// </summary>
+    public static void ApplyExactRotation(Component component, double exactRotationDegrees)
+    {
+        var residual = NormalizeDegrees(exactRotationDegrees - component.RotationDegrees);
+        if (residual > 180)
+            residual -= 360; // Shortest signed residual, e.g. 350 -> -10.
+
+        if (Math.Abs(residual) > AngleEpsilonDegrees)
+            RotateByDegrees(component, residual);
+
+        component.RotationDegrees = NormalizeDegrees(exactRotationDegrees);
+    }
+
+    /// <summary>
+    /// Mirrors the physical pins across the component's horizontal centerline in
+    /// its LOCAL (unrotated) frame: offset Y flips within the box, the angle maps
+    /// θ → −θ (a down-pointing pin becomes up-pointing). This is the app-space
+    /// effect of the GDS STRANS flag (reflection across the GDS x-axis) on pins.
+    /// Geometry (parts, outlines) is NOT mirrored: the core model has no mirror
+    /// support (v1 limitation). Toggles <see cref="Component.IsMirroredHorizontally"/>
+    /// so persistence can re-apply the mirror on load.
+    /// </summary>
+    public static void MirrorPinsHorizontally(Component component)
+    {
+        foreach (var pin in component.PhysicalPins)
+        {
+            pin.OffsetYMicrometers = component.HeightMicrometers - pin.OffsetYMicrometers;
+            pin.AngleDegrees = (360.0 - pin.AngleDegrees) % 360.0;
+        }
+        component.IsMirroredHorizontally = !component.IsMirroredHorizontally;
+    }
+
+    /// <summary>
+    /// The component's continuous rotation when it differs from its discrete
+    /// quarter-turn rotation, otherwise null. Persistence writes this into the
+    /// optional <c>RotationDegrees</c> field so cardinal-only designs keep the
+    /// compact legacy format.
+    /// </summary>
+    public static double? GetNonCardinalRotationDegrees(Component component)
+    {
+        var cardinal = (int)component.Rotation90CounterClock * 90.0;
+        var delta = NormalizeDegrees(component.RotationDegrees - cardinal);
+        if (delta > 180)
+            delta = 360 - delta;
+        return delta > AngleEpsilonDegrees ? component.RotationDegrees : null;
+    }
+
+    /// <summary>
+    /// Records the pre-rotation footprint dims ONCE as the unrotated outline
+    /// frame (<see cref="Component.UnrotatedWidthMicrometers"/>). Idempotent by
+    /// design: the unrotated frame is invariant under further rotations, and
+    /// undo/redo cycles must never overwrite it with already-rotated dims.
+    /// </summary>
+    private static void RecordUnrotatedDimensions(Component component)
+    {
+        if (component.UnrotatedWidthMicrometers <= 0 || component.UnrotatedHeightMicrometers <= 0)
+        {
+            component.UnrotatedWidthMicrometers = component.WidthMicrometers;
+            component.UnrotatedHeightMicrometers = component.HeightMicrometers;
+        }
+    }
+
+    /// <summary>Normalizes an angle to the range [0, 360).</summary>
+    private static double NormalizeDegrees(double degrees) => ((degrees % 360) + 360) % 360;
+}

--- a/UnitTests/Commands/RotateComponentCommandTests.cs
+++ b/UnitTests/Commands/RotateComponentCommandTests.cs
@@ -110,18 +110,18 @@ public class RotateComponentCommandTests
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void ApplyModelRotation_RecordsUnrotatedDimensionsOnce()
+    public void RotateByDegrees_RecordsUnrotatedDimensionsOnce()
     {
         var comp = CreateComponent(widthMicrometers: 20, heightMicrometers: 10);
 
-        RotateComponentCommand.ApplyModelRotation(comp, 30);
+        ComponentPoseTransform.RotateByDegrees(comp, 30);
 
         comp.UnrotatedWidthMicrometers.ShouldBe(20, 1e-9);
         comp.UnrotatedHeightMicrometers.ShouldBe(10, 1e-9);
 
         // Further rotations (and undo/redo cycles) must never overwrite the frame.
-        RotateComponentCommand.ApplyModelRotation(comp, 15);
-        RotateComponentCommand.ApplyModelRotation90(comp);
+        ComponentPoseTransform.RotateByDegrees(comp, 15);
+        ComponentPoseTransform.Rotate90CounterClockwise(comp);
 
         comp.UnrotatedWidthMicrometers.ShouldBe(20, 1e-9);
         comp.UnrotatedHeightMicrometers.ShouldBe(10, 1e-9);

--- a/UnitTests/Components/ComponentGroupCloningTests.cs
+++ b/UnitTests/Components/ComponentGroupCloningTests.cs
@@ -63,6 +63,30 @@ public class ComponentGroupCloningTests
     }
 
     /// <summary>
+    /// Verifies that cloning preserves pose metadata (non-cardinal rotation, mirroring,
+    /// unrotated dimensions) on child components, so a later save/load does not rotate
+    /// the already-transformed pins a second time.
+    /// </summary>
+    [Fact]
+    public void Clone_GroupWithChildren_PreservesChildPoseMetadata()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("ParentGroup", addChildren: true);
+        var originalChild = original.ChildComponents[0];
+        originalChild.RotationDegrees = 30.0;
+        originalChild.IsMirroredHorizontally = true;
+        originalChild.UnrotatedWidthMicrometers = 120.0;
+        originalChild.UnrotatedHeightMicrometers = 40.0;
+
+        var cloned = (ComponentGroup)original.Clone();
+
+        var clonedChild = cloned.ChildComponents[0];
+        clonedChild.RotationDegrees.ShouldBe(30.0);
+        clonedChild.IsMirroredHorizontally.ShouldBeTrue();
+        clonedChild.UnrotatedWidthMicrometers.ShouldBe(120.0);
+        clonedChild.UnrotatedHeightMicrometers.ShouldBe(40.0);
+    }
+
+    /// <summary>
     /// Verifies that cloned children have their ParentGroup reference set correctly.
     /// </summary>
     [Fact]

--- a/UnitTests/Components/ComponentPoseTransformTests.cs
+++ b/UnitTests/Components/ComponentPoseTransformTests.cs
@@ -1,0 +1,152 @@
+using CAP_Core.Components.Core;
+using Shouldly;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Core pose math shared by rotation, GDS placement and .lun persistence:
+/// 90° quarter turns, exact non-cardinal rotation, horizontal pin mirroring
+/// and the "only persist when non-cardinal" helper.
+/// </summary>
+public class ComponentPoseTransformTests
+{
+    private const double Tolerance = 1e-9;
+
+    [Fact]
+    public void Rotate90CounterClockwise_MovesPinsAndSwapsDimensions()
+    {
+        // 250×250 coupler: west0 at (0, 80), east1 at (250, 180).
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("rot90");
+
+        ComponentPoseTransform.Rotate90CounterClockwise(component);
+
+        // (x, y) → (−y, x) around the center (125, 125).
+        var west0 = component.PhysicalPins.First(p => p.Name == "west0");
+        west0.OffsetXMicrometers.ShouldBe(170, Tolerance);
+        west0.OffsetYMicrometers.ShouldBe(0, Tolerance);
+        var east1 = component.PhysicalPins.First(p => p.Name == "east1");
+        east1.OffsetXMicrometers.ShouldBe(70, Tolerance);
+        east1.OffsetYMicrometers.ShouldBe(250, Tolerance);
+        component.RotationDegrees.ShouldBe(90, Tolerance);
+    }
+
+    [Fact]
+    public void ApplyExactRotation_RotatesPinsByShortestResidual()
+    {
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("exact330");
+
+        ComponentPoseTransform.ApplyExactRotation(component, 330);
+
+        // 330° from 0° is a −30° residual; west0 (0, 80) rotates around the old
+        // center (125, 125) and is re-based into the rotated footprint's AABB —
+        // the same frame the GDS projector places non-cardinal instances in.
+        var radians = -30 * Math.PI / 180.0;
+        var cos = Math.Cos(radians);
+        var sin = Math.Sin(radians);
+        var aabbSize = 250 * Math.Abs(cos) + 250 * Math.Abs(sin);
+        var expectedX = -125 * cos - -45 * sin + aabbSize / 2;
+        var expectedY = -125 * sin + -45 * cos + aabbSize / 2;
+        var west0 = component.PhysicalPins.First(p => p.Name == "west0");
+        west0.OffsetXMicrometers.ShouldBe(expectedX, Tolerance);
+        west0.OffsetYMicrometers.ShouldBe(expectedY, Tolerance);
+        component.WidthMicrometers.ShouldBe(aabbSize, Tolerance);
+        component.HeightMicrometers.ShouldBe(aabbSize, Tolerance);
+        component.UnrotatedWidthMicrometers.ShouldBe(250, Tolerance);
+        component.RotationDegrees.ShouldBe(330, Tolerance);
+    }
+
+    [Fact]
+    public void ApplyExactRotation_MatchesQuarterTurnConvention()
+    {
+        // Continuous 90° must land the pins exactly where a discrete quarter turn does.
+        var exact = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("exact90");
+        var discrete = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("disc90");
+
+        ComponentPoseTransform.ApplyExactRotation(exact, 90);
+        ComponentPoseTransform.Rotate90CounterClockwise(discrete);
+
+        for (int i = 0; i < exact.PhysicalPins.Count; i++)
+        {
+            exact.PhysicalPins[i].OffsetXMicrometers
+                .ShouldBe(discrete.PhysicalPins[i].OffsetXMicrometers, Tolerance);
+            exact.PhysicalPins[i].OffsetYMicrometers
+                .ShouldBe(discrete.PhysicalPins[i].OffsetYMicrometers, Tolerance);
+        }
+    }
+
+    [Fact]
+    public void ApplyExactRotation_AtCurrentAngle_LeavesPinsUntouched()
+    {
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("noop");
+
+        ComponentPoseTransform.ApplyExactRotation(component, 0);
+
+        var west0 = component.PhysicalPins.First(p => p.Name == "west0");
+        west0.OffsetXMicrometers.ShouldBe(0, Tolerance);
+        west0.OffsetYMicrometers.ShouldBe(80, Tolerance);
+        component.RotationDegrees.ShouldBe(0, Tolerance);
+    }
+
+    [Fact]
+    public void MirrorPinsHorizontally_FlipsOffsetsAnglesAndFlag()
+    {
+        // 250×250 coupler: west0 (0, 80), west1 (0, 180), east0/east1 mirrored right.
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("mirror");
+
+        ComponentPoseTransform.MirrorPinsHorizontally(component);
+
+        component.IsMirroredHorizontally.ShouldBeTrue();
+        var west0 = component.PhysicalPins.First(p => p.Name == "west0");
+        west0.OffsetYMicrometers.ShouldBe(170, Tolerance);
+        west0.AngleDegrees.ShouldBe(180, Tolerance);
+        var east1 = component.PhysicalPins.First(p => p.Name == "east1");
+        east1.OffsetYMicrometers.ShouldBe(70, Tolerance);
+        east1.AngleDegrees.ShouldBe(0, Tolerance);
+    }
+
+    [Fact]
+    public void MirrorPinsHorizontally_Twice_IsIdentity()
+    {
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("involution");
+
+        ComponentPoseTransform.MirrorPinsHorizontally(component);
+        ComponentPoseTransform.MirrorPinsHorizontally(component);
+
+        component.IsMirroredHorizontally.ShouldBeFalse();
+        var west0 = component.PhysicalPins.First(p => p.Name == "west0");
+        west0.OffsetYMicrometers.ShouldBe(80, Tolerance);
+        west0.AngleDegrees.ShouldBe(180, Tolerance);
+    }
+
+    [Fact]
+    public void GetNonCardinalRotationDegrees_IsNullForCardinalPoses()
+    {
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("c");
+        ComponentPoseTransform.GetNonCardinalRotationDegrees(component).ShouldBeNull();
+
+        ComponentPoseTransform.Rotate90CounterClockwise(component);
+        ComponentPoseTransform.GetNonCardinalRotationDegrees(component).ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetNonCardinalRotationDegrees_ReturnsExactAngleWhenOffCardinal()
+    {
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("c");
+        ComponentPoseTransform.ApplyExactRotation(component, 330);
+
+        ComponentPoseTransform.GetNonCardinalRotationDegrees(component)
+            .ShouldNotBeNull()
+            .ShouldBe(330, Tolerance);
+    }
+
+    [Fact]
+    public void Clone_PreservesMirrorFlag()
+    {
+        var component = TestComponentFactory.CreateFourPinCouplerWithPhysicalPins("c");
+        ComponentPoseTransform.MirrorPinsHorizontally(component);
+
+        var clone = (Component)component.Clone();
+
+        clone.IsMirroredHorizontally.ShouldBeTrue();
+    }
+}

--- a/UnitTests/Persistence/NonCardinalRotationPersistenceTests.cs
+++ b/UnitTests/Persistence/NonCardinalRotationPersistenceTests.cs
@@ -1,0 +1,211 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using System.Collections.ObjectModel;
+
+namespace UnitTests.Persistence;
+
+/// <summary>
+/// Regression tests for issue #872: a GDS-imported instance at a non-cardinal
+/// angle (e.g. 330°) and/or with a STRANS-mirrored pin layout must survive a
+/// .lun save/load cycle — both standalone and as a group child. Old-format
+/// cardinal designs must keep the compact file format (no new JSON fields).
+/// </summary>
+public class NonCardinalRotationPersistenceTests
+{
+    private const double Tolerance = 1e-9;
+    private const double ExactAngle = 330;
+
+    private readonly ObservableCollection<ComponentTemplate> _library =
+        new(TestPdkLoader.LoadAllTemplates());
+
+    [Fact]
+    public async Task StandaloneComponent_NonCardinalRotationAndMirror_SurviveRoundtrip()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pose_{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas) = CreateSetup();
+            var component = PlaceTemplateComponent(saveCanvas, "rotated_mirrored", 100, 100);
+            ComponentPoseTransform.MirrorPinsHorizontally(component);
+            ComponentPoseTransform.ApplyExactRotation(component, ExactAngle);
+            var expectedPins = SnapshotPins(component);
+
+            await SaveToFile(saveVm, tempFile);
+
+            var (loadVm, loadCanvas) = CreateSetup();
+            await LoadFromFile(loadVm, tempFile);
+
+            var loaded = loadCanvas.Components
+                .First(c => c.Component.Identifier == "rotated_mirrored").Component;
+            loaded.RotationDegrees.ShouldBe(ExactAngle, Tolerance);
+            loaded.IsMirroredHorizontally.ShouldBeTrue();
+            AssertPinsMatch(loaded, expectedPins);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task GroupChild_NonCardinalRotationAndMirror_SurviveRoundtrip()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pose_{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas) = CreateSetup();
+            var posed = PlaceTemplateComponent(saveCanvas, "child_posed", 0, 0);
+            ComponentPoseTransform.MirrorPinsHorizontally(posed);
+            ComponentPoseTransform.ApplyExactRotation(posed, ExactAngle);
+            var plain = PlaceTemplateComponent(saveCanvas, "child_plain", 600, 0);
+            var expectedPins = SnapshotPins(posed);
+
+            var members = saveCanvas.Components
+                .Where(c => c.Component == posed || c.Component == plain).ToList();
+            new CreateGroupCommand(saveCanvas, members).Execute();
+
+            await SaveToFile(saveVm, tempFile);
+
+            var (loadVm, loadCanvas) = CreateSetup();
+            await LoadFromFile(loadVm, tempFile);
+
+            var group = (ComponentGroup)loadCanvas.Components
+                .First(c => c.Component is ComponentGroup).Component;
+            var loadedChild = group.ChildComponents
+                .First(c => c.Identifier == "child_posed");
+            loadedChild.RotationDegrees.ShouldBe(ExactAngle, Tolerance);
+            loadedChild.IsMirroredHorizontally.ShouldBeTrue();
+            AssertPinsMatch(loadedChild, expectedPins);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task CardinalUnmirroredDesign_OmitsNewJsonFields()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pose_{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas) = CreateSetup();
+            var component = PlaceTemplateComponent(saveCanvas, "cardinal_only", 100, 100);
+            ComponentPoseTransform.Rotate90CounterClockwise(component);
+
+            await SaveToFile(saveVm, tempFile);
+
+            var json = await File.ReadAllTextAsync(tempFile);
+            json.ShouldNotContain("\"RotationDegrees\"",
+                customMessage: "cardinal designs must keep the compact legacy format");
+            json.ShouldNotContain("\"Mirrored\"",
+                customMessage: "unmirrored designs must keep the compact legacy format");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task QuarterTurnPlusExactRotation_RestoresCombinedPose()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"pose_{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas) = CreateSetup();
+            var component = PlaceTemplateComponent(saveCanvas, "combined_pose", 100, 100);
+            ComponentPoseTransform.Rotate90CounterClockwise(component);
+            ComponentPoseTransform.ApplyExactRotation(component, 120);
+            var expectedPins = SnapshotPins(component);
+
+            await SaveToFile(saveVm, tempFile);
+
+            var (loadVm, loadCanvas) = CreateSetup();
+            await LoadFromFile(loadVm, tempFile);
+
+            var loaded = loadCanvas.Components
+                .First(c => c.Component.Identifier == "combined_pose").Component;
+            loaded.RotationDegrees.ShouldBe(120, Tolerance);
+            loaded.Rotation90CounterClock.ShouldBe(DiscreteRotation.R90);
+            AssertPinsMatch(loaded, expectedPins);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    // ── Helpers (same harness as MultiSliderPersistenceTests) ────────────────
+
+    private Component PlaceTemplateComponent(
+        DesignCanvasViewModel canvas, string identifier, double x, double y)
+    {
+        var template = _library.First(t => t.Name == "1x2 MMI Splitter");
+        var component = ComponentTemplates.CreateFromTemplate(template, x, y);
+        component.Identifier = identifier;
+        canvas.AddComponent(component, template.Name);
+        return component;
+    }
+
+    private static List<(string Name, double X, double Y, double Angle)> SnapshotPins(
+        Component component) =>
+        component.PhysicalPins
+            .Select(p => (p.Name, p.OffsetXMicrometers, p.OffsetYMicrometers, p.AngleDegrees))
+            .ToList();
+
+    private static void AssertPinsMatch(
+        Component loaded, List<(string Name, double X, double Y, double Angle)> expected)
+    {
+        foreach (var (name, x, y, angle) in expected)
+        {
+            var pin = loaded.PhysicalPins.First(p => p.Name == name);
+            pin.OffsetXMicrometers.ShouldBe(x, Tolerance, $"pin {name} offset X");
+            pin.OffsetYMicrometers.ShouldBe(y, Tolerance, $"pin {name} offset Y");
+            pin.AngleDegrees.ShouldBe(angle, Tolerance, $"pin {name} angle");
+        }
+    }
+
+    private (FileOperationsViewModel vm, DesignCanvasViewModel canvas) CreateSetup()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var vm = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new CAP_Core.Export.SaxExporter(),
+            _library,
+            new GdsExportViewModel(new CAP_Core.Export.GdsExportService()),
+            new PhotonTorchExportViewModel(new CAP_Core.Export.PhotonTorchExporter(), canvas),
+            null!);
+        return (vm, canvas);
+    }
+
+    private static async Task SaveToFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(filePath).ShouldBeTrue("Design file must be created during save");
+    }
+
+    private static async Task LoadFromFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.LoadDesignCommand.ExecuteAsync(null);
+    }
+}

--- a/UnitTests/Rendering/ComponentOutlineRendererTests.cs
+++ b/UnitTests/Rendering/ComponentOutlineRendererTests.cs
@@ -152,7 +152,7 @@ public class ComponentOutlineRendererTests
         const double compX = 100, compY = 50;
 
         var local = new OutlinePoint(20, 0);
-        // Model-level pin math (RotateComponentCommand.ApplyModelRotation):
+        // Model-level pin math (ComponentPoseTransform.RotateByDegrees):
         // rotate around the old center, re-base into the new AABB.
         double lx = local.X - unrotW / 2, ly = local.Y - unrotH / 2;
         double expectedX = compX + (newW / 2) + (lx * cos) - (ly * sin);

--- a/UnitTests/Routing/InterconnectRouting/DirectRouteBodyCrossingTests.cs
+++ b/UnitTests/Routing/InterconnectRouting/DirectRouteBodyCrossingTests.cs
@@ -27,8 +27,8 @@ public class DirectRouteBodyCrossingTests
 
         var gc = ComponentTemplates.CreateFromTemplate(gcTemplate, 1219.227, -623.007);
         var mmi = ComponentTemplates.CreateFromTemplate(mmiTemplate, 1057.015, -584.181);
-        RotateComponentCommand.ApplyModelRotation90(mmi);
-        RotateComponentCommand.ApplyModelRotation90(mmi);
+        ComponentPoseTransform.Rotate90CounterClockwise(mmi);
+        ComponentPoseTransform.Rotate90CounterClockwise(mmi);
 
         var start = mmi.PhysicalPins.First(p => p.Name == "in");
         var end = gc.PhysicalPins.First(p => p.Name == "port 2");

--- a/UnitTests/Services/GdsImport/GdsBondPadOffsetProbeTests.cs
+++ b/UnitTests/Services/GdsImport/GdsBondPadOffsetProbeTests.cs
@@ -162,7 +162,7 @@ public class GdsBondPadOffsetProbeTests : IDisposable
             // Rotate like the app's RotateComponentCommand (90° CCW about the box
             // centre, pin offsets included) — same precedent as GdsMziElectricalFixture.
             for (var q = (int)Math.Round(rot / 90.0); q > 0; q--)
-                CAP.Avalonia.Commands.RotateComponentCommand.ApplyModelRotation90(comp);
+                CAP_Core.Components.Core.ComponentPoseTransform.Rotate90CounterClockwise(comp);
             canvas.AddComponent(comp, template.Name, template.PdkSource);
             var placement = NazcaCoordinateMapper.GetCellPlacement(comp, rawOverrideAnchor: null);
             expected.Add((id,

--- a/UnitTests/Services/GdsImport/GdsMziElectricalFixture.cs
+++ b/UnitTests/Services/GdsImport/GdsMziElectricalFixture.cs
@@ -50,7 +50,7 @@ internal static class GdsMziElectricalFixture
             // box centre, pin offsets included) — a bare RotationDegrees assignment
             // would leave the pin offsets unrotated.
             for (var quarterTurns = (int)Math.Round(rotation / 90.0); quarterTurns > 0; quarterTurns--)
-                CAP.Avalonia.Commands.RotateComponentCommand.ApplyModelRotation90(component);
+                CAP_Core.Components.Core.ComponentPoseTransform.Rotate90CounterClockwise(component);
             canvas.AddComponent(component, templateName, pdk);
             return component;
         }


### PR DESCRIPTION
Automated implementation for #872

That background run was the earlier `smart_test.py` attempt that hit its internal 5-minute cap — already superseded by the direct `dotnet test --filter "Category!=Slow"` run (5295 passed, 1 pre-existing failure). Nothing further to do; the work is committed as f5c71c79.

=== PR SUMMARY ===
- Fixes #872: non-cardinal rotation and mirrored pins now survive .lun save/load
- New core `ComponentPoseTransform`: shared 90°, exact-angle, and pin-mirror math
- Moved `ApplyModelRotation90`/`MirrorPinsHorizontally` from CAP.Avalonia commands into CAP_Core
- Added `Component.IsMirroredHorizontally`; cloned and persisted with designs
- Optional `RotationDegrees`/`Mirrored` DTO fields in both .lun persistence paths
- Load order: mirror → quarter turns → exact residual rotation
- Cardinal, unmirrored designs keep the compact legacy file format
- 13 new tests: pose math plus standalone/group-child round-trip regressions
- Pre-existing failure noted: FileSizeLimit test already red on clean branch


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 105,666
- **Estimated cost:** $0.0592 USD

**Custom Tools Used:** None

---
*Generated by autonomous agent using Claude Code.*