### PR TITLE
Agent: Truth-table extraction for grouped logic circuits, NAND-game rung-4 seed (#934)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicOutputValue.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicOutputValue.cs
@@ -1,0 +1,13 @@
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// One evaluated logic output of a truth-table row: the classified bit together with
+/// the raw simulated power, so it stays visible <em>why</em> an output is 1 —
+/// a 0.93 and a 0.51 above the same threshold teach different lessons about the gate.
+/// </summary>
+/// <param name="IsOne">True when <see cref="Power"/> reached the table's power threshold.</param>
+/// <param name="Power">
+/// Normalized optical power leaving the group through this output pin
+/// (1.0 = the full power of one active input).
+/// </param>
+public sealed record LogicOutputValue(bool IsOne, double Power);

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTable.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTable.cs
@@ -1,0 +1,51 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The digital truth table extracted from a <see cref="ComponentGroup"/> by
+/// <see cref="TruthTableExtractor"/>: every binary input combination mapped to the
+/// resulting logic outputs, each output carrying both its classified bit and the
+/// raw simulated power behind it.
+/// </summary>
+public sealed class TruthTable
+{
+    /// <summary>Assembles an immutable extraction result.</summary>
+    public TruthTable(
+        string groupName,
+        IReadOnlyList<string> inputPinNames,
+        IReadOnlyList<string> outputPinNames,
+        double powerThreshold,
+        int wavelengthNm,
+        IReadOnlyList<TruthTableRow> rows)
+    {
+        GroupName = groupName;
+        InputPinNames = inputPinNames;
+        OutputPinNames = outputPinNames;
+        PowerThreshold = powerThreshold;
+        WavelengthNm = wavelengthNm;
+        Rows = rows;
+    }
+
+    /// <summary>Name of the group the table was extracted from.</summary>
+    public string GroupName { get; }
+
+    /// <summary>Logic input pin names, in the bit order used by <see cref="Rows"/>.</summary>
+    public IReadOnlyList<string> InputPinNames { get; }
+
+    /// <summary>Logic output pin names.</summary>
+    public IReadOnlyList<string> OutputPinNames { get; }
+
+    /// <summary>Normalized power threshold used for classification (power ≥ threshold is logic 1).</summary>
+    public double PowerThreshold { get; }
+
+    /// <summary>Laser wavelength in nm the table was simulated at.</summary>
+    public int WavelengthNm { get; }
+
+    /// <summary>
+    /// One row per binary input combination — 2^<see cref="InputPinNames"/>.Count rows
+    /// in binary counting order: bit i of the row index is the logic level of
+    /// InputPinNames[i], so row 0 is all inputs off and the last row is all inputs on.
+    /// </summary>
+    public IReadOnlyList<TruthTableRow> Rows { get; }
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTableExtractor.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTableExtractor.cs
@@ -1,0 +1,231 @@
+using System.Numerics;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.ExternalPorts;
+using CAP_Core.Grid;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Extracts a digital truth table from a grouped photonic circuit by running the
+/// existing S-matrix simulation (<see cref="GridLightCalculator"/>) once per binary
+/// input combination: an "on" logic input means coherent laser light (unit amplitude,
+/// zero phase) is injected at that group pin, and an output counts as logic 1 when
+/// its normalized optical power reaches the caller-supplied threshold. All "on"
+/// inputs of one combination are simulated together — coherent, exactly like the
+/// regular field simulation — so interference shows up in the raw power values.
+/// The group is always simulated in isolation; canvas connections around the group
+/// are irrelevant for its gate behavior.
+///
+/// Boundaries: at most <see cref="MaxLogicInputs"/> logic inputs (the combination
+/// count grows as 2^n and each combination is a full simulation run), the power
+/// threshold is a mandatory parameter (no guessing), and the whole table is
+/// extracted at one laser wavelength.
+/// </summary>
+public sealed class TruthTableExtractor
+{
+    /// <summary>
+    /// Maximum number of logic inputs: 4 inputs produce 16 simulation runs, which
+    /// stays fast enough for interactive use and covers the gates of the NAND game.
+    /// </summary>
+    public const int MaxLogicInputs = 4;
+
+    /// <summary>In-flow field of an "on" input: unit amplitude, zero phase — coherent across all on inputs.</summary>
+    private static readonly Complex OnInputField = new(1.0, 0.0);
+
+    /// <summary>
+    /// Simulates every binary input combination of <paramref name="group"/> and
+    /// classifies each output against <paramref name="powerThreshold"/>.
+    /// </summary>
+    /// <param name="group">The grouped circuit under test; its external pins form the gate interface.</param>
+    /// <param name="inputPinNames">
+    /// Names of the group's external pins to drive as logic inputs
+    /// (1 to <see cref="MaxLogicInputs"/> entries, no duplicates, disjoint from the outputs).
+    /// </param>
+    /// <param name="outputPinNames">Names of the group's external pins to observe as logic outputs.</param>
+    /// <param name="powerThreshold">
+    /// Normalized power threshold in the open interval (0, 1): an output is logic 1 when
+    /// its power is ≥ threshold. Each active input injects power 1.
+    /// </param>
+    /// <param name="wavelengthNm">Laser wavelength in nm shared by all inputs (the active laser).</param>
+    /// <param name="cancellationToken">Cancels the extraction between combinations.</param>
+    /// <returns>The truth table, including the raw simulated power behind every output bit.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="group"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// A pin list is empty, contains duplicates, overlaps the other list, exceeds
+    /// <see cref="MaxLogicInputs"/> inputs, or names a pin the group does not expose.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="powerThreshold"/> lies outside (0, 1), or <paramref name="wavelengthNm"/> is not positive.
+    /// </exception>
+    public async Task<TruthTable> ExtractAsync(
+        ComponentGroup group,
+        IReadOnlyList<string> inputPinNames,
+        IReadOnlyList<string> outputPinNames,
+        double powerThreshold,
+        int wavelengthNm,
+        CancellationToken cancellationToken = default)
+    {
+        if (group == null) throw new ArgumentNullException(nameof(group));
+        ValidateArguments(inputPinNames, outputPinNames, powerThreshold, wavelengthNm);
+        var inputs = ResolvePins(group, inputPinNames, nameof(inputPinNames));
+        var outputs = ResolvePins(group, outputPinNames, nameof(outputPinNames));
+
+        // Compute the group closure once up front: a group that cannot simulate at
+        // all fails before the first row, and the per-combination runs reuse it.
+        group.EnsureSMatrixComputed();
+
+        var rowCount = 1 << inputs.Count;
+        var rows = new List<TruthTableRow>(rowCount);
+        for (var pattern = 0; pattern < rowCount; pattern++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            rows.Add(await SimulateCombinationAsync(
+                group, inputs, outputs, pattern, powerThreshold, wavelengthNm, cancellationToken));
+        }
+
+        return new TruthTable(
+            group.GroupName,
+            inputPinNames.ToArray(),
+            outputPinNames.ToArray(),
+            powerThreshold,
+            wavelengthNm,
+            rows);
+    }
+
+    /// <summary>Simulates one input bit pattern and classifies every declared output pin.</summary>
+    private static async Task<TruthTableRow> SimulateCombinationAsync(
+        ComponentGroup group,
+        IReadOnlyList<GroupPin> inputs,
+        IReadOnlyList<GroupPin> outputs,
+        int pattern,
+        double powerThreshold,
+        int wavelengthNm,
+        CancellationToken cancellationToken)
+    {
+        var portManager = new PhysicalExternalPortManager();
+        var inputBits = new Dictionary<string, bool>(inputs.Count);
+        for (var i = 0; i < inputs.Count; i++)
+        {
+            var isOn = (pattern & (1 << i)) != 0;
+            inputBits[inputs[i].Name] = isOn;
+            if (isOn)
+            {
+                portManager.AddLightSource(CreateOnInput(inputs[i], wavelengthNm), InFlowIdOf(inputs[i]));
+            }
+        }
+
+        var fields = await RunSimulationAsync(group, portManager, wavelengthNm, cancellationToken);
+
+        var outputValues = new Dictionary<string, LogicOutputValue>(outputs.Count);
+        foreach (var output in outputs)
+        {
+            var power = OutputPower(fields, output);
+            outputValues[output.Name] = new LogicOutputValue(power >= powerThreshold, power);
+        }
+
+        return new TruthTableRow(inputBits, outputValues);
+    }
+
+    /// <summary>Runs the flat S-matrix field propagation over the group with the given light sources.</summary>
+    private static async Task<Dictionary<Guid, Complex>> RunSimulationAsync(
+        ComponentGroup group,
+        PhysicalExternalPortManager portManager,
+        int wavelengthNm,
+        CancellationToken cancellationToken)
+    {
+        var tileManager = new ComponentListTileManager();
+        tileManager.AddComponent(group);
+        var connectionManager = new WaveguideConnectionManager(new WaveguideRouter());
+        var grid = GridManager.CreateForSimulation(tileManager, connectionManager, portManager);
+        var calculator = new GridLightCalculator(new SystemMatrixBuilder(grid), grid);
+        using var cancelSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var fields = await calculator.CalculateFieldPropagationAsync(cancelSource, wavelengthNm);
+
+        // The solver maps cancellation to an empty result; honor the caller's token instead.
+        cancellationToken.ThrowIfCancellationRequested();
+        return fields;
+    }
+
+    /// <summary>Creates the coherent laser input for one "on" pin at the shared wavelength.</summary>
+    private static ExternalInput CreateOnInput(GroupPin pin, int wavelengthNm) =>
+        new(pin.Name, new LaserType(LightColor.Red, wavelengthNm), 0, OnInputField, true);
+
+    /// <summary>The flow ID light is injected at: the in-flow of the pin's internal component pin.</summary>
+    private static Guid InFlowIdOf(GroupPin pin) => pin.InternalPin!.LogicalPin!.IDInFlow;
+
+    /// <summary>
+    /// Normalized power leaving the group through <paramref name="pin"/> — the squared
+    /// field magnitude at the out-flow. A pin flow missing from the simulated field
+    /// map carries no light and therefore reads as 0.
+    /// </summary>
+    private static double OutputPower(Dictionary<Guid, Complex> fields, GroupPin pin)
+    {
+        var outFlowId = pin.InternalPin!.LogicalPin!.IDOutFlow;
+        return fields.TryGetValue(outFlowId, out var field) ? field.Magnitude * field.Magnitude : 0.0;
+    }
+
+    /// <summary>Checks the pure list/threshold invariants that need no group lookup.</summary>
+    private static void ValidateArguments(
+        IReadOnlyList<string> inputPinNames,
+        IReadOnlyList<string> outputPinNames,
+        double powerThreshold,
+        int wavelengthNm)
+    {
+        if (inputPinNames == null || inputPinNames.Count == 0)
+            throw new ArgumentException("At least one logic input pin is required.", nameof(inputPinNames));
+        if (inputPinNames.Count > MaxLogicInputs)
+            throw new ArgumentException(
+                $"At most {MaxLogicInputs} logic inputs are supported ({1 << MaxLogicInputs} combinations); got {inputPinNames.Count}.",
+                nameof(inputPinNames));
+        if (outputPinNames == null || outputPinNames.Count == 0)
+            throw new ArgumentException("At least one logic output pin is required.", nameof(outputPinNames));
+
+        ThrowOnDuplicates(inputPinNames, nameof(inputPinNames));
+        ThrowOnDuplicates(outputPinNames, nameof(outputPinNames));
+        var overlap = inputPinNames.Intersect(outputPinNames).FirstOrDefault();
+        if (overlap != null)
+            throw new ArgumentException(
+                $"Pin '{overlap}' is declared as both a logic input and a logic output.", nameof(outputPinNames));
+
+        if (double.IsNaN(powerThreshold) || powerThreshold <= 0.0 || powerThreshold >= 1.0)
+            throw new ArgumentOutOfRangeException(
+                nameof(powerThreshold), powerThreshold,
+                "Normalized power threshold must lie in the open interval (0, 1).");
+        if (wavelengthNm <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(wavelengthNm), wavelengthNm, "Wavelength must be a positive number of nanometers.");
+    }
+
+    /// <summary>Maps pin names onto the group's external pins, failing clearly on unknown or unsimulatable pins.</summary>
+    private static List<GroupPin> ResolvePins(
+        ComponentGroup group, IReadOnlyList<string> pinNames, string parameterName)
+    {
+        var pins = new List<GroupPin>(pinNames.Count);
+        foreach (var name in pinNames)
+        {
+            var pin = group.ExternalPins.FirstOrDefault(p => p.Name == name);
+            if (pin == null)
+                throw new ArgumentException(
+                    $"Group '{group.GroupName}' exposes no external pin named '{name}'. " +
+                    $"Available pins: {string.Join(", ", group.ExternalPins.Select(p => p.Name))}.",
+                    parameterName);
+            if (pin.InternalPin?.LogicalPin == null)
+                throw new ArgumentException(
+                    $"External pin '{name}' of group '{group.GroupName}' is not bound to a simulatable component pin.",
+                    parameterName);
+            pins.Add(pin);
+        }
+        return pins;
+    }
+
+    /// <summary>Rejects duplicated pin names — one pin name, one logic wire.</summary>
+    private static void ThrowOnDuplicates(IReadOnlyList<string> pinNames, string parameterName)
+    {
+        var duplicate = pinNames.GroupBy(n => n).FirstOrDefault(g => g.Count() > 1)?.Key;
+        if (duplicate != null)
+            throw new ArgumentException($"Pin '{duplicate}' is listed more than once.", parameterName);
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTableRow.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTableRow.cs
@@ -1,0 +1,25 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// One row of a <see cref="TruthTable"/>: one binary input combination mapped to the
+/// evaluated logic outputs of the grouped circuit.
+/// </summary>
+public sealed class TruthTableRow
+{
+    /// <summary>Assembles one extraction row.</summary>
+    public TruthTableRow(
+        IReadOnlyDictionary<string, bool> inputBits,
+        IReadOnlyDictionary<string, LogicOutputValue> outputs)
+    {
+        InputBits = inputBits;
+        Outputs = outputs;
+    }
+
+    /// <summary>Logic level per input pin name for this combination.</summary>
+    public IReadOnlyDictionary<string, bool> InputBits { get; }
+
+    /// <summary>Evaluated logic outputs (bit plus raw power) per output pin name.</summary>
+    public IReadOnlyDictionary<string, LogicOutputValue> Outputs { get; }
+}

--- a/UnitTests/Analysis/LogicAnalysis/LogicGateFixtureFactory.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicGateFixtureFactory.cs
@@ -1,0 +1,206 @@
+using System.Numerics;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Numeric fixture circuits for the truth-table tests: the same self-contained
+/// S-matrix templates as the #929 multi-chiplet journey (a lossless 50/50 coupler
+/// with a +90° cross port and a unity-through waveguide), baked at one wavelength —
+/// no PDK, no Nazca, fully deterministic.
+/// </summary>
+public static class LogicGateFixtureFactory
+{
+    /// <summary>Wavelength all fixture S-matrices are baked for (the standard red laser, 1550 nm).</summary>
+    public static int WavelengthNm => StandardWaveLengths.RedNM;
+
+    // Lossless 50/50 coupler: through port at 0°, cross port at +90° — the phase is
+    // what makes the MZI recombination below interfere at all.
+    private static readonly Complex Through = new(Math.Sqrt(0.5), 0);
+    private static readonly Complex Cross = new(0, Math.Sqrt(0.5));
+
+    private const double CouplerWidth = 250;
+    private const double CouplerHeight = 80;
+    private const double WaveguideLength = 100;
+    private const double WaveguideThickness = 5;
+
+    /// <summary>
+    /// A single 50/50 coupler exposed as a two-input/one-output circuit: a = in1,
+    /// b = in2, y = out1 (out2 stays unexposed). Any single input delivers half its
+    /// power at y; both inputs recombine coherently into full power at y.
+    /// </summary>
+    public static ComponentGroup CreateCombinerGroup()
+    {
+        var coupler = CreateCoupler("combine");
+        var group = new ComponentGroup("Combiner (OR candidate)");
+        group.AddChild(coupler);
+        group.AddExternalPin(Exposed("a", coupler, "in1"));
+        group.AddExternalPin(Exposed("b", coupler, "in2"));
+        group.AddExternalPin(Exposed("y", coupler, "out1"));
+        return group;
+    }
+
+    /// <summary>
+    /// A balanced Mach-Zehnder: a splitter, two equal unity-through arms and a
+    /// recombiner, wired exactly like the composed chiplets in #929. Exposes
+    /// in = split.in1, dark = combine.out1 (the extinguished through port) and
+    /// bright = combine.out2 (the cross port that collects all the power).
+    /// </summary>
+    public static ComponentGroup CreateBalancedMziGroup()
+    {
+        var split = CreateCoupler("split");
+        var arm1 = CreateWaveguide("arm1");
+        arm1.PhysicalX = CouplerWidth + WaveguideThickness;
+        arm1.PhysicalY = 7.5;
+        var arm2 = CreateWaveguide("arm2");
+        arm2.PhysicalX = CouplerWidth + WaveguideThickness;
+        arm2.PhysicalY = 67.5;
+        var combine = CreateCoupler("combine");
+        combine.PhysicalX = CouplerWidth + 2 * WaveguideThickness + WaveguideLength;
+
+        var group = new ComponentGroup("Balanced MZI");
+        group.AddChild(split);
+        group.AddChild(arm1);
+        group.AddChild(arm2);
+        group.AddChild(combine);
+        ConnectLossless(group, Pin(split, "out1"), Pin(arm1, "a0"));
+        ConnectLossless(group, Pin(split, "out2"), Pin(arm2, "a0"));
+        ConnectLossless(group, Pin(arm1, "b0"), Pin(combine, "in1"));
+        ConnectLossless(group, Pin(arm2, "b0"), Pin(combine, "in2"));
+        group.AddExternalPin(Exposed("in", split, "in1"));
+        group.AddExternalPin(Exposed("dark", combine, "out1"));
+        group.AddExternalPin(Exposed("bright", combine, "out2"));
+        return group;
+    }
+
+    /// <summary>
+    /// Four independent unity-through waveguides exposed as in0..in3 / out0..out3:
+    /// a 4-bit identity bus — the fixture for the maximum-width (16-row) extraction.
+    /// </summary>
+    public static ComponentGroup CreateFourBitBusGroup()
+    {
+        var group = new ComponentGroup("4-bit bus");
+        for (var i = 0; i < TruthTableExtractor.MaxLogicInputs; i++)
+        {
+            var waveguide = CreateWaveguide($"lane{i}");
+            waveguide.PhysicalX = 0;
+            waveguide.PhysicalY = i * 20;
+            group.AddChild(waveguide);
+            group.AddExternalPin(Exposed($"in{i}", waveguide, "a0"));
+            group.AddExternalPin(Exposed($"out{i}", waveguide, "b0"));
+        }
+        return group;
+    }
+
+    /// <summary>Lossless 50/50 coupler: pins in1/in2 (left), out1/out2 (right).</summary>
+    private static Component CreateCoupler(string identifier) => CreateComponent(
+        identifier,
+        CouplerWidth,
+        CouplerHeight,
+        new[]
+        {
+            ("in1", 0.0, 10.0, 180.0),
+            ("in2", 0.0, 70.0, 180.0),
+            ("out1", CouplerWidth, 10.0, 0.0),
+            ("out2", CouplerWidth, 70.0, 0.0),
+        },
+        new Dictionary<(string From, string To), Complex>
+        {
+            { ("in1", "out1"), Through }, { ("in1", "out2"), Cross },
+            { ("in2", "out1"), Cross }, { ("in2", "out2"), Through },
+            { ("out1", "in1"), Through }, { ("out1", "in2"), Cross },
+            { ("out2", "in1"), Cross }, { ("out2", "in2"), Through },
+        });
+
+    /// <summary>Unity-through waveguide: pins a0 (left), b0 (right).</summary>
+    private static Component CreateWaveguide(string identifier) => CreateComponent(
+        identifier,
+        WaveguideLength,
+        WaveguideThickness,
+        new[]
+        {
+            ("a0", 0.0, 2.5, 180.0),
+            ("b0", WaveguideLength, 2.5, 0.0),
+        },
+        new Dictionary<(string From, string To), Complex>
+        {
+            { ("a0", "b0"), Complex.One },
+            { ("b0", "a0"), Complex.One },
+        });
+
+    /// <summary>
+    /// Builds a component with baking-solved numeric S-matrix transfers: logical pins
+    /// live in one-part-per-pin parts, physical pins bind to them by name.
+    /// </summary>
+    private static Component CreateComponent(
+        string identifier,
+        double widthMicrometers,
+        double heightMicrometers,
+        IReadOnlyList<(string Name, double OffsetX, double OffsetY, double AngleDegrees)> pinDefinitions,
+        IReadOnlyDictionary<(string From, string To), Complex> transfers)
+    {
+        var parts = new Part[pinDefinitions.Count, 1];
+        var logicalPins = new Dictionary<string, Pin>();
+        for (var i = 0; i < pinDefinitions.Count; i++)
+        {
+            var pin = new Pin(pinDefinitions[i].Name, i, MatterType.Light, RectSide.Left);
+            parts[i, 0] = new Part(new List<Pin> { pin });
+            logicalPins[pin.Name] = pin;
+        }
+
+        var pinIds = logicalPins.Values.SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+        var matrix = new SMatrix(pinIds, new List<(Guid, double)>());
+        matrix.SetValues(transfers.ToDictionary(
+            t => (logicalPins[t.Key.From].IDInFlow, logicalPins[t.Key.To].IDOutFlow),
+            t => t.Value));
+        var matrices = new Dictionary<int, SMatrix> { { WavelengthNm, matrix } };
+
+        var component = new Component(matrices, new(), $"fixture.{identifier}", "", parts, 0, identifier, DiscreteRotation.R0)
+        {
+            WidthMicrometers = widthMicrometers,
+            HeightMicrometers = heightMicrometers,
+        };
+        foreach (var (name, offsetX, offsetY, angleDegrees) in pinDefinitions)
+        {
+            component.PhysicalPins.Add(new PhysicalPin
+            {
+                Name = name,
+                ParentComponent = component,
+                LogicalPin = logicalPins[name],
+                OffsetXMicrometers = offsetX,
+                OffsetYMicrometers = offsetY,
+                AngleDegrees = angleDegrees,
+            });
+        }
+        return component;
+    }
+
+    /// <summary>Freezes a lossless straight path between two pins inside the group.</summary>
+    private static void ConnectLossless(ComponentGroup group, PhysicalPin from, PhysicalPin to)
+    {
+        var (x1, y1) = from.GetAbsolutePosition();
+        var (x2, y2) = to.GetAbsolutePosition();
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, 0));
+        group.AddInternalPath(new FrozenWaveguidePath
+        {
+            Path = path,
+            StartPin = from,
+            EndPin = to,
+            PropagationLossDbPerCm = 0,
+        });
+    }
+
+    /// <summary>Exposes one internal component pin of the group under an external name.</summary>
+    private static GroupPin Exposed(string name, Component owner, string internalPinName) =>
+        new() { Name = name, InternalPin = Pin(owner, internalPinName) };
+
+    /// <summary>Looks up a physical pin on a fixture component.</summary>
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.Single(p => p.Name == name);
+}

--- a/UnitTests/Analysis/LogicAnalysis/TruthTableExtractorGateTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/TruthTableExtractorGateTests.cs
@@ -1,0 +1,169 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Gate-level truth-table extraction over the numeric #929 fixtures: a 50/50
+/// combiner behaves as an OR gate at threshold 0.25, and a balanced MZI keeps its
+/// dark port dark — with the raw powers staying visible next to every bit.
+/// </summary>
+public class TruthTableExtractorGateTests
+{
+    private const double Threshold025 = 0.25;
+
+    // |amplitude|² doubles the relative error of the #929 amplitude tolerance
+    // (1e-3 around solver convergence noise of ~3e-5), so power asserts use 1e-3.
+    private const double PowerTolerance = 1e-3;
+
+    [Fact]
+    public async Task ExtractAsync_CombinerAtThreshold025_IsAnOrGateWithVisiblePowers()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group,
+            new[] { "a", "b" },
+            new[] { "y" },
+            Threshold025,
+            LogicGateFixtureFactory.WavelengthNm);
+
+        table.Rows.Count.ShouldBe(4, "two inputs produce exactly four combinations");
+
+        var offOff = RowFor(table, false, false).Outputs["y"];
+        offOff.IsOne.ShouldBeFalse();
+        offOff.Power.ShouldBe(0.0, PowerTolerance);
+
+        var onOff = RowFor(table, true, false).Outputs["y"];
+        onOff.IsOne.ShouldBeTrue("0.5 ≥ 0.25");
+        onOff.Power.ShouldBe(0.5, PowerTolerance, "one input splits its power across both coupler outputs");
+
+        var offOn = RowFor(table, false, true).Outputs["y"];
+        offOn.IsOne.ShouldBeTrue("0.5 ≥ 0.25");
+        offOn.Power.ShouldBe(0.5, PowerTolerance);
+
+        var onOn = RowFor(table, true, true).Outputs["y"];
+        onOn.IsOne.ShouldBeTrue();
+        onOn.Power.ShouldBe(1.0, PowerTolerance, "both coherent inputs recombine into full power at y");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_CombinerAtThreshold075_OnlyTheCoherentRowStaysOn()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group,
+            new[] { "a", "b" },
+            new[] { "y" },
+            powerThreshold: 0.75,
+            LogicGateFixtureFactory.WavelengthNm);
+
+        RowFor(table, false, false).Outputs["y"].IsOne.ShouldBeFalse();
+        RowFor(table, true, false).Outputs["y"].IsOne.ShouldBeFalse("0.5 < 0.75");
+        RowFor(table, false, true).Outputs["y"].IsOne.ShouldBeFalse("0.5 < 0.75");
+        RowFor(table, true, true).Outputs["y"].IsOne.ShouldBeTrue("only full recombined power reaches 0.75");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_BalancedMzi_KeepsDarkPortDarkForEveryCombination()
+    {
+        var group = LogicGateFixtureFactory.CreateBalancedMziGroup();
+
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group,
+            new[] { "in" },
+            new[] { "dark", "bright" },
+            Threshold025,
+            LogicGateFixtureFactory.WavelengthNm);
+
+        table.Rows.Count.ShouldBe(2);
+        foreach (var row in table.Rows)
+        {
+            row.Outputs["dark"].IsOne.ShouldBeFalse("the dark port of a balanced MZI never reaches threshold");
+            row.Outputs["dark"].Power.ShouldBeLessThan(PowerTolerance);
+        }
+
+        var inputOn = RowFor(table, true);
+        inputOn.Outputs["bright"].IsOne.ShouldBeTrue();
+        inputOn.Outputs["bright"].Power.ShouldBe(1.0, PowerTolerance);
+
+        var inputOff = RowFor(table, false);
+        inputOff.Outputs["bright"].IsOne.ShouldBeFalse();
+        inputOff.Outputs["bright"].Power.ShouldBe(0.0, PowerTolerance);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_FourInputs_ExtractsAllSixteenRowsBitAccurately()
+    {
+        var group = LogicGateFixtureFactory.CreateFourBitBusGroup();
+
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group,
+            new[] { "in0", "in1", "in2", "in3" },
+            new[] { "out0", "out1", "out2", "out3" },
+            powerThreshold: 0.5,
+            LogicGateFixtureFactory.WavelengthNm);
+
+        table.Rows.Count.ShouldBe(1 << TruthTableExtractor.MaxLogicInputs);
+        foreach (var row in table.Rows)
+        {
+            for (var i = 0; i < TruthTableExtractor.MaxLogicInputs; i++)
+            {
+                var expected = row.InputBits[$"in{i}"];
+                var output = row.Outputs[$"out{i}"];
+                output.IsOne.ShouldBe(expected, $"lane {i} is a straight-through waveguide");
+                output.Power.ShouldBe(expected ? 1.0 : 0.0, PowerTolerance);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExtractAsync_TwoRunsOnIdenticalGroups_ProduceIdenticalPowers()
+    {
+        var first = await new TruthTableExtractor().ExtractAsync(
+            LogicGateFixtureFactory.CreateCombinerGroup(),
+            new[] { "a" },
+            new[] { "y" },
+            Threshold025,
+            LogicGateFixtureFactory.WavelengthNm);
+        var second = await new TruthTableExtractor().ExtractAsync(
+            LogicGateFixtureFactory.CreateCombinerGroup(),
+            new[] { "a" },
+            new[] { "y" },
+            Threshold025,
+            LogicGateFixtureFactory.WavelengthNm);
+
+        first.Rows.Select(r => r.Outputs["y"].Power)
+            .ShouldBe(second.Rows.Select(r => r.Outputs["y"].Power));
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ResultCarriesExtractionContext()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group,
+            new[] { "a", "b" },
+            new[] { "y" },
+            Threshold025,
+            LogicGateFixtureFactory.WavelengthNm);
+
+        table.GroupName.ShouldBe(group.GroupName);
+        table.InputPinNames.ShouldBe(new[] { "a", "b" });
+        table.OutputPinNames.ShouldBe(new[] { "y" });
+        table.PowerThreshold.ShouldBe(Threshold025);
+        table.WavelengthNm.ShouldBe(LogicGateFixtureFactory.WavelengthNm);
+    }
+
+    /// <summary>Finds the row whose input bits match the given levels (order of InputPinNames).</summary>
+    private static TruthTableRow RowFor(TruthTable table, params bool[] inputLevels)
+    {
+        table.InputPinNames.Count.ShouldBe(inputLevels.Length);
+        return table.Rows.Single(row => table.InputPinNames
+            .Select((name, i) => row.InputBits[name] == inputLevels[i])
+            .All(matches => matches));
+    }
+}

--- a/UnitTests/Analysis/LogicAnalysis/TruthTableExtractorValidationTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/TruthTableExtractorValidationTests.cs
@@ -1,0 +1,138 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Boundary and validation behavior of <see cref="TruthTableExtractor"/>: the gate
+/// contract (pin lists, threshold, wavelength) fails loudly with clear exceptions
+/// instead of silently simulating nonsense.
+/// </summary>
+public class TruthTableExtractorValidationTests
+{
+    private static readonly string[] Inputs = { "a", "b" };
+    private static readonly string[] Outputs = { "y" };
+    private const double Threshold = 0.25;
+
+    [Fact]
+    public async Task ExtractAsync_NullGroup_ThrowsArgumentNullException()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(() => new TruthTableExtractor().ExtractAsync(
+            null!, Inputs, Outputs, Threshold, LogicGateFixtureFactory.WavelengthNm));
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyInputList_ThrowsArgumentException()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var exception = await Should.ThrowAsync<ArgumentException>(() => new TruthTableExtractor().ExtractAsync(
+            group, Array.Empty<string>(), Outputs, Threshold, LogicGateFixtureFactory.WavelengthNm));
+
+        exception.ParamName.ShouldBe("inputPinNames");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyOutputList_ThrowsArgumentException()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var exception = await Should.ThrowAsync<ArgumentException>(() => new TruthTableExtractor().ExtractAsync(
+            group, Inputs, Array.Empty<string>(), Threshold, LogicGateFixtureFactory.WavelengthNm));
+
+        exception.ParamName.ShouldBe("outputPinNames");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_MoreThanMaxInputs_ThrowsArgumentException()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        var fiveInputs = new[] { "in0", "in1", "in2", "in3", "in4" };
+
+        var exception = await Should.ThrowAsync<ArgumentException>(() => new TruthTableExtractor().ExtractAsync(
+            group, fiveInputs, Outputs, Threshold, LogicGateFixtureFactory.WavelengthNm));
+
+        exception.Message.ShouldContain(TruthTableExtractor.MaxLogicInputs.ToString());
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ExactlyMaxInputs_IsAccepted()
+    {
+        var group = LogicGateFixtureFactory.CreateFourBitBusGroup();
+
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group,
+            new[] { "in0", "in1", "in2", "in3" },
+            new[] { "out0" },
+            Threshold,
+            LogicGateFixtureFactory.WavelengthNm);
+
+        table.Rows.Count.ShouldBe(16);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_DuplicateInputPin_ThrowsArgumentException()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var exception = await Should.ThrowAsync<ArgumentException>(() => new TruthTableExtractor().ExtractAsync(
+            group, new[] { "a", "a" }, Outputs, Threshold, LogicGateFixtureFactory.WavelengthNm));
+
+        exception.Message.ShouldContain("'a'");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_SamePinAsInputAndOutput_ThrowsArgumentException()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var exception = await Should.ThrowAsync<ArgumentException>(() => new TruthTableExtractor().ExtractAsync(
+            group, new[] { "a" }, new[] { "a" }, Threshold, LogicGateFixtureFactory.WavelengthNm));
+
+        exception.Message.ShouldContain("'a'");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_UnknownInputPin_ThrowsArgumentExceptionNamingThePin()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var exception = await Should.ThrowAsync<ArgumentException>(() => new TruthTableExtractor().ExtractAsync(
+            group, new[] { "a", "does-not-exist" }, Outputs, Threshold, LogicGateFixtureFactory.WavelengthNm));
+
+        exception.Message.ShouldContain("'does-not-exist'");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_UnknownOutputPin_ThrowsArgumentExceptionNamingThePin()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var exception = await Should.ThrowAsync<ArgumentException>(() => new TruthTableExtractor().ExtractAsync(
+            group, new[] { "a" }, new[] { "does-not-exist" }, Threshold, LogicGateFixtureFactory.WavelengthNm));
+
+        exception.Message.ShouldContain("'does-not-exist'");
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(1.0)]
+    [InlineData(-0.5)]
+    public async Task ExtractAsync_ThresholdOutsideOpenInterval_ThrowsArgumentOutOfRangeException(double threshold)
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() => new TruthTableExtractor().ExtractAsync(
+            group, Inputs, Outputs, threshold, LogicGateFixtureFactory.WavelengthNm));
+    }
+
+    [Fact]
+    public async Task ExtractAsync_NonPositiveWavelength_ThrowsArgumentOutOfRangeException()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        await Should.ThrowAsync<ArgumentOutOfRangeException>(() => new TruthTableExtractor().ExtractAsync(
+            group, Inputs, Outputs, Threshold, wavelengthNm: 0));
+    }
+}


### PR DESCRIPTION
## What & why

Implements #934 — the rung-4 (behavioral/gate layer) seed for the NAND-game path ("gates from components, chips from gates"). It answers the question **"does my grouped circuit behave like a logic gate?"** — grounded on the #929 proof that groups simulate correctly across boundaries.

New slice `Connect-A-Pic-Core/Analysis/LogicAnalysis/` (**Recipe B: Core + Tests, deliberately NO UI** — the truth-table panel / gate animation is a separate follow-up issue):

- **`TruthTableExtractor`**: takes a `ComponentGroup`, a named list of its external pins as logic inputs, one as logic outputs, a mandatory normalized power threshold, and the laser wavelength. For every binary input combination it runs the existing simulation machinery (`GridLightCalculator`, same setup pattern as `MultiChipletCompositionJourneyTests` #929 — `PhysicalExternalPortManager` + `ComponentListTileManager` + `GridManager.CreateForSimulation`), with all "on" inputs injected coherently (unit amplitude, zero phase, shared wavelength), and classifies output power ≥ threshold as logic 1.
- **Result types** (`TruthTable` / `TruthTableRow` / `LogicOutputValue`): per combination the input bits → output bits **plus the raw simulated powers**, so the education persona (Jonas) sees *why* an output is 1 — 0.93 and 0.51 above the same threshold are different lessons.
- **Boundaries drawn explicitly**: max 4 inputs (`TruthTableExtractor.MaxLogicInputs`, 16 combinations), wavelength is an explicit parameter, threshold is mandatory and must lie in the open interval (0, 1). Clear `ArgumentException` / `ArgumentOutOfRangeException` failures for empty pin lists, unknown pin names, duplicates, input/output overlap, and >4 inputs.

No ViewModel, no View, no i18n strings, no DI wiring.

## How it was tested

19 new deterministic headless tests in `UnitTests/Analysis/LogicAnalysis/`, built on the numeric fixture templates of #929 (lossless 50/50 coupler with a +90° cross port, unity-through waveguide — no PDK, no Nazca):

- **OR gate**: a 50/50 combiner at threshold 0.25 yields OR (single input on → raw power 0.5 → 1, both coherently on → recombined power 1.0 → 1, all off → 0). At threshold 0.75 only the recombined row stays on — proving the threshold is honored, not invented.
- **Balanced MZI** (split + two equal arms + recombine, wired like the #929 chiplets): the dark port stays constant 0 (power < tolerance) for every input combination; the bright port takes full power (≈1.0) when the input is on.
- **4-bit bus** (four independent unity-through waveguides): exactly 4 inputs → all 16 rows extracted bit-accurately (max-input boundary).
- **Result context**: group name, pin orders, threshold, and wavelength are carried into the result; two runs produce identical powers.
- **Edge cases**: null group, empty input/output lists, >4 inputs, duplicate pins, same pin as input and output, unknown pin names (message names the pin), threshold outside (0, 1), non-positive wavelength.

Every new production file is ≤ 250 lines with XML docs; `FileSizeLimitTests` and `VerticalSliceConventionTests` pass.

Local suite: 5609 passed, 0 failed
