### PR TITLE
Agent: Cornerstone SiN pre-DRC values — foundry-true DRC-lite limits (#920)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/ProcessDefinition.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/DTOs/ProcessDefinition.cs
@@ -80,6 +80,15 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper.DTOs
         [JsonPropertyName("minWaveguideSpacingUm")]
         [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
         public double? MinWaveguideSpacingUm { get; set; }
+
+        /// <summary>
+        /// Provenance of the process-level DRC values (e.g. <see cref="MinWaveguideSpacingUm"/>):
+        /// the foundry document/table/script the numbers were taken from. Nullable so PDKs
+        /// written before this field existed round-trip byte-identically.
+        /// </summary>
+        [JsonPropertyName("drcSource")]
+        [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public string? DrcSource { get; set; }
     }
 
     /// <summary>A single GDS layer in the process stack.</summary>
@@ -134,6 +143,15 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper.DTOs
         [JsonPropertyName("widthUm")]
         public double WidthUm { get; set; }
 
+        /// <summary>
+        /// Fabrication minimum feature width for this cross-section in µm (the foundry DRC
+        /// limit; <see cref="WidthUm"/> is the standard design width and may be larger).
+        /// Nullable so PDKs written before this field existed round-trip byte-identically.
+        /// </summary>
+        [JsonPropertyName("minWidthUm")]
+        [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public double? MinWidthUm { get; set; }
+
         /// <summary>Minimum allowed bend radius in µm.</summary>
         [JsonPropertyName("minRadiusUm")]
         public double MinRadiusUm { get; set; }
@@ -149,6 +167,15 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper.DTOs
         /// <summary>Human-readable description.</summary>
         [JsonPropertyName("description")]
         public string? Description { get; set; }
+
+        /// <summary>
+        /// Provenance of this cross-section's DRC values (<see cref="MinWidthUm"/>,
+        /// <see cref="MinRadiusUm"/>): the foundry document/table/script the numbers were
+        /// taken from.
+        /// </summary>
+        [JsonPropertyName("drcSource")]
+        [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public string? DrcSource { get; set; }
     }
 
     /// <summary>

--- a/CAP-DataAccess/PDKs/cornerstone-sin-pdk.json
+++ b/CAP-DataAccess/PDKs/cornerstone-sin-pdk.json
@@ -60,23 +60,27 @@
         "name": "xs_nc",
         "kind": "Optical",
         "widthUm": 1.2,
+        "minWidthUm": 0.25,
         "minRadiusUm": 30.0,
         "recommendedRadiusUm": 30.0,
         "layers": [
           "NITRIDE"
         ],
-        "description": "SiN C-band strip waveguide"
+        "description": "SiN C-band strip waveguide",
+        "drcSource": "Min. waveguide width 250 nm: CORNERSTONE SiN 300nm MPW-13 Design Guidelines, section 5.4 Table 4 (GDS 203 NITRIDE min. feature size). Min. bend radius 30 um: cspdk.sin300 tech constants radius_nc/radius_no applied as radius_min (gdsfactory/cspdk); the published guidelines define no hard bend-radius minimum."
       },
       {
         "name": "xs_no",
         "kind": "Optical",
         "widthUm": 0.95,
+        "minWidthUm": 0.25,
         "minRadiusUm": 30.0,
         "recommendedRadiusUm": 30.0,
         "layers": [
           "NITRIDE"
         ],
-        "description": "SiN O-band strip waveguide"
+        "description": "SiN O-band strip waveguide",
+        "drcSource": "Min. waveguide width 250 nm: CORNERSTONE SiN 300nm MPW-13 Design Guidelines, section 5.4 Table 4 (GDS 203 NITRIDE min. feature size). Min. bend radius 30 um: cspdk.sin300 tech constants radius_nc/radius_no applied as radius_min (gdsfactory/cspdk); the published guidelines define no hard bend-radius minimum."
       },
       {
         "name": "metal_routing",
@@ -110,7 +114,9 @@
         "name": "SiO2",
         "role": "cladding"
       }
-    ]
+    ],
+    "minWaveguideSpacingUm": 0.25,
+    "drcSource": "Min. waveguide gap 250 nm: CORNERSTONE SiN 300nm MPW-13 Design Guidelines, section 5.4 Table 4 (GDS 203 NITRIDE, light field) - the limit the foundry KLayout pre-DRC script flags as 'Minimum gap violation' (references/CORNERSTONE_Pre_DRC.pdf in gdsfactory/cspdk). The guidelines' >=10 um waveguide separation is a crosstalk recommendation, not a hard DRC rule."
   },
   "components": [
     {

--- a/CAP.Avalonia/Services/AddCustomComponent/ProcessDefinitionCloner.cs
+++ b/CAP.Avalonia/Services/AddCustomComponent/ProcessDefinitionCloner.cs
@@ -18,8 +18,9 @@ public static class ProcessDefinitionCloner
         }).ToList(),
         Xsections = source.Xsections.Select(x => new ProcessXsection
         {
-            Name = x.Name, Kind = x.Kind, WidthUm = x.WidthUm, MinRadiusUm = x.MinRadiusUm,
+            Name = x.Name, Kind = x.Kind, WidthUm = x.WidthUm, MinWidthUm = x.MinWidthUm, MinRadiusUm = x.MinRadiusUm,
             RecommendedRadiusUm = x.RecommendedRadiusUm, Layers = new List<string>(x.Layers), Description = x.Description,
+            DrcSource = x.DrcSource,
         }).ToList(),
         Materials = source.Materials.Select(m => new ProcessMaterial
         {
@@ -28,5 +29,6 @@ public static class ProcessDefinitionCloner
         AllowedAngles = new List<int>(source.AllowedAngles),
         ElectricalBridgeRequired = source.ElectricalBridgeRequired,
         MinWaveguideSpacingUm = source.MinWaveguideSpacingUm,
+        DrcSource = source.DrcSource,
     };
 }

--- a/UnitTests/Analysis/CornerstoneSinPreDrcTests.cs
+++ b/UnitTests/Analysis/CornerstoneSinPreDrcTests.cs
@@ -1,0 +1,183 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Analysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis;
+
+/// <summary>
+/// Issue #920: the bundled CornerStone SiN 300nm PDK carries the foundry's public pre-DRC
+/// limits and the existing DRC-lite rules fire with those limits instead of the generic
+/// defaults. The numbers come from the public CORNERSTONE documents in the cspdk repo
+/// (references/CORNERSTONE_Pre_DRC.pdf + the SiN 300nm MPW-13 Design Guidelines §5.4
+/// Table 4 it defers to): 250 nm minimum gap and 250 nm minimum feature width on the
+/// waveguide layer (GDS 203 NITRIDE); the 30 µm bend floor is cspdk.sin300's own tech
+/// constant (<c>radius_min</c>). Everything runs through production machinery on the real
+/// bundled PDK (pattern: <see cref="DrcLiteEndToEndJourneyTests"/>).
+/// </summary>
+public class CornerstoneSinPreDrcTests
+{
+    private const string CornerstonePdkFile = "cornerstone-sin-pdk.json";
+
+    /// <summary>MPW-13 §5.4 Table 4: min. gap on GDS 203 NITRIDE (what the pre-DRC script flags).</summary>
+    private const double FoundryMinSpacingUm = 0.25;
+    /// <summary>MPW-13 §5.4 Table 4: min. feature size on GDS 203 NITRIDE.</summary>
+    private const double FoundryMinWidthUm = 0.25;
+    /// <summary>cspdk.sin300 tech constant (radius_nc/radius_no, applied as radius_min).</summary>
+    private const double FoundryMinBendRadiusUm = 30.0;
+    /// <summary>xs_nc standard design width — what DRC-lite stamps on every optical pin.</summary>
+    private const double CornerstoneStripWidthUm = 1.2;
+
+    [Fact]
+    public void BundledPdk_DeclaresFoundryPreDrcValues_WithSources()
+    {
+        var process = LoadCornerstone().Process!;
+
+        process.MinWaveguideSpacingUm.ShouldBe(FoundryMinSpacingUm);
+        process.DrcSource.ShouldNotBeNullOrWhiteSpace();
+        process.DrcSource.ShouldContain("MPW-13");
+        process.DrcSource.ShouldContain("250 nm");
+
+        var optical = process.Xsections.Where(x => x.Kind == XsectionKind.Optical).ToList();
+        optical.Count.ShouldBe(2, "xs_nc and xs_no are the optical cross-sections");
+        foreach (var xsection in optical)
+        {
+            xsection.MinWidthUm.ShouldBe(FoundryMinWidthUm);
+            xsection.MinRadiusUm.ShouldBe(FoundryMinBendRadiusUm);
+            xsection.DrcSource.ShouldNotBeNullOrWhiteSpace();
+            xsection.DrcSource.ShouldContain("MPW-13");
+        }
+        process.Xsections.Where(x => x.Kind == XsectionKind.Metal)
+            .ShouldAllBe(x => x.MinWidthUm == null, "min width is an optical DRC concept here");
+
+        // The resolvers DRC-lite consumes return the foundry values, not the generic defaults.
+        process.GetMinWaveguideSpacingMicrometersOrDefault().ShouldBe(FoundryMinSpacingUm);
+        WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[] { process })
+            .ShouldBe(FoundryMinBendRadiusUm);
+    }
+
+    [Fact]
+    public void TooCloseSpacing_FiresWithFoundryLimit_CompliantPairStaysClean()
+    {
+        var pdk = LoadCornerstone();
+        double minSpacing = pdk.Process.GetMinWaveguideSpacingMicrometersOrDefault();
+        minSpacing.ShouldBe(FoundryMinSpacingUm);
+
+        // Two parallel 1.2 µm strip routes, 1.3 µm centerline pitch → 0.10 µm edge-to-edge:
+        // below the foundry 250 nm gap.
+        var broken = BuildParallelPair(pdk, pitchUm: 1.3);
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            broken.Connections,
+            allComponents: broken.Components,
+            minWaveguideSpacingMicrometers: minSpacing);
+
+        var spacing = panel.Issues.Where(i => i.Type == DesignIssueType.WaveguideSpacingViolation).ToList();
+        spacing.Count.ShouldBe(1, Describe(panel));
+        spacing[0].Description.ShouldContain("too close");
+        spacing[0].Description.ShouldContain("distance 0.10");
+        spacing[0].Description.ShouldContain("minimum 0.25");
+
+        // Same pair respaced to 2.5 µm pitch → 1.3 µm edge: above the foundry floor, so DRC-lite
+        // stays silent — under the former generic 2.0 µm default this would have fired.
+        var compliant = BuildParallelPair(pdk, pitchUm: 2.5);
+        var compliantPanel = new DesignValidationViewModel();
+        compliantPanel.RunValidation(
+            compliant.Connections,
+            allComponents: compliant.Components,
+            minWaveguideSpacingMicrometers: minSpacing);
+
+        compliantPanel.Issues.Where(i => i.Type == DesignIssueType.WaveguideSpacingViolation)
+            .ShouldBeEmpty(Describe(compliantPanel));
+    }
+
+    [Fact]
+    public void TooNarrowWaveguide_IsCaughtByWidthMismatch_AgainstProcessStandardWidth()
+    {
+        var pdk = LoadCornerstone();
+        var coupler = Place(pdk, "Coupler", 0, 0);
+        var straight = Place(pdk, "Straight", 200, 0);
+
+        var standardPin = Pin(coupler, "o3");
+        standardPin.WaveguideWidthMicrometers.ShouldBe(CornerstoneStripWidthUm);
+        standardPin.Layer.ShouldBe(203, "NITRIDE, resolved through the process layer stack");
+
+        // A user-narrowed 0.2 µm waveguide pin: below the foundry 250 nm min. feature it
+        // cannot butt-join the 1.2 µm process standard — DRC-lite reports the width step.
+        var narrowPin = Pin(straight, "o1");
+        narrowPin.WaveguideWidthMicrometers = 0.2;
+        narrowPin.WaveguideWidthMicrometers!.Value.ShouldBeLessThan(FoundryMinWidthUm);
+
+        var connection = new WaveguideConnection { StartPin = standardPin, EndPin = narrowPin };
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            new[] { connection },
+            allComponents: new Component[] { coupler, straight },
+            minWaveguideSpacingMicrometers: pdk.Process.GetMinWaveguideSpacingMicrometersOrDefault());
+
+        var mismatches = panel.Issues.Where(i => i.Type == DesignIssueType.PinMismatch).ToList();
+        mismatches.Count.ShouldBe(1, Describe(panel));
+        mismatches[0].Description.ShouldContain("width mismatch");
+        mismatches[0].Description.ShouldContain("0.2");
+        mismatches[0].Description.ShouldContain("1.2");
+    }
+
+    private static (List<Component> Components, List<WaveguideConnection> Connections)
+        BuildParallelPair(PdkDraft pdk, double pitchUm)
+    {
+        var components = new List<Component>
+        {
+            Place(pdk, "Straight", 0, 0),
+            Place(pdk, "Straight", 210, 0),
+            Place(pdk, "Straight", 0, pitchUm),
+            Place(pdk, "Straight", 210, pitchUm),
+        };
+        var connections = new List<WaveguideConnection>
+        {
+            Link(Pin(components[0], "o2"), Pin(components[1], "o1")),
+            Link(Pin(components[2], "o2"), Pin(components[3], "o1")),
+        };
+        return (components, connections);
+    }
+
+    /// <summary>
+    /// Hand-built straight route standing in for a user-styled waveguide (the auto-router
+    /// enforces spacing by construction, so a violation can only exist on a styled route).
+    /// Carries the Cornerstone strip width so the detector measures true edge-to-edge gap.
+    /// </summary>
+    private static WaveguideConnection Link(PhysicalPin start, PhysicalPin end)
+    {
+        var (x1, y1) = start.GetAbsolutePosition();
+        var (x2, y2) = end.GetAbsolutePosition();
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, start.GetAbsoluteAngle()));
+        var connection = new WaveguideConnection { StartPin = start, EndPin = end };
+        connection.RestoreCachedPath(path);
+        connection.WidthMicrometers = CornerstoneStripWidthUm;
+        return connection;
+    }
+
+    private static Component Place(PdkDraft pdk, string templateName, double x, double y)
+    {
+        var template = PdkTemplateConverter.ConvertToTemplate(
+            pdk.Components.First(c => c.Name == templateName), pdk.Name, pdk.NazcaModuleName, process: pdk.Process);
+        return ComponentTemplates.CreateFromTemplate(template, x, y);
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+
+    private static PdkDraft LoadCornerstone() =>
+        new PdkLoader().LoadFromFile(
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PDKs", CornerstonePdkFile));
+
+    private static string Describe(DesignValidationViewModel panel) =>
+        string.Join(" | ", panel.Issues.Select(i => $"{i.Type}: {i.Description}"));
+}

--- a/docs/PDK_JSON_FORMAT.md
+++ b/docs/PDK_JSON_FORMAT.md
@@ -97,8 +97,28 @@ New Design. Declare the block so your PDK participates in that grouping:
 | `coreThicknessNm` | No | Waveguide-core thickness in nm — the key axis for process compatibility |
 | `materials` | No | Optical materials; the entries with `role` `"core"` and `"cladding"` feed the compatibility fingerprint |
 | `layers` | No | GDS layer stack (name, layer/datatype) |
-| `xsections` | No | Waveguide/metal cross-sections (`widthUm`, bend radii) for routing |
+| `xsections` | No | Waveguide/metal cross-sections (`widthUm`, bend radii) for routing — see below |
 | `allowedAngles` | No | Allowed placement/connection angles in degrees |
+| `minWaveguideSpacingUm` | No | Foundry minimum edge-to-edge waveguide gap in µm; consumed by the DRC-lite spacing rule via `GetMinWaveguideSpacingMicrometersOrDefault` (falls back to a conservative default when absent) |
+| `drcSource` | No | Provenance of the process-level DRC values — the foundry document/table/script they were taken from |
+
+### Cross-Section Fields (`process.xsections[]`)
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Cross-section name (e.g. `"xs_nc"`, `"strip"`) |
+| `kind` | Yes | `"Optical"` (light-guiding waveguide) or `"Metal"` (electrical line) |
+| `widthUm` | Yes | Standard design width in µm |
+| `minWidthUm` | No | Foundry minimum feature width in µm (DRC limit; may be smaller than `widthUm`) |
+| `minRadiusUm` | No | Minimum allowed bend radius in µm — consumed by the DRC-lite bend rule via `WaveguideBendRadiusResolver` |
+| `recommendedRadiusUm` | No | Foundry-recommended bend radius in µm (≥ minimum) |
+| `layers` | No | Names of the `process.layers` entries this cross-section is drawn on |
+| `description` | No | Human-readable description |
+| `drcSource` | No | Provenance of the DRC values (`minWidthUm`, `minRadiusUm`) — the foundry document/table/script they were taken from |
+
+The bundled `cornerstone-sin-pdk.json` shows the DRC fields filled from the public
+CORNERSTONE SiN 300nm documents (MPW-13 Design Guidelines §5.4 Table 4, pre-DRC script),
+each with its `drcSource` citation.
 
 PDKs **without** a `process` block still load, but each forms its own unnamed
 singleton process. Tool PDKs (analyzers, probes) should instead set top-level

--- a/scripts/generate_cspdk_sin300_pdk.py
+++ b/scripts/generate_cspdk_sin300_pdk.py
@@ -88,6 +88,30 @@ XSECTION_SPECS = [
     ("heater_metal", "Metal", "HEATER", "Heater trace metal"),
 ]
 
+# Foundry DRC values from the public CORNERSTONE SiN 300nm documents (cspdk references/,
+# issue #920). The foundry's KLayout pre-DRC script enforces Table 4 of the MPW-13 Design
+# Guidelines: min. gap 250 nm and min. feature width 250 nm on GDS 203 (NITRIDE, light
+# field). The guidelines' ">=10 µm between waveguides" line is a crosstalk recommendation,
+# NOT a hard DRC rule, so it is not the spacing floor. Bend minima come from cspdk's own
+# tech constants (radius_nc/radius_no = 30, applied as radius_min — keep reading them from
+# the activated PDK below so a cspdk change is caught on regeneration); the published
+# guidelines define no hard bend-radius rule.
+DRC_MIN_WAVEGUIDE_SPACING_UM = 0.25
+DRC_OPTICAL_MIN_WIDTH_UM = 0.25
+DRC_PROCESS_SOURCE = (
+    "Min. waveguide gap 250 nm: CORNERSTONE SiN 300nm MPW-13 Design Guidelines, "
+    "section 5.4 Table 4 (GDS 203 NITRIDE, light field) - the limit the foundry KLayout "
+    "pre-DRC script flags as 'Minimum gap violation' (references/CORNERSTONE_Pre_DRC.pdf "
+    "in gdsfactory/cspdk). The guidelines' >=10 um waveguide separation is a crosstalk "
+    "recommendation, not a hard DRC rule."
+)
+DRC_XSECTION_SOURCE = (
+    "Min. waveguide width 250 nm: CORNERSTONE SiN 300nm MPW-13 Design Guidelines, "
+    "section 5.4 Table 4 (GDS 203 NITRIDE min. feature size). Min. bend radius 30 um: "
+    "cspdk.sin300 tech constants radius_nc/radius_no applied as radius_min "
+    "(gdsfactory/cspdk); the published guidelines define no hard bend-radius minimum."
+)
+
 
 def _num(v):
     """kdb.DBox left/right/top/bottom are float properties; width()/height() are methods;
@@ -320,20 +344,26 @@ def build_layers(sin):
 
 def build_xsections():
     """Real cross-section width/bend-radius numbers from cspdk.sin300's activated PDK
-    (gf.get_cross_section), not invented — see XSECTION_SPECS."""
+    (gf.get_cross_section), not invented — see XSECTION_SPECS. Optical sections
+    additionally carry the foundry DRC limits (see DRC_* constants, #920)."""
     import gdsfactory as gf
     xsections = []
     for name, kind, layer_name, description in XSECTION_SPECS:
         xs = gf.get_cross_section(name)
-        xsections.append({
+        entry = {
             "name": name,
             "kind": kind,
             "widthUm": round(float(xs.width), 3),
-            "minRadiusUm": round(float(xs.radius_min or 0), 3),
-            "recommendedRadiusUm": round(float(xs.radius or 0), 3),
-            "layers": [layer_name],
-            "description": description,
-        })
+        }
+        if kind == "Optical":
+            entry["minWidthUm"] = DRC_OPTICAL_MIN_WIDTH_UM
+        entry["minRadiusUm"] = round(float(xs.radius_min or 0), 3)
+        entry["recommendedRadiusUm"] = round(float(xs.radius or 0), 3)
+        entry["layers"] = [layer_name]
+        entry["description"] = description
+        if kind == "Optical":
+            entry["drcSource"] = DRC_XSECTION_SOURCE
+        xsections.append(entry)
     return xsections
 
 
@@ -384,6 +414,9 @@ def main():
                 {"name": "Si3N4", "role": "core"},
                 {"name": "SiO2", "role": "cladding"},
             ],
+            # Foundry-true DRC limits for DRC-lite (#920) — see the DRC_* constants above.
+            "minWaveguideSpacingUm": DRC_MIN_WAVEGUIDE_SPACING_UM,
+            "drcSource": DRC_PROCESS_SOURCE,
         },
         "components": sorted(components, key=lambda c: (c["category"], c["name"])),
     }


### PR DESCRIPTION
# Cornerstone SiN: foundry-true pre-DRC values for DRC-lite (#920)

## What & why

First slice of #810 (roadmap rung 2→7). DRC-lite is fully wired (4 rules, E2E journey #915/#919) but fired with generic values; this makes the **bundled Cornerstone SiN 300nm PDK** carry the foundry's public pre-DRC limits so the existing rules fire with the real numbers, for Priya's fab hookup and the rung-7 manufacturing path.

**Values now in `CAP-DataAccess/PDKs/cornerstone-sin-pdk.json` (all with `drcSource` citations):**

| Value | Number | Source |
|---|---|---|
| `process.minWaveguideSpacingUm` | **0.25 µm** | CORNERSTONE SiN 300nm MPW-13 Design Guidelines §5.4 Table 4 — min. gap 250 nm on GDS 203 NITRIDE, i.e. the limit the foundry KLayout pre-DRC script flags as "Minimum gap violation" |
| `xsections[xs_nc/xs_no].minWidthUm` (new schema field) | **0.25 µm** | same table — min. feature size 250 nm on GDS 203 |
| `xsections[xs_nc/xs_no].minRadiusUm` | **30 µm** (unchanged) | cspdk.sin300 tech constants `radius_nc/radius_no`, applied as `radius_min` — the guidelines publish no hard bend-radius rule |

Schema additions (nullable + `WhenWritingNull`, so every other PDK round-trips byte-identically): `ProcessDefinition.DrcSource`, `ProcessXsection.MinWidthUm`, `ProcessXsection.DrcSource` — `ProcessDefinitionCloner` carries them through the PDK editor. Documented in `docs/PDK_JSON_FORMAT.md` (incl. the previously undocumented `minWaveguideSpacingUm`).

`scripts/generate_cspdk_sin300_pdk.py` emits the same fields from `DRC_*` constants (verified textually identical to the shipped JSON), so a regeneration does not lose the values.

## Source-value judgement call (please sanity-check after vacation)

`references/CORNERSTONE_Pre_DRC.pdf` in gdsfactory/cspdk contains **no numeric rules** — it is a 3-page KLayout how-to whose results screenshot shows an example "Minimum gap violation". The enforced numbers live in its sibling document `CORNERSTONE-Silicon-Nitride-MPW-13-Design-Guidelines.pdf` (same folder, the SiN 300nm platform whose layer stack 203/204/39/41/22/99/100 matches our PDK exactly): §5.4 Table 4 gives min gap = min feature = 250 nm on the waveguide layer. The guidelines' "≥10 µm between waveguides" line is a crosstalk recommendation, **not** a hard DRC rule, so it was deliberately not used as the spacing floor (this is recorded in the `drcSource` strings and the generator comments). If the actual closed `.lydrc` deck turns out to use stricter values, one constant each in the generator updates everything.

## How it was tested (headless)

New `UnitTests/Analysis/CornerstoneSinPreDrcTests.cs` runs everything through production machinery on the real bundled PDK (pattern of `DrcLiteEndToEndJourneyTests`):

- `BundledPdk_DeclaresFoundryPreDrcValues_WithSources` — the loaded PDK carries 0.25 µm spacing, 0.25 µm min width and 30 µm min bend radius with `MPW-13`/`250 nm` citations, and DRC-lite's actual resolvers (`GetMinWaveguideSpacingMicrometersOrDefault`, `WaveguideBendRadiusResolver.Resolve`) return exactly those values.
- `TooCloseSpacing_FiresWithFoundryLimit_CompliantPairStaysClean` — styled parallel strip routes at 1.3 µm pitch (0.10 µm edge-to-edge) produce exactly one `WaveguideSpacingViolation` quoting `distance 0.10 µm, minimum 0.25 µm`; the same pair respaced to 1.3 µm edge stays clean, proving the foundry 0.25 µm floor replaced the generic 2.0 µm default.
- `TooNarrowWaveguide_IsCaughtByWidthMismatch_AgainstProcessStandardWidth` — a pin narrowed to 0.2 µm (below the 250 nm min feature) joined to the 1.2 µm process-standard strip produces the width-mismatch finding quoting both widths (layer still 203 NITRIDE on both sides, so no layer false positive).

Note: per the issue's scope ("keine neuen DRC-Regeltypen") there is intentionally **no** new waveguide-below-min-width rule type; `minWidthUm` ships as schema/data so the #810 follow-up rule can read it trivially. The width finding above rides the existing pin-mismatch rule.

Existing Cornerstone bend behaviour stays covered by the #919 journey test (30 µm floor) and the foundry value pins it via the resolver assertion above.

## Verification

- `dotnet build CAP.Desktop/CAP.Desktop.csproj` — 0 errors
- Local suite: 5559 passed, 0 failed (15 skipped)

No UI changes, no new user-visible strings, no manual verification needed.
