### PR TITLE
Agent: Multi-process chiplet journey — inventory of single-process assumptions (#933)

### DIFF
--- a/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
@@ -185,16 +185,25 @@ internal sealed class MultiProcessChipletJourneyDesign
     }
 
     /// <summary>
-    /// Connects two pins inside one chiplet with an explicit straight route, frozen so
-    /// the group captures the deterministic geometry (same recipe as #929).
+    /// Builds an explicit straight route between two pins — the deterministic geometry
+    /// recipe the journey uses wherever a connection must not depend on router heuristics.
     /// </summary>
-    private static void Wire(DesignCanvasViewModel canvas, PhysicalPin from, PhysicalPin to)
+    public static RoutedPath StraightPath(PhysicalPin from, PhysicalPin to)
     {
         var (x1, y1) = from.GetAbsolutePosition();
         var (x2, y2) = to.GetAbsolutePosition();
         var path = new RoutedPath();
         path.Segments.Add(new StraightSegment(x1, y1, x2, y2, 0));
-        var connection = canvas.ConnectPinsWithCachedRoute(from, to, path);
+        return path;
+    }
+
+    /// <summary>
+    /// Connects two pins inside one chiplet with an explicit straight route, frozen so
+    /// the group captures the deterministic geometry (same recipe as #929).
+    /// </summary>
+    private static void Wire(DesignCanvasViewModel canvas, PhysicalPin from, PhysicalPin to)
+    {
+        var connection = canvas.ConnectPinsWithCachedRoute(from, to, StraightPath(from, to));
         connection.ShouldNotBeNull($"route {from.Name} -> {to.Name} must be created");
         connection!.Connection.IsRouteFrozen = true;
     }

--- a/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
@@ -1,0 +1,204 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Components.Core;
+using CAP_Core.Routing;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Builds the two-chiplet composition for the multi-process journey (#933):
+/// chiplet A ("Splitter Chiplet") from the bundled CornerStone SiN 300nm PDK
+/// (Coupler → Mmi1x2), chiplet B ("Receiver Chiplet") from the bundled SiEPIC
+/// EBeam PDK (Y-Branch → Taper), each grouped on one shared canvas and composed
+/// pin-to-pin (cs_mmi.o2 abuts si_ybranch.port 1, standing in for a later
+/// edge-coupler pair). Everything goes through production machinery: the real
+/// bundled PDK JSONs, real template conversion (pins carry PDK-stamped
+/// width/layer, #913), real grouping and the real router abutment (#923) —
+/// the same headless recipe as the single-process composition journey (#929,
+/// <see cref="MultiChipletCompositionJourneyTests"/>), now across two
+/// fabrication processes.
+/// </summary>
+internal sealed class MultiProcessChipletJourneyDesign
+{
+    public const string CornerstonePdkFile = "cornerstone-sin-pdk.json";
+    public const string SiepicPdkFile = "siepic-ebeam-pdk.json";
+
+    public const string ChipletAName = "Cornerstone Splitter Chiplet";
+    public const string ChipletBName = "SiEPIC Receiver Chiplet";
+
+    // S-matrix magnitudes at 1550 nm, straight from the bundled PDK JSONs.
+    public const double CouplerThrough = 0.683101;   // Cornerstone Coupler o1→o3
+    public const double MmiThrough = 0.683101;       // Cornerstone Mmi1x2 o1→o2
+    public const double TaperThrough = 0.991384;     // SiEPIC Taper port1→port2
+
+    /// <summary>Cornerstone xs_nc: MPW-13 §5.4 Table 4 min. feature size (#924/#926).</summary>
+    public const double CornerstoneMinWidthUm = 0.25;
+    /// <summary>Cornerstone xs_nc: cspdk.sin300 radius_min tech constant (#924).</summary>
+    public const double CornerstoneMinBendRadiusUm = 30.0;
+    /// <summary>Cornerstone NITRIDE waveguide layer.</summary>
+    public const int CornerstoneGdsLayer = 203;
+    /// <summary>SiEPIC WG waveguide layer.</summary>
+    public const int SiepicGdsLayer = 1;
+
+    /// <summary>Amplitude leaving chiplet A through the abutted arm (exact product, lossless wires).</summary>
+    public const double ExpectedBoundaryAmplitude = CouplerThrough * MmiThrough;
+    /// <summary>
+    /// Amplitude at chiplet B's output: boundary × Y-branch in→arm × taper. The draft
+    /// lists both directions per pair (0.69361/0.698147) and the converter mirrors them,
+    /// so the expectation is the midpoint of both readings; the tolerance covers the
+    /// spread plus the iterative solver's convergence noise.
+    /// </summary>
+    public const double ExpectedOutputAmplitude = 0.3219;
+    /// <summary>Amplitude leaving the Y-branch's free arm (same reasoning as the output).</summary>
+    public const double ExpectedFreeArmAmplitude = 0.3247;
+    public const double SolverValueTolerance = 5e-3;
+
+    private const int WavelengthNm = 1550;
+    private const double WireGapMicrometers = 5;
+
+    public static readonly string[] ChipletAPinNames =
+        { "cs_coupler_o1", "cs_coupler_o2", "cs_coupler_o4", "cs_mmi_o2", "cs_mmi_o3" };
+    public static readonly string[] ChipletBPinNames =
+        { "si_ybranch_port 1", "si_ybranch_port 3", "si_taper_port 2" };
+
+    private MultiProcessChipletJourneyDesign(
+        DesignCanvasViewModel canvas,
+        ComponentGroup chipletA,
+        ComponentGroup chipletB,
+        List<ComponentTemplate> templates,
+        PdkDraft cornerstone,
+        PdkDraft siepic)
+    {
+        Canvas = canvas;
+        ChipletA = chipletA;
+        ChipletB = chipletB;
+        Templates = templates;
+        Cornerstone = cornerstone;
+        Siepic = siepic;
+    }
+
+    public DesignCanvasViewModel Canvas { get; }
+    public ComponentGroup ChipletA { get; }
+    public ComponentGroup ChipletB { get; }
+    public List<ComponentTemplate> Templates { get; }
+    public PdkDraft Cornerstone { get; }
+    public PdkDraft Siepic { get; }
+
+    /// <summary>Loads one bundled PDK JSON from the test output's PDKs folder.</summary>
+    public static PdkDraft LoadPdk(string fileName)
+    {
+        var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PDKs", fileName);
+        return new PdkLoader().LoadFromFile(path);
+    }
+
+    /// <summary>Converts one component of the draft through the production PDK→template path.</summary>
+    public static ComponentTemplate TemplateFor(PdkDraft pdk, string componentName) =>
+        PdkTemplateConverter.ConvertToTemplate(
+            pdk.Components.First(c => c.Name == componentName),
+            pdk.Name,
+            pdk.NazcaModuleName,
+            pdk.GdsFactoryRoutingCrossSection,
+            process: pdk.Process);
+
+    /// <summary>The connectable canvas-side pin behind a group's exposed pin.</summary>
+    public static PhysicalPin ExposedPin(ComponentGroup group, string pinName) =>
+        group.ExternalPins.Single(p => p.Name == pinName).InternalPin!;
+
+    /// <summary>
+    /// Builds the full composition: both chiplets grouped, chiplet B aligned so its
+    /// Y-branch input sits exactly on chiplet A's MMI output, and the coincident pin
+    /// pair routed through the real router (#923 abutment).
+    /// </summary>
+    public static MultiProcessChipletJourneyDesign BuildComposed()
+    {
+        var cornerstone = LoadPdk(CornerstonePdkFile);
+        var siepic = LoadPdk(SiepicPdkFile);
+        var couplerTemplate = TemplateFor(cornerstone, "Coupler");
+        var mmiTemplate = TemplateFor(cornerstone, "Mmi1x2");
+        var yBranchTemplate = TemplateFor(siepic, "Y-Branch 1550");
+        var taperTemplate = TemplateFor(siepic, "Taper TE 1550");
+
+        var canvas = new DesignCanvasViewModel();
+
+        // Chiplet A: Coupler at the origin, MMI with its input facing the coupler's
+        // o3 output across a 5 µm gap (Coupler o3: (60, 0.6); MMI o1: (0, 6) rel).
+        var coupler = Place(canvas, "cs_coupler", couplerTemplate, 0, 0);
+        var mmi = Place(canvas, "cs_mmi", mmiTemplate, 65, 0.6 - 6);
+        Wire(canvas, Pin(coupler, "o3"), Pin(mmi, "o1"));
+
+        // Chiplet B, far away: Y-branch at (1000, 0), taper input facing port 2
+        // (port 2: (14.9, 0.75) rel; Taper port 1: (0.01, 6) rel).
+        var yBranch = Place(canvas, "si_ybranch", yBranchTemplate, 1000, 0);
+        var taper = Place(canvas, "si_taper", taperTemplate, 1014.9 + WireGapMicrometers, 0.75 - 6);
+        Wire(canvas, Pin(yBranch, "port 2"), Pin(taper, "port 1"));
+
+        var chipletA = Group(canvas, ChipletAName, coupler, mmi);
+        var chipletB = Group(canvas, ChipletBName, yBranch, taper);
+
+        // Align chiplet B so its Y-branch input coincides with chiplet A's MMI output.
+        var aOut = ExposedPin(chipletA, "cs_mmi_o2");
+        var bIn = ExposedPin(chipletB, "si_ybranch_port 1");
+        var (ax, ay) = aOut.GetAbsolutePosition();
+        var (bx, by) = bIn.GetAbsolutePosition();
+        chipletB.MoveGroup(ax - bx, ay - by);
+
+        // #923 on group level, across the process boundary: coincident opposing pins.
+        var path = canvas.Router.Route(aOut, bIn);
+        path.IsBlockedFallback.ShouldBeFalse("the cross-process abutment must not fall back to a blocked route");
+        path.IsValid.ShouldBeTrue("the cross-process abutment must be a valid route");
+        var abutment = canvas.ConnectPinsWithCachedRoute(aOut, bIn, path);
+        abutment.ShouldNotBeNull("the cross-process abutment must be created");
+        abutment!.Connection.IsRouteFrozen = true;
+
+        return new MultiProcessChipletJourneyDesign(
+            canvas,
+            chipletA,
+            chipletB,
+            new List<ComponentTemplate> { couplerTemplate, mmiTemplate, yBranchTemplate, taperTemplate },
+            cornerstone,
+            siepic);
+    }
+
+    private static Component Place(
+        DesignCanvasViewModel canvas, string identifier, ComponentTemplate template, double x, double y)
+    {
+        var component = ComponentTemplates.CreateFromTemplate(template, x, y);
+        component.Identifier = identifier;
+        canvas.AddComponent(component, template.Name, template.PdkSource);
+        return component;
+    }
+
+    /// <summary>Groups the given components (Ctrl+G equivalent) and returns the group.</summary>
+    private static ComponentGroup Group(DesignCanvasViewModel canvas, string name, params Component[] children)
+    {
+        var command = new CreateGroupCommand(
+            canvas,
+            children.Select(c => canvas.Components.Single(vm => vm.Component == c)).ToList(),
+            name);
+        command.Execute();
+        return command.CreatedGroup.ShouldNotBeNull($"grouping '{name}' must succeed");
+    }
+
+    /// <summary>
+    /// Connects two pins inside one chiplet with an explicit straight route, frozen so
+    /// the group captures the deterministic geometry (same recipe as #929).
+    /// </summary>
+    private static void Wire(DesignCanvasViewModel canvas, PhysicalPin from, PhysicalPin to)
+    {
+        var (x1, y1) = from.GetAbsolutePosition();
+        var (x2, y2) = to.GetAbsolutePosition();
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, 0));
+        var connection = canvas.ConnectPinsWithCachedRoute(from, to, path);
+        connection.ShouldNotBeNull($"route {from.Name} -> {to.Name} must be created");
+        connection!.Connection.IsRouteFrozen = true;
+    }
+
+    private static PhysicalPin Pin(Component component, string pinName) =>
+        component.PhysicalPins.Single(p => p.Name == pinName);
+}

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
@@ -1,0 +1,132 @@
+using CAP.Avalonia.Services.GdsFactoryExport;
+using CAP.Avalonia.Services.GdsFactoryExport.MixedBackend;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Green "today" pins for the documented-red stations of the multi-process journey:
+/// each test proves the current single-process behavior the red steps 3 (#935), 5
+/// (#937) and 8 (#939) describe, so a future per-chiplet fix turns the pin red as a
+/// tripwire. See <see cref="MultiProcessChipletJourneyTests"/> for the full journey.
+/// </summary>
+public partial class MultiProcessChipletJourneyTests
+{
+    /// <summary>SiEPIC strip minimum bend radius (µm) from the bundled PDK.</summary>
+    private const double SiepicMinBendRadiusUm = 5.0;
+
+    [Fact]
+    public void Placement_ProcessLockedCanvas_RejectsSecondChipletProcess_Today()
+    {
+        // Companion to red step 3 (#935): the canvas-global lock really rejects the
+        // second chiplet's process today — only Playground admits both.
+        var (cornerstone, siepic, catalog) = LoadProcessCatalog();
+        var cornerstoneLock = ActiveProcessSelection.ForGroup(
+            catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name)));
+
+        SingleProcessPolicy.CheckPlacement(cornerstoneLock, cornerstone.Name)
+            .IsAllowed.ShouldBeTrue("chiplet A's own process must stay placeable");
+
+        var (allowed, blockReason) = SingleProcessPolicy.CheckPlacement(cornerstoneLock, siepic.Name);
+        allowed.ShouldBeFalse("today the design-global lock rejects chiplet B's process (#935)");
+        blockReason.ShouldNotBeNull();
+        blockReason!.ShouldContain("monolithic");
+
+        SingleProcessPolicy.CheckPlacement(ActiveProcessSelection.Playground(), cornerstone.Name)
+            .IsAllowed.ShouldBeTrue();
+        SingleProcessPolicy.CheckPlacement(ActiveProcessSelection.Playground(), siepic.Name)
+            .IsAllowed.ShouldBeTrue("Playground is the only mode that can hold both chiplets today");
+    }
+
+    [Fact]
+    public void BendRadius_LockedProcess_ResolvesEachProcessMinimum_Today()
+    {
+        // Companion to red step 5 (#937): per-process limits exist and are honored —
+        // but only while the whole design is locked to that one process.
+        var (cornerstone, siepic, catalog) = LoadProcessCatalog();
+        var pdks = new List<PdkDraft> { cornerstone, siepic };
+
+        WaveguideBendRadiusResolver.Resolve(
+                ActiveProcessSelection.ForGroup(
+                    catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name))), pdks)
+            .ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+                "a Cornerstone-locked design resolves xs_nc's 30 µm minimum");
+        WaveguideBendRadiusResolver.Resolve(
+                ActiveProcessSelection.ForGroup(
+                    catalog.Single(g => g.MemberPdkNames.Contains(siepic.Name))), pdks)
+            .ShouldBe(SiepicMinBendRadiusUm,
+                "a SiEPIC-locked design resolves the strip 5 µm minimum");
+    }
+
+    [Fact]
+    public void BendRadius_Playground_OneFallbackForBothChiplets_Today()
+    {
+        // Companion to red step 5 (#937): Playground is the only mode that can hold both
+        // chiplets — and there the resolver knows neither chiplet's limit; one global
+        // fallback silently covers every route in the design.
+        var (cornerstone, siepic, _) = LoadProcessCatalog();
+        var pdks = new List<PdkDraft> { cornerstone, siepic };
+
+        var resolved = WaveguideBendRadiusResolver.Resolve(ActiveProcessSelection.Playground(), pdks);
+
+        resolved.ShouldBe(WaveguideBendRadiusResolver.FallbackMinimumMicrometers);
+        resolved.ShouldNotBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm);
+        resolved.ShouldNotBe(SiepicMinBendRadiusUm);
+    }
+
+    [Fact]
+    public void GdsExport_AllRoutedWaveguidesShareOneMajorityCrossSection_Today()
+    {
+        // Companion to red step 8 (#939): today's export sizes every routed waveguide
+        // with the single majority-process cross-section; the other chiplet's geometry
+        // never appears on any route. Assertions run on the generated export scripts
+        // (headless, deterministic, no Python/nazca execution).
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+
+        MixedBackendGdsOrchestrator.IsMixedBackendDesign(design.Canvas, design.Templates).ShouldBeTrue(
+            "Cornerstone (gdsfactory-native) + SiEPIC (nazca-native) is a mixed-backend design");
+
+        var scripts = new MixedBackendGdsOrchestrator().BuildScripts(
+            design.Canvas,
+            new GdsFactoryExportOptions(GdsFactoryComponentMode.StandaloneStubs),
+            null,
+            design.Templates,
+            Path.Combine(Path.GetTempPath(), "chiplet_journey", "main.py"));
+
+        var routeSizings = RouteSizings(scripts.GdsFactoryScript);
+        routeSizings.ShouldNotBeEmpty("the design carries routed waveguides the script must emit");
+        routeSizings.Distinct().Count().ShouldBe(1,
+            "today one majority-process cross-section sizes every route in BOTH chiplets (#939)");
+        routeSizings[0].ShouldBe("cross_section='xs_nc'",
+            "the majority process (Cornerstone) owns the one global route cross-section");
+
+        // The nazca partial renders SiEPIC placements only — no routed waveguide geometry.
+        scripts.NazcaPartialScript.ShouldContain("ebeam_taper_te1550");
+        scripts.NazcaPartialScript.ShouldNotContain("cross_section");
+    }
+
+    /// <summary>Loads both bundled PDKs and builds the production process catalog over them.</summary>
+    private static (PdkDraft Cornerstone, PdkDraft Siepic, IReadOnlyList<ProcessGroup> Catalog)
+        LoadProcessCatalog()
+    {
+        var cornerstone = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.CornerstonePdkFile);
+        var siepic = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.SiepicPdkFile);
+        var catalog = ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(cornerstone.Name, ProcessFingerprintFactory.From(cornerstone)),
+            new PdkProcessEntry(siepic.Name, ProcessFingerprintFactory.From(siepic)),
+        });
+        return (cornerstone, siepic, catalog);
+    }
+
+    /// <summary>The sizing keyword argument of every routed straight the script emits.</summary>
+    private static List<string> RouteSizings(string script) =>
+        System.Text.RegularExpressions.Regex
+            .Matches(script, @"gf\.components\.straight\(length=[\d.]+, ([^)]+)\)")
+            .Select(m => m.Groups[1].Value)
+            .ToList();
+}

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
@@ -1,0 +1,134 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Documented-red inventory stations of the multi-process journey (steps 3–5, 7–8) —
+/// each Skip links the issue filed for that exact single-process assumption. See
+/// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
+/// </summary>
+public partial class MultiProcessChipletJourneyTests
+{
+    [Fact(Skip = "Single-process assumption (#933 inventory): the placement policy is canvas-global — a process-locked canvas rejects the second chiplet's process; per-chiplet process scope is https://github.com/aignermax/Lunima/issues/935")]
+    public void Step3_ProcessLockedCanvas_AcceptsSecondProcessChiplet()
+    {
+        var cornerstone = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.CornerstonePdkFile);
+        var siepic = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.SiepicPdkFile);
+        var catalog = ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(cornerstone.Name, ProcessFingerprintFactory.From(cornerstone)),
+            new PdkProcessEntry(siepic.Name, ProcessFingerprintFactory.From(siepic)),
+        });
+        var active = ActiveProcessSelection.ForGroup(
+            catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name)));
+
+        var canvas = new DesignCanvasViewModel();
+        var interaction = new CanvasInteractionViewModel(canvas, new CommandManager());
+        interaction.PlacementContext = new PlacementPolicyContext(
+            () => active, () => Array.Empty<string>(), _ => null);
+
+        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(cornerstone, "Coupler");
+        interaction.CanvasClicked(100, 100);
+        canvas.Components.Count.ShouldBe(1, "the Cornerstone chiplet's process owns the canvas");
+
+        // Rung 6: a SiEPIC chiplet must be placeable NEXT TO the Cornerstone chiplet,
+        // carrying its own process — today the canvas-global lock rejects it.
+        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(siepic, "Y-Branch 1550");
+        interaction.CanvasClicked(500, 100);
+        canvas.Components.Count.ShouldBe(2,
+            "rung 6: the second chiplet's process must be placeable as a chiplet-scoped process (#935)");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): DRC-lite derives its whole rule set from the single active process (first member PDK) — per-chiplet limits are https://github.com/aignermax/Lunima/issues/936")]
+    public void Step4_DrcLite_ChecksEachChipletAgainstItsOwnProcess()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+
+        // A deliberately narrow styled route inside chiplet A's process scope:
+        // 0.2 µm < Cornerstone's 0.25 µm foundry minimum (#924).
+        var narrow = design.Canvas.ConnectPinsWithCachedRoute(
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3"),
+            MultiProcessChipletJourneyDesign.StraightPath(
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3")));
+        narrow.ShouldNotBeNull();
+        narrow!.Connection.WidthMicrometers = 0.2;
+
+        // Production behavior for a two-process design: it can only exist in Playground
+        // (#935), so RunDesignChecks runs with processLockActive = false and NO process
+        // rules at all — the Cornerstone violation passes silently.
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            design.Canvas.ConnectionManager.Connections,
+            allComponents: design.Canvas.Components.Select(vm => vm.Component),
+            processLockActive: false);
+
+        panel.Issues.ShouldContain(
+            i => i.Type == DesignIssueType.WaveguideBelowMinWidth && ReferenceEquals(i.Connection, narrow.Connection),
+            "chiplet A must be checked against Cornerstone's 0.25 µm minimum (#936)");
+        panel.Issues.Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth
+                && i.Description.Contains("si_")).ShouldBe(0,
+            "chiplet B must stay silent: SiEPIC declares no minWidthUm — no invented values (#926)");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): the router bend-radius floor is one canvas-wide value (Playground fallback 10 µm) — per-chiplet floors are https://github.com/aignermax/Lunima/issues/937")]
+    public void Step5_BendRadiusFloor_FollowsEachChipletsProcess()
+    {
+        // What production applies on a two-process (Playground) canvas: no member PDKs,
+        // so the resolver falls back to the generic 10 µm for EVERY route.
+        var floorForChipletA = WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[0]);
+
+        floorForChipletA.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+            "chiplet A's routes must honor the Cornerstone 30 µm floor, not the fallback (#937)");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): .lun persists one design-level ActiveProcess and no per-chiplet process binding — https://github.com/aignermax/Lunima/issues/938")]
+    public async Task Step7_LunRoundTrip_PerChipletProcessBindingSurvives()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+
+        var loadedCanvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
+        var loadDialog = new Mock<IFileDialogService>();
+        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        loadVm.FileDialogService = loadDialog.Object;
+        await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+        // Rung 6: chiplet A must reload bound to the Cornerstone process and chiplet B
+        // to the SiEPIC process — the design as a whole is not one process.
+        loadVm.ActiveProcess.ShouldNotBeNull();
+        loadVm.ActiveProcess!.IsPlayground.ShouldBeFalse(
+            "each chiplet's process binding must survive the round-trip (#938)");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): GDS export routes every waveguide through one global interconnect (width/radius/layer from a user preference) — per-chiplet stacks are https://github.com/aignermax/Lunima/issues/939")]
+    public void Step8_GdsExport_EachChipletRoutesOnItsOwnProcessStack()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var script = new SimpleNazcaExporter().Export(design.Canvas);
+
+        // Today the header holds ONE global interconnect — neither chiplet's stack appears.
+        script.ShouldContain("layer=203"); // chiplet A: Cornerstone NITRIDE (xs_nc, 1.2 µm) (#939)
+        script.ShouldContain("layer=1"); // chiplet B: SiEPIC WG (strip, 0.5 µm) (#939)
+    }
+}

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RoundTrip.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RoundTrip.cs
@@ -1,0 +1,98 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Green .lun round-trip station of the multi-process journey (step 6) — see
+/// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
+/// </summary>
+public partial class MultiProcessChipletJourneyTests
+{
+    [Fact]
+    public async Task Step6_LunRoundTrip_BothPdkAssignmentsSurvive()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var fieldsBefore = await SimulateAsync(design.Canvas,
+            InjectLight("source", MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o1")));
+        double outputBefore = Amplitude(fieldsBefore,
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2").LogicalPin!.IDOutFlow);
+
+        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(_designFilePath).ShouldBeTrue("Step 6: design file must be written");
+
+        // Both per-component PDK assignments are persisted in the file itself.
+        var fileText = File.ReadAllText(_designFilePath);
+        fileText.ShouldContain(design.Cornerstone.Name);
+        fileText.ShouldContain(design.Siepic.Name);
+
+        var loadedCanvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
+        loadVm.ProcessCatalogProvider = () => ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(design.Cornerstone.Name, ProcessFingerprintFactory.From(design.Cornerstone)),
+            new PdkProcessEntry(design.Siepic.Name, ProcessFingerprintFactory.From(design.Siepic)),
+        });
+        string? migrationWarning = null;
+        loadVm.OnProcessMigrationWarning = w => migrationWarning = w;
+        var loadDialog = new Mock<IFileDialogService>();
+        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        loadVm.FileDialogService = loadDialog.Object;
+        await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+        var loadedGroups = loadedCanvas.Components
+            .Where(c => c.Component is ComponentGroup)
+            .Select(c => (ComponentGroup)c.Component)
+            .ToList();
+        loadedGroups.Count.ShouldBe(2, "Step 6: both chiplets survive the round-trip");
+        var loadedA = loadedGroups.SingleOrDefault(g => g.Identifier == design.ChipletA.Identifier)
+            .ShouldNotBeNull("Step 6: chiplet A identity survives");
+        var loadedB = loadedGroups.SingleOrDefault(g => g.Identifier == design.ChipletB.Identifier)
+            .ShouldNotBeNull("Step 6: chiplet B identity survives");
+        loadedA.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
+            MultiProcessChipletJourneyDesign.ChipletAPinNames.OrderBy(n => n),
+            "Step 6: chiplet A keeps its exposed pins");
+        loadedB.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
+            MultiProcessChipletJourneyDesign.ChipletBPinNames.OrderBy(n => n),
+            "Step 6: chiplet B keeps its exposed pins");
+
+        loadedCanvas.Connections.Count.ShouldBe(1, "Step 6: the inter-chiplet abutment survives");
+        var abutment = loadedCanvas.Connections.Single();
+        var startGroup = abutment.Connection.StartPin.ParentComponent?.ParentGroup;
+        var endGroup = abutment.Connection.EndPin.ParentComponent?.ParentGroup;
+        startGroup.ShouldNotBeNull("Step 6: the abutment start pin must stay inside chiplet A");
+        endGroup.ShouldNotBeNull("Step 6: the abutment end pin must stay inside chiplet B");
+        ReferenceEquals(startGroup, endGroup).ShouldBeFalse(
+            "Step 6: the abutment must keep bridging the two chiplets");
+
+        // Current behavior, pinned honestly: the design-level process record cannot
+        // represent two processes, so the reloaded design collapses to Playground
+        // ("not manufacturable"). The desired per-chiplet binding is step 7 (#938).
+        loadVm.ActiveProcess.ShouldNotBeNull();
+        loadVm.ActiveProcess!.IsPlayground.ShouldBeTrue(
+            "Step 6: today a two-process design reloads as Playground — the single design-level " +
+            "ActiveProcess cannot hold both processes (#938)");
+        migrationWarning.ShouldNotBeNull();
+        migrationWarning!.ShouldContain("multiple processes");
+
+        var loadedFields = await SimulateAsync(loadedCanvas,
+            InjectLight("source", MultiProcessChipletJourneyDesign.ExposedPin(loadedA, "cs_coupler_o1")));
+        Amplitude(loadedFields,
+                MultiProcessChipletJourneyDesign.ExposedPin(loadedB, "si_taper_port 2").LogicalPin!.IDOutFlow)
+            .ShouldBe(outputBefore, AmplitudeTolerance,
+                "Step 6: the reloaded two-process system delivers the same output power");
+    }
+}

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -51,8 +51,14 @@ namespace UnitTests.Components;
 ///   Step 7 (RED, #938): no per-chiplet process binding exists to persist.
 ///   Step 8 (RED, #939): GDS export routes every waveguide through one global
 ///         interconnect (width/radius/layer), not each chiplet's own stack.
+///
+/// The red steps 3, 5 and 8 additionally carry GREEN "today" pins in the
+/// CurrentBehavior partial: the canvas-global lock really does reject the second
+/// process, the Playground bend floor really is one fallback for everything, and
+/// GDS export really does size every route with one majority cross-section — so a
+/// future per-chiplet fix turns those pins red as a tripwire.
 /// </summary>
-public class MultiProcessChipletJourneyTests : IDisposable
+public partial class MultiProcessChipletJourneyTests : IDisposable
 {
     private const int WavelengthNm = 1550;
     private const double AmplitudeTolerance = 1e-6;
@@ -147,209 +153,7 @@ public class MultiProcessChipletJourneyTests : IDisposable
             "Step 2: only the Y-branch's port-1 reflection leaks back to the unexcited coupler input");
     }
 
-    [Fact(Skip = "Single-process assumption (#933 inventory): the placement policy is canvas-global — a process-locked canvas rejects the second chiplet's process; per-chiplet process scope is https://github.com/aignermax/Lunima/issues/935")]
-    public void Step3_ProcessLockedCanvas_AcceptsSecondProcessChiplet()
-    {
-        var cornerstone = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.CornerstonePdkFile);
-        var siepic = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.SiepicPdkFile);
-        var catalog = ProcessCatalog.BuildGroups(new[]
-        {
-            new PdkProcessEntry(cornerstone.Name, ProcessFingerprintFactory.From(cornerstone)),
-            new PdkProcessEntry(siepic.Name, ProcessFingerprintFactory.From(siepic)),
-        });
-        var active = ActiveProcessSelection.ForGroup(
-            catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name)));
-
-        var canvas = new DesignCanvasViewModel();
-        var interaction = new CanvasInteractionViewModel(canvas, new CommandManager());
-        interaction.PlacementContext = new PlacementPolicyContext(
-            () => active, () => Array.Empty<string>(), _ => null);
-
-        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(cornerstone, "Coupler");
-        interaction.CanvasClicked(100, 100);
-        canvas.Components.Count.ShouldBe(1, "the Cornerstone chiplet's process owns the canvas");
-
-        // Rung 6: a SiEPIC chiplet must be placeable NEXT TO the Cornerstone chiplet,
-        // carrying its own process — today the canvas-global lock rejects it.
-        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(siepic, "Y-Branch 1550");
-        interaction.CanvasClicked(500, 100);
-        canvas.Components.Count.ShouldBe(2,
-            "rung 6: the second chiplet's process must be placeable as a chiplet-scoped process (#935)");
-    }
-
-    [Fact(Skip = "Single-process assumption (#933 inventory): DRC-lite derives its whole rule set from the single active process (first member PDK) — per-chiplet limits are https://github.com/aignermax/Lunima/issues/936")]
-    public void Step4_DrcLite_ChecksEachChipletAgainstItsOwnProcess()
-    {
-        var design = MultiProcessChipletJourneyDesign.BuildComposed();
-
-        // A deliberately narrow styled route inside chiplet A's process scope:
-        // 0.2 µm < Cornerstone's 0.25 µm foundry minimum (#924).
-        var narrow = design.Canvas.ConnectPinsWithCachedRoute(
-            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
-            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3"),
-            StraightPath(
-                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
-                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3")));
-        narrow.ShouldNotBeNull();
-        narrow!.Connection.WidthMicrometers = 0.2;
-
-        // Production behavior for a two-process design: it can only exist in Playground
-        // (#935), so RunDesignChecks runs with processLockActive = false and NO process
-        // rules at all — the Cornerstone violation passes silently.
-        var panel = new DesignValidationViewModel();
-        panel.RunValidation(
-            design.Canvas.ConnectionManager.Connections,
-            allComponents: design.Canvas.Components.Select(vm => vm.Component),
-            processLockActive: false);
-
-        panel.Issues.ShouldContain(
-            i => i.Type == DesignIssueType.WaveguideBelowMinWidth && ReferenceEquals(i.Connection, narrow.Connection),
-            "chiplet A must be checked against Cornerstone's 0.25 µm minimum (#936)");
-        panel.Issues.Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth
-                && i.Description.Contains("si_")).ShouldBe(0,
-            "chiplet B must stay silent: SiEPIC declares no minWidthUm — no invented values (#926)");
-    }
-
-    [Fact(Skip = "Single-process assumption (#933 inventory): the router bend-radius floor is one canvas-wide value (Playground fallback 10 µm) — per-chiplet floors are https://github.com/aignermax/Lunima/issues/937")]
-    public void Step5_BendRadiusFloor_FollowsEachChipletsProcess()
-    {
-        // What production applies on a two-process (Playground) canvas: no member PDKs,
-        // so the resolver falls back to the generic 10 µm for EVERY route.
-        var floorForChipletA = WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[0]);
-
-        floorForChipletA.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
-            "chiplet A's routes must honor the Cornerstone 30 µm floor, not the fallback (#937)");
-    }
-
-    [Fact]
-    public async Task Step6_LunRoundTrip_BothPdkAssignmentsSurvive()
-    {
-        var design = MultiProcessChipletJourneyDesign.BuildComposed();
-        var fieldsBefore = await SimulateAsync(design.Canvas,
-            InjectLight("source", MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o1")));
-        double outputBefore = Amplitude(fieldsBefore,
-            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2").LogicalPin!.IDOutFlow);
-
-        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
-        var saveDialog = new Mock<IFileDialogService>();
-        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(_designFilePath);
-        saveVm.FileDialogService = saveDialog.Object;
-        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
-        File.Exists(_designFilePath).ShouldBeTrue("Step 6: design file must be written");
-
-        // Both per-component PDK assignments are persisted in the file itself.
-        var fileText = File.ReadAllText(_designFilePath);
-        fileText.ShouldContain(design.Cornerstone.Name);
-        fileText.ShouldContain(design.Siepic.Name);
-
-        var loadedCanvas = new DesignCanvasViewModel();
-        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
-        loadVm.ProcessCatalogProvider = () => ProcessCatalog.BuildGroups(new[]
-        {
-            new PdkProcessEntry(design.Cornerstone.Name, ProcessFingerprintFactory.From(design.Cornerstone)),
-            new PdkProcessEntry(design.Siepic.Name, ProcessFingerprintFactory.From(design.Siepic)),
-        });
-        string? migrationWarning = null;
-        loadVm.OnProcessMigrationWarning = w => migrationWarning = w;
-        var loadDialog = new Mock<IFileDialogService>();
-        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(_designFilePath);
-        loadVm.FileDialogService = loadDialog.Object;
-        await loadVm.LoadDesignCommand.ExecuteAsync(null);
-
-        var loadedGroups = loadedCanvas.Components
-            .Where(c => c.Component is ComponentGroup)
-            .Select(c => (ComponentGroup)c.Component)
-            .ToList();
-        loadedGroups.Count.ShouldBe(2, "Step 6: both chiplets survive the round-trip");
-        var loadedA = loadedGroups.SingleOrDefault(g => g.Identifier == design.ChipletA.Identifier)
-            .ShouldNotBeNull("Step 6: chiplet A identity survives");
-        var loadedB = loadedGroups.SingleOrDefault(g => g.Identifier == design.ChipletB.Identifier)
-            .ShouldNotBeNull("Step 6: chiplet B identity survives");
-        loadedA.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
-            MultiProcessChipletJourneyDesign.ChipletAPinNames.OrderBy(n => n),
-            "Step 6: chiplet A keeps its exposed pins");
-        loadedB.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
-            MultiProcessChipletJourneyDesign.ChipletBPinNames.OrderBy(n => n),
-            "Step 6: chiplet B keeps its exposed pins");
-
-        loadedCanvas.Connections.Count.ShouldBe(1, "Step 6: the inter-chiplet abutment survives");
-        var abutment = loadedCanvas.Connections.Single();
-        var startGroup = abutment.Connection.StartPin.ParentComponent?.ParentGroup;
-        var endGroup = abutment.Connection.EndPin.ParentComponent?.ParentGroup;
-        startGroup.ShouldNotBeNull("Step 6: the abutment start pin must stay inside chiplet A");
-        endGroup.ShouldNotBeNull("Step 6: the abutment end pin must stay inside chiplet B");
-        ReferenceEquals(startGroup, endGroup).ShouldBeFalse(
-            "Step 6: the abutment must keep bridging the two chiplets");
-
-        // Current behavior, pinned honestly: the design-level process record cannot
-        // represent two processes, so the reloaded design collapses to Playground
-        // ("not manufacturable"). The desired per-chiplet binding is step 7 (#938).
-        loadVm.ActiveProcess.ShouldNotBeNull();
-        loadVm.ActiveProcess!.IsPlayground.ShouldBeTrue(
-            "Step 6: today a two-process design reloads as Playground — the single design-level " +
-            "ActiveProcess cannot hold both processes (#938)");
-        migrationWarning.ShouldNotBeNull();
-        migrationWarning!.ShouldContain("multiple processes");
-
-        var loadedFields = await SimulateAsync(loadedCanvas,
-            InjectLight("source", MultiProcessChipletJourneyDesign.ExposedPin(loadedA, "cs_coupler_o1")));
-        Amplitude(loadedFields,
-                MultiProcessChipletJourneyDesign.ExposedPin(loadedB, "si_taper_port 2").LogicalPin!.IDOutFlow)
-            .ShouldBe(outputBefore, AmplitudeTolerance,
-                "Step 6: the reloaded two-process system delivers the same output power");
-    }
-
-    [Fact(Skip = "Single-process assumption (#933 inventory): .lun persists one design-level ActiveProcess and no per-chiplet process binding — https://github.com/aignermax/Lunima/issues/938")]
-    public async Task Step7_LunRoundTrip_PerChipletProcessBindingSurvives()
-    {
-        var design = MultiProcessChipletJourneyDesign.BuildComposed();
-        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
-        var saveDialog = new Mock<IFileDialogService>();
-        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(_designFilePath);
-        saveVm.FileDialogService = saveDialog.Object;
-        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
-
-        var loadedCanvas = new DesignCanvasViewModel();
-        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
-        var loadDialog = new Mock<IFileDialogService>();
-        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(_designFilePath);
-        loadVm.FileDialogService = loadDialog.Object;
-        await loadVm.LoadDesignCommand.ExecuteAsync(null);
-
-        // Rung 6: chiplet A must reload bound to the Cornerstone process and chiplet B
-        // to the SiEPIC process — the design as a whole is not one process.
-        loadVm.ActiveProcess.ShouldNotBeNull();
-        loadVm.ActiveProcess!.IsPlayground.ShouldBeFalse(
-            "each chiplet's process binding must survive the round-trip (#938)");
-    }
-
-    [Fact(Skip = "Single-process assumption (#933 inventory): GDS export routes every waveguide through one global interconnect (width/radius/layer from a user preference) — per-chiplet stacks are https://github.com/aignermax/Lunima/issues/939")]
-    public void Step8_GdsExport_EachChipletRoutesOnItsOwnProcessStack()
-    {
-        var design = MultiProcessChipletJourneyDesign.BuildComposed();
-        var script = new SimpleNazcaExporter().Export(design.Canvas);
-
-        // Today the header holds ONE global interconnect — neither chiplet's stack appears.
-        script.ShouldContain("layer=203"); // chiplet A: Cornerstone NITRIDE (xs_nc, 1.2 µm) (#939)
-        script.ShouldContain("layer=1"); // chiplet B: SiEPIC WG (strip, 0.5 µm) (#939)
-    }
-
     // ── Journey helpers ─────────────────────────────────────────────────────────
-
-    private static RoutedPath StraightPath(PhysicalPin from, PhysicalPin to)
-    {
-        var (x1, y1) = from.GetAbsolutePosition();
-        var (x2, y2) = to.GetAbsolutePosition();
-        var path = new RoutedPath();
-        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, 0));
-        return path;
-    }
 
     private static (ExternalInput Input, Guid PinIdInFlow) InjectLight(string name, PhysicalPin pin) =>
         (new ExternalInput(name, new LaserType(LightColor.Red), 0, new Complex(1.0, 0), true),

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -1,0 +1,401 @@
+using System.Collections.ObjectModel;
+using System.Numerics;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Process;
+using CAP_Core.ExternalPorts;
+using CAP_Core.Grid;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components;
+
+/// <summary>
+/// Multi-process chiplet journey (issue #933, #537-guardrail, rung-6 pre-probe),
+/// exercised headlessly on the real bundled PDKs — chiplet A from CornerStone SiN
+/// 300nm, chiplet B from SiEPIC EBeam — composed pin-to-pin on one canvas
+/// (<see cref="MultiProcessChipletJourneyDesign"/>, recipe: #929).
+///
+/// The journey is an INVENTORY of the single-process assumptions on the road to
+/// per-chiplet fabrication layer stacks (north-star #537, rung 6/7). Green steps
+/// prove real behavior with honest value assertions; every station that hits a
+/// single-process/single-chip assumption stays documented-red via Skip + link to
+/// the issue filed for that exact assumption (pattern #910 → #909). The test does
+/// not lie green.
+///
+///   Step 1 (green): both chiplets group, place and compose pin-to-pin across the
+///         process boundary; pins carry their own PDK's width/layer stamps.
+///   Step 2 (green): S-matrix simulation delivers physically correct power across
+///         the chiplet boundary (value assertions from the bundled PDK data).
+///   Step 3 (RED, #935): placement policy is canvas-global — a process-locked
+///         canvas cannot take a second-process chiplet; only Playground can mix.
+///   Step 4 (RED, #936): DRC-lite rules come from the single active process — a
+///         two-process design checks nothing PDK-dependent at all.
+///   Step 5 (RED, #937): the router's bend-radius floor is one canvas-wide value.
+///   Step 6 (green): .lun round-trip — both per-component PDK assignments, the
+///         groups, the abutment and the physics survive (the design reloads as
+///         Playground: pinned here as current behavior, #938 is the fix).
+///   Step 7 (RED, #938): no per-chiplet process binding exists to persist.
+///   Step 8 (RED, #939): GDS export routes every waveguide through one global
+///         interconnect (width/radius/layer), not each chiplet's own stack.
+/// </summary>
+public class MultiProcessChipletJourneyTests : IDisposable
+{
+    private const int WavelengthNm = 1550;
+    private const double AmplitudeTolerance = 1e-6;
+    private const double PositionTolerance = 1e-9;
+
+    private readonly string _designFilePath =
+        Path.Combine(Path.GetTempPath(), $"multiprocess_chiplet_{Guid.NewGuid():N}.lun");
+
+    public void Dispose()
+    {
+        try
+        {
+            if (File.Exists(_designFilePath)) File.Delete(_designFilePath);
+        }
+        catch
+        {
+            // Temp cleanup must never fail the test run.
+        }
+    }
+
+    [Fact]
+    public void Step1_PlaceAndCompose_TwoProcessChiplets_OnOneCanvas()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+
+        design.ChipletA.ChildComponents.Count.ShouldBe(2, "Step 1: chiplet A owns coupler + MMI");
+        design.ChipletA.InternalPaths.Count.ShouldBe(1, "Step 1: the coupler→MMI wire freezes into chiplet A");
+        design.ChipletA.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
+            MultiProcessChipletJourneyDesign.ChipletAPinNames.OrderBy(n => n),
+            "Step 1: chiplet A exposes the free coupler ports and both MMI outputs");
+        design.ChipletB.ChildComponents.Count.ShouldBe(2, "Step 1: chiplet B owns Y-branch + taper");
+        design.ChipletB.InternalPaths.Count.ShouldBe(1, "Step 1: the Y-branch→taper wire freezes into chiplet B");
+        design.ChipletB.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
+            MultiProcessChipletJourneyDesign.ChipletBPinNames.OrderBy(n => n),
+            "Step 1: chiplet B exposes the combiner input, the free arm and the output");
+
+        // Every pin keeps the width/layer stamp of the PDK it came from — the
+        // per-component data substrate any per-chiplet stack must build on.
+        var aOut = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o2");
+        var bIn = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 1");
+        aOut.WaveguideWidthMicrometers.ShouldBe(1.2, "Step 1: Cornerstone xs_nc width stamps chiplet A's pins");
+        aOut.Layer.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneGdsLayer,
+            "Step 1: Cornerstone NITRIDE layer stamps chiplet A's pins");
+        bIn.WaveguideWidthMicrometers.ShouldBe(0.5, "Step 1: SiEPIC strip width stamps chiplet B's pins");
+        bIn.Layer.ShouldBe(MultiProcessChipletJourneyDesign.SiepicGdsLayer,
+            "Step 1: SiEPIC WG layer stamps chiplet B's pins");
+
+        var (ax, ay) = aOut.GetAbsolutePosition();
+        var (bx, by) = bIn.GetAbsolutePosition();
+        bx.ShouldBe(ax, PositionTolerance, "Step 1: the cross-process pin pair must coincide in X");
+        by.ShouldBe(ay, PositionTolerance, "Step 1: the cross-process pin pair must coincide in Y");
+
+        design.Canvas.ConnectionManager.Connections.Count.ShouldBe(1,
+            "Step 1: exactly the one inter-chiplet abutment exists at canvas level");
+        var findings = new DesignValidator().Validate(design.Canvas.ConnectionManager.Connections);
+        findings.ShouldAllBe(
+            i => i.Type == DesignIssueType.PinMismatch,
+            "Step 1: the only findings at the boundary are the honest pin mismatches — a direct " +
+            "SiN↔SOI butt joint really has a width (1.2↔0.5 µm) and layer (203↔1) step a real " +
+            "edge coupler would absorb; the PDK-stamped pins report it correctly");
+        findings.Count.ShouldBe(2, "Step 1: one width + one layer mismatch, nothing else");
+        findings.ShouldAllBe(
+            i => ReferenceEquals(i.Connection, design.Canvas.ConnectionManager.Connections.Single()),
+            "Step 1: both mismatches attribute to the inter-chiplet abutment");
+        findings.Count(i => i.Type == DesignIssueType.BlockedPath).ShouldBe(0,
+            "Step 1: the cross-process abutment must not raise BlockedPath (#923)");
+    }
+
+    [Fact]
+    public async Task Step2_Simulation_LightCrossesChipletBoundary()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var input = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o1");
+        var fields = await SimulateAsync(design.Canvas, InjectLight("source", input));
+
+        double boundary = Amplitude(fields,
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o2").LogicalPin!.IDOutFlow);
+        double output = Amplitude(fields,
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2").LogicalPin!.IDOutFlow);
+        double freeArm = Amplitude(fields,
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 3").LogicalPin!.IDOutFlow);
+        double leakage = Amplitude(fields,
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o2").LogicalPin!.IDOutFlow);
+
+        boundary.ShouldBe(MultiProcessChipletJourneyDesign.ExpectedBoundaryAmplitude, 2e-3,
+            "Step 2: coupler × MMI from the Cornerstone S-matrices leaves chiplet A");
+        output.ShouldBe(MultiProcessChipletJourneyDesign.ExpectedOutputAmplitude, MultiProcessChipletJourneyDesign.SolverValueTolerance,
+            "Step 2: boundary × Y-branch × taper from the SiEPIC S-matrices arrives at chiplet B's output");
+        freeArm.ShouldBe(MultiProcessChipletJourneyDesign.ExpectedFreeArmAmplitude, MultiProcessChipletJourneyDesign.SolverValueTolerance,
+            "Step 2: the Y-branch's free arm carries its physical share — the boundary is truly crossed");
+        leakage.ShouldBeLessThan(0.02,
+            "Step 2: only the Y-branch's port-1 reflection leaks back to the unexcited coupler input");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): the placement policy is canvas-global — a process-locked canvas rejects the second chiplet's process; per-chiplet process scope is https://github.com/aignermax/Lunima/issues/935")]
+    public void Step3_ProcessLockedCanvas_AcceptsSecondProcessChiplet()
+    {
+        var cornerstone = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.CornerstonePdkFile);
+        var siepic = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.SiepicPdkFile);
+        var catalog = ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(cornerstone.Name, ProcessFingerprintFactory.From(cornerstone)),
+            new PdkProcessEntry(siepic.Name, ProcessFingerprintFactory.From(siepic)),
+        });
+        var active = ActiveProcessSelection.ForGroup(
+            catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name)));
+
+        var canvas = new DesignCanvasViewModel();
+        var interaction = new CanvasInteractionViewModel(canvas, new CommandManager());
+        interaction.PlacementContext = new PlacementPolicyContext(
+            () => active, () => Array.Empty<string>(), _ => null);
+
+        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(cornerstone, "Coupler");
+        interaction.CanvasClicked(100, 100);
+        canvas.Components.Count.ShouldBe(1, "the Cornerstone chiplet's process owns the canvas");
+
+        // Rung 6: a SiEPIC chiplet must be placeable NEXT TO the Cornerstone chiplet,
+        // carrying its own process — today the canvas-global lock rejects it.
+        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(siepic, "Y-Branch 1550");
+        interaction.CanvasClicked(500, 100);
+        canvas.Components.Count.ShouldBe(2,
+            "rung 6: the second chiplet's process must be placeable as a chiplet-scoped process (#935)");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): DRC-lite derives its whole rule set from the single active process (first member PDK) — per-chiplet limits are https://github.com/aignermax/Lunima/issues/936")]
+    public void Step4_DrcLite_ChecksEachChipletAgainstItsOwnProcess()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+
+        // A deliberately narrow styled route inside chiplet A's process scope:
+        // 0.2 µm < Cornerstone's 0.25 µm foundry minimum (#924).
+        var narrow = design.Canvas.ConnectPinsWithCachedRoute(
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3"),
+            StraightPath(
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3")));
+        narrow.ShouldNotBeNull();
+        narrow!.Connection.WidthMicrometers = 0.2;
+
+        // Production behavior for a two-process design: it can only exist in Playground
+        // (#935), so RunDesignChecks runs with processLockActive = false and NO process
+        // rules at all — the Cornerstone violation passes silently.
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            design.Canvas.ConnectionManager.Connections,
+            allComponents: design.Canvas.Components.Select(vm => vm.Component),
+            processLockActive: false);
+
+        panel.Issues.ShouldContain(
+            i => i.Type == DesignIssueType.WaveguideBelowMinWidth && ReferenceEquals(i.Connection, narrow.Connection),
+            "chiplet A must be checked against Cornerstone's 0.25 µm minimum (#936)");
+        panel.Issues.Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth
+                && i.Description.Contains("si_")).ShouldBe(0,
+            "chiplet B must stay silent: SiEPIC declares no minWidthUm — no invented values (#926)");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): the router bend-radius floor is one canvas-wide value (Playground fallback 10 µm) — per-chiplet floors are https://github.com/aignermax/Lunima/issues/937")]
+    public void Step5_BendRadiusFloor_FollowsEachChipletsProcess()
+    {
+        // What production applies on a two-process (Playground) canvas: no member PDKs,
+        // so the resolver falls back to the generic 10 µm for EVERY route.
+        var floorForChipletA = WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[0]);
+
+        floorForChipletA.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+            "chiplet A's routes must honor the Cornerstone 30 µm floor, not the fallback (#937)");
+    }
+
+    [Fact]
+    public async Task Step6_LunRoundTrip_BothPdkAssignmentsSurvive()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var fieldsBefore = await SimulateAsync(design.Canvas,
+            InjectLight("source", MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o1")));
+        double outputBefore = Amplitude(fieldsBefore,
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2").LogicalPin!.IDOutFlow);
+
+        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(_designFilePath).ShouldBeTrue("Step 6: design file must be written");
+
+        // Both per-component PDK assignments are persisted in the file itself.
+        var fileText = File.ReadAllText(_designFilePath);
+        fileText.ShouldContain(design.Cornerstone.Name);
+        fileText.ShouldContain(design.Siepic.Name);
+
+        var loadedCanvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
+        loadVm.ProcessCatalogProvider = () => ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(design.Cornerstone.Name, ProcessFingerprintFactory.From(design.Cornerstone)),
+            new PdkProcessEntry(design.Siepic.Name, ProcessFingerprintFactory.From(design.Siepic)),
+        });
+        string? migrationWarning = null;
+        loadVm.OnProcessMigrationWarning = w => migrationWarning = w;
+        var loadDialog = new Mock<IFileDialogService>();
+        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        loadVm.FileDialogService = loadDialog.Object;
+        await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+        var loadedGroups = loadedCanvas.Components
+            .Where(c => c.Component is ComponentGroup)
+            .Select(c => (ComponentGroup)c.Component)
+            .ToList();
+        loadedGroups.Count.ShouldBe(2, "Step 6: both chiplets survive the round-trip");
+        var loadedA = loadedGroups.SingleOrDefault(g => g.Identifier == design.ChipletA.Identifier)
+            .ShouldNotBeNull("Step 6: chiplet A identity survives");
+        var loadedB = loadedGroups.SingleOrDefault(g => g.Identifier == design.ChipletB.Identifier)
+            .ShouldNotBeNull("Step 6: chiplet B identity survives");
+        loadedA.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
+            MultiProcessChipletJourneyDesign.ChipletAPinNames.OrderBy(n => n),
+            "Step 6: chiplet A keeps its exposed pins");
+        loadedB.ExternalPins.Select(p => p.Name).OrderBy(n => n).ShouldBe(
+            MultiProcessChipletJourneyDesign.ChipletBPinNames.OrderBy(n => n),
+            "Step 6: chiplet B keeps its exposed pins");
+
+        loadedCanvas.Connections.Count.ShouldBe(1, "Step 6: the inter-chiplet abutment survives");
+        var abutment = loadedCanvas.Connections.Single();
+        var startGroup = abutment.Connection.StartPin.ParentComponent?.ParentGroup;
+        var endGroup = abutment.Connection.EndPin.ParentComponent?.ParentGroup;
+        startGroup.ShouldNotBeNull("Step 6: the abutment start pin must stay inside chiplet A");
+        endGroup.ShouldNotBeNull("Step 6: the abutment end pin must stay inside chiplet B");
+        ReferenceEquals(startGroup, endGroup).ShouldBeFalse(
+            "Step 6: the abutment must keep bridging the two chiplets");
+
+        // Current behavior, pinned honestly: the design-level process record cannot
+        // represent two processes, so the reloaded design collapses to Playground
+        // ("not manufacturable"). The desired per-chiplet binding is step 7 (#938).
+        loadVm.ActiveProcess.ShouldNotBeNull();
+        loadVm.ActiveProcess!.IsPlayground.ShouldBeTrue(
+            "Step 6: today a two-process design reloads as Playground — the single design-level " +
+            "ActiveProcess cannot hold both processes (#938)");
+        migrationWarning.ShouldNotBeNull();
+        migrationWarning!.ShouldContain("multiple processes");
+
+        var loadedFields = await SimulateAsync(loadedCanvas,
+            InjectLight("source", MultiProcessChipletJourneyDesign.ExposedPin(loadedA, "cs_coupler_o1")));
+        Amplitude(loadedFields,
+                MultiProcessChipletJourneyDesign.ExposedPin(loadedB, "si_taper_port 2").LogicalPin!.IDOutFlow)
+            .ShouldBe(outputBefore, AmplitudeTolerance,
+                "Step 6: the reloaded two-process system delivers the same output power");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): .lun persists one design-level ActiveProcess and no per-chiplet process binding — https://github.com/aignermax/Lunima/issues/938")]
+    public async Task Step7_LunRoundTrip_PerChipletProcessBindingSurvives()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+
+        var loadedCanvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
+        var loadDialog = new Mock<IFileDialogService>();
+        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        loadVm.FileDialogService = loadDialog.Object;
+        await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+        // Rung 6: chiplet A must reload bound to the Cornerstone process and chiplet B
+        // to the SiEPIC process — the design as a whole is not one process.
+        loadVm.ActiveProcess.ShouldNotBeNull();
+        loadVm.ActiveProcess!.IsPlayground.ShouldBeFalse(
+            "each chiplet's process binding must survive the round-trip (#938)");
+    }
+
+    [Fact(Skip = "Single-process assumption (#933 inventory): GDS export routes every waveguide through one global interconnect (width/radius/layer from a user preference) — per-chiplet stacks are https://github.com/aignermax/Lunima/issues/939")]
+    public void Step8_GdsExport_EachChipletRoutesOnItsOwnProcessStack()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var script = new SimpleNazcaExporter().Export(design.Canvas);
+
+        // Today the header holds ONE global interconnect — neither chiplet's stack appears.
+        script.ShouldContain("layer=203"); // chiplet A: Cornerstone NITRIDE (xs_nc, 1.2 µm) (#939)
+        script.ShouldContain("layer=1"); // chiplet B: SiEPIC WG (strip, 0.5 µm) (#939)
+    }
+
+    // ── Journey helpers ─────────────────────────────────────────────────────────
+
+    private static RoutedPath StraightPath(PhysicalPin from, PhysicalPin to)
+    {
+        var (x1, y1) = from.GetAbsolutePosition();
+        var (x2, y2) = to.GetAbsolutePosition();
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, 0));
+        return path;
+    }
+
+    private static (ExternalInput Input, Guid PinIdInFlow) InjectLight(string name, PhysicalPin pin) =>
+        (new ExternalInput(name, new LaserType(LightColor.Red), 0, new Complex(1.0, 0), true),
+         pin.LogicalPin!.IDInFlow);
+
+    /// <summary>Runs the S-matrix field propagation over everything currently on the canvas.</summary>
+    private static async Task<Dictionary<Guid, Complex>> SimulateAsync(
+        DesignCanvasViewModel canvas, params (ExternalInput Input, Guid PinIdInFlow)[] inputs)
+    {
+        var portManager = new PhysicalExternalPortManager();
+        foreach (var (input, pinIdInFlow) in inputs)
+        {
+            portManager.AddLightSource(input, pinIdInFlow);
+        }
+
+        var tileManager = new ComponentListTileManager();
+        foreach (var viewModel in canvas.Components)
+        {
+            tileManager.AddComponent(viewModel.Component);
+        }
+
+        var grid = GridManager.CreateForSimulation(tileManager, canvas.ConnectionManager, portManager);
+        var calculator = new GridLightCalculator(new SystemMatrixBuilder(grid), grid);
+        return await calculator.CalculateFieldPropagationAsync(new CancellationTokenSource(), WavelengthNm);
+    }
+
+    private static double Amplitude(Dictionary<Guid, Complex> fields, Guid pinFlow) =>
+        fields.TryGetValue(pinFlow, out var value)
+            ? value.Magnitude
+            : throw new ShouldAssertException($"pin flow {pinFlow} missing from simulated fields");
+
+    /// <summary>Creates the file-operations facade used for the .lun save/load round-trip.</summary>
+    private static FileOperationsViewModel CreateFileOperations(
+        DesignCanvasViewModel canvas, List<ComponentTemplate> templates)
+    {
+        var library = new ObservableCollection<ComponentTemplate>(templates);
+        return new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new CAP_Core.Export.SaxExporter(),
+            library,
+            new GdsExportViewModel(new CAP_Core.Export.GdsExportService()),
+            new CAP.Avalonia.ViewModels.Export.PhotonTorchExportViewModel(
+                new CAP_Core.Export.PhotonTorchExporter(), canvas),
+            null!,
+            errorConsole: new CAP_Core.ErrorConsoleService());
+    }
+}


### PR DESCRIPTION
## What & why

Issue #933 (#537 guardrail, rung-6 pre-probe): before per-chiplet fabrication layer stacks (north-star rung 6/7) can become real, we need an honest inventory of where the **single-process assumption** lives. This PR adds the journey test that produces that inventory — no refactoring, deliverable = test + findings.

New journey `UnitTests/Components/MultiProcessChipletJourneyTests.cs` (+ design builder `MultiProcessChipletJourneyDesign.cs`), patterned on #929 (`MultiChipletCompositionJourneyTests`) and #915 (`DrcLiteJourneyDesign`):

- **Chiplet A** from the bundled **CornerStone SiN 300nm** PDK (Coupler → Mmi1x2), **chiplet B** from the bundled **SiEPIC EBeam** PDK (Y-Branch → Taper), each grouped on one canvas and composed pin-to-pin through the real router (#923 abutment across the process boundary).
- Runs headless, deterministic, **without nazca**.

### Green steps (honest, value-asserted)

- **Step 1 — placement & composition**: both chiplets group/place/compose; pins keep their own PDK's stamps (1.2 µm/layer 203 vs 0.5 µm/layer 1); the only validator findings at the boundary are the two *physically honest* pin mismatches (width + layer) a real edge coupler would absorb.
- **Step 2 — simulation across the boundary**: S-matrix propagation delivers the PDK-true power at chiplet B's output (coupler × MMI × Y-branch × taper from the bundled JSONs, ±5e-3 solver/mirror tolerance; free-arm share and back-reflection leakage asserted too).
- **Step 6 — .lun round-trip**: both per-component `PdkSource` assignments survive (asserted in the file text itself), both groups/exposed pins/the cross-chiplet abutment survive, and the reloaded system reproduces the exact same output amplitude (±1e-6). Honestly pinned: the design reloads as **Playground** with the "multiple processes — not manufacturable" warning (that IS today's behavior; #938 is the fix).

### Documented-red steps (Skip + link to the filed issue; the test does not lie green)

| Step | Assumption | Issue |
|---|---|---|
| 3 | Placement policy is canvas-global; groups carry no process identity — two processes only coexist in Playground | #935 |
| 4 | DRC-lite takes its whole rule set from the single active process (first member PDK) — a two-process design checks nothing PDK-dependent | #936 |
| 5 | The router's bend-radius floor is one canvas-wide value (Playground fallback 10 µm under-enforces Cornerstone's 30 µm) | #937 |
| 7 | .lun persists one design-level `ActiveProcess`; no per-chiplet process binding exists | #938 |
| 8 | GDS export routes every waveguide through one global interconnect (width/radius/layer from a user preference) | #939 |

Each red step contains the desired-behavior assertions so it can be un-skipped when its issue lands (pattern #910 → #909).

## How tested

`dotnet test UnitTests/UnitTests.csproj --filter "Category!=Slow"`

Local suite: 5593 passed, 0 failed (20 skipped, 5 of them the documented-red journey steps above).

No production code changed; no UI changed — no manual verification needed after vacation.