### PR TITLE
Agent: DRC-lite: populate pin waveguide width/layer from the PDK (#906)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PhysicalPinDraft.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/PhysicalPinDraft.cs
@@ -59,5 +59,23 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper.DTOs
         /// </summary>
         [JsonPropertyName("polarization")]
         public string? Polarization { get; set; }
+
+        /// <summary>
+        /// Optional waveguide width in micrometers at this pin (DRC-lite pin-mismatch
+        /// rule). When omitted, the process' default optical cross-section width is
+        /// used at template conversion; when neither exists the value stays null and
+        /// the rule stays silent (legacy PDKs never produce false positives).
+        /// </summary>
+        [JsonPropertyName("waveguideWidthMicrometers")]
+        public double? WaveguideWidthMicrometers { get; set; }
+
+        /// <summary>
+        /// Optional GDS layer number of this pin's waveguide (DRC-lite pin-mismatch
+        /// rule). When omitted, the layer of the process' default optical
+        /// cross-section is used at template conversion; when neither exists the
+        /// value stays null.
+        /// </summary>
+        [JsonPropertyName("layer")]
+        public int? Layer { get; set; }
     }
 }

--- a/CAP-DataAccess/Components/ComponentDraftMapper/ProcessOpticalDefaultsResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/ProcessOpticalDefaultsResolver.cs
@@ -1,0 +1,75 @@
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP_DataAccess.Components.ComponentDraftMapper
+{
+    /// <summary>
+    /// Resolves the default optical waveguide width (µm) and GDS layer of a
+    /// fabrication process, used to stamp <c>PhysicalPin.WaveguideWidthMicrometers</c>
+    /// and <c>PhysicalPin.Layer</c> so the DRC-lite pin-mismatch rule fires on real
+    /// designs. The default is the process' FIRST declared optical cross-section;
+    /// its layer is the first cross-section layer name resolved to a GDS layer
+    /// number via the process layer stack. Mirrors the
+    /// <see cref="WaveguideBendRadiusResolver"/> pattern of turning an
+    /// <see cref="ActiveProcessSelection"/> plus the loaded PDK drafts into a
+    /// process parameter. Unresolvable data yields null — callers must keep the
+    /// pin values null then, so legacy designs stay silent (no false positives).
+    /// </summary>
+    public static class ProcessOpticalDefaultsResolver
+    {
+        /// <summary>
+        /// Resolves the default optical waveguide width and layer from a single
+        /// process definition. Null process, no optical cross-section, or a
+        /// cross-section layer name unknown to the layer stack yields null for
+        /// the respective value.
+        /// </summary>
+        public static (double? WidthUm, int? Layer) Resolve(ProcessDefinition? process)
+        {
+            var xsection = process?.Xsections?.FirstOrDefault(x => x.Kind == XsectionKind.Optical);
+            if (xsection == null)
+                return (null, null);
+
+            double? width = xsection.WidthUm > 0 ? xsection.WidthUm : null;
+            int? layer = ResolveLayerNumber(process!, xsection);
+            return (width, layer);
+        }
+
+        /// <summary>
+        /// Resolves the defaults from the design's active process selection and the
+        /// loaded PDK drafts: the first member PDK (in selection order) whose process
+        /// declares an optical cross-section wins. Null selection/drafts or playground
+        /// mode yields (null, null).
+        /// </summary>
+        /// <param name="active">The design's active process selection, or null when unset.</param>
+        /// <param name="loadedPdks">All currently loaded PDK drafts.</param>
+        public static (double? WidthUm, int? Layer) Resolve(
+            ActiveProcessSelection? active, IReadOnlyList<PdkDraft>? loadedPdks)
+        {
+            if (active == null || active.IsPlayground || loadedPdks == null)
+                return (null, null);
+
+            foreach (var memberName in active.MemberPdkNames)
+            {
+                var process = loadedPdks.FirstOrDefault(
+                    d => string.Equals(d.Name, memberName, StringComparison.OrdinalIgnoreCase))?.Process;
+                var defaults = Resolve(process);
+                if (defaults.WidthUm != null || defaults.Layer != null)
+                    return defaults;
+            }
+
+            return (null, null);
+        }
+
+        /// <summary>The GDS layer number of the cross-section's first layer name, or null when unknown.</summary>
+        private static int? ResolveLayerNumber(ProcessDefinition process, ProcessXsection xsection)
+        {
+            var layerName = xsection.Layers?.FirstOrDefault();
+            if (layerName == null)
+                return null;
+
+            var layer = process.Layers?.FirstOrDefault(
+                l => string.Equals(l.Name, layerName, StringComparison.OrdinalIgnoreCase));
+            return layer?.Layer;
+        }
+    }
+}

--- a/CAP-DataAccess/Import/Gds/DetectedPin.cs
+++ b/CAP-DataAccess/Import/Gds/DetectedPin.cs
@@ -43,6 +43,14 @@ public sealed record DetectedPin
     /// <summary>Pin width in micrometers; 0 when unknown (e.g. pins derived from labels only).</summary>
     public double WidthUm { get; init; }
 
+    /// <summary>
+    /// GDS layer number the pin was detected on (the port label's layer, the port
+    /// shape's layer, or the waveguide polygon's layer); null when no single layer
+    /// is attributable. Feeds <c>PhysicalPin.Layer</c> for the DRC-lite
+    /// pin-mismatch rule.
+    /// </summary>
+    public int? Layer { get; init; }
+
     /// <summary>How this pin was detected.</summary>
     public DetectedPinSource Source { get; init; }
 

--- a/CAP-DataAccess/Import/Gds/GdsPinDetector.EdgeScan.cs
+++ b/CAP-DataAccess/Import/Gds/GdsPinDetector.EdgeScan.cs
@@ -39,6 +39,12 @@ public static partial class GdsPinDetector
         var waveguidePolygons = flattened.Polygons
             .Where(p => ContainsLayer(options.WaveguideLayers, p.Layer, p.DataType))
             .ToList();
+        // Attribute a layer to edge-heuristic pins only when every contributing
+        // waveguide polygon agrees on one — mixed-layer geometry stays null.
+        int? waveguideLayer = waveguidePolygons.Count > 0
+            && waveguidePolygons.All(p => p.Layer == waveguidePolygons[0].Layer)
+                ? waveguidePolygons[0].Layer
+                : null;
         var edgeFrame = cellBBox;
         if (labelFree && waveguidePolygons.Count > 0)
         {
@@ -91,6 +97,7 @@ public static partial class GdsPinDetector
                     YUm = ToAppY(midpoint.Y, cellBBox),
                     AngleDegrees = OutwardAngleDegrees(edge),
                     WidthUm = width,
+                    Layer = waveguideLayer,
                     Source = DetectedPinSource.EdgeHeuristic,
                 }));
             }
@@ -104,7 +111,7 @@ public static partial class GdsPinDetector
         if (labelFree && touches.Count > 0
             && !candidates.Any(c => c.Pin.Source == DetectedPinSource.EdgeHeuristic))
         {
-            AddDegenerateChannelFallbackPins(candidates, touches, edgeFrame, cellBBox, options);
+            AddDegenerateChannelFallbackPins(candidates, touches, edgeFrame, cellBBox, options, waveguideLayer);
         }
     }
 
@@ -148,7 +155,8 @@ public static partial class GdsPinDetector
         SortedList<CellEdge, List<(double Start, double End)>> touches,
         GdsBoundingBox edgeFrame,
         GdsBoundingBox cellBBox,
-        GdsPinDetectionOptions options)
+        GdsPinDetectionOptions options,
+        int? waveguideLayer = null)
     {
         double tolerance = options.EdgeTouchToleranceUm;
         foreach (var (edge, intervals) in touches)
@@ -175,6 +183,7 @@ public static partial class GdsPinDetector
                     YUm = ToAppY(midpoint.Y, cellBBox),
                     AngleDegrees = OutwardAngleDegrees(edge),
                     WidthUm = width,
+                    Layer = waveguideLayer,
                     Source = DetectedPinSource.EdgeHeuristic,
                 }));
             }

--- a/CAP-DataAccess/Import/Gds/GdsPinDetector.LabelPins.cs
+++ b/CAP-DataAccess/Import/Gds/GdsPinDetector.LabelPins.cs
@@ -74,6 +74,7 @@ public static partial class GdsPinDetector
                     ? SegmentOutwardAngleDegrees(directionPolygon, geometry.P1, geometry.P2)
                     : OutwardAngleDegrees(edge),
                 WidthUm = portShapeWidth,
+                Layer = text.Layer,
                 Source = DetectedPinSource.Label,
                 IsElectrical = InferLabelPinKind(text.Text, geometry),
             }));
@@ -117,6 +118,7 @@ public static partial class GdsPinDetector
                     ? SegmentOutwardAngleDegrees(markerPolygon, geometry.P1, geometry.P2)
                     : OutwardAngleDegrees(edge),
                 WidthUm = 0,
+                Layer = geometry.Polygon?.Layer,
                 Source = DetectedPinSource.ArrowMarker,
                 IsElectrical = InferLabelPinKind(string.Empty, geometry),
             }));

--- a/CAP-DataAccess/Import/Gds/GdsPinDetector.PortShapes.cs
+++ b/CAP-DataAccess/Import/Gds/GdsPinDetector.PortShapes.cs
@@ -161,6 +161,7 @@ public static partial class GdsPinDetector
                 YUm = ToAppY(shape.Midpoint.Y, cellBBox),
                 AngleDegrees = OutwardAngleDegrees(shape.Edge),
                 WidthUm = shape.WidthUm,
+                Layer = shape.LayerPair.Layer,
                 Source = DetectedPinSource.PortShape,
                 IsElectrical = IsPortShapeElectrical(shape, options) ? true : null,
             }));

--- a/CAP-DataAccess/Import/Gds/GdsPinDetector.TerminusFaces.cs
+++ b/CAP-DataAccess/Import/Gds/GdsPinDetector.TerminusFaces.cs
@@ -74,6 +74,7 @@ public static partial class GdsPinDetector
                     YUm = appY,
                     AngleDegrees = outward,
                     WidthUm = width,
+                    Layer = polygon.Layer,
                     Source = DetectedPinSource.EdgeHeuristic,
                 }));
             }

--- a/CAP-DataAccess/Persistence/PIR/OverridePinData.cs
+++ b/CAP-DataAccess/Persistence/PIR/OverridePinData.cs
@@ -28,6 +28,16 @@ public class OverridePinData
     /// </summary>
     public double AngleDegrees { get; set; }
 
+    /// <summary>
+    /// Waveguide width in µm at this pin (PDK-sourced; DRC-lite pin-mismatch rule).
+    /// Null when the source pin carries none — preserved across capture/apply so an
+    /// override round-trip never silently drops the PDK data.
+    /// </summary>
+    public double? WaveguideWidthMicrometers { get; set; }
+
+    /// <summary>GDS layer number of this pin's waveguide (PDK-sourced); null when the source pin carries none.</summary>
+    public int? Layer { get; set; }
+
     /// <summary>Creates an independent copy of this pin data.</summary>
     public OverridePinData Clone() => new()
     {
@@ -35,5 +45,7 @@ public class OverridePinData
         OffsetXMicrometers = OffsetXMicrometers,
         OffsetYMicrometers = OffsetYMicrometers,
         AngleDegrees = AngleDegrees,
+        WaveguideWidthMicrometers = WaveguideWidthMicrometers,
+        Layer = Layer,
     };
 }

--- a/CAP.Avalonia/DI/GdsImportFeatureExtensions.cs
+++ b/CAP.Avalonia/DI/GdsImportFeatureExtensions.cs
@@ -33,7 +33,15 @@ internal static class GdsImportFeatureExtensions
             var leftPanel = sp.GetRequiredService<LeftPanelViewModel>();
             return new GdsImportService(
                 sp.GetRequiredService<DesignScopedGdsComponentService>(),
-                () => leftPanel.AllTemplates.ToList());
+                () => leftPanel.AllTemplates.ToList(),
+                // Resolved lazily inside the delegate (like the bend-radius wiring in
+                // MainViewModel): the active process changes per design, and resolving
+                // FileOperationsViewModel here in the factory would risk a DI cycle.
+                () => CAP_DataAccess.Components.ComponentDraftMapper.ProcessOpticalDefaultsResolver
+                    .Resolve(
+                        sp.GetRequiredService<FileOperationsViewModel>().ActiveProcess,
+                        leftPanel.GetLoadedPdkDrafts())
+                    .WidthUm);
         });
         services.AddSingleton(sp =>
         {

--- a/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/CustomComponentLibraryRegistrar.cs
@@ -22,7 +22,12 @@ public static class CustomComponentLibraryRegistrar
         Action reapplyActiveProcess,
         Action filterComponents)
     {
-        var template = PdkTemplateConverter.ConvertToTemplate(draft, pdkName, null);
+        // The PDK-level process is looked up from the cached drafts so the template's
+        // optical pins carry the process' default waveguide width/layer (DRC-lite).
+        var process = loadedPdkDrafts
+            .FirstOrDefault(d => string.Equals(d.Name, pdkName, StringComparison.OrdinalIgnoreCase))
+            ?.Process;
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, pdkName, null, process: process);
         template.IsCustom = true;
 
         // An edit-save re-registers an existing component: the on-disk PDK already replaced the

--- a/CAP.Avalonia/Services/GdsImport/GdsCellDraftMapper.cs
+++ b/CAP.Avalonia/Services/GdsImport/GdsCellDraftMapper.cs
@@ -42,7 +42,14 @@ public static class GdsCellDraftMapper
     /// Optional warning sink (the import's warning list) receiving one entry per
     /// renamed pin; null discards the warnings (renames still happen).
     /// </param>
-    public static PdkComponentDraft Map(GdsCellDraft draft, string gdsFilePathForRawCode, List<string>? warnings = null)
+    /// <param name="processDefaultWidthUm">
+    /// Waveguide width (µm) of the active process' default optical cross-section,
+    /// stamped on optical pins for the DRC-lite pin-mismatch rule; the pin layer
+    /// always comes from the detected port layer. Null leaves the width null, so
+    /// the rule stays silent instead of guessing.
+    /// </param>
+    public static PdkComponentDraft Map(GdsCellDraft draft, string gdsFilePathForRawCode, List<string>? warnings = null,
+        double? processDefaultWidthUm = null)
     {
         ArgumentNullException.ThrowIfNull(draft);
         ArgumentException.ThrowIfNullOrEmpty(gdsFilePathForRawCode);
@@ -69,6 +76,8 @@ public static class GdsCellDraftMapper
                 PinKind = p.IsElectrical == true
                     ? CAP_Core.Components.PinKinds.PinKindHelper.ElectricalKindName
                     : null,
+                WaveguideWidthMicrometers = p.IsElectrical == true ? null : processDefaultWidthUm,
+                Layer = p.Layer,
             }).ToList(),
             SMatrix = null,
             RawCode = SubstituteGdsFileName(draft.RawCode, gdsFilePathForRawCode),

--- a/CAP.Avalonia/Services/GdsImport/GdsImportService.cs
+++ b/CAP.Avalonia/Services/GdsImport/GdsImportService.cs
@@ -40,6 +40,7 @@ public sealed partial class GdsImportService
 
     private readonly DesignScopedGdsComponentService _designScope;
     private readonly Func<IReadOnlyList<ComponentTemplate>>? _templateProvider;
+    private readonly Func<double?>? _processDefaultWidthProvider;
 
     /// <summary>Initializes a new <see cref="GdsImportService"/>.</summary>
     /// <param name="designScope">
@@ -51,12 +52,21 @@ public sealed partial class GdsImportService
     /// resolution (e.g. <c>() => leftPanel.AllTemplates</c>); null/empty treats
     /// every cell as unknown (all become drafts).
     /// </param>
+    /// <param name="processDefaultWidthProvider">
+    /// Supplies the waveguide width (µm) of the active process' default optical
+    /// cross-section, so imported cells stamp it on their optical pins (DRC-lite
+    /// pin-mismatch rule). Null provider or null value leaves the widths null.
+    /// Like <paramref name="templateProvider"/> it is invoked on the caller's
+    /// context before the background handoff.
+    /// </param>
     public GdsImportService(
         DesignScopedGdsComponentService? designScope = null,
-        Func<IReadOnlyList<ComponentTemplate>>? templateProvider = null)
+        Func<IReadOnlyList<ComponentTemplate>>? templateProvider = null,
+        Func<double?>? processDefaultWidthProvider = null)
     {
         _designScope = designScope ?? new DesignScopedGdsComponentService();
         _templateProvider = templateProvider;
+        _processDefaultWidthProvider = processDefaultWidthProvider;
     }
 
     /// <summary>
@@ -218,9 +228,11 @@ public sealed partial class GdsImportService
 
         // Heavy stages on a thread-pool thread (see the class remarks); the await
         // resumes on the caller's context, so the design-scope registration below
-        // mutates the UI-bound library exactly where it did before.
+        // mutates the UI-bound library exactly where it did before. The process
+        // default width is likewise read here, on the caller's context.
+        var processDefaultWidthUm = _processDefaultWidthProvider?.Invoke();
         var prepared = await Task.Run(
-            () => ParseAndPrepareAsync(gdsPath, topCellName, options, warnings, infos, progress, ct, preParsedLibrary), ct);
+            () => ParseAndPrepareAsync(gdsPath, topCellName, options, warnings, infos, progress, ct, preParsedLibrary, processDefaultWidthUm), ct);
 
         if (prepared.PdkDrafts.Count > 0)
         {
@@ -268,7 +280,8 @@ public sealed partial class GdsImportService
         List<string> infos,
         IProgress<string>? progress,
         CancellationToken ct,
-        GdsLibrary? preParsedLibrary = null)
+        GdsLibrary? preParsedLibrary = null,
+        double? processDefaultWidthUm = null)
     {
         progress?.Report($"Reading '{Path.GetFileName(gdsPath)}'…");
         var library = preParsedLibrary ?? await ReadLibraryAsync(gdsPath, ct);
@@ -308,7 +321,7 @@ public sealed partial class GdsImportService
                 // identity and the stored drafts keep the portable token form —
                 // the runtime path is substituted only into the registration
                 // copies (see DesignScopedGdsComponentService.AddAndRegister).
-                var pdkDraft = GdsCellDraftMapper.Map(cellDraft, GdsHierarchyImporter.GdsFileNameToken, warnings);
+                var pdkDraft = GdsCellDraftMapper.Map(cellDraft, GdsHierarchyImporter.GdsFileNameToken, warnings, processDefaultWidthUm);
                 pdkDraft.Name = DeduplicateName(pdkDraft.Name, cellDraft.CellName, usedNames, warnings);
                 pdkDrafts.Add(pdkDraft);
                 registered.Add(new GdsRegisteredComponent(cellDraft.CellName, pdkDraft.Name));

--- a/CAP.Avalonia/Services/PdkTemplateConverter.cs
+++ b/CAP.Avalonia/Services/PdkTemplateConverter.cs
@@ -12,20 +12,35 @@ namespace CAP.Avalonia.Services;
 
 public static class PdkTemplateConverter
 {
+    /// <summary>
+    /// Converts a PDK component draft to a library template. Optical pins carry the
+    /// PDK's waveguide width/layer onto every placed instance (DRC-lite pin-mismatch
+    /// rule): an explicit per-pin draft value wins; otherwise the default optical
+    /// cross-section of <paramref name="process"/> fills in. When neither exists the
+    /// values stay null and the rule stays silent (legacy PDKs, playground).
+    /// </summary>
     public static ComponentTemplate ConvertToTemplate(
         PdkComponentDraft pdkComp,
         string pdkName,
         string? nazcaModuleName,
-        string? gdsFactoryRoutingCrossSection = null)
+        string? gdsFactoryRoutingCrossSection = null,
+        ProcessDefinition? process = null)
     {
-        var pinDefs = pdkComp.Pins.Select(p => new PinDefinition(
-            p.Name,
-            p.OffsetXMicrometers,
-            p.OffsetYMicrometers,
-            p.AngleDegrees,
-            PinKindHelper.Parse(p.PinKind),
-            PolarizationRules.Resolve(p.Polarization, pdkComp.Name, pdkComp.NazcaFunction)
-        )).ToArray();
+        var opticalDefaults = ProcessOpticalDefaultsResolver.Resolve(process);
+        var pinDefs = pdkComp.Pins.Select(p =>
+        {
+            var kind = PinKindHelper.Parse(p.PinKind);
+            bool isOptical = kind == MatterType.Light;
+            return new PinDefinition(
+                p.Name,
+                p.OffsetXMicrometers,
+                p.OffsetYMicrometers,
+                p.AngleDegrees,
+                kind,
+                PolarizationRules.Resolve(p.Polarization, pdkComp.Name, pdkComp.NazcaFunction),
+                p.WaveguideWidthMicrometers ?? (isOptical ? opticalDefaults.WidthUm : null),
+                p.Layer ?? (isOptical ? opticalDefaults.Layer : null));
+        }).ToArray();
 
         double nazcaOriginOffsetX = pdkComp.NazcaOriginOffsetX ?? 0;
         double nazcaOriginOffsetY = pdkComp.NazcaOriginOffsetY ?? 0;

--- a/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/OverridePinMapper.cs
+++ b/CAP.Avalonia/ViewModels/ComponentSettings/InstanceOverride/OverridePinMapper.cs
@@ -60,6 +60,8 @@ public static class OverridePinMapper
             OffsetXMicrometers = p.OffsetXMicrometers,
             OffsetYMicrometers = p.OffsetYMicrometers,
             AngleDegrees = p.AngleDegrees,
+            WaveguideWidthMicrometers = p.WaveguideWidthMicrometers,
+            Layer = p.Layer,
         }).ToList();
 
     /// <summary>
@@ -88,6 +90,8 @@ public static class OverridePinMapper
                 AngleDegrees = pd.AngleDegrees,
                 ParentComponent = comp,
                 LogicalPin = logicalByName.GetValueOrDefault(pd.Name),
+                WaveguideWidthMicrometers = pd.WaveguideWidthMicrometers,
+                Layer = pd.Layer,
             });
         }
     }

--- a/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
+++ b/CAP.Avalonia/ViewModels/Library/ComponentTemplates.cs
@@ -80,7 +80,9 @@ public static class ComponentTemplates
                 OffsetXMicrometers = def.OffsetX,
                 OffsetYMicrometers = def.OffsetY,
                 AngleDegrees = def.AngleDegrees,
-                LogicalPin = logicalPins[i]
+                LogicalPin = logicalPins[i],
+                WaveguideWidthMicrometers = def.WaveguideWidthMicrometers,
+                Layer = def.Layer
             });
         }
 
@@ -223,8 +225,19 @@ public class PinDefinition
 
     public PolarizationKind Polarization { get; }
 
+    /// <summary>
+    /// Waveguide width in µm at this pin from the PDK (per-pin value or the process'
+    /// default optical cross-section); null when the PDK declares neither — the
+    /// pin-mismatch rule then stays silent for this pin.
+    /// </summary>
+    public double? WaveguideWidthMicrometers { get; }
+
+    /// <summary>GDS layer number of this pin's waveguide from the PDK; null when undeclared.</summary>
+    public int? Layer { get; }
+
     public PinDefinition(string name, double offsetX, double offsetY, double angleDegrees,
-        MatterType kind = MatterType.Light, PolarizationKind polarization = PolarizationKind.TE)
+        MatterType kind = MatterType.Light, PolarizationKind polarization = PolarizationKind.TE,
+        double? waveguideWidthMicrometers = null, int? layer = null)
     {
         Name = name;
         OffsetX = offsetX;
@@ -232,5 +245,7 @@ public class PinDefinition
         AngleDegrees = angleDegrees;
         Kind = kind;
         Polarization = polarization;
+        WaveguideWidthMicrometers = waveguideWidthMicrometers;
+        Layer = layer;
     }
 }

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.BundledPdkShadow.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.BundledPdkShadow.cs
@@ -194,7 +194,7 @@ public partial class LeftPanelViewModel
         int componentCount = 0;
         foreach (var pdkComp in pdk.Components)
         {
-            var template = ConvertPdkComponentToTemplate(pdkComp, pdk.Name, pdk.NazcaModuleName, pdk.GdsFactoryRoutingCrossSection);
+            var template = ConvertPdkComponentToTemplate(pdkComp, pdk.Name, pdk.NazcaModuleName, pdk.GdsFactoryRoutingCrossSection, pdk.Process);
             template.IsCustom = false;
             AllTemplates.Add(template);
             if (!Categories.Contains(template.Category))
@@ -362,7 +362,7 @@ public partial class LeftPanelViewModel
 
         AllTemplates.Remove(customized);
         var restored = ConvertPdkComponentToTemplate(
-            counterpart, pdkInfo.Name, forkDraft?.NazcaModuleName, forkDraft?.GdsFactoryRoutingCrossSection);
+            counterpart, pdkInfo.Name, forkDraft?.NazcaModuleName, forkDraft?.GdsFactoryRoutingCrossSection, forkDraft?.Process);
         restored.IsCustom = true;
         AllTemplates.Add(restored);
         if (!Categories.Contains(restored.Category))

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.UserPdkStartupReload.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.UserPdkStartupReload.cs
@@ -121,7 +121,7 @@ public partial class LeftPanelViewModel
         int addedCount = 0;
         foreach (var pdkComp in pdk.Components)
         {
-            var template = ConvertPdkComponentToTemplate(pdkComp, pdk.Name, pdk.NazcaModuleName, pdk.GdsFactoryRoutingCrossSection);
+            var template = ConvertPdkComponentToTemplate(pdkComp, pdk.Name, pdk.NazcaModuleName, pdk.GdsFactoryRoutingCrossSection, pdk.Process);
             template.IsCustom = true;
             AllTemplates.Add(template);
             if (!Categories.Contains(template.Category))

--- a/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/LeftPanelViewModel.cs
@@ -184,7 +184,7 @@ public partial class LeftPanelViewModel : ObservableObject
                 foreach (var pdkComp in pdk.Components)
                 {
                     var template = ConvertPdkComponentToTemplate(
-                        pdkComp, pdk.Name, pdk.NazcaModuleName, pdk.GdsFactoryRoutingCrossSection);
+                        pdkComp, pdk.Name, pdk.NazcaModuleName, pdk.GdsFactoryRoutingCrossSection, pdk.Process);
                     template.IsCustom = false;
                     AllTemplates.Add(template);
                     componentCount++;
@@ -363,7 +363,7 @@ public partial class LeftPanelViewModel : ObservableObject
             int addedCount = 0;
             foreach (var pdkComp in pdk.Components)
             {
-                var template = ConvertPdkComponentToTemplate(pdkComp, pdk.Name, pdk.NazcaModuleName);
+                var template = ConvertPdkComponentToTemplate(pdkComp, pdk.Name, pdk.NazcaModuleName, process: pdk.Process);
                 template.IsCustom = true;
                 AllTemplates.Add(template);
                 if (!Categories.Contains(template.Category))
@@ -388,7 +388,8 @@ public partial class LeftPanelViewModel : ObservableObject
 
     private static ComponentTemplate ConvertPdkComponentToTemplate(
         PdkComponentDraft pdkComp, string pdkName, string? nazcaModuleName,
-        string? gdsFactoryRoutingCrossSection = null)
+        string? gdsFactoryRoutingCrossSection = null,
+        CAP_DataAccess.Components.ComponentDraftMapper.DTOs.ProcessDefinition? process = null)
         => PdkTemplateConverter.ConvertToTemplate(
-            pdkComp, pdkName, nazcaModuleName, gdsFactoryRoutingCrossSection);
+            pdkComp, pdkName, nazcaModuleName, gdsFactoryRoutingCrossSection, process);
 }

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -723,7 +723,9 @@ public class ComponentGroup : Component, INotifyPropertyChanged
                 OffsetXMicrometers = p.OffsetXMicrometers,
                 OffsetYMicrometers = p.OffsetYMicrometers,
                 AngleDegrees = p.AngleDegrees,
-                LogicalPin = p.LogicalPin
+                LogicalPin = p.LogicalPin,
+                WaveguideWidthMicrometers = p.WaveguideWidthMicrometers,
+                Layer = p.Layer
             }).ToList()
         )
         {
@@ -863,7 +865,9 @@ public class ComponentGroup : Component, INotifyPropertyChanged
                 OffsetXMicrometers = externalPin.RelativeX,
                 OffsetYMicrometers = externalPin.RelativeY,
                 AngleDegrees = externalPin.AngleDegrees,
-                LogicalPin = externalPin.InternalPin.LogicalPin
+                LogicalPin = externalPin.InternalPin.LogicalPin,
+                WaveguideWidthMicrometers = externalPin.InternalPin.WaveguideWidthMicrometers,
+                Layer = externalPin.InternalPin.Layer
             };
 
             PhysicalPins.Add(physicalPin);

--- a/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
+++ b/Connect-A-Pic-Core/Components/Creation/GroupTemplateSerializer.cs
@@ -161,7 +161,9 @@ public static class GroupTemplateSerializer
             LogicalPinIdInFlow = p.LogicalPin?.IDInFlow ?? Guid.Empty,
             LogicalPinIdOutFlow = p.LogicalPin?.IDOutFlow ?? Guid.Empty,
             MatterType = p.MatterType,
-            Polarization = p.LogicalPin?.Polarization.ToString()
+            Polarization = p.LogicalPin?.Polarization.ToString(),
+            WaveguideWidthMicrometers = p.WaveguideWidthMicrometers,
+            Layer = p.Layer
         }).ToList();
 
         // Serialize S-Matrices so child components keep their simulation data after reload.
@@ -233,7 +235,9 @@ public static class GroupTemplateSerializer
                 OffsetXMicrometers = p.OffsetX,
                 OffsetYMicrometers = p.OffsetY,
                 AngleDegrees = p.AngleDegrees,
-                LogicalPin = logicalPin
+                LogicalPin = logicalPin,
+                WaveguideWidthMicrometers = p.WaveguideWidthMicrometers,
+                Layer = p.Layer
             };
         }).ToList();
 
@@ -568,6 +572,15 @@ public class PinDto
     /// Null in old prefab files — deserializes to the TE default.
     /// </summary>
     public string? Polarization { get; set; }
+
+    /// <summary>
+    /// PDK-sourced waveguide width in µm at this pin (DRC-lite pin-mismatch rule).
+    /// Null in old prefab files and for pins without PDK data.
+    /// </summary>
+    public double? WaveguideWidthMicrometers { get; set; }
+
+    /// <summary>PDK-sourced GDS layer number of this pin's waveguide; null in old prefab files.</summary>
+    public int? Layer { get; set; }
 }
 
 /// <summary>

--- a/UnitTests/Analysis/DesignValidatorPdkPinMismatchTests.cs
+++ b/UnitTests/Analysis/DesignValidatorPdkPinMismatchTests.cs
@@ -1,0 +1,95 @@
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Analysis;
+using CAP_Core.Components.Connections;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis;
+
+/// <summary>
+/// Acceptance tests for issue #906: pins of components instantiated from a PDK
+/// carry the PDK's waveguide width/layer (per-pin value or the process' default
+/// optical cross-section), so the <see cref="DesignValidator"/> pin-mismatch rule
+/// fires on real designs without any test-side property stuffing. PDKs without
+/// optical data keep the values null and the rule stays silent.
+/// </summary>
+public class DesignValidatorPdkPinMismatchTests
+{
+    private readonly DesignValidator _validator = new();
+
+    [Fact]
+    public void SiepicComponent_PinsCarryProcessWidthAndLayer()
+    {
+        var template = TestPdkLoader.LoadFromPdk("siepic-ebeam-pdk.json")
+            .First(t => t.Name == "Y-Branch 1550");
+
+        var component = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+
+        component.PhysicalPins.ShouldNotBeEmpty();
+        foreach (var pin in component.PhysicalPins)
+        {
+            pin.WaveguideWidthMicrometers.ShouldBe(0.5, "the strip xsection of the SiEPIC process is 0.5 µm wide");
+            pin.Layer.ShouldBe(1, "the strip xsection is drawn on the WG layer (GDS layer 1)");
+        }
+    }
+
+    [Fact]
+    public void MixedPdkDesign_WithDifferentWidths_ProducesPinMismatch()
+    {
+        var siepic = ComponentTemplates.CreateFromTemplate(
+            TestPdkLoader.LoadFromPdk("siepic-ebeam-pdk.json").First(t => t.Name == "Y-Branch 1550"), 0, 0);
+        var cornerstone = ComponentTemplates.CreateFromTemplate(
+            TestPdkLoader.LoadFromPdk("cornerstone-sin-pdk.json").First(t => t.Name == "Coupler"), 500, 0);
+        var connection = new WaveguideConnection
+        {
+            StartPin = siepic.PhysicalPins[0],
+            EndPin = cornerstone.PhysicalPins[0]
+        };
+
+        var result = _validator.Validate(new[] { connection });
+
+        // SiEPIC strip (0.5 µm on layer 1) vs Cornerstone xs_nc (1.2 µm on layer 203):
+        // both the width and the layer rule fire.
+        result.Count(i => i.Type == DesignIssueType.PinMismatch).ShouldBe(2);
+        result.ShouldContain(i => i.Description.Contains("0.5") && i.Description.Contains("1.2"));
+        result.ShouldContain(i => i.Description.Contains("layer 1") && i.Description.Contains("layer 203"));
+    }
+
+    [Fact]
+    public void SamePdkDesign_MatchingPins_ProducesNoPinMismatch()
+    {
+        var first = ComponentTemplates.CreateFromTemplate(
+            TestPdkLoader.LoadFromPdk("siepic-ebeam-pdk.json").First(t => t.Name == "Y-Branch 1550"), 0, 0);
+        var second = ComponentTemplates.CreateFromTemplate(
+            TestPdkLoader.LoadFromPdk("siepic-ebeam-pdk.json").First(t => t.Name == "Y-Branch 1550"), 500, 0);
+        var connection = new WaveguideConnection
+        {
+            StartPin = first.PhysicalPins[0],
+            EndPin = second.PhysicalPins[0]
+        };
+
+        var result = _validator.Validate(new[] { connection });
+
+        result.ShouldNotContain(i => i.Type == DesignIssueType.PinMismatch);
+    }
+
+    [Fact]
+    public void DemoPdk_WithoutOpticalXsection_KeepsPinsNullAndRuleSilent()
+    {
+        var templates = TestPdkLoader.LoadFromPdk("demo-pdk.json");
+        templates.ShouldNotBeEmpty();
+        var first = ComponentTemplates.CreateFromTemplate(templates[0], 0, 0);
+        var second = ComponentTemplates.CreateFromTemplate(templates[0], 500, 0);
+
+        first.PhysicalPins.ShouldAllBe(p => p.WaveguideWidthMicrometers == null && p.Layer == null,
+            "the demo PDK declares no optical cross-section — legacy behavior keeps the values null");
+
+        var connection = new WaveguideConnection
+        {
+            StartPin = first.PhysicalPins[0],
+            EndPin = second.PhysicalPins[0]
+        };
+        _validator.Validate(new[] { connection })
+            .ShouldNotContain(i => i.Type == DesignIssueType.PinMismatch);
+    }
+}

--- a/UnitTests/Components/Process/ProcessOpticalDefaultsResolverTests.cs
+++ b/UnitTests/Components/Process/ProcessOpticalDefaultsResolverTests.cs
@@ -1,0 +1,191 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.PinKinds;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.Process;
+
+/// <summary>
+/// Tests for <see cref="ProcessOpticalDefaultsResolver"/> and the waveguide
+/// width/layer population in <see cref="PdkTemplateConverter.ConvertToTemplate"/>:
+/// per-pin draft values win, the process' default optical cross-section fills
+/// optical pins, and absent PDK data keeps the values null (DRC-lite guard).
+/// </summary>
+public class ProcessOpticalDefaultsResolverTests
+{
+    private static ProcessDefinition SoiProcess() => new()
+    {
+        Name = "Generic SOI",
+        Layers =
+        {
+            new ProcessLayer { Name = "WG", Layer = 1, Datatype = 0 },
+            new ProcessLayer { Name = "M1", Layer = 11, Datatype = 0 },
+        },
+        Xsections =
+        {
+            new ProcessXsection { Name = "metal", Kind = XsectionKind.Metal, WidthUm = 10, Layers = { "M1" } },
+            new ProcessXsection { Name = "strip", Kind = XsectionKind.Optical, WidthUm = 0.5, Layers = { "WG" } },
+        },
+    };
+
+    [Fact]
+    public void Resolve_FirstOpticalXsection_ProvidesWidthAndLayer()
+    {
+        var (width, layer) = ProcessOpticalDefaultsResolver.Resolve(SoiProcess());
+
+        width.ShouldBe(0.5);
+        layer.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Resolve_MultipleOpticalXsections_FirstOneWins()
+    {
+        var process = SoiProcess();
+        process.Xsections.Add(new ProcessXsection
+        {
+            Name = "rib", Kind = XsectionKind.Optical, WidthUm = 0.45, Layers = { "WG" }
+        });
+
+        var (width, _) = ProcessOpticalDefaultsResolver.Resolve(process);
+
+        width.ShouldBe(0.5);
+    }
+
+    [Fact]
+    public void Resolve_NoOpticalXsection_YieldsNulls()
+    {
+        var process = SoiProcess();
+        process.Xsections.RemoveAll(x => x.Kind == XsectionKind.Optical);
+
+        var (width, layer) = ProcessOpticalDefaultsResolver.Resolve(process);
+
+        width.ShouldBeNull();
+        layer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_UnknownXsectionLayerName_YieldsNullLayer()
+    {
+        var process = SoiProcess();
+        process.Xsections.First(x => x.Kind == XsectionKind.Optical).Layers.Clear();
+
+        var (width, layer) = ProcessOpticalDefaultsResolver.Resolve(process);
+
+        width.ShouldBe(0.5);
+        layer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_NullProcess_YieldsNulls()
+    {
+        var (width, layer) = ProcessOpticalDefaultsResolver.Resolve((ProcessDefinition?)null);
+
+        width.ShouldBeNull();
+        layer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Resolve_ActiveProcessSelection_ResolvesAcrossMemberPdks()
+    {
+        var drafts = new List<PdkDraft> { new() { Name = "My PDK", Process = SoiProcess() } };
+        var active = new ActiveProcessSelection("SOI", null, new List<string> { "My PDK" }, IsPlayground: false);
+
+        var (width, layer) = ProcessOpticalDefaultsResolver.Resolve(active, drafts);
+
+        width.ShouldBe(0.5);
+        layer.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Resolve_PlaygroundSelection_YieldsNulls()
+    {
+        var drafts = new List<PdkDraft> { new() { Name = "My PDK", Process = SoiProcess() } };
+
+        var (width, layer) = ProcessOpticalDefaultsResolver.Resolve(ActiveProcessSelection.Playground(), drafts);
+
+        width.ShouldBeNull();
+        layer.ShouldBeNull();
+    }
+
+    private static PdkComponentDraft ComponentDraft(params PhysicalPinDraft[] pins) => new()
+    {
+        Name = "Cell",
+        WidthMicrometers = 10,
+        HeightMicrometers = 4,
+        Pins = pins.ToList(),
+    };
+
+    [Fact]
+    public void ConvertToTemplate_OpticalPinWithoutValue_InheritsProcessDefault()
+    {
+        var draft = ComponentDraft(new PhysicalPinDraft { Name = "o1" });
+
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, "P", null, process: SoiProcess());
+
+        template.PinDefinitions[0].WaveguideWidthMicrometers.ShouldBe(0.5);
+        template.PinDefinitions[0].Layer.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ConvertToTemplate_PerPinValues_WinOverProcessDefault()
+    {
+        var draft = ComponentDraft(new PhysicalPinDraft
+        {
+            Name = "o1", WaveguideWidthMicrometers = 3.0, Layer = 99
+        });
+
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, "P", null, process: SoiProcess());
+
+        template.PinDefinitions[0].WaveguideWidthMicrometers.ShouldBe(3.0);
+        template.PinDefinitions[0].Layer.ShouldBe(99);
+    }
+
+    [Fact]
+    public void ConvertToTemplate_ElectricalPin_GetsNoProcessDefault()
+    {
+        var draft = ComponentDraft(new PhysicalPinDraft
+        {
+            Name = "e1", PinKind = PinKindHelper.ElectricalKindName
+        });
+
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, "P", null, process: SoiProcess());
+
+        template.PinDefinitions[0].Kind.ShouldBe(MatterType.Electricity);
+        template.PinDefinitions[0].WaveguideWidthMicrometers.ShouldBeNull();
+        template.PinDefinitions[0].Layer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ConvertToTemplate_NoProcess_KeepsValuesNull()
+    {
+        var draft = ComponentDraft(new PhysicalPinDraft { Name = "o1" });
+
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, "P", null);
+
+        template.PinDefinitions[0].WaveguideWidthMicrometers.ShouldBeNull();
+        template.PinDefinitions[0].Layer.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CreateFromTemplate_StampsWidthAndLayerOnPhysicalPins()
+    {
+        var draft = ComponentDraft(
+            new PhysicalPinDraft { Name = "o1", AngleDegrees = 180 },
+            new PhysicalPinDraft { Name = "o2", AngleDegrees = 0 });
+        var template = PdkTemplateConverter.ConvertToTemplate(draft, "P", null, process: SoiProcess());
+
+        var component = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+
+        component.PhysicalPins.Count.ShouldBe(2);
+        foreach (var pin in component.PhysicalPins)
+        {
+            pin.WaveguideWidthMicrometers.ShouldBe(0.5);
+            pin.Layer.ShouldBe(1);
+        }
+    }
+}

--- a/UnitTests/Helpers/TestPdkLoader.cs
+++ b/UnitTests/Helpers/TestPdkLoader.cs
@@ -31,7 +31,7 @@ public static class TestPdkLoader
             {
                 var pdk = loader.LoadFromFile(file);
                 foreach (var comp in pdk.Components)
-                    templates.Add(PdkTemplateConverter.ConvertToTemplate(comp, pdk.Name, pdk.NazcaModuleName));
+                    templates.Add(PdkTemplateConverter.ConvertToTemplate(comp, pdk.Name, pdk.NazcaModuleName, process: pdk.Process));
             }
             catch
             {
@@ -56,7 +56,7 @@ public static class TestPdkLoader
         var loader = new PdkLoader();
         var pdk = loader.LoadFromFile(filePath);
         return pdk.Components
-            .Select(c => PdkTemplateConverter.ConvertToTemplate(c, pdk.Name, pdk.NazcaModuleName))
+            .Select(c => PdkTemplateConverter.ConvertToTemplate(c, pdk.Name, pdk.NazcaModuleName, process: pdk.Process))
             .ToList();
     }
 }

--- a/UnitTests/Import/Gds/GdsPinDetectorTests.cs
+++ b/UnitTests/Import/Gds/GdsPinDetectorTests.cs
@@ -38,6 +38,42 @@ public class GdsPinDetectorTests
         pin.WidthUm.ShouldBe(0, Tolerance);
     }
 
+    // ── Pin layer attribution (DRC-lite) ─────────────────────────────────────
+
+    [Fact]
+    public void Label_Pin_CarriesThePortLabelsLayer()
+    {
+        var cell = Cell(Label(1, 10, "o1", x: 0, y: 3));
+
+        var pins = GdsPinDetector.Detect(cell, Box10x4);
+
+        pins.ShouldHaveSingleItem().Layer.ShouldBe(1);
+    }
+
+    [Fact]
+    public void PortShape_Pin_CarriesThePortShapesLayer()
+    {
+        var cell = Cell(Poly(1, 10, (0, 1.5), (0.5, 1.5), (0.5, 2.5), (0, 2.5), (0, 1.5)));
+
+        var pins = GdsPinDetector.Detect(cell, Box10x4);
+
+        var pin = pins.ShouldHaveSingleItem();
+        pin.Source.ShouldBe(DetectedPinSource.PortShape);
+        pin.Layer.ShouldBe(1);
+    }
+
+    [Fact]
+    public void EdgeHeuristic_Pins_CarryTheWaveguideLayer_WhenUnambiguous()
+    {
+        // Straight waveguide on layer 1/0 touching the left and right edges.
+        var cell = Cell(Poly(1, 0, (0, 1.75), (10, 1.75), (10, 2.25), (0, 2.25), (0, 1.75)));
+
+        var pins = GdsPinDetector.Detect(cell, Box10x4);
+
+        pins.ShouldNotBeEmpty();
+        pins.ShouldAllBe(p => p.Layer == 1);
+    }
+
     [Fact]
     public void Label_SlightlyInsideLeftEdge_StillUsesThatEdge()
     {
@@ -1194,17 +1230,23 @@ public class GdsPinDetectorTests
                         ? SegmentOutwardAngleDegrees(geometry.Polygon, geometry.P1, geometry.P2)
                         : OutwardAngleDegrees(edge),
                     WidthUm = 0,
+                    Layer = text.Layer,
                     Source = DetectedPinSource.Label,
                     IsElectrical = InferLabelPinKind(text.Text, geometry),
                 }));
             }
 
-            var touches = new SortedList<CellEdge, List<(double Start, double End)>>();
-            foreach (var polygon in flattened.Polygons)
-            {
-                if (!ContainsLayer(options.WaveguideLayers, polygon.Layer, polygon.DataType))
-                    continue;
+            var waveguidePolygons = flattened.Polygons
+                .Where(p => ContainsLayer(options.WaveguideLayers, p.Layer, p.DataType))
+                .ToList();
+            int? waveguideLayer = waveguidePolygons.Count > 0
+                && waveguidePolygons.All(p => p.Layer == waveguidePolygons[0].Layer)
+                    ? waveguidePolygons[0].Layer
+                    : null;
 
+            var touches = new SortedList<CellEdge, List<(double Start, double End)>>();
+            foreach (var polygon in waveguidePolygons)
+            {
                 foreach (var (p1, p2) in Segments(polygon))
                 {
                     CellEdge? edge = TouchingEdge(p1, p2, cellBBox, tolerance);
@@ -1239,6 +1281,7 @@ public class GdsPinDetectorTests
                         YUm = ToAppY(midpoint.Y, cellBBox),
                         AngleDegrees = OutwardAngleDegrees(edge),
                         WidthUm = width,
+                        Layer = waveguideLayer,
                         Source = DetectedPinSource.EdgeHeuristic,
                     }));
                 }

--- a/UnitTests/Persistence/PinWaveguideDataPersistenceTests.cs
+++ b/UnitTests/Persistence/PinWaveguideDataPersistenceTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using CAP.Avalonia.ViewModels.ComponentSettings.InstanceOverride;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Grid;
+using CAP_Core.Helpers;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using CAP_DataAccess.Persistence.PIR;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Persistence;
+
+/// <summary>
+/// Persistence round-trips for the PDK-sourced pin waveguide width/layer
+/// (issue #906): the values survive the PDK JSON saver/loader, group template
+/// serialization, pin-override capture/apply, group cloning, and .lun save/load.
+/// Pins without data keep null everywhere, so legacy files stay byte-compatible
+/// and the pin-mismatch rule stays silent for them.
+/// </summary>
+public class PinWaveguideDataPersistenceTests
+{
+    [Fact]
+    public void PhysicalPinDraft_WidthAndLayer_RoundtripThroughPdkSaverAndLoader()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "lunima-pindata-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "p.json");
+        var pdk = new PdkDraft
+        {
+            Name = "My P",
+            Components = new()
+            {
+                new PdkComponentDraft
+                {
+                    Name = "My Cell", WidthMicrometers = 10, HeightMicrometers = 2,
+                    Pins = new()
+                    {
+                        new PhysicalPinDraft { Name = "o1", WaveguideWidthMicrometers = 0.5, Layer = 1 },
+                        new PhysicalPinDraft { Name = "o2" },
+                    }
+                }
+            }
+        };
+
+        new PdkJsonSaver().SaveToFile(pdk, path);
+        var reloaded = new PdkLoader().LoadFromFileForEditing(path);
+
+        reloaded.Components[0].Pins[0].WaveguideWidthMicrometers.ShouldBe(0.5);
+        reloaded.Components[0].Pins[0].Layer.ShouldBe(1);
+        reloaded.Components[0].Pins[1].WaveguideWidthMicrometers.ShouldBeNull();
+        reloaded.Components[0].Pins[1].Layer.ShouldBeNull();
+        Directory.Delete(dir, true);
+    }
+
+    [Fact]
+    public void OverridePinData_WidthAndLayer_SurviveCaptureApplyAndSerialization()
+    {
+        var component = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        foreach (var pin in component.PhysicalPins)
+        {
+            pin.WaveguideWidthMicrometers = 0.5;
+            pin.Layer = 1;
+        }
+
+        var captured = OverridePinMapper.CaptureAsPinData(component.PhysicalPins);
+        var json = JsonSerializer.Serialize(captured);
+        var restored = JsonSerializer.Deserialize<List<OverridePinData>>(json)!;
+
+        OverridePinMapper.ApplyPinsToComponent(component, restored);
+
+        component.PhysicalPins.ShouldAllBe(p => p.WaveguideWidthMicrometers == 0.5 && p.Layer == 1);
+    }
+
+    [Fact]
+    public void GroupTemplateSerializer_Roundtrip_PreservesPinWidthAndLayer()
+    {
+        var child = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        foreach (var pin in child.PhysicalPins)
+        {
+            pin.WaveguideWidthMicrometers = 1.2;
+            pin.Layer = 203;
+        }
+        var group = new ComponentGroup("g");
+        group.AddChild(child);
+
+        var restored = GroupTemplateSerializer.Deserialize(GroupTemplateSerializer.Serialize(group))!;
+
+        restored.ChildComponents[0].PhysicalPins
+            .ShouldAllBe(p => p.WaveguideWidthMicrometers == 1.2 && p.Layer == 203);
+    }
+
+    [Fact]
+    public void GroupClone_PreservesChildPinWidthAndLayer()
+    {
+        var child = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        foreach (var pin in child.PhysicalPins)
+        {
+            pin.WaveguideWidthMicrometers = 0.5;
+            pin.Layer = 1;
+        }
+        var group = new ComponentGroup("g");
+        group.AddChild(child);
+
+        var clone = (ComponentGroup)group.Clone();
+
+        clone.ChildComponents[0].PhysicalPins
+            .ShouldAllBe(p => p.WaveguideWidthMicrometers == 0.5 && p.Layer == 1);
+    }
+
+    [Fact]
+    public async Task LunSaveLoad_PreservesPinWidthAndLayer_ViaTemplateRecreation()
+    {
+        var placed = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        foreach (var pin in placed.PhysicalPins)
+        {
+            pin.WaveguideWidthMicrometers = 0.5;
+            pin.Layer = 1;
+        }
+        var grid = new GridManager(24, 12);
+        grid.ComponentMover.PlaceComponent(0, 5, placed);
+
+        var draft = (Component)placed.Clone();
+        var componentFactory = new ComponentFactory();
+        componentFactory.InitializeComponentDrafts(new List<Component> { draft });
+
+        var persistence = new GridPersistenceManager(grid, new FileDataAccessor());
+        var tempSavePath = Path.GetTempFileName();
+        await persistence.SaveAsync(tempSavePath);
+        await persistence.LoadAsync(tempSavePath, componentFactory);
+
+        var loaded = grid.ComponentMover.GetComponentAt(0, 5);
+        loaded.PhysicalPins.ShouldNotBeEmpty();
+        loaded.PhysicalPins.ShouldAllBe(p => p.WaveguideWidthMicrometers == 0.5 && p.Layer == 1);
+    }
+}

--- a/UnitTests/Services/GdsImport/GdsCellDraftMapperTests.cs
+++ b/UnitTests/Services/GdsImport/GdsCellDraftMapperTests.cs
@@ -253,4 +253,67 @@ public class GdsCellDraftMapperTests
         PinKindHelper.IsElectrical(component.PhysicalPins.Single(p => p.Name == "anode")).ShouldBeTrue();
         PinKindHelper.IsElectrical(component.PhysicalPins.Single(p => p.Name == "o1")).ShouldBeFalse();
     }
+
+    // ── Pin waveguide width / layer (DRC-lite) ───────────────────────────────
+
+    [Fact]
+    public void Map_StampsDetectedPortLayerOnPins()
+    {
+        var draft = Draft() with
+        {
+            Pins = new[]
+            {
+                new DetectedPin
+                {
+                    Name = "o1", XUm = 0, YUm = 2, AngleDegrees = 180,
+                    Source = DetectedPinSource.Label, Layer = 1,
+                },
+                new DetectedPin
+                {
+                    Name = "o2", XUm = 10, YUm = 2, AngleDegrees = 0,
+                    Source = DetectedPinSource.Label, Layer = null,
+                },
+            },
+        };
+
+        var result = GdsCellDraftMapper.Map(draft, "/tmp/lib/circuit.gds");
+
+        result.Pins[0].Layer.ShouldBe(1, "the detected port layer feeds the DRC-lite layer rule");
+        result.Pins[1].Layer.ShouldBeNull("pins without an attributable layer stay null");
+    }
+
+    [Fact]
+    public void Map_ProcessDefaultWidth_StampsOpticalPinsOnly()
+    {
+        var draft = Draft() with
+        {
+            Pins = new[]
+            {
+                new DetectedPin
+                {
+                    Name = "anode", XUm = 0, YUm = 2, AngleDegrees = 180,
+                    Source = DetectedPinSource.Label, IsElectrical = true,
+                },
+                new DetectedPin
+                {
+                    Name = "o1", XUm = 10, YUm = 2, AngleDegrees = 0,
+                    Source = DetectedPinSource.Label, IsElectrical = null,
+                },
+            },
+        };
+
+        var result = GdsCellDraftMapper.Map(draft, "/tmp/lib/circuit.gds", processDefaultWidthUm: 0.5);
+
+        result.Pins[0].WaveguideWidthMicrometers.ShouldBeNull("electrical pins carry no optical width");
+        result.Pins[1].WaveguideWidthMicrometers.ShouldBe(0.5);
+    }
+
+    [Fact]
+    public void Map_NoProcessDefaultWidth_KeepsWidthNull()
+    {
+        var result = GdsCellDraftMapper.Map(Draft(), "/tmp/lib/circuit.gds");
+
+        result.Pins.ShouldAllBe(p => p.WaveguideWidthMicrometers == null,
+            "without process data the width stays null and the mismatch rule stays silent");
+    }
 }

--- a/docs/PDK_JSON_FORMAT.md
+++ b/docs/PDK_JSON_FORMAT.md
@@ -145,6 +145,8 @@ and never appear in the process picker.
 | `offsetYMicrometers` | Yes | Y position relative to the bounding box **top-left** corner (µm), increasing **down** |
 | `angleDegrees` | Yes | Port direction: `0`=right, `90`=up, `180`=left, `270`=down |
 | `pinKind` | No | Signal domain: `"Optical"` (default when absent) or `"Electrical"`. Electrical pins (heater/modulator contacts, detector anode/cathode, bond pads) can only be connected to other electrical pins — never to optical ports — and are excluded from the optical S-matrix and the optical (Nazca/gdsfactory/photontorch) export. |
+| `waveguideWidthMicrometers` | No | Waveguide width at this pin (µm), used by the DRC-lite pin-mismatch design check. When absent, optical pins inherit the width of the process' first optical `xsections` entry; when neither exists the value stays unset and the check stays silent for this pin. |
+| `layer` | No | GDS layer number of this pin's waveguide, used by the DRC-lite pin-mismatch design check. When absent, optical pins inherit the layer of the process' default optical cross-section (resolved via the process `layers` stack). |
 
 ### Outline Polygon Fields (`outlinePolygons`)
 


### PR DESCRIPTION
## What & why

Issue #906 (roadmap rung 2 — "width + layer rules with PDK-driven values"). PR #894 added the `PinMismatch` rule comparing `PhysicalPin.WaveguideWidthMicrometers` and `PhysicalPin.Layer`, but nothing populated those nullable properties, so the rule could only fire in tests. This PR populates them at component instantiation:

- **PDK components:** `PdkTemplateConverter.ConvertToTemplate` now takes the PDK's `ProcessDefinition` (new optional parameter, wired through all `LeftPanelViewModel` load paths and `CustomComponentLibraryRegistrar`). Each optical pin gets its width/layer from an explicit per-pin draft value first (new optional `waveguideWidthMicrometers` / `layer` pin fields in the PDK JSON, documented in `docs/PDK_JSON_FORMAT.md`), falling back to the process' default optical cross-section (first optical `xsections` entry; its layer name resolved via the process layer stack) — new `ProcessOpticalDefaultsResolver`, mirroring the `WaveguideBendRadiusResolver` pattern. `ComponentTemplates.CreateFromTemplate` stamps both onto the placed `PhysicalPin`s.
- **Imported GDS cells:** `DetectedPin` gains a `Layer` (the detected port layer: port label layer, port-shape layer, or the waveguide polygon layer when unambiguous), mapped onto the pin draft by `GdsCellDraftMapper`; the width comes from the active process' default optical xsection, resolved via DI from `FileOperationsViewModel.ActiveProcess` + the loaded PDK drafts (invoked on the caller's context, like the template provider).
- **Persistence:** values survive `Component.Clone()` (already), group copy/paste (`ComponentGroup.CloneComponent`), group external-pin sync, group-template serialization (`PinDto`), pin overrides (`OverridePinData` + `OverridePinMapper`), PDK JSON save/load (STJ, null-omitting so legacy files stay byte-compatible), and .lun save/load (regular components via template re-instantiation; imported GDS sets via their embedded drafts).
- **Guard:** absent PDK data keeps null — the rule stays silent, no false positives on legacy designs (covered by a demo-PDK test: it declares no optical xsection, so its pins stay null).

## How it was tested

- New `ProcessOpticalDefaultsResolverTests` (12 facts): resolver defaults/fallbacks + converter population (per-pin wins, electrical pins excluded, no-process → null) + `CreateFromTemplate` stamping.
- New `DesignValidatorPdkPinMismatchTests` (4 facts): the acceptance case — a SiEPIC EBeam component (strip, 0.5 µm, layer 1) connected to a Cornerstone SiN component (xs_nc, 1.2 µm, layer 203) produces both PinMismatch issues via `DesignValidator` with no test-side property stuffing; same-PDK pairs stay clean; demo-PDK (no optical xsection) stays null and silent.
- Extended `GdsCellDraftMapperTests` (+3) and `GdsPinDetectorTests` (+3, plus the sequential-reference detector mirrors layer attribution): GDS-imported pins carry the detected port layer and the process default width.
- New `PinWaveguideDataPersistenceTests` (5 facts): PDK JSON round-trip, override capture/apply + JSON round-trip, group-template round-trip, group clone, .lun save/load.

Local suite: 5529 passed, 0 failed

No UI changes — headless verification only, no manual steps needed after vacation.