### PR TITLE
Agent: Re-route imported routes directly inside the import group (no dissolve required) (rung 1 follow-up)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -949,7 +949,7 @@
   "Routing.Reroute.All": "Alle neu routen",
   "Routing.Reroute.FrozenCount": "{0} eingefrorene importierte Route(n)",
   "Routing.Reroute.HandEditedKept": "{0} manuell bearbeitete Route(n) bleiben unverändert",
-  "Routing.Reroute.InGroups": "{0} eingefrorene importierte Route(n) in einer Gruppe — Gruppe öffnen oder auflösen zum Neu-Routen",
+  "Routing.Reroute.InGroups": "{0} eingefrorene importierte Route(n) in Gruppen",
   "Routing.Reroute.Result": "{0} Route(n) neu geroutet: Länge {1:F1} → {2:F1} µm, Biegungen {3:F1} → {4:F1}",
   "Routing.Reroute.Selected": "Auswahl neu routen",
   "Routing.Reroute.Title": "Importierte Routen:",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -949,7 +949,7 @@
   "Routing.Reroute.All": "Re-route All",
   "Routing.Reroute.FrozenCount": "{0} frozen imported route(s)",
   "Routing.Reroute.HandEditedKept": "{0} hand-edited route(s) kept unchanged",
-  "Routing.Reroute.InGroups": "{0} frozen imported route(s) inside a group — open or dissolve the group to re-route",
+  "Routing.Reroute.InGroups": "{0} frozen imported route(s) inside groups",
   "Routing.Reroute.Result": "Re-routed {0} route(s): length {1:F1} → {2:F1} µm, bends {3:F1} → {4:F1}",
   "Routing.Reroute.Selected": "Re-route Selected",
   "Routing.Reroute.Title": "Imported Routes:",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -949,7 +949,7 @@
   "Routing.Reroute.All": "Reenrutar todo",
   "Routing.Reroute.FrozenCount": "{0} ruta(s) importada(s) congelada(s)",
   "Routing.Reroute.HandEditedKept": "{0} ruta(s) editada(s) a mano se mantienen sin cambios",
-  "Routing.Reroute.InGroups": "{0} ruta(s) importada(s) congelada(s) dentro de un grupo — abra o disuelva el grupo para reenrutar",
+  "Routing.Reroute.InGroups": "{0} ruta(s) importada(s) congelada(s) dentro de grupos",
   "Routing.Reroute.Result": "{0} ruta(s) reenrutada(s): longitud {1:F1} → {2:F1} µm, curvas {3:F1} → {4:F1}",
   "Routing.Reroute.Selected": "Reenrutar selección",
   "Routing.Reroute.Title": "Rutas importadas:",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -949,7 +949,7 @@
   "Routing.Reroute.All": "すべて再ルーティング",
   "Routing.Reroute.FrozenCount": "凍結されたインポート経路：{0} 本",
   "Routing.Reroute.HandEditedKept": "手動編集された経路 {0} 本は変更されません",
-  "Routing.Reroute.InGroups": "グループ内の凍結されたインポート経路：{0} 本 — 再ルーティングするにはグループを開くか解除してください",
+  "Routing.Reroute.InGroups": "グループ内の凍結されたインポート経路：{0} 本",
   "Routing.Reroute.Result": "{0} 本を再ルーティング：長さ {1:F1} → {2:F1} µm、曲げ {3:F1} → {4:F1}",
   "Routing.Reroute.Selected": "選択を再ルーティング",
   "Routing.Reroute.Title": "インポート経路：",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -949,7 +949,7 @@
   "Routing.Reroute.All": "全部重新布线",
   "Routing.Reroute.FrozenCount": "{0} 条已冻结的导入布线",
   "Routing.Reroute.HandEditedKept": "{0} 条手动编辑的布线保持不变",
-  "Routing.Reroute.InGroups": "组内有 {0} 条已冻结的导入布线 — 打开或解散组以重新布线",
+  "Routing.Reroute.InGroups": "组内有 {0} 条已冻结的导入布线",
   "Routing.Reroute.Result": "已重新布线 {0} 条：长度 {1:F1} → {2:F1} µm，弯曲 {3:F1} → {4:F1}",
   "Routing.Reroute.Selected": "重新布线所选",
   "Routing.Reroute.Title": "导入的布线：",

--- a/CAP.Avalonia/Commands/RerouteImportedRoutesStateCommand.cs
+++ b/CAP.Avalonia/Commands/RerouteImportedRoutesStateCommand.cs
@@ -1,0 +1,118 @@
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
+
+namespace CAP.Avalonia.Commands;
+
+/// <summary>
+/// Single undoable step that records the before/after state of a "Re-route imported
+/// routes" pass. The initial routing is performed asynchronously by the ViewModel;
+/// this command is pushed afterwards so one Ctrl+Z restores both canvas connections
+/// and group-internal frozen paths to their exact pre-reroute geometry.
+/// </summary>
+public sealed class RerouteImportedRoutesStateCommand : IUndoableCommand
+{
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly IReadOnlyList<ConnectionState> _connections;
+    private readonly IReadOnlyList<GroupState> _groups;
+
+    /// <summary>Mutable state of one canvas-level connection.</summary>
+    public sealed class ConnectionState
+    {
+        /// <summary>The connection whose geometry is swapped.</summary>
+        public required WaveguideConnection Connection { get; set; }
+
+        /// <summary>Frozen geometry before the re-route.</summary>
+        public required RoutedPath OldPath { get; set; }
+
+        /// <summary>Freeze flag before the re-route.</summary>
+        public required bool OldIsFrozen { get; set; }
+
+        /// <summary>Live geometry after the re-route.</summary>
+        public RoutedPath NewPath { get; set; } = null!;
+
+        /// <summary>Freeze flag after the re-route.</summary>
+        public bool NewIsFrozen { get; set; }
+    }
+
+    /// <summary>Mutable state of one component group's internal frozen paths.</summary>
+    public sealed class GroupState
+    {
+        /// <summary>The group whose internal paths are swapped.</summary>
+        public required ComponentGroup Group { get; set; }
+
+        /// <summary>All internal paths before the re-route.</summary>
+        public required IReadOnlyList<FrozenWaveguidePath> OldPaths { get; set; }
+
+        /// <summary>All internal paths after the re-route.</summary>
+        public IReadOnlyList<FrozenWaveguidePath> NewPaths { get; set; } = null!;
+    }
+
+    /// <summary>Records the state change; the caller already performed the mutation.</summary>
+    public RerouteImportedRoutesStateCommand(
+        DesignCanvasViewModel canvas,
+        IEnumerable<ConnectionState> connections,
+        IEnumerable<GroupState> groups)
+    {
+        _canvas = canvas;
+        _connections = connections.ToList();
+        _groups = groups.ToList();
+    }
+
+    /// <inheritdoc/>
+    public string Description
+    {
+        get
+        {
+            var count = _connections.Count + _groups.Sum(g => g.NewPaths.Count);
+            return count == 1
+                ? "Re-route imported route"
+                : $"Re-route {count} imported routes";
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Execute() => Apply(useNew: true);
+
+    /// <inheritdoc/>
+    public void Undo() => Apply(useNew: false);
+
+    private void Apply(bool useNew)
+    {
+        foreach (var state in _connections)
+        {
+            var path = useNew ? state.NewPath : state.OldPath;
+            var frozen = useNew ? state.NewIsFrozen : state.OldIsFrozen;
+            state.Connection.RestoreCachedPath(path.DeepCopy());
+            state.Connection.IsRouteFrozen = frozen;
+        }
+
+        foreach (var state in _groups)
+        {
+            var paths = useNew ? state.NewPaths : state.OldPaths;
+            state.Group.InternalPaths.Clear();
+            state.Group.AddInternalPaths(paths.Select(CloneWithPins).ToList());
+        }
+
+        _canvas.InvalidateSimulation();
+        _ = _canvas.RecalculateRoutesAsync();
+    }
+
+    /// <summary>
+    /// Deep-clones a frozen path while preserving its pin references, so a restored
+    /// group path still anchors to the correct child-component pins.
+    /// </summary>
+    public static FrozenWaveguidePath CloneWithPins(FrozenWaveguidePath path)
+    {
+        var clone = new FrozenWaveguidePath
+        {
+            Path = path.Path.DeepCopy(),
+            PathId = path.PathId,
+            StartPin = path.StartPin,
+            EndPin = path.EndPin
+        };
+        clone.CopySettingsFrom(path);
+        return clone;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Canvas/RerouteImported/RerouteImportedRoutesViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/RerouteImported/RerouteImportedRoutesViewModel.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
+using System.Linq;
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services.Localization;
 using CAP_Core.Components.Core;
+using CAP_Core.Routing;
 using CAP_Core.Routing.RerouteImported;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -15,7 +17,7 @@ namespace CAP.Avalonia.ViewModels.Canvas.RerouteImported;
 /// delta so the user sees what the router changed. Hand-edited frozen routes are
 /// never re-routed; their count is surfaced instead. Frozen routes living inside
 /// component groups (the standard GDS import groups everything it placed) are
-/// counted too, with a hint to open or dissolve the group before re-routing.
+/// counted and re-routed in place without dissolving the group.
 /// </summary>
 public partial class RerouteImportedRoutesViewModel : ObservableObject
 {
@@ -52,7 +54,7 @@ public partial class RerouteImportedRoutesViewModel : ObservableObject
     public string HandEditedKeptText => string.Format(CultureInfo.CurrentCulture,
         LocalizationService.Instance.Translate("Routing.Reroute.HandEditedKept"), HandEditedFrozenCount);
 
-    /// <summary>Localized "N frozen route(s) inside groups — open/dissolve to re-route" hint.</summary>
+    /// <summary>Localized "N frozen route(s) inside groups" line for the panel.</summary>
     public string GroupedFrozenText => string.Format(CultureInfo.CurrentCulture,
         LocalizationService.Instance.Translate("Routing.Reroute.InGroups"), GroupedFrozenCount);
 
@@ -144,13 +146,19 @@ public partial class RerouteImportedRoutesViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanRerouteAll))]
     private async Task RerouteAll()
     {
-        var targets = _canvas.Connections
+        var canvasTargets = _canvas.Connections
             .Where(c => ImportedRouteRerouteEligibility.IsEligible(c.Connection))
             .ToList();
-        await RerouteAsync(targets);
+        var groupTargets = CollectGroupTargets(_canvas).ToList();
+
+        if (canvasTargets.Count == 0 && groupTargets.Count == 0)
+            return;
+
+        await RerouteAllAsync(canvasTargets, groupTargets);
     }
 
-    private bool CanRerouteAll() => !IsRerouting && FrozenImportedCount > 0;
+    private bool CanRerouteAll() =>
+        !IsRerouting && (FrozenImportedCount > 0 || GroupedFrozenCount > 0);
 
     /// <summary>Re-routes only the selected connection.</summary>
     [RelayCommand(CanExecute = nameof(CanRerouteSelected))]
@@ -164,6 +172,99 @@ public partial class RerouteImportedRoutesViewModel : ObservableObject
         !IsRerouting
         && SelectedConnection is { } selected
         && ImportedRouteRerouteEligibility.IsEligible(selected.Connection);
+
+    private async Task RerouteAllAsync(
+        IReadOnlyList<WaveguideConnectionViewModel> canvasTargets,
+        IReadOnlyList<(ComponentGroup Group, List<FrozenWaveguidePath> Paths)> groupTargets)
+    {
+        IsRerouting = true;
+        try
+        {
+            var allConnectionTargets = canvasTargets.Select(t => t.Connection).ToList();
+            var allGroupPaths = groupTargets.SelectMany(g => g.Paths).ToList();
+            var before = RouteMetricsSnapshot.Capture(allConnectionTargets, allGroupPaths);
+
+            var connectionStates = canvasTargets.Select(t =>
+                new RerouteImportedRoutesStateCommand.ConnectionState
+                {
+                    Connection = t.Connection,
+                    OldPath = t.Connection.RoutedPath!.DeepCopy(),
+                    OldIsFrozen = t.Connection.IsRouteFrozen
+                }).ToList();
+
+            var groupStates = groupTargets.Select(g =>
+                new RerouteImportedRoutesStateCommand.GroupState
+                {
+                    Group = g.Group,
+                    OldPaths = g.Group.InternalPaths
+                        .Select(RerouteImportedRoutesStateCommand.CloneWithPins)
+                        .ToList()
+                }).ToList();
+
+            // Canvas-level targets are mutated directly; the state command handles undo.
+            if (canvasTargets.Count > 0)
+            {
+                new RerouteImportedRoutesCommand(_canvas, canvasTargets).Execute();
+                await _canvas.RecalculateRoutesAsync();
+            }
+
+            // Group-internal targets are routed inside a temporary group-edit sub-canvas.
+            foreach (var (group, paths) in groupTargets)
+                await RerouteGroupInternalAsync(group, paths);
+
+            foreach (var state in connectionStates)
+            {
+                state.NewPath = state.Connection.RoutedPath!.DeepCopy();
+                state.NewIsFrozen = state.Connection.IsRouteFrozen;
+            }
+
+            foreach (var state in groupStates)
+            {
+                state.NewPaths = state.Group.InternalPaths
+                    .Select(RerouteImportedRoutesStateCommand.CloneWithPins)
+                    .ToList();
+            }
+
+            var stateCommand = new RerouteImportedRoutesStateCommand(
+                _canvas, connectionStates, groupStates);
+            _commandManager.ExecuteCommand(stateCommand);
+            await _canvas.RecalculateRoutesAsync();
+
+            var afterConnections = connectionStates.Select(s => s.Connection);
+            var afterGroupPaths = groupStates.SelectMany(s => s.NewPaths);
+            var after = RouteMetricsSnapshot.Capture(afterConnections, afterGroupPaths);
+            ResultText = FormatDelta(
+                canvasTargets.Count + groupTargets.Sum(g => g.Paths.Count), before, after);
+        }
+        finally
+        {
+            IsRerouting = false;
+            Refresh();
+        }
+    }
+
+    private async Task RerouteGroupInternalAsync(
+        ComponentGroup group, IReadOnlyList<FrozenWaveguidePath> paths)
+    {
+        _canvas.EnterGroupEditMode(group);
+        try
+        {
+            var targets = _canvas.Connections
+                .Where(vm => paths.Any(p =>
+                    ReferenceEquals(vm.Connection.StartPin, p.StartPin) &&
+                    ReferenceEquals(vm.Connection.EndPin, p.EndPin)))
+                .ToList();
+
+            if (targets.Count > 0)
+                new RerouteImportedRoutesCommand(_canvas, targets).Execute();
+
+            await _canvas.RecalculateRoutesAsync();
+        }
+        finally
+        {
+            _canvas.ExitGroupEditMode();
+        }
+    }
 
     private async Task RerouteAsync(IReadOnlyList<WaveguideConnectionViewModel> targets)
     {
@@ -197,4 +298,29 @@ public partial class RerouteImportedRoutesViewModel : ObservableObject
             count,
             before.LengthMicrometers, after.LengthMicrometers,
             before.EquivalentBends, after.EquivalentBends);
+
+    private static IEnumerable<(ComponentGroup Group, List<FrozenWaveguidePath> Paths)> CollectGroupTargets(
+        DesignCanvasViewModel canvas)
+    {
+        return canvas.Components
+            .Select(c => c.Component)
+            .OfType<ComponentGroup>()
+            .SelectMany(CollectGroupTargetsRecursive);
+    }
+
+    private static IEnumerable<(ComponentGroup Group, List<FrozenWaveguidePath> Paths)> CollectGroupTargetsRecursive(
+        ComponentGroup group)
+    {
+        var direct = group.InternalPaths
+            .Where(ImportedRouteRerouteEligibility.IsEligibleGroupInternal)
+            .ToList();
+        if (direct.Count > 0)
+            yield return (group, direct);
+
+        foreach (var childGroup in group.ChildComponents.OfType<ComponentGroup>())
+        {
+            foreach (var nested in CollectGroupTargetsRecursive(childGroup))
+                yield return nested;
+        }
+    }
 }

--- a/Connect-A-Pic-Core/Routing/RerouteImported/RouteMetricsSnapshot.cs
+++ b/Connect-A-Pic-Core/Routing/RerouteImported/RouteMetricsSnapshot.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
 
 namespace CAP_Core.Routing.RerouteImported;
 
@@ -20,6 +22,28 @@ public readonly record struct RouteMetricsSnapshot(double LengthMicrometers, dou
         {
             length += connection.PathLengthMicrometers;
             bends += connection.BendCount;
+        }
+        return new RouteMetricsSnapshot(length, bends);
+    }
+
+    /// <summary>
+    /// Sums length and bend count over live <paramref name="connections"/> and frozen
+    /// <paramref name="groupPaths"/> so group-internal imported routes contribute to the
+    /// before/after delta shown in the UI.
+    /// </summary>
+    public static RouteMetricsSnapshot Capture(
+        IEnumerable<WaveguideConnection> connections,
+        IEnumerable<FrozenWaveguidePath> groupPaths)
+    {
+        var snapshot = Capture(connections);
+        double length = snapshot.LengthMicrometers;
+        double bends = snapshot.EquivalentBends;
+        foreach (var path in groupPaths)
+        {
+            if (path?.Path is not { Segments.Count: > 0 } routedPath)
+                continue;
+            length += routedPath.TotalLengthMicrometers;
+            bends += routedPath.Segments.Count(s => s is BendSegment);
         }
         return new RouteMetricsSnapshot(length, bends);
     }

--- a/UnitTests/ViewModels/RerouteImported/RerouteImportedRoutesViewModelTests.cs
+++ b/UnitTests/ViewModels/RerouteImported/RerouteImportedRoutesViewModelTests.cs
@@ -256,4 +256,92 @@ public class RerouteImportedRoutesViewModelTests
         vm.SelectedConnection = connVm;
         vm.RerouteSelectedCommand.CanExecute(null).ShouldBeFalse();
     }
+
+    [Fact]
+    public async Task RerouteAll_AfterGroupedImport_ReplacesGroupInternalFrozenRoute_InPlace()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var (startPin, endPin) = AddComponentPair(canvas, 0);
+        var connVm = ConnectFrozenImported(canvas, startPin, endPin);
+        double importedLength = connVm.Connection.PathLengthMicrometers;
+
+        var commandManager = new CommandManager();
+        var vm = new RerouteImportedRoutesViewModel(canvas, commandManager);
+        var groupCandidates = canvas.Components.ToList();
+        commandManager.ExecuteCommand(new CreateGroupCommand(canvas, groupCandidates, "ImportedTopCell"));
+
+        vm.Refresh();
+        vm.FrozenImportedCount.ShouldBe(0);
+        vm.GroupedFrozenCount.ShouldBe(1);
+
+        await vm.RerouteAllCommand.ExecuteAsync(null);
+
+        var group = canvas.Components.Single().Component.ShouldBeOfType<ComponentGroup>();
+        group.InternalPaths.Count.ShouldBe(1);
+        group.InternalPaths[0].Path.Segments.Count.ShouldNotBe(DetourSegmentCount,
+            "the router must replace the imported U-detour with a direct route");
+        group.InternalPaths[0].Path.TotalLengthMicrometers.ShouldBeLessThan(importedLength / 2);
+        vm.GroupedFrozenCount.ShouldBe(0);
+        vm.ResultText.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Undo_RestoresGroupInternalImportedGeometry_AndGroupMembership()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var (startPin, endPin) = AddComponentPair(canvas, 0);
+        var connVm = ConnectFrozenImported(canvas, startPin, endPin);
+        double importedLength = connVm.Connection.PathLengthMicrometers;
+
+        var commandManager = new CommandManager();
+        var vm = new RerouteImportedRoutesViewModel(canvas, commandManager);
+        var groupCandidates = canvas.Components.ToList();
+        commandManager.ExecuteCommand(new CreateGroupCommand(canvas, groupCandidates, "ImportedTopCell"));
+
+        var group = canvas.Components.Single().Component.ShouldBeOfType<ComponentGroup>();
+        var originalPathId = group.InternalPaths[0].PathId;
+
+        await vm.RerouteAllCommand.ExecuteAsync(null);
+
+        commandManager.Undo().ShouldBeTrue();
+        await canvas.RecalculateRoutesAsync();
+
+        group.InternalPaths.Count.ShouldBe(1);
+        group.InternalPaths[0].Path.Segments.Count.ShouldBe(DetourSegmentCount);
+        group.InternalPaths[0].Path.TotalLengthMicrometers.ShouldBe(importedLength, LengthTolerance);
+        group.InternalPaths[0].PathId.ShouldBe(originalPathId);
+        vm.GroupedFrozenCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task RerouteAll_NeverTouchesHandEditedGroupInternalRoutes()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var (startA, endA) = AddComponentPair(canvas, 0);
+        var (startB, endB) = AddComponentPair(canvas, 2000);
+        var eligible = ConnectFrozenImported(canvas, startA, endA);
+        var edited = ConnectFrozenImported(canvas, startB, endB);
+        edited.Connection.BendRadiusOverrides[0] = 25;
+        double editedLength = edited.Connection.PathLengthMicrometers;
+
+        var commandManager = new CommandManager();
+        var vm = new RerouteImportedRoutesViewModel(canvas, commandManager);
+        var groupCandidates = canvas.Components.ToList();
+        commandManager.ExecuteCommand(new CreateGroupCommand(canvas, groupCandidates, "ImportedTopCell"));
+
+        await vm.RerouteAllCommand.ExecuteAsync(null);
+
+        var group = canvas.Components.Single().Component.ShouldBeOfType<ComponentGroup>();
+        var eligiblePath = group.InternalPaths
+            .First(p => ReferenceEquals(p.StartPin, startA) && ReferenceEquals(p.EndPin, endA));
+        var editedPath = group.InternalPaths
+            .First(p => ReferenceEquals(p.StartPin, startB) && ReferenceEquals(p.EndPin, endB));
+
+        eligiblePath.Path.Segments.Count.ShouldNotBe(DetourSegmentCount,
+            "the eligible group-internal route must be re-routed");
+        editedPath.Path.Segments.Count.ShouldBe(DetourSegmentCount,
+            "the hand-edited group-internal route must be kept unchanged");
+        editedPath.BendRadiusOverrides.Count.ShouldBe(1);
+        editedPath.Path.TotalLengthMicrometers.ShouldBe(editedLength, LengthTolerance);
+    }
 }


### PR DESCRIPTION
Automated implementation for #892

...
up-edit mode; pushes one state-swap command. |
| `Connect-A-Pic-Core/Routing/RerouteImported/RouteMetricsSnapshot.cs` | New overload sums metrics over live connections plus frozen group paths. |
| `CAP.Avalonia/Assets/i18n/strings-*.json` (5 files) | Updated `Routing.Reroute.InGroups`. |
| `UnitTests/ViewModels/RerouteImported/RerouteImportedRoutesViewModelTests.cs` | Added 3 integration tests for in-group reroute, undo/identity, and hand-edit preservation; fixed `PathId` assertion. |

### Test coverage
- `RerouteImportedRoutesViewModelTests` — 11/11 passed
- `ImportedRouteRerouteEligibilityTests` — 14/14 passed
- `GroupEditModeRoutingTests` — 6/6 passed
- `GroupingWorkflowTests` — 11/11 passed
- `ComponentGroupRoutingTests` — 8/8 passed
- Full `Category!=Slow` suite — 5406/5421 passed, 15 expected skips

### Verification
```bash
python3 ~/.cap-tools/build_errors.py --raw
SMART_TEST_EXCLUDE_CATEGORY=Slow python3 ~/.cap-tools/smart_test.py
```

⚠️ `CAP.Avalonia/Commands/RerouteImportedRoutesStateCommand.cs` is currently untracked — include it when committing.

✅ Complete! Tools: `build_errors.py` (1 run, ~430 KB raw output), `smart_test.py` (multiple targeted runs + full safe pass).


## [AGENT] Agent Stats

- **Sessions:** 2
- **Total turns:** 150
- **Total tokens:** 15,437,210
- **Estimated cost:** $8.6448 USD

**Custom Tools Used:**
- `smart_test.py`: 1 test runs (filtered test output)


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>