### PR TITLE
Agent: DRC-lite: Waveguide-Mindestbreiten-Regel aus minWidthUm des PDK (Rung 2->7, naechste Scheibe von #810)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/ProcessDefinitionExtensions.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/ProcessDefinitionExtensions.cs
@@ -1,3 +1,4 @@
+using CAP_Core.Analysis;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 
 namespace CAP_DataAccess.Components.ComponentDraftMapper;
@@ -19,5 +20,56 @@ public static class ProcessDefinitionExtensions
     public static double GetMinWaveguideSpacingMicrometersOrDefault(this ProcessDefinition? process)
     {
         return process?.MinWaveguideSpacingUm ?? CAP_Core.PhotonicConstants.DefaultMinWaveguideSpacingMicrometers;
+    }
+
+    /// <summary>
+    /// Builds the DRC-lite min-width rules of the process: one
+    /// <see cref="WaveguideMinWidthRule"/> per optical cross-section that declares
+    /// <c>minWidthUm</c>, with its layer names resolved to GDS layer numbers via the
+    /// process layer stack (the same resolution
+    /// <see cref="ProcessOpticalDefaultsResolver"/> stamps onto pins). Metal
+    /// cross-sections, cross-sections without a declared minimum, and cross-sections
+    /// whose layers are all unknown to the stack are skipped — no fallback values are
+    /// invented, so a PDK that declares nothing yields an empty list and the rule
+    /// stays silent.
+    /// </summary>
+    /// <param name="process">The active process definition (may be null).</param>
+    /// <returns>The declared min-width rules, empty when the process declares none.</returns>
+    public static IReadOnlyList<WaveguideMinWidthRule> GetMinWaveguideWidthRules(this ProcessDefinition? process)
+    {
+        var rules = new List<WaveguideMinWidthRule>();
+        if (process?.Xsections is null)
+            return rules;
+
+        foreach (var xsection in process.Xsections)
+        {
+            if (xsection.Kind != XsectionKind.Optical)
+                continue;
+            if (xsection.MinWidthUm is not > 0)
+                continue;
+
+            var layers = ResolveLayerNumbers(process, xsection);
+            if (layers.Count == 0)
+                continue;
+
+            rules.Add(new WaveguideMinWidthRule(
+                xsection.MinWidthUm.Value, layers, xsection.Name, xsection.DrcSource));
+        }
+
+        return rules;
+    }
+
+    private static List<int> ResolveLayerNumbers(ProcessDefinition process, ProcessXsection xsection)
+    {
+        var numbers = new List<int>();
+        foreach (var layerName in xsection.Layers)
+        {
+            var layer = process.Layers?.FirstOrDefault(
+                l => string.Equals(l.Name, layerName, StringComparison.OrdinalIgnoreCase));
+            if (layer is not null && !numbers.Contains(layer.Layer))
+                numbers.Add(layer.Layer);
+        }
+
+        return numbers;
     }
 }

--- a/CAP.Avalonia/ViewModels/Diagnostics/DesignValidationViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/DesignValidationViewModel.cs
@@ -59,9 +59,10 @@ public partial class DesignValidationViewModel : ObservableObject
     /// Detects invalid geometry, blocked paths, overlaps with frozen group paths,
     /// per-connection pin width/layer mismatches, (when components are provided) dangling
     /// optical pins, (when a positive minimum spacing is provided) waveguides closer than
-    /// the process minimum, (when chip bounds are provided) out-of-bounds component
-    /// placement, and (when PDK data is provided) placed components whose PDK no longer
-    /// matches the active process.
+    /// the process minimum, (when min-width rules are provided) waveguides narrower than
+    /// the fabrication minimum of their cross-section, (when chip bounds are provided)
+    /// out-of-bounds component placement, and (when PDK data is provided) placed
+    /// components whose PDK no longer matches the active process.
     /// </summary>
     /// <param name="connections">Waveguide connections to validate.</param>
     /// <param name="groups">ComponentGroups whose frozen paths are checked for overlap. Optional.</param>
@@ -74,6 +75,7 @@ public partial class DesignValidationViewModel : ObservableObject
     /// <param name="processLockActive">Whether a real (non-Playground) fabrication process is active.</param>
     /// <param name="externalPortPins">Pins treated as external ports; exempt from the dangling-pin check. Optional.</param>
     /// <param name="minWaveguideSpacingMicrometers">Process minimum edge-to-edge waveguide spacing; ≤0 disables the spacing check. Optional.</param>
+    /// <param name="minWaveguideWidthRules">Per-cross-section minimum feature widths of the active process; null/empty disables the min-width check. Optional.</param>
     public void RunValidation(
         IEnumerable<WaveguideConnection> connections,
         IEnumerable<ComponentGroup>? groups = null,
@@ -85,20 +87,22 @@ public partial class DesignValidationViewModel : ObservableObject
         IReadOnlyCollection<string>? enabledPdkNames = null,
         bool processLockActive = true,
         IEnumerable<PhysicalPin>? externalPortPins = null,
-        double minWaveguideSpacingMicrometers = 0)
+        double minWaveguideSpacingMicrometers = 0,
+        IReadOnlyList<WaveguideMinWidthRule>? minWaveguideWidthRules = null)
     {
         Issues.Clear();
         CurrentIndex = -1;
         HighlightConnection?.Invoke(null);
 
         // Single full-aggregation call: per-connection checks + frozen-path overlap +
-        // dangling pins + spacing each contribute their findings exactly once (#915).
+        // dangling pins + spacing + min width each contribute their findings exactly once (#915).
         var results = _validator.Validate(
             connections,
             groups ?? Array.Empty<ComponentGroup>(),
             allComponents ?? Array.Empty<Component>(),
             externalPortPins,
-            minWaveguideSpacingMicrometers);
+            minWaveguideSpacingMicrometers,
+            minWaveguideWidthRules);
 
         foreach (var issue in results)
             Issues.Add(issue);

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -1175,10 +1175,12 @@ public partial class MainViewModel : ObservableObject
         var processLockActive = FileOperations.ActiveProcess is { IsPlayground: false };
         var compatiblePdkNames = LeftPanel.PdkManager.GetProcessCompatiblePdkNames();
 
-        // DRC-lite min waveguide spacing (#899, wired for #915): the first member PDK
-        // process of the active selection provides the declared value (or the conservative
-        // default); without a real process (Playground) the check stays off (0 = disabled).
+        // DRC-lite min waveguide spacing (#899, wired for #915) and min feature width:
+        // the first member PDK process of the active selection provides the declared
+        // values (spacing falls back to the conservative default); without a real
+        // process (Playground) both checks stay off (0/null = disabled).
         double minWaveguideSpacingMicrometers = 0;
+        IReadOnlyList<CAP_Core.Analysis.WaveguideMinWidthRule>? minWaveguideWidthRules = null;
         if (processLockActive)
         {
             var memberProcess = LeftPanel.ResolveLiveMemberPdkNames(FileOperations.ActiveProcess!)
@@ -1186,6 +1188,7 @@ public partial class MainViewModel : ObservableObject
                     d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase))?.Process)
                 .FirstOrDefault(p => p is not null);
             minWaveguideSpacingMicrometers = memberProcess.GetMinWaveguideSpacingMicrometersOrDefault();
+            minWaveguideWidthRules = memberProcess.GetMinWaveguideWidthRules();
         }
 
         RightPanel.DesignValidation.RunValidation(
@@ -1198,7 +1201,8 @@ public partial class MainViewModel : ObservableObject
             LeftPanel.GetProcessAgnosticPdkNames(),
             compatiblePdkNames,
             processLockActive,
-            minWaveguideSpacingMicrometers: minWaveguideSpacingMicrometers);
+            minWaveguideSpacingMicrometers: minWaveguideSpacingMicrometers,
+            minWaveguideWidthRules: minWaveguideWidthRules);
 
         StatusText = RightPanel.DesignValidation.StatusText;
     }

--- a/Connect-A-Pic-Core/Analysis/DesignIssue.cs
+++ b/Connect-A-Pic-Core/Analysis/DesignIssue.cs
@@ -69,7 +69,15 @@ public enum DesignIssueType
     /// Two waveguide routes are closer than the active process' minimum edge-to-edge
     /// spacing. The reported distance and required minimum are included in the issue.
     /// </summary>
-    WaveguideSpacingViolation
+    WaveguideSpacingViolation,
+
+    /// <summary>
+    /// An optical waveguide route (or one of its endpoint pins) is narrower than the
+    /// fabrication minimum feature width (<c>minWidthUm</c>) of the associated
+    /// cross-section of the active process. Only fires when the PDK declares the
+    /// limit; the reported width, minimum, and its source are included in the issue.
+    /// </summary>
+    WaveguideBelowMinWidth
 }
 
 /// <summary>

--- a/Connect-A-Pic-Core/Analysis/DesignValidator.cs
+++ b/Connect-A-Pic-Core/Analysis/DesignValidator.cs
@@ -15,6 +15,7 @@ public class DesignValidator
 {
     private readonly WaveguideOverlapDetector _overlapDetector = new();
     private readonly WaveguideSpacingDetector _spacingDetector = new();
+    private readonly WaveguideMinWidthChecker _minWidthChecker = new();
 
     /// <summary>
     /// Validates all provided waveguide connections and returns any issues found.
@@ -132,9 +133,11 @@ public class DesignValidator
     /// <summary>
     /// Full DRC-lite aggregation: validates waveguide connections, detects overlaps with
     /// frozen paths, checks every optical pin on the provided components for a connection,
-    /// and (when <paramref name="minWaveguideSpacingMicrometers"/> &gt; 0) checks edge-to-edge
-    /// waveguide spacing against the process minimum. Each rule contributes its findings
-    /// exactly once.
+    /// (when <paramref name="minWaveguideSpacingMicrometers"/> &gt; 0) checks edge-to-edge
+    /// waveguide spacing against the process minimum, and (when
+    /// <paramref name="minWaveguideWidthRules"/> are provided) flags waveguides narrower
+    /// than the fabrication minimum of their cross-section. Each rule contributes its
+    /// findings exactly once.
     /// </summary>
     /// <param name="connections">Regular waveguide connections to validate.</param>
     /// <param name="groups">ComponentGroups whose frozen internal paths are checked for overlap.</param>
@@ -143,13 +146,18 @@ public class DesignValidator
     /// <param name="minWaveguideSpacingMicrometers">
     /// Minimum required edge-to-edge spacing; ≤0 disables the spacing check.
     /// </param>
+    /// <param name="minWaveguideWidthRules">
+    /// Per-cross-section minimum feature widths of the active process; null/empty disables
+    /// the min-width check (the PDK declares no <c>minWidthUm</c>).
+    /// </param>
     /// <returns>A list of all design issues found, empty if the design is valid.</returns>
     public List<DesignIssue> Validate(
         IEnumerable<WaveguideConnection> connections,
         IEnumerable<ComponentGroup> groups,
         IEnumerable<Component> components,
         IEnumerable<PhysicalPin>? externalPortPins,
-        double minWaveguideSpacingMicrometers = 0)
+        double minWaveguideSpacingMicrometers = 0,
+        IReadOnlyList<WaveguideMinWidthRule>? minWaveguideWidthRules = null)
     {
         ArgumentNullException.ThrowIfNull(connections);
         ArgumentNullException.ThrowIfNull(groups);
@@ -161,6 +169,10 @@ public class DesignValidator
         {
             issues.AddRange(_spacingDetector.DetectViolations(
                 connectionList, groups, minWaveguideSpacingMicrometers));
+        }
+        if (minWaveguideWidthRules is { Count: > 0 })
+        {
+            issues.AddRange(_minWidthChecker.CheckConnections(connectionList, minWaveguideWidthRules));
         }
         return issues;
     }

--- a/Connect-A-Pic-Core/Analysis/WaveguideMinWidthChecker.cs
+++ b/Connect-A-Pic-Core/Analysis/WaveguideMinWidthChecker.cs
@@ -1,0 +1,132 @@
+using System.Globalization;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis;
+
+/// <summary>
+/// DRC-lite rule: flags optical waveguide connections whose effective width falls
+/// below the fabrication minimum (<c>minWidthUm</c>) of the associated cross-section
+/// of the active process. The effective width is the narrowest fabricated feature
+/// along the route — the connection width (what the export draws) and, when stamped
+/// from the PDK, the endpoint pin widths. Association runs through the pins' GDS
+/// layer; connections without layer information are skipped (no fallback guessing),
+/// as are PDKs that declare no <c>minWidthUm</c>. Frozen group paths are out of
+/// scope — they carry no pins to associate a cross-section with.
+/// </summary>
+public class WaveguideMinWidthChecker
+{
+    /// <summary>Float-noise guard so a width exactly at the minimum never fires.</summary>
+    private const double WidthToleranceMicrometers = 1e-9;
+
+    /// <summary>
+    /// Checks every optical connection against the applicable cross-section rules.
+    /// When several cross-sections share a layer, the smallest declared minimum
+    /// governs — the check only flags widths no cross-section on that layer allows,
+    /// so it never invents a violation the foundry would not.
+    /// </summary>
+    /// <param name="connections">The connections to check.</param>
+    /// <param name="rules">Per-cross-section minimums of the active process.</param>
+    /// <returns>One issue per violating connection, empty when all are compliant.</returns>
+    public List<DesignIssue> CheckConnections(
+        IEnumerable<WaveguideConnection> connections,
+        IReadOnlyList<WaveguideMinWidthRule> rules)
+    {
+        ArgumentNullException.ThrowIfNull(connections);
+        ArgumentNullException.ThrowIfNull(rules);
+
+        var issues = new List<DesignIssue>();
+        if (rules.Count == 0)
+            return issues;
+
+        foreach (var connection in connections)
+        {
+            var issue = CheckConnection(connection, rules);
+            if (issue is not null)
+                issues.Add(issue);
+        }
+
+        return issues;
+    }
+
+    private static DesignIssue? CheckConnection(
+        WaveguideConnection connection,
+        IReadOnlyList<WaveguideMinWidthRule> rules)
+    {
+        if (connection.IsElectrical)
+            return null;
+        if (connection.StartPin == null || connection.EndPin == null)
+            return null;
+
+        var rule = FindApplicableRule(connection, rules);
+        if (rule is null)
+            return null;
+
+        double effectiveWidth = EffectiveWidth(connection);
+        if (effectiveWidth >= rule.MinWidthMicrometers - WidthToleranceMicrometers)
+            return null;
+
+        var (startX, startY) = connection.StartPin.GetAbsolutePosition();
+        var (endX, endY) = connection.EndPin.GetAbsolutePosition();
+        string sourceSuffix = string.IsNullOrWhiteSpace(rule.DrcSource)
+            ? string.Empty
+            : $"; source: {rule.DrcSource}";
+        string description = string.Create(
+            CultureInfo.InvariantCulture,
+            $"Waveguide width below minimum: {FormatPinName(connection.StartPin)} → {FormatPinName(connection.EndPin)} "
+            + $"(width {effectiveWidth:F2} µm, minimum {rule.MinWidthMicrometers:F2} µm, "
+            + $"cross-section {rule.XsectionName}{sourceSuffix})");
+
+        return new DesignIssue(
+            DesignIssueType.WaveguideBelowMinWidth,
+            connection,
+            (startX + endX) / 2,
+            (startY + endY) / 2,
+            description);
+    }
+
+    /// <summary>
+    /// The smallest minimum among the rules whose layers cover either endpoint pin's
+    /// layer; null when no rule applies (pins carry no layer, or their layer belongs
+    /// to a cross-section without a declared minimum).
+    /// </summary>
+    private static WaveguideMinWidthRule? FindApplicableRule(
+        WaveguideConnection connection,
+        IReadOnlyList<WaveguideMinWidthRule> rules)
+    {
+        WaveguideMinWidthRule? applicable = null;
+        foreach (var rule in rules)
+        {
+            if (!CoversPin(rule, connection.StartPin) && !CoversPin(rule, connection.EndPin))
+                continue;
+            if (applicable is null || rule.MinWidthMicrometers < applicable.MinWidthMicrometers)
+                applicable = rule;
+        }
+
+        return applicable;
+    }
+
+    private static bool CoversPin(WaveguideMinWidthRule rule, PhysicalPin pin)
+    {
+        return pin.Layer.HasValue && rule.GdsLayers.Contains(pin.Layer.Value);
+    }
+
+    /// <summary>
+    /// The narrowest fabricated feature along the route: the connection width (the
+    /// geometry the export draws) plus any PDK-stamped endpoint pin widths.
+    /// </summary>
+    private static double EffectiveWidth(WaveguideConnection connection)
+    {
+        double width = connection.WidthMicrometers;
+        if (connection.StartPin.WaveguideWidthMicrometers is double startWidth && startWidth < width)
+            width = startWidth;
+        if (connection.EndPin.WaveguideWidthMicrometers is double endWidth && endWidth < width)
+            width = endWidth;
+        return width;
+    }
+
+    private static string FormatPinName(PhysicalPin pin)
+    {
+        return $"{pin.ParentComponent.Identifier}.{pin.Name}";
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/WaveguideMinWidthRule.cs
+++ b/Connect-A-Pic-Core/Analysis/WaveguideMinWidthRule.cs
@@ -1,0 +1,42 @@
+namespace CAP_Core.Analysis;
+
+/// <summary>
+/// Fabrication minimum feature width of one optical cross-section of the active
+/// process, resolved from the PDK's <c>minWidthUm</c> declaration. A connection is
+/// associated with a rule through the GDS layer stamped on its endpoint pins
+/// (see <c>PhysicalPin.Layer</c>); rules are built per design from the active
+/// process, so no single-process assumption is baked in.
+/// </summary>
+public sealed class WaveguideMinWidthRule
+{
+    /// <summary>
+    /// Creates a rule for one optical cross-section.
+    /// </summary>
+    /// <param name="minWidthMicrometers">Foundry minimum feature width in µm.</param>
+    /// <param name="gdsLayers">GDS layer numbers of the cross-section (resolved via the process layer stack).</param>
+    /// <param name="xsectionName">Cross-section name (e.g. "xs_nc"), for message attribution.</param>
+    /// <param name="drcSource">Provenance of the value (foundry document/table), optional.</param>
+    public WaveguideMinWidthRule(
+        double minWidthMicrometers,
+        IReadOnlyCollection<int> gdsLayers,
+        string xsectionName,
+        string? drcSource)
+    {
+        MinWidthMicrometers = minWidthMicrometers;
+        GdsLayers = gdsLayers;
+        XsectionName = xsectionName;
+        DrcSource = drcSource;
+    }
+
+    /// <summary>Foundry minimum feature width in µm for this cross-section.</summary>
+    public double MinWidthMicrometers { get; }
+
+    /// <summary>GDS layer numbers this cross-section is drawn on.</summary>
+    public IReadOnlyCollection<int> GdsLayers { get; }
+
+    /// <summary>Cross-section name the limit belongs to.</summary>
+    public string XsectionName { get; }
+
+    /// <summary>Provenance of the limit (foundry document/table/script), when declared.</summary>
+    public string? DrcSource { get; }
+}

--- a/UnitTests/Analysis/WaveguideMinWidthCheckerTests.cs
+++ b/UnitTests/Analysis/WaveguideMinWidthCheckerTests.cs
@@ -1,0 +1,225 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Analysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis;
+
+/// <summary>
+/// The DRC-lite min-width rule flags optical waveguide routes whose effective width
+/// falls below the fabrication minimum (<c>minWidthUm</c>) of the associated
+/// cross-section of the active process. Everything runs through production machinery
+/// on the real bundled PDKs (pattern: <see cref="CornerstoneSinPreDrcTests"/>):
+/// components are instantiated from the bundled PDK JSON so pins carry the
+/// PDK-stamped width/layer the rule associates cross-sections with. A PDK that
+/// declares no <c>minWidthUm</c> stays silent.
+/// </summary>
+public class WaveguideMinWidthCheckerTests
+{
+    private const string CornerstonePdkFile = "cornerstone-sin-pdk.json";
+    private const string SiepicPdkFile = "siepic-ebeam-pdk.json";
+
+    /// <summary>MPW-13 §5.4 Table 4: min. feature size on GDS 203 NITRIDE.</summary>
+    private const double FoundryMinWidthUm = 0.25;
+    /// <summary>xs_nc standard design width — what the PDK stamps on every optical pin.</summary>
+    private const double CornerstoneStripWidthUm = 1.2;
+
+    [Fact]
+    public void Resolver_BuildsRulesFromDeclaredOpticalXsections_Only()
+    {
+        var process = LoadPdk(CornerstonePdkFile).Process!;
+
+        var rules = process.GetMinWaveguideWidthRules();
+
+        rules.Count.ShouldBe(2, "xs_nc and xs_no declare minWidthUm; the metal cross-sections do not");
+        foreach (var rule in rules)
+        {
+            rule.MinWidthMicrometers.ShouldBe(FoundryMinWidthUm);
+            rule.GdsLayers.ShouldBe(new[] { 203 }, "NITRIDE, resolved through the process layer stack");
+            rule.DrcSource.ShouldNotBeNullOrWhiteSpace();
+            rule.DrcSource.ShouldContain("MPW-13");
+        }
+
+        LoadPdk(SiepicPdkFile).Process.GetMinWaveguideWidthRules()
+            .ShouldBeEmpty("SiEPIC declares no minWidthUm — no fallback values are invented");
+        ((ProcessDefinition?)null).GetMinWaveguideWidthRules()
+            .ShouldBeEmpty("no active process resolves to no rules");
+
+        var metalOnly = new ProcessDefinition
+        {
+            Layers = new() { new ProcessLayer { Name = "M1", Layer = 11 } },
+            Xsections = new()
+            {
+                new ProcessXsection
+                {
+                    Name = "metal_routing", Kind = XsectionKind.Metal,
+                    WidthUm = 10, MinWidthUm = 2.0, Layers = new() { "M1" },
+                },
+            },
+        };
+        metalOnly.GetMinWaveguideWidthRules()
+            .ShouldBeEmpty("min width is resolved from optical cross-sections only");
+
+        var unknownLayer = new ProcessDefinition
+        {
+            Layers = new() { new ProcessLayer { Name = "WG", Layer = 1 } },
+            Xsections = new()
+            {
+                new ProcessXsection
+                {
+                    Name = "strip", Kind = XsectionKind.Optical,
+                    WidthUm = 0.5, MinWidthUm = 0.25, Layers = new() { "NOT_IN_STACK" },
+                },
+            },
+        };
+        unknownLayer.GetMinWaveguideWidthRules()
+            .ShouldBeEmpty("a cross-section whose layers are unknown to the stack cannot be associated");
+    }
+
+    [Fact]
+    public void NarrowRoute_FiresWithFoundryLimit_NamingWidthMinimumAndSource()
+    {
+        var pdk = LoadPdk(CornerstonePdkFile);
+        var (components, connection) = BuildCornerstonePair(pdk, routeWidthUm: 0.2);
+
+        var panel = RunPanel(pdk, components, connection);
+
+        var findings = panel.Issues.Where(i => i.Type == DesignIssueType.WaveguideBelowMinWidth).ToList();
+        findings.Count.ShouldBe(1, Describe(panel));
+        findings[0].Connection.ShouldBe(connection);
+        findings[0].Description.ShouldContain("0.20 µm");
+        findings[0].Description.ShouldContain("0.25 µm");
+        findings[0].Description.ShouldContain("MPW-13"); // the finding names the drcSource of the declared limit
+    }
+
+    [Fact]
+    public void StandardWidthRoute_AndRouteExactlyAtMinimum_StayClean()
+    {
+        var pdk = LoadPdk(CornerstonePdkFile);
+
+        var (standardComponents, standardConnection) = BuildCornerstonePair(pdk, routeWidthUm: CornerstoneStripWidthUm);
+        RunPanel(pdk, standardComponents, standardConnection).Issues
+            .Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth)
+            .ShouldBe(0, "the 1.2 µm process standard width is far above the 250 nm floor");
+
+        var (atMinComponents, atMinConnection) = BuildCornerstonePair(pdk, routeWidthUm: FoundryMinWidthUm);
+        RunPanel(pdk, atMinComponents, atMinConnection).Issues
+            .Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth)
+            .ShouldBe(0, "a width exactly at the minimum is compliant");
+    }
+
+    [Fact]
+    public void NarrowedEndpointPin_FiresOnPinEvidence()
+    {
+        var pdk = LoadPdk(CornerstonePdkFile);
+        var (components, connection) = BuildCornerstonePair(pdk, routeWidthUm: CornerstoneStripWidthUm);
+        connection.EndPin.WaveguideWidthMicrometers = 0.2;
+
+        var panel = RunPanel(pdk, components, connection);
+
+        var findings = panel.Issues.Where(i => i.Type == DesignIssueType.WaveguideBelowMinWidth).ToList();
+        findings.Count.ShouldBe(1, Describe(panel));
+        findings[0].Description.ShouldContain("0.20 µm");
+        findings[0].Description.ShouldContain("0.25 µm");
+    }
+
+    [Fact]
+    public void PdkWithoutMinWidth_AndMissingRules_StaySilent()
+    {
+        var siepic = LoadPdk(SiepicPdkFile);
+        siepic.Process.GetMinWaveguideWidthRules().ShouldBeEmpty();
+
+        var template = PdkTemplateConverter.ConvertToTemplate(
+            siepic.Components.First(c => c.Name == "Y-Branch 1550"),
+            siepic.Name, siepic.NazcaModuleName, process: siepic.Process);
+        var branchA = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+        var branchB = ComponentTemplates.CreateFromTemplate(template, 200, 0);
+        var connection = Link(
+            branchA.PhysicalPins.First(p => p.Name == "port 2"),
+            branchB.PhysicalPins.First(p => p.Name == "port 1"),
+            routeWidthUm: 0.2);
+
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            new[] { connection },
+            allComponents: new Component[] { branchA, branchB },
+            minWaveguideWidthRules: siepic.Process.GetMinWaveguideWidthRules());
+        panel.Issues.Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth)
+            .ShouldBe(0, "a PDK without minWidthUm declares no limit — the rule must not fire");
+
+        var cornerstone = LoadPdk(CornerstonePdkFile);
+        var (components, narrowConnection) = BuildCornerstonePair(cornerstone, routeWidthUm: 0.2);
+        var silentPanel = new DesignValidationViewModel();
+        silentPanel.RunValidation(new[] { narrowConnection }, allComponents: components);
+        silentPanel.Issues.Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth)
+            .ShouldBe(0, "without the active process' rules there is nothing to check against (no guessing)");
+    }
+
+    private static DesignValidationViewModel RunPanel(
+        PdkDraft pdk, List<Component> components, WaveguideConnection connection)
+    {
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            new[] { connection },
+            allComponents: components,
+            minWaveguideWidthRules: pdk.Process.GetMinWaveguideWidthRules());
+        return panel;
+    }
+
+    /// <summary>
+    /// A Cornerstone coupler output routed into a straight waveguide — the same
+    /// production-machinery pair <see cref="CornerstoneSinPreDrcTests"/> uses, with a
+    /// hand-built straight route of the requested width standing in for a user-styled
+    /// waveguide.
+    /// </summary>
+    private static (List<Component> Components, WaveguideConnection Connection)
+        BuildCornerstonePair(PdkDraft pdk, double routeWidthUm)
+    {
+        var components = new List<Component>
+        {
+            Place(pdk, "Coupler", 0, 0),
+            Place(pdk, "Straight", 200, 0),
+        };
+        var connection = Link(
+            Pin(components[0], "o3"), Pin(components[1], "o1"), routeWidthUm);
+        connection.StartPin.WaveguideWidthMicrometers.ShouldBe(CornerstoneStripWidthUm);
+        connection.StartPin.Layer.ShouldBe(203, "NITRIDE — the layer the rule associates the xs_nc/xs_no minimum with");
+        return (components, connection);
+    }
+
+    private static WaveguideConnection Link(PhysicalPin start, PhysicalPin end, double routeWidthUm)
+    {
+        var (x1, y1) = start.GetAbsolutePosition();
+        var (x2, y2) = end.GetAbsolutePosition();
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, start.GetAbsoluteAngle()));
+        var connection = new WaveguideConnection { StartPin = start, EndPin = end };
+        connection.RestoreCachedPath(path);
+        connection.WidthMicrometers = routeWidthUm;
+        return connection;
+    }
+
+    private static Component Place(PdkDraft pdk, string templateName, double x, double y)
+    {
+        var template = PdkTemplateConverter.ConvertToTemplate(
+            pdk.Components.First(c => c.Name == templateName), pdk.Name, pdk.NazcaModuleName, process: pdk.Process);
+        return ComponentTemplates.CreateFromTemplate(template, x, y);
+    }
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+
+    private static PdkDraft LoadPdk(string fileName) =>
+        new PdkLoader().LoadFromFile(
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PDKs", fileName));
+
+    private static string Describe(DesignValidationViewModel panel) =>
+        string.Join(" | ", panel.Issues.Select(i => $"{i.Type}: {i.Description}"));
+}


### PR DESCRIPTION
Automated implementation for #926

Already processed — that suite result (5580 passed, 0 failed, 15 skipped) was the verification basis for the commit. Issue #926 is done: committed as `a9cf0215`, pushed to `origin/agent/issue-926-1786792896`, PR summary delivered. No further action needed.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 152,610
- **Estimated cost:** $0.0855 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>