### PR TITLE
Agent: Grid ownership: neighbour padding over own pin corridor no longer unfreezes edited routes (#801)

### DIFF
--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.CollisionHandling.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnectionManager.CollisionHandling.cs
@@ -1,3 +1,4 @@
+using CAP_Core.Components.Core;
 using CAP_Core.Routing;
 
 namespace CAP_Core.Components.Connections;
@@ -20,6 +21,10 @@ public partial class WaveguideConnectionManager
     /// pass still holds a grid rebuilt from the removed group — the marking is then a
     /// ghost of the very connection being judged and unfreezing would silently discard
     /// the user's manual edits.
+    /// The route may hug its own pins: cells inside the pin corridors of the connection's
+    /// endpoint pins that only a NEIGHBOUR's padding band covers are tolerated — a foreign
+    /// component placed next to a pin must not unfreeze a collapsed manual edit. A foreign
+    /// component body inside the corridor still unfreezes.
     /// Styled routes (Type != Auto) are never unfrozen here — their shape is forced and a
     /// collision is surfaced via <see cref="RoutedPath.PassesThroughComponent"/> instead.
     /// </summary>
@@ -30,13 +35,22 @@ public partial class WaveguideConnectionManager
             return false;
         if (!connection.FrozenPathStillMatchesPins())
             return false; // Endpoint moved: RecalculateTransmission already unfreezes.
-        if (!router.IsPathBlockedByComponentOnly(connection.RoutedPath!.Segments))
+        if (!router.IsPathBlockedByComponentOnly(connection.RoutedPath!.Segments, OwnEndpointPins(connection)))
             return false;
 
         connection.IsRouteFrozen = false;
         connection.BendRadiusOverrides.Clear();
         connection.StraightShiftOffsets.Clear();
         return true;
+    }
+
+    /// <summary>The connection's endpoint pins, whose pin corridors the route may hug.</summary>
+    private static List<PhysicalPin> OwnEndpointPins(WaveguideConnection connection)
+    {
+        var pins = new List<PhysicalPin>(2);
+        if (connection.StartPin != null) pins.Add(connection.StartPin);
+        if (connection.EndPin != null) pins.Add(connection.EndPin);
+        return pins;
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.Ownership.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.Ownership.cs
@@ -1,0 +1,173 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Routing.AStarPathfinder;
+
+/// <summary>
+/// Ownership-aware cell bookkeeping for <see cref="PathfindingGrid"/>. Rasterizing a
+/// component records for every blocked cell WHO blocked it and HOW (body rectangle vs.
+/// surrounding padding band), and keeps the carved pin-corridor cells per pin. Read-only
+/// predicates can then distinguish "the route hugs its own pin inside that pin's corridor,
+/// and only a foreign padding band reaches across" (tolerated — the corridor belongs to the
+/// route) from "a foreign component body occupies the corridor" (a real collision).
+/// The cell states themselves are untouched — routing cost and obstacle semantics do not
+/// change; this data only feeds the collision verdicts of already-routed paths.
+/// </summary>
+public partial class PathfindingGrid
+{
+    /// <summary>How a component occupies a blocked cell.</summary>
+    private enum ComponentCellKind
+    {
+        /// <summary>Cell lies inside the component's physical body rectangle.</summary>
+        Body,
+
+        /// <summary>Cell lies in the padding band around the body (keep-out for spacing).</summary>
+        Padding,
+    }
+
+    /// <summary>One component's claim on a blocked cell.</summary>
+    private readonly record struct CellOwnership(Component Owner, ComponentCellKind Kind);
+
+    // Who blocks a cell (a cell can be claimed by several overlapping components).
+    private readonly Dictionary<(int x, int y), List<CellOwnership>> _cellOwners = new();
+
+    // Rasterized pin-corridor cells per pin — the same geometry the obstacle rasterization
+    // carves out of its own component's blocked cells.
+    private readonly Dictionary<PhysicalPin, HashSet<(int x, int y)>> _pinCorridorCells = new();
+
+    // Which pins a component registered corridors for, so removal does not depend on the
+    // component's current (possibly already mutated) pin list.
+    private readonly Dictionary<Component, List<PhysicalPin>> _componentCorridorPins = new();
+    private readonly object _ownershipLock = new();
+
+    /// <summary>
+    /// Records the ownership of a component's freshly blocked cells and its pin corridors.
+    /// Called by the obstacle rasterization right after the cells were marked.
+    /// </summary>
+    private void RegisterComponentOwnership(
+        Component component,
+        HashSet<(int x, int y)> bodyCells,
+        HashSet<(int x, int y)> paddingCells,
+        Dictionary<PhysicalPin, HashSet<(int x, int y)>> pinCorridors)
+    {
+        lock (_ownershipLock)
+        {
+            foreach (var cell in bodyCells)
+                AddOwnership(cell, component, ComponentCellKind.Body);
+            foreach (var cell in paddingCells)
+                AddOwnership(cell, component, ComponentCellKind.Padding);
+
+            foreach (var (pin, cells) in pinCorridors)
+                _pinCorridorCells[pin] = cells;
+            _componentCorridorPins[component] = pinCorridors.Keys.ToList();
+        }
+    }
+
+    /// <summary>
+    /// Drops a component's ownership claims and pin corridors. The freed cells become free
+    /// in the cell grid at the same time, so their whole owner list is discarded — a claim
+    /// by an overlapping second component is re-registered when that component is next
+    /// (re)added, mirroring the cell-state semantics of obstacle removal.
+    /// </summary>
+    private void UnregisterComponentOwnership(Component component, IEnumerable<(int x, int y)>? freedCells)
+    {
+        lock (_ownershipLock)
+        {
+            if (freedCells != null)
+            {
+                foreach (var cell in freedCells)
+                    _cellOwners.Remove(cell);
+            }
+            if (_componentCorridorPins.Remove(component, out var pins))
+            {
+                foreach (var pin in pins)
+                    _pinCorridorCells.Remove(pin);
+            }
+        }
+    }
+
+    /// <summary>Clears all ownership and pin-corridor bookkeeping (grid rebuild).</summary>
+    private void ClearOwnership()
+    {
+        lock (_ownershipLock)
+        {
+            _cellOwners.Clear();
+            _pinCorridorCells.Clear();
+            _componentCorridorPins.Clear();
+        }
+    }
+
+    private void AddOwnership((int x, int y) cell, Component owner, ComponentCellKind kind)
+    {
+        if (!_cellOwners.TryGetValue(cell, out var owners))
+        {
+            owners = new List<CellOwnership>();
+            _cellOwners[cell] = owners;
+        }
+        owners.Add(new CellOwnership(owner, kind));
+    }
+
+    /// <summary>
+    /// Union of the rasterized pin-corridor cells of the given pins, as carved when their
+    /// components were registered as obstacles. Pins without a registered corridor (their
+    /// component is no routing obstacle) contribute nothing.
+    /// </summary>
+    public HashSet<(int x, int y)> GetPinCorridorCells(IEnumerable<PhysicalPin> pins)
+    {
+        var result = new HashSet<(int x, int y)>();
+        lock (_ownershipLock)
+        {
+            foreach (var pin in pins)
+            {
+                if (_pinCorridorCells.TryGetValue(pin, out var cells))
+                    result.UnionWith(cells);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Like <see cref="IsBlockedByComponent(int, int)"/>, but tolerates a route hugging its
+    /// own pins: a blocked cell inside one of the <paramref name="toleratedCorridorCells"/>
+    /// (the corridors of the route's own endpoint pins) counts as blocked only when a
+    /// component BODY claims it — foreign padding reaching across the corridor does not.
+    /// Frozen group path markings (state 3) stay blocking regardless.
+    /// </summary>
+    public bool IsBlockedByComponent(int gridX, int gridY, IReadOnlySet<(int x, int y)> toleratedCorridorCells)
+    {
+        if (!IsInBounds(gridX, gridY)) return true;
+        byte state = _cells[gridX, gridY];
+        if (state == 3) return true;
+        if (state != 1) return false;
+        return BlocksDespiteCorridorTolerance(gridX, gridY, toleratedCorridorCells);
+    }
+
+    /// <summary>
+    /// Like <see cref="IsBlockedByComponentOnly(int, int)"/> (component geometry only,
+    /// excluding frozen group path markings) with the same own-pin-corridor tolerance as
+    /// the <see cref="IsBlockedByComponent(int, int)"/> overload above.
+    /// </summary>
+    public bool IsBlockedByComponentOnly(int gridX, int gridY, IReadOnlySet<(int x, int y)> toleratedCorridorCells)
+    {
+        if (!IsInBounds(gridX, gridY)) return true;
+        if (_cells[gridX, gridY] != 1) return false;
+        return BlocksDespiteCorridorTolerance(gridX, gridY, toleratedCorridorCells);
+    }
+
+    /// <summary>
+    /// True when a component-blocked cell stays blocking despite the corridor tolerance:
+    /// either it lies outside the tolerated corridors, or a body (not just padding) claims
+    /// it. A blocked cell without any ownership record stays blocking — conservative.
+    /// </summary>
+    private bool BlocksDespiteCorridorTolerance(
+        int gridX, int gridY, IReadOnlySet<(int x, int y)> toleratedCorridorCells)
+    {
+        if (!toleratedCorridorCells.Contains((gridX, gridY)))
+            return true;
+        lock (_ownershipLock)
+        {
+            if (!_cellOwners.TryGetValue((gridX, gridY), out var owners) || owners.Count == 0)
+                return true;
+            return owners.Any(owner => owner.Kind == ComponentCellKind.Body);
+        }
+    }
+}

--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathfindingGrid.cs
@@ -256,11 +256,13 @@ public partial class PathfindingGrid
         // Collect pin corridor cells that should remain open
         // Only clear a small area OUTSIDE the component where the waveguide approaches
         var pinCorridorCells = new HashSet<(int, int)>();
+        var pinCorridors = new Dictionary<PhysicalPin, HashSet<(int x, int y)>>();
         double corridorLength = 10.0; // Length of corridor OUTWARD from pin (not into component)
         double corridorWidth = 4.0;   // Narrow corridor width (just enough for waveguide)
 
         foreach (var pin in component.PhysicalPins)
         {
+            var corridorCells = new HashSet<(int x, int y)>();
             var (pinX, pinY) = pin.GetAbsolutePosition();
             double pinAngle = pin.GetAbsoluteAngle();
 
@@ -282,12 +284,21 @@ public partial class PathfindingGrid
                     double cellX = centerX + perpX * offset;
                     double cellY = centerY + perpY * offset;
                     var (gx, gy) = PhysicalToGrid(cellX, cellY);
+                    corridorCells.Add((gx, gy));
                     pinCorridorCells.Add((gx, gy));
                 }
             }
+            pinCorridors[pin] = corridorCells;
         }
 
+        // Body rectangle in grid coordinates, to classify blocked cells as body vs. padding.
+        var (bx1, by1) = PhysicalToGrid(component.PhysicalX, component.PhysicalY);
+        var (bx2, by2) = PhysicalToGrid(component.PhysicalX + component.WidthMicrometers,
+                                        component.PhysicalY + component.HeightMicrometers);
+
         var cells = new HashSet<(int, int)>();
+        var bodyCells = new HashSet<(int x, int y)>();
+        var paddingCells = new HashSet<(int x, int y)>();
         for (int gx = gx1; gx <= gx2; gx++)
         {
             for (int gy = gy1; gy <= gy2; gy++)
@@ -296,6 +307,10 @@ public partial class PathfindingGrid
                 {
                     _cells[gx, gy] = 1; // Blocked by obstacle
                     cells.Add((gx, gy));
+                    if (gx >= bx1 && gx <= bx2 && gy >= by1 && gy <= by2)
+                        bodyCells.Add((gx, gy));
+                    else
+                        paddingCells.Add((gx, gy));
                 }
             }
         }
@@ -303,6 +318,7 @@ public partial class PathfindingGrid
         {
             _componentCells[component] = cells;
         }
+        RegisterComponentOwnership(component, bodyCells, paddingCells, pinCorridors);
 
         // Mark pin reservation zones — soft penalty area around each pin.
         // Routes can pass through but A* prefers to avoid them.
@@ -347,6 +363,7 @@ public partial class PathfindingGrid
                 }
             }
         }
+        UnregisterComponentOwnership(component, cells);
         UnregisterPinZones(component);
     }
 
@@ -383,6 +400,7 @@ public partial class PathfindingGrid
                         }
                     }
                 }
+                UnregisterComponentOwnership(child, cells);
                 UnregisterPinZones(child);
             }
         }
@@ -583,6 +601,7 @@ public partial class PathfindingGrid
             _componentPinZones.Clear();
             _pinZoneRefCounts.Clear();
         }
+        ClearOwnership();
 
         foreach (var component in components)
         {

--- a/Connect-A-Pic-Core/Routing/InterconnectRouting/SegmentShift/SegmentShiftEditor.cs
+++ b/Connect-A-Pic-Core/Routing/InterconnectRouting/SegmentShift/SegmentShiftEditor.cs
@@ -1,4 +1,5 @@
 using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
 
 namespace CAP_Core.Routing.InterconnectRouting.SegmentShift;
 
@@ -72,6 +73,10 @@ public static class SegmentShiftEditor
     /// records the result on <see cref="RoutedPath.PassesThroughComponent"/>, so a shift into
     /// an obstacle is flagged through the existing design-issue pipeline instead of silently
     /// producing an invalid route. Call after a drop and after undo/redo.
+    /// The route may hug its own pins: cells inside the pin corridors of the connection's
+    /// endpoint pins that only a NEIGHBOUR's padding band covers are tolerated — a foreign
+    /// component placed next to a pin must not raise a false collision flag on a collapsed
+    /// route. A foreign component body inside the corridor still flags.
     /// </summary>
     /// <param name="connection">The connection whose path was edited.</param>
     /// <param name="router">The router owning the pathfinding grid.</param>
@@ -80,7 +85,16 @@ public static class SegmentShiftEditor
         if (connection.RoutedPath == null)
             return;
         connection.RoutedPath.PassesThroughComponent =
-            router.IsPathBlockedByComponents(connection.RoutedPath.Segments);
+            router.IsPathBlockedByComponents(connection.RoutedPath.Segments, OwnEndpointPins(connection));
+    }
+
+    /// <summary>The connection's endpoint pins, whose pin corridors the route may hug.</summary>
+    private static List<PhysicalPin> OwnEndpointPins(WaveguideConnection connection)
+    {
+        var pins = new List<PhysicalPin>(2);
+        if (connection.StartPin != null) pins.Add(connection.StartPin);
+        if (connection.EndPin != null) pins.Add(connection.EndPin);
+        return pins;
     }
 
     /// <summary>Returns the segment index of the n-th straight segment, or -1 when out of range.</summary>

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.PathBlocking.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.PathBlocking.cs
@@ -1,3 +1,5 @@
+using CAP_Core.Components.Core;
+
 namespace CAP_Core.Routing;
 
 /// <summary>
@@ -18,5 +20,36 @@ public partial class WaveguideRouter
     {
         if (PathfindingGrid == null) return false;
         return IsPathBlocked(segments, PathfindingGrid.IsBlockedByComponentOnly);
+    }
+
+    /// <summary>
+    /// Same verdict as <see cref="IsPathBlockedByComponentOnly(IEnumerable{PathSegment})"/>,
+    /// but with the own-pin tolerance: cells inside the pin corridors of
+    /// <paramref name="ownPins"/> that only a foreign component's padding band reaches
+    /// across do not count as blocked — a route may hug its own pin. A foreign component
+    /// body inside the corridor still blocks.
+    /// </summary>
+    public bool IsPathBlockedByComponentOnly(
+        IEnumerable<PathSegment> segments, IReadOnlyCollection<PhysicalPin> ownPins)
+    {
+        if (PathfindingGrid == null) return false;
+        var corridors = PathfindingGrid.GetPinCorridorCells(ownPins);
+        return IsPathBlocked(segments,
+            (gx, gy) => PathfindingGrid.IsBlockedByComponentOnly(gx, gy, corridors));
+    }
+
+    /// <summary>
+    /// Same verdict as <see cref="IsPathBlockedByComponents(IEnumerable{PathSegment})"/>
+    /// (component geometry plus frozen group path markings), with the own-pin tolerance
+    /// described at
+    /// <see cref="IsPathBlockedByComponentOnly(IEnumerable{PathSegment}, IReadOnlyCollection{PhysicalPin})"/>.
+    /// </summary>
+    public bool IsPathBlockedByComponents(
+        IEnumerable<PathSegment> segments, IReadOnlyCollection<PhysicalPin> ownPins)
+    {
+        if (PathfindingGrid == null) return false;
+        var corridors = PathfindingGrid.GetPinCorridorCells(ownPins);
+        return IsPathBlocked(segments,
+            (gx, gy) => PathfindingGrid.IsBlockedByComponent(gx, gy, corridors));
     }
 }

--- a/UnitTests/Routing/PinCorridorOwnershipTests.cs
+++ b/UnitTests/Routing/PinCorridorOwnershipTests.cs
@@ -1,0 +1,168 @@
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.Routing;
+using CAP_Core.Routing.AStarPathfinder;
+using CAP_Core.Routing.InterconnectRouting.SegmentShift;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// Grid ownership regressions (issue #801): a neighbouring component whose PADDING band
+/// reaches across a foreign pin corridor re-marks those corridor cells as blocked. A
+/// collapsed, manually edited route whose bend hugs its own pin inside that corridor must
+/// survive — unfreezing would silently discard the user's edit, and a false
+/// <c>PassesThroughComponent</c> flag would cry wolf during shift drags. A foreign
+/// component BODY inside the corridor is a real collision and still blocks.
+/// </summary>
+public class PinCorridorOwnershipTests
+{
+    /// <summary>Bend radius (µm) of the U-turn fixtures, mirroring the collapse hardening tests.</summary>
+    private const double Radius = 10.0;
+
+    /// <summary>Residual tolerance for a "collapsed to the pin" lead (floating-point noise).</summary>
+    private const double CollapsedTolerance = 1e-3;
+
+    [Fact]
+    public void ForeignPaddingOverPinCorridor_DoesNotUnfreezeCollapsedFrozenRoute()
+    {
+        var (manager, router, connection, startPin, _) = RouteUTurn();
+        StartPinLead(connection.RoutedPath!, startPin).ShouldBe(0, CollapsedTolerance,
+            "precondition: the departure lead is collapsed onto the pin");
+        ShiftFirstShiftableStraight(connection);
+        connection.IsRouteFrozen.ShouldBeTrue("precondition: the manual shift freezes the route");
+        var frozenPath = connection.RoutedPath!;
+        var offsets = new Dictionary<int, double>(connection.StraightShiftOffsets);
+
+        // Body at x 50–54, y 16–20; only its 5 µm padding band reaches the corridor cells.
+        router.AddComponentObstacle(TestComponentFactory.CreatePinlessComponent(50, 16, width: 4, height: 4));
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeTrue(
+            "a neighbour's padding over the own pin corridor is no collision — unfreezing would destroy the manual edit");
+        connection.RoutedPath.ShouldBeSameAs(frozenPath);
+        connection.StraightShiftOffsets.Count.ShouldBe(offsets.Count);
+        foreach (var (index, offset) in offsets)
+            connection.StraightShiftOffsets[index].ShouldBe(offset, 1e-9);
+    }
+
+    [Fact]
+    public void ForeignPaddingOverPinCorridor_DoesNotFlagCollisionDuringShiftDrag()
+    {
+        var (_, router, connection, _, _) = RouteUTurn();
+        ShiftFirstShiftableStraight(connection);
+
+        router.AddComponentObstacle(TestComponentFactory.CreatePinlessComponent(50, 16, width: 4, height: 4));
+        SegmentShiftEditor.RefreshComponentCollision(connection, router);
+
+        connection.RoutedPath!.PassesThroughComponent.ShouldBeFalse(
+            "a bend hugging its own pin inside the pin corridor is not a component collision, "
+            + "even when a neighbour's padding band covers the corridor cells");
+    }
+
+    [Fact]
+    public void ForeignBodyInsidePinCorridor_StillUnfreezesCollapsedFrozenRoute()
+    {
+        var (manager, router, connection, _, _) = RouteUTurn();
+        ShiftFirstShiftableStraight(connection);
+
+        // Body lands INSIDE the corridor zone (same fixture as the collapse hardening tests).
+        router.AddComponentObstacle(TestComponentFactory.CreatePinlessComponent(53, 23, width: 17, height: 4));
+        manager.RecalculateAllTransmissions();
+
+        connection.IsRouteFrozen.ShouldBeFalse(
+            "a foreign body over the pin corridor is a real collision and must unfreeze the route");
+        connection.StraightShiftOffsets.ShouldBeEmpty("the manual edit is discarded like on any collision");
+        connection.IsPathValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GridOwnership_PaddingOverForeignCorridorIsTolerated_BodyStillBlocks()
+    {
+        var grid = new PathfindingGrid(-100, -100, 500, 500, cellSize: 4.0, padding: 5.0);
+        var owner = TestComponentFactory.CreatePinlessComponent(0, 0);
+        var pin = TestComponentFactory.CreateRoutingPin(owner, 50, 25, 0);
+        owner.PhysicalPins.Add(pin);
+        grid.AddComponentObstacle(owner);
+
+        var corridors = grid.GetPinCorridorCells(new[] { pin });
+        corridors.ShouldNotBeEmpty("the registered pin carves its persistent corridor");
+
+        // Corridor cell (38, 31): the padding-only neighbour claims it, so the plain verdict
+        // reports blocked while the corridor-tolerant verdict does not.
+        grid.AddComponentObstacle(TestComponentFactory.CreatePinlessComponent(54, 16, width: 8, height: 4));
+        corridors.ShouldContain((38, 31));
+        grid.GetCellState(38, 31).ShouldBe((byte)1);
+        grid.IsBlockedByComponentOnly(38, 31).ShouldBeTrue();
+        grid.IsBlockedByComponentOnly(38, 31, corridors).ShouldBeFalse(
+            "only foreign padding reaches across the corridor cell");
+        grid.IsBlockedByComponent(38, 31, corridors).ShouldBeFalse();
+
+        // A foreign body over the same corridor cell must keep blocking, tolerance or not.
+        grid.AddComponentObstacle(TestComponentFactory.CreatePinlessComponent(53, 23, width: 17, height: 4));
+        grid.IsBlockedByComponentOnly(38, 31, corridors).ShouldBeTrue(
+            "a foreign component body inside the corridor is a real collision");
+        grid.IsBlockedByComponent(38, 31, corridors).ShouldBeTrue();
+    }
+
+    /// <summary>Shifts the first shiftable straight, trying both normal directions so the
+    /// test is robust against the router's orientation of the middle straight.</summary>
+    private static void ShiftFirstShiftableStraight(WaveguideConnection connection)
+    {
+        var handles = SegmentShiftGeometry.GetHandles(connection.GetPathSegments());
+        handles.ShouldNotBeEmpty("the collapsed route must expose a shiftable straight");
+        var handle = handles[0];
+
+        if (!SegmentShiftEditor.TryApplyShift(connection, handle.StraightIndex, 4.0, out _) &&
+            !SegmentShiftEditor.TryApplyShift(connection, handle.StraightIndex, -4.0, out var error))
+        {
+            throw new InvalidOperationException($"Neither shift direction fits the route: {error}");
+        }
+    }
+
+    /// <summary>Routes the symmetric U-turn through the real pipeline (A* + collapse pass),
+    /// mirroring <see cref="PinLeadCollapseHardeningTests"/>.</summary>
+    private static (WaveguideConnectionManager Manager, WaveguideRouter Router,
+        WaveguideConnection Connection, PhysicalPin StartPin, PhysicalPin EndPin) RouteUTurn()
+    {
+        var router = new WaveguideRouter
+        {
+            MinBendRadiusMicrometers = Radius,
+            MinWaveguideSpacingMicrometers = 2.0,
+            UseDiagonalRouting = false,
+            // The collapse pass only applies to grid routes, so force the A* pipeline.
+            PreferDirectStyledRoutes = false,
+        };
+        var start = TestComponentFactory.CreatePinlessComponent(0, 0);
+        var end = TestComponentFactory.CreatePinlessComponent(0, 275);
+        var startPin = TestComponentFactory.CreateRoutingPin(start, 50, 25, 0);
+        var endPin = TestComponentFactory.CreateRoutingPin(end, 50, 25, 0);
+        // Registered pins carve the persistent pin corridors during the grid rebuild,
+        // exactly like every real component.
+        start.PhysicalPins.Add(startPin);
+        end.PhysicalPins.Add(endPin);
+        router.InitializePathfindingGrid(-100, -100, 500, 500, new List<Component> { start, end });
+
+        var manager = new WaveguideConnectionManager(router);
+        var connection = new WaveguideConnection
+        {
+            StartPin = startPin,
+            EndPin = endPin,
+            BendRadiusMicrometers = Radius,
+        };
+        manager.AddExistingConnection(connection);
+        manager.RecalculateAllTransmissions();
+        connection.IsPathValid.ShouldBeTrue();
+        return (manager, router, connection, startPin, endPin);
+    }
+
+    private static double StartPinLead(RoutedPath path, PhysicalPin startPin)
+    {
+        var (sx, sy) = startPin.GetAbsolutePosition();
+        var firstBend = path.Segments.OfType<BendSegment>().First();
+        double dx = firstBend.StartPoint.X - sx;
+        double dy = firstBend.StartPoint.Y - sy;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+}


### PR DESCRIPTION
## What & why

Fixes #801.

`PathfindingGrid.AddSingleComponentObstacle` skipped only the registering component's **own** pin corridors when rasterizing body + `ObstaclePaddingMicrometers`. A component placed close to **another** component's pin re-marked that foreign pin corridor's cells as blocked. For any route whose bend hugs its pin inside the corridor (manual full collapse via the #792 segment-shift handle, or the #795 auto-collapse) this had two consequences:

1. `TryUnfreezeCollidedAutoRoute` saw the frozen, user-edited route as colliding → unfroze it → the next recalculation silently discarded `BendRadiusOverrides`/`StraightShiftOffsets`.
2. `SegmentShiftEditor.RefreshComponentCollision` raised a false `PassesThroughComponent` design issue during shift drags.

## How

Persistent, ownership-aware cell state, kept read-only for all validation predicates (new partial `PathfindingGrid.Ownership.cs`):

- Rasterization now records per blocked cell **who** owns it and **how** (body rectangle vs. padding band), and keeps the carved corridor cells **per pin**.
- New predicate overloads `IsBlockedByComponent(Only)(gx, gy, toleratedCorridorCells)`: a blocked cell inside the corridors of the route's own endpoint pins counts as blocked only when a component **body** claims it — foreign **padding** reaching across the corridor is tolerated. Cells outside corridors, frozen group path markings (state 3), and blocked cells without ownership records stay blocking (conservative).
- `TryUnfreezeCollidedAutoRoute` and `SegmentShiftEditor.RefreshComponentCollision` pass the connection's endpoint pins, reinstating the own-pin tolerance on top of the ownership data. The styled-route check and the collapse acceptance check are deliberately unchanged (conservative).

## How it was tested

New `UnitTests/Routing/PinCorridorOwnershipTests.cs` (mirrors the collapse-hardening fixtures):

- Collapsed + shift-frozen route **survives** a neighbour whose padding band covers its pin corridor (stays frozen, same path instance, shift offsets intact).
- Shift drag on a collapsed route with neighbour padding over the corridor raises **no** false `PassesThroughComponent` flag.
- A foreign **body** inside the corridor still unfreezes the route and re-routes.
- Grid-level: padding-over-foreign-corridor is tolerated by the new predicates, body still blocks.

Local suite: 5560 passed, 0 failed

## Manual verification after vacation

Not strictly required (fully covered headlessly), but a quick UI sanity check:

1. Open the Mach-Zehnder example, pick any connection and collapse its pin lead fully with the segment-shift handle (route freezes).
2. Drag another component so its edge sits ~2–3 µm next to that pin (padding reaches the pin, body does not).
3. Expected: the route keeps its edited shape (no silent re-route) and no design issue appears.
4. Drag the component further so its body covers the pin. Expected: the route unfreezes and re-routes around the component.