### PR TITLE
Agent: Router treats coincident-pin connections as valid abutments (#812)

### DIFF
--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
@@ -39,6 +39,15 @@ public partial class WaveguideRouter
     private const double RadiusToleranceMicrometers = 1e-6;
 
     /// <summary>
+    /// Pin-to-pin distance (µm) below which the two pins sit at the same point — a
+    /// perfect abutment (gdsfactory-style touching cells, pins snapped together on the
+    /// canvas). Matches the router's endpoint tolerance
+    /// (<see cref="SameEndpointToleranceMicrometers"/> in the direct-route partial) and the
+    /// import pipeline's degenerate-route threshold, so all three agree on what an abutment is.
+    /// </summary>
+    private const double AbutmentPinDistanceMicrometers = 1.0;
+
+    /// <summary>
     /// Allowed bend radii in micrometers (foundry-style discrete values).
     /// If empty, any radius >= MinBendRadiusMicrometers is allowed.
     /// When set, smoothing snaps each bend to the smallest allowed radius that fits; a
@@ -211,6 +220,9 @@ public partial class WaveguideRouter
     /// if all A* attempts fail; a self-intersecting or blocked fallback at the floor radius
     /// is discarded in favor of the connection radius, and unresolvable results are marked
     /// <see cref="RoutedPath.IsBlockedFallback"/>.
+    /// Pins closer together than <see cref="AbutmentPinDistanceMicrometers"/> short-circuit
+    /// all of the above: they sit at the same point, so the route is a minimal butt joint —
+    /// a valid, unflagged pin-to-pin straight.
     /// </summary>
     /// <param name="startPin">Source pin.</param>
     /// <param name="endPin">Target pin.</param>
@@ -222,6 +234,14 @@ public partial class WaveguideRouter
         var (endX, endY) = endPin.GetAbsolutePosition();
         double startAngle = startPin.GetAbsoluteAngle();
         double endAngle = endPin.GetAbsoluteAngle();
+
+        double abutmentDx = endX - startX;
+        double abutmentDy = endY - startY;
+        if (abutmentDx * abutmentDx + abutmentDy * abutmentDy
+            < AbutmentPinDistanceMicrometers * AbutmentPinDistanceMicrometers)
+        {
+            return BuildAbutmentRoute(startX, startY, endX, endY);
+        }
 
         double endInputAngle = AngleUtilities.NormalizeAngle(endAngle + 180);
 
@@ -275,6 +295,24 @@ public partial class WaveguideRouter
         startPin.MatterType == MatterType.Electricity || endPin.MatterType == MatterType.Electricity
             ? MetalProcessMinBendRadiusMicrometers
             : ProcessMinBendRadiusMicrometers;
+
+    /// <summary>
+    /// The route for a perfect abutment: both pins sit at the same point, so the honest
+    /// geometry is a single (possibly zero-length) pin-to-pin straight — no bends, no
+    /// fallback, no blocked flag. This is the same shape the GDS import pipeline builds
+    /// for coincident-pin abutments.
+    /// </summary>
+    private static RoutedPath BuildAbutmentRoute(double startX, double startY, double endX, double endY)
+    {
+        double dx = endX - startX;
+        double dy = endY - startY;
+        double headingDegrees = dx != 0 || dy != 0
+            ? AngleUtilities.NormalizeAngle(Math.Atan2(dy, dx) * 180.0 / Math.PI)
+            : 0.0;
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(startX, startY, endX, endY, headingDegrees));
+        return path;
+    }
 
     /// <summary>
     /// Manhattan (CSC) fallback when all A* attempts fail. Tries the process floor radius

--- a/UnitTests/Routing/CoincidentPinAbutmentTests.cs
+++ b/UnitTests/Routing/CoincidentPinAbutmentTests.cs
@@ -1,0 +1,171 @@
+using CAP_Core.Analysis;
+using CAP_Core.Components;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.FormulaReading;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing;
+
+/// <summary>
+/// A connection whose two pins sit at the same point (below the router's 1 µm
+/// endpoint tolerance) is a perfect abutment — two cells touching pin-to-pin.
+/// The router must return a minimal butt joint for it, not a degenerate CSC
+/// fallback flagged <see cref="RoutedPath.IsBlockedFallback"/>, and the design
+/// checks must not report <see cref="DesignIssueType.BlockedPath"/>.
+/// </summary>
+public class CoincidentPinAbutmentTests
+{
+    private const double BendRadius = 10.0;
+    private const double GeometryToleranceMicrometers = 1e-6;
+
+    [Fact]
+    public void Route_ExactlyCoincidentOpposingPins_NoGrid_ReturnsUnblockedAbutment()
+    {
+        var (startPin, endPin, router) = CreateAbutmentPair(pinSeparation: 0, useGrid: false);
+
+        var path = router.Route(startPin, endPin);
+
+        AssertValidAbutment(path, startPin, endPin);
+    }
+
+    [Fact]
+    public void Route_ExactlyCoincidentOpposingPins_WithGrid_ReturnsUnblockedAbutment()
+    {
+        var (startPin, endPin, router) = CreateAbutmentPair(pinSeparation: 0, useGrid: true);
+
+        var path = router.Route(startPin, endPin);
+
+        AssertValidAbutment(path, startPin, endPin);
+    }
+
+    [Fact]
+    public void Route_NearlyCoincidentPins_BelowEndpointTolerance_ReturnsUnblockedAbutment()
+    {
+        var (startPin, endPin, router) = CreateAbutmentPair(pinSeparation: 0.5, useGrid: true);
+
+        var path = router.Route(startPin, endPin);
+
+        AssertValidAbutment(path, startPin, endPin);
+    }
+
+    [Fact]
+    public void Route_CoincidentPinsSameDirection_ReturnsUnblockedAbutment()
+    {
+        var (startPin, endPin, router) = CreateAbutmentPair(pinSeparation: 0, useGrid: true, endPinAngle: 0);
+
+        var path = router.Route(startPin, endPin);
+
+        AssertValidAbutment(path, startPin, endPin);
+    }
+
+    [Fact]
+    public void Route_PinsAboveEndpointTolerance_StillRoutedNormally()
+    {
+        var startComponent = CreateComponent(0, 0);
+        var endComponent = CreateComponent(40, 0);
+        var startPin = CreatePin(startComponent, 10, 5, 0);
+        var endPin = CreatePin(endComponent, 0, 5, 180);
+        var router = CreateRouter(startComponent, endComponent);
+
+        var path = router.Route(startPin, endPin);
+
+        path.IsBlockedFallback.ShouldBeFalse();
+        path.IsValid.ShouldBeTrue();
+        path.TotalLengthMicrometers.ShouldBeGreaterThan(1.0);
+    }
+
+    [Fact]
+    public void DesignValidator_CoincidentPinConnection_ReportsNoIssues()
+    {
+        var (startPin, endPin, router) = CreateAbutmentPair(pinSeparation: 0, useGrid: true);
+        var connection = new WaveguideConnection { StartPin = startPin, EndPin = endPin };
+
+        connection.RecalculateTransmission(router);
+        var issues = new DesignValidator().Validate(new[] { connection });
+
+        connection.IsBlockedFallback.ShouldBeFalse();
+        issues.ShouldBeEmpty();
+    }
+
+    private static void AssertValidAbutment(RoutedPath path, PhysicalPin startPin, PhysicalPin endPin)
+    {
+        var (startX, startY) = startPin.GetAbsolutePosition();
+        var (endX, endY) = endPin.GetAbsolutePosition();
+
+        path.IsBlockedFallback.ShouldBeFalse();
+        path.IsPlaceholderGeometry.ShouldBeFalse();
+        path.IsInvalidGeometry.ShouldBeFalse();
+        path.IsValid.ShouldBeTrue();
+        path.Segments.Count.ShouldBe(1);
+        var straight = path.Segments[0].ShouldBeOfType<StraightSegment>();
+        straight.StartPoint.X.ShouldBe(startX, GeometryToleranceMicrometers);
+        straight.StartPoint.Y.ShouldBe(startY, GeometryToleranceMicrometers);
+        straight.EndPoint.X.ShouldBe(endX, GeometryToleranceMicrometers);
+        straight.EndPoint.Y.ShouldBe(endY, GeometryToleranceMicrometers);
+    }
+
+    /// <summary>
+    /// Creates two 10×10 µm components abutting side by side so the start pin
+    /// (east edge of the first) and the end pin (west edge of the second) sit
+    /// <paramref name="pinSeparation"/> µm apart, facing each other.
+    /// </summary>
+    private static (PhysicalPin start, PhysicalPin end, WaveguideRouter router) CreateAbutmentPair(
+        double pinSeparation, bool useGrid, double endPinAngle = 180)
+    {
+        var startComponent = CreateComponent(0, 0);
+        var endComponent = CreateComponent(10 + pinSeparation, 0);
+        var startPin = CreatePin(startComponent, 10, 5, 0);
+        var endPin = CreatePin(endComponent, 0, 5, endPinAngle);
+        var router = useGrid
+            ? CreateRouter(startComponent, endComponent)
+            : new WaveguideRouter { MinBendRadiusMicrometers = BendRadius };
+        return (startPin, endPin, router);
+    }
+
+    private static WaveguideRouter CreateRouter(params Component[] components)
+    {
+        var router = new WaveguideRouter
+        {
+            MinBendRadiusMicrometers = BendRadius,
+            MinWaveguideSpacingMicrometers = 2.0,
+        };
+        router.InitializePathfindingGrid(-50, -50, 200, 200, components);
+        return router;
+    }
+
+    private static PhysicalPin CreatePin(Component component, double offsetX, double offsetY, double angle) =>
+        new()
+        {
+            Name = angle < 90 || angle > 270 ? "output" : "input",
+            OffsetXMicrometers = offsetX,
+            OffsetYMicrometers = offsetY,
+            AngleDegrees = angle,
+            ParentComponent = component,
+        };
+
+    private static Component CreateComponent(double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+        return new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: "test",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: $"AbutmentCell_{x}_{y}",
+            rotationCounterClock: DiscreteRotation.R0)
+        {
+            WidthMicrometers = 10,
+            HeightMicrometers = 10,
+            PhysicalX = x,
+            PhysicalY = y,
+        };
+    }
+}


### PR DESCRIPTION
## What & why

A waveguide connection whose two pins sit at the same point (pin distance < 1.0 µm, the router's own endpoint tolerance) produced a degenerate route that the CSC (Manhattan) fallback flagged as `IsBlockedFallback` — so `DesignValidator` reported `BlockedPath` for geometrically perfect abutments (gdsfactory-style touching cells, or two components snapped pin-to-pin on the canvas). This affected live canvas connections and the Design Checks panel, not just GDS imports.

## Fix

`WaveguideRouter.Route` now short-circuits pin pairs closer than 1.0 µm (new `AbutmentPinDistanceMicrometers` constant, aligned with the router's `SameEndpointToleranceMicrometers` and the import pipeline's `DegenerateRouteThresholdUm`) and returns a minimal butt joint: a single pin-to-pin straight (zero-length for exactly coincident pins), valid and unflagged — the exact shape the GDS import pipeline already builds for coincident-pin abutments. No UI changes, no new user-visible strings.

The import pipeline's pre-validation filter (threshold 1.0 µm) is kept as-is: with the router fixed it is now redundant but harmless, and removing it is out of scope for a minimal diff.

## How it was tested

New `UnitTests/Routing/CoincidentPinAbutmentTests.cs` (6 tests, mirroring existing routing-test patterns):

- exactly coincident opposing pins, with and without the A* grid → valid, unflagged, zero-length butt joint (both failed before the fix)
- near-coincident pins (0.5 µm, below the endpoint tolerance) → unflagged abutment
- coincident pins facing the same direction → unflagged abutment
- pins above the tolerance still route normally (guard against over-matching)
- `DesignValidator` on a routed coincident-pin connection reports no issues (`BlockedPath` false positive reproduced before the fix)

Local suite: 5562 passed, 0 failed

## Manual verification after vacation

Optional sanity check in the running app:

1. Open Lunima, place two components from the PDK on the canvas.
2. Drag them so an output pin of the first snaps exactly onto the facing input pin of the second (pin-to-pin abutment).
3. Connect the two pins with a waveguide (Auto style).
4. Open the Design Checks panel: no `BlockedPath` issue must appear for that connection, and the connection must not render red/dashed.