### PR TITLE
Agent: Per-chiplet process scope for placement (#935) + per-connection router bend-radius floor (#937)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/WaveguideBendRadiusResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/WaveguideBendRadiusResolver.cs
@@ -13,6 +13,9 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
     /// pattern of turning an <see cref="ActiveProcessSelection"/> plus the loaded PDK drafts into
     /// a routing parameter. When no process is resolvable (playground / no selection / no optical
     /// minimum declared) it falls back to <see cref="FallbackMinimumMicrometers"/>.
+    /// <see cref="ResolveForEndpointPdkNames"/> is the per-connection counterpart (issue #937):
+    /// it floors one connection by its endpoint components' own PDK processes instead of the
+    /// canvas-wide value.
     /// </summary>
     public static class WaveguideBendRadiusResolver
     {
@@ -70,20 +73,69 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             double? smallest = null;
             foreach (var process in processes)
             {
-                var xsections = process?.Xsections;
-                if (xsections == null)
-                    continue;
-
-                foreach (var xsection in xsections)
-                {
-                    if (xsection.Kind != XsectionKind.Optical || xsection.MinRadiusUm <= 0)
-                        continue;
-                    if (smallest == null || xsection.MinRadiusUm < smallest.Value)
-                        smallest = xsection.MinRadiusUm;
-                }
+                var candidate = SmallestOpticalMinimum(process);
+                if (candidate != null && (smallest == null || candidate < smallest.Value))
+                    smallest = candidate;
             }
 
             return smallest ?? FallbackMinimumMicrometers;
+        }
+
+        /// <summary>
+        /// Resolves the per-connection minimum bend radius (µm) from the endpoint components'
+        /// PDK sources (issue #937): each endpoint PDK contributes the smallest positive
+        /// optical <see cref="ProcessXsection.MinRadiusUm"/> of its own process, and the
+        /// STRICTER (larger) of the two governs the connection. On a multi-process canvas
+        /// (e.g. a Cornerstone SiN chiplet next to a SiEPIC SOI chiplet) this keeps a
+        /// Cornerstone route at its 30 µm foundry floor instead of dragging it down to the
+        /// neighbour's 5 µm — and lets a SiEPIC-to-SiEPIC route use its declared 5 µm instead
+        /// of the generic fallback. Returns null when neither endpoint PDK resolves to a
+        /// positive optical minimum, so the caller keeps the canvas-wide floor.
+        /// </summary>
+        /// <param name="startPdkName">PDK source name of the start endpoint's component (null = unknown).</param>
+        /// <param name="endPdkName">PDK source name of the end endpoint's component (null = unknown).</param>
+        /// <param name="loadedPdks">All currently loaded PDK drafts.</param>
+        public static double? ResolveForEndpointPdkNames(
+            string? startPdkName, string? endPdkName, IReadOnlyList<PdkDraft>? loadedPdks)
+        {
+            if (loadedPdks == null)
+                return null;
+
+            double? start = SmallestOpticalMinimum(FindProcess(startPdkName, loadedPdks));
+            double? end = SmallestOpticalMinimum(FindProcess(endPdkName, loadedPdks));
+            if (start == null)
+                return end;
+            if (end == null)
+                return start;
+            return Math.Max(start.Value, end.Value);
+        }
+
+        /// <summary>Finds the process definition of the named loaded PDK (null when unknown).</summary>
+        private static ProcessDefinition? FindProcess(string? pdkName, IReadOnlyList<PdkDraft> loadedPdks) =>
+            string.IsNullOrEmpty(pdkName)
+                ? null
+                : loadedPdks.FirstOrDefault(
+                    d => string.Equals(d.Name, pdkName, StringComparison.OrdinalIgnoreCase))?.Process;
+
+        /// <summary>
+        /// The smallest positive optical <see cref="ProcessXsection.MinRadiusUm"/> of one
+        /// process definition, or null when it declares none.
+        /// </summary>
+        private static double? SmallestOpticalMinimum(ProcessDefinition? process)
+        {
+            if (process?.Xsections == null)
+                return null;
+
+            double? smallest = null;
+            foreach (var xsection in process.Xsections)
+            {
+                if (xsection.Kind != XsectionKind.Optical || xsection.MinRadiusUm <= 0)
+                    continue;
+                if (smallest == null || xsection.MinRadiusUm < smallest.Value)
+                    smallest = xsection.MinRadiusUm;
+            }
+
+            return smallest;
         }
     }
 }

--- a/CAP.Avalonia/Commands/PlaceGroupTemplateCommand.cs
+++ b/CAP.Avalonia/Commands/PlaceGroupTemplateCommand.cs
@@ -110,6 +110,13 @@ public class PlaceGroupTemplateCommand : IUndoableCommand
 
     public string Description => $"Place group template '{_template.Name}'";
 
+    /// <summary>
+    /// The group instance this command places on <see cref="Execute"/> (created once in
+    /// <c>TryCreate</c>). Lets the caller pin placement-time metadata — e.g. the chiplet
+    /// process binding (issue #935) — onto the instance before it lands on the canvas.
+    /// </summary>
+    public ComponentGroup GroupToPlace => _groupToPlace;
+
     public void Execute()
     {
         // Add the group as a single component to the canvas

--- a/CAP.Avalonia/Selection/ComponentClipboard.cs
+++ b/CAP.Avalonia/Selection/ComponentClipboard.cs
@@ -53,6 +53,21 @@ public class ComponentClipboard
             .ToList();
 
     /// <summary>
+    /// PDK sources per TOP-LEVEL copied entry (issue #935): a copied group yields one entry
+    /// marked <c>IsGroup</c> carrying its recursive non-group children's sources; a loose
+    /// component yields its single source. Lets the paste guard admit a copied chiplet as a
+    /// whole while loose foreign components stay checked against the canvas process.
+    /// </summary>
+    public IReadOnlyList<(bool IsGroup, IReadOnlyList<string?> Sources)> PeekEntryPdkSources() =>
+        _entries.Select(e => e.OriginalComponent is ComponentGroup group
+                ? (true, (IReadOnlyList<string?>)group.GetAllComponentsRecursive()
+                    .Where(child => child is not ComponentGroup)
+                    .Select(child => PdkSourceResolver?.Invoke(child))
+                    .ToList())
+                : (false, (IReadOnlyList<string?>)new[] { e.PdkSource ?? PdkSourceResolver?.Invoke(e.OriginalComponent) }))
+            .ToList();
+
+    /// <summary>
     /// Copies the given components and their internal connections.
     /// </summary>
     public void Copy(

--- a/CAP.Avalonia/ViewModels/Canvas/Services/RoutingOrchestrator.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/Services/RoutingOrchestrator.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CAP_Core.Components;
 using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
 using CAP_Core.Routing;
 
 namespace CAP.Avalonia.ViewModels.Canvas.Services;
@@ -63,6 +64,17 @@ public class RoutingOrchestrator
     /// the metal defaults stay unchanged.
     /// </summary>
     public Func<CAP_Core.Routing.MetalRouting.MetalRoutingSpec>? GetMetalRoutingSpec { get; set; }
+
+    /// <summary>
+    /// Factory building the per-connection process bend-floor provider for one routing pass
+    /// (wired by <c>MainViewModel</c>, issue #937). Invoked on the UI thread at pass start —
+    /// together with the canvas-wide floor refresh — so the returned provider closes over
+    /// pass-start snapshots of the component library and PDK drafts and the routing thread
+    /// never enumerates live ViewModel collections. A null factory (or a null provider)
+    /// clears <see cref="WaveguideRouter.ConnectionProcessFloorProvider"/> and the
+    /// canvas-wide floor governs every connection.
+    /// </summary>
+    public Func<Func<PhysicalPin, PhysicalPin, double?>?>? BuildConnectionProcessFloorProvider { get; set; }
 
     /// <summary>
     /// Raised when IsRouting or RoutingStatusText changes.
@@ -130,6 +142,10 @@ public class RoutingOrchestrator
             _router.MetalProcessMinBendRadiusMicrometers = metalSpec.MinBendRadiusMicrometers;
             _connectionManager.MetalTraceWidthMicrometers = metalSpec.TraceWidthMicrometers;
         }
+        // Per-connection floor (issue #937): the factory runs here on the UI thread, so the
+        // provider it builds can close over pass-start snapshots; the router then consults
+        // it per connection on the routing thread.
+        _router.ConnectionProcessFloorProvider = BuildConnectionProcessFloorProvider?.Invoke();
 
         _routingCts?.Cancel();
         _routingCts?.Dispose();

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -394,6 +394,26 @@ public partial class MainViewModel : ObservableObject
         _canvas.Routing.GetMetalRoutingSpec = metalSpecProvider;
         CanvasInteraction.GetMetalMinBendRadiusMicrometers =
             () => metalSpecProvider().MinBendRadiusMicrometers;
+        // Per-connection process floor (issue #937): on a multi-process canvas each
+        // connection is floored by its own endpoint components' PDK process (the stricter
+        // chiplet governs a cross-chiplet route), not by one canvas-wide value. The factory
+        // runs on the UI thread at pass start and snapshots the library and drafts, so the
+        // provider the router calls per connection on the routing thread never touches live
+        // ViewModel collections. Unresolvable endpoints (built-ins, groups, PDK-less drafts)
+        // yield null and the canvas-wide floor above governs.
+        _canvas.Routing.BuildConnectionProcessFloorProvider = () =>
+        {
+            var templates = LeftPanel.AllTemplates.ToList();
+            var drafts = LeftPanel.GetLoadedPdkDrafts().ToList();
+            return (startPin, endPin) =>
+                CAP_DataAccess.Components.ComponentDraftMapper.WaveguideBendRadiusResolver.ResolveForEndpointPdkNames(
+                    PdkSourceOf(startPin), PdkSourceOf(endPin), drafts);
+
+            string? PdkSourceOf(CAP_Core.Components.Core.PhysicalPin pin) =>
+                pin.ParentComponent is { } component
+                    ? ViewModels.Library.ComponentPdkSourceResolver.Resolve(component, templates)
+                    : null;
+        };
         // Let a Nazca export that hits gdsfactory-native components hand off to the gdsfactory export.
         FileOperations.RequestGdsFactoryExport = () => GdsFactoryExport.Export();
         ExportMenu = new ExportMenuViewModel(new IExportFormat[]

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -446,7 +446,10 @@ public partial class MainViewModel : ObservableObject
             resolveLiveMemberPdkNames: () =>
                 FileOperations.ActiveProcess is { } activeProcess
                     ? LeftPanel.ResolveLiveMemberPdkNames(activeProcess)
-                    : null);
+                    : null,
+            // Per-chiplet scoping (issue #935): the live catalog lets the policy derive a
+            // group's chiplet process binding from its children.
+            getProcessCatalog: () => ProcessCatalog.BuildGroups(LeftPanel.GetLoadedPdkProcessEntries()));
 
         CanvasInteraction.PlacementContext = placementContext;
         _canvas.Clipboard.PdkSourceResolver = placementContext.ResolveComponentPdkSource;

--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -428,7 +428,10 @@ public partial class CanvasInteractionViewModel : ObservableObject
     {
         if (SelectedTemplate == null) return;
 
-        var (isAllowed, blockReason) = PlacementContext.CheckPlacement(SelectedTemplate.PdkSource);
+        // Per-chiplet scope (issue #935): dropping onto a process-bound chiplet resolves
+        // against that chiplet's process; everywhere else the canvas-level process applies.
+        var (isAllowed, blockReason) = PlacementContext.CheckPlacementAt(
+            SelectedTemplate.PdkSource, ChipletAt(x, y));
         if (!isAllowed)
         {
             UpdateStatus?.Invoke(blockReason ?? "Process mismatch — cannot place component.");
@@ -462,8 +465,12 @@ public partial class CanvasInteractionViewModel : ObservableObject
 
         // Single-process enforcement over the group's children (issue #653): a group has no
         // PdkSource of its own, so a foreign-process child must not slip in via grouping.
-        var (isAllowed, blockReason) = PlacementContext.CheckGroupPlacement(
-            ChildPdkSources(SelectedGroupTemplate.TemplateGroup),
+        // Per-chiplet scope (issue #935): onto a bound chiplet the chiplet's process decides;
+        // at canvas level a uniformly foreign-process group is placeable as its own chiplet
+        // and gets that process pinned as its binding.
+        var (isAllowed, blockReason, derivedBinding) = PlacementContext.CheckGroupPlacementAt(
+            SelectedGroupTemplate.TemplateGroup,
+            ChipletAt(x, y),
             SelectedGroupTemplate.Name);
         if (!isAllowed)
         {
@@ -493,18 +500,27 @@ public partial class CanvasInteractionViewModel : ObservableObject
             return;
         }
 
+        // Pin the chiplet process binding resolved by the policy check onto the instance.
+        if (derivedBinding != null)
+        {
+            cmd.GroupToPlace.ProcessBinding = derivedBinding;
+        }
+
         _commandManager.ExecuteCommand(cmd);
         UpdateStatus?.Invoke($"Placed group '{SelectedGroupTemplate.Name}' at ({x:F0}, {y:F0})µm");
     }
 
     /// <summary>
-    /// Resolved PDK source of every recursive non-group child of <paramref name="group"/>,
-    /// used to check the single-process policy over a group's contents (issue #653).
+    /// The topmost group whose bounds contain the point — the chiplet a placement at that
+    /// position targets (issue #935); null when the drop lands on ungrouped canvas.
     /// </summary>
-    private IEnumerable<string?> ChildPdkSources(ComponentGroup group) =>
-        group.GetAllComponentsRecursive()
-            .Where(child => child is not ComponentGroup)
-            .Select(child => PlacementContext.ResolveComponentPdkSource(child));
+    private ComponentGroup? ChipletAt(double x, double y) =>
+        _canvas.Components
+            .Where(c => c.Component is ComponentGroup
+                        && x >= c.X && x <= c.X + c.Width
+                        && y >= c.Y && y <= c.Y + c.Height)
+            .Select(c => (ComponentGroup)c.Component)
+            .LastOrDefault();
 
     /// <summary>
     /// Selects the component or connection at the given canvas position, keeping the
@@ -922,11 +938,14 @@ public partial class CanvasInteractionViewModel : ObservableObject
     {
         if (!_canvas.Clipboard.HasContent) return;
 
-        // PeekPdkSources expands groups to their resolved children (the clipboard's
+        // PeekEntryPdkSources expands groups to their resolved children (the clipboard's
         // PdkSourceResolver is wired by MainViewModel), so a copied group cannot
         // smuggle foreign-process components past the paste guard (issue #653).
-        var blockedCount = _canvas.Clipboard.PeekPdkSources()
-            .Count(pdk => !PlacementContext.CheckPlacement(pdk).IsAllowed);
+        // Per entry (issue #935): a copied group whose children uniformly belong to one
+        // other catalog process pastes as its own chiplet; loose foreign components
+        // stay blocked by the canvas lock.
+        var blockedCount = _canvas.Clipboard.PeekEntryPdkSources()
+            .Count(entry => !PlacementContext.IsPasteEntryAllowed(entry.IsGroup, entry.Sources));
         if (blockedCount > 0)
         {
             // A blocked component implies a non-null, non-Playground active process.

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -166,12 +166,10 @@ namespace CAP_Core.Components.Connections
 
             // The effective bend radius honors both the connection's own setting and the
             // fabrication process' minimum: the larger of the two governs the geometry.
-            // Electrical connections use the metal floor (RF traces bend at the metal
-            // cross-section radius, issue #854), optical ones the waveguide floor.
-            double processFloor = IsElectrical
-                ? router.MetalProcessMinBendRadiusMicrometers
-                : router.ProcessMinBendRadiusMicrometers;
-            double effectiveBendRadius = Math.Max(BendRadiusMicrometers, processFloor);
+            // The floor is per-pin-pair: electrical pairs bend at the metal cross-section
+            // floor (issue #854), optical pairs at their endpoints' process floor when the
+            // router carries a provider (issue #937), else the canvas-wide floor.
+            double effectiveBendRadius = Math.Max(BendRadiusMicrometers, router.ResolveProcessFloorFor(StartPin, EndPin));
 
             if (Type != WaveguideType.Auto)
             {

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
 
@@ -76,6 +77,16 @@ public class ComponentGroup : Component, INotifyPropertyChanged
     /// Only prefabs appear in the "Saved Groups" panel.
     /// </summary>
     public bool IsPrefab { get; set; }
+
+    /// <summary>
+    /// Optional process binding of this group as a chiplet (issue #935): the fabrication
+    /// process the group's contents belong to. Null = unbound — placement checks then
+    /// derive the scope live from the children (see
+    /// <see cref="GroupProcessPolicy.DeriveProcessBinding"/>). Held in memory only;
+    /// persisting the binding in .lun files is issue #938.
+    /// </summary>
+    [JsonIgnore]
+    public ActiveProcessSelection? ProcessBinding { get; set; }
 
     /// <summary>
     /// Reference to parent group if this group is nested within another group.
@@ -576,6 +587,8 @@ public class ComponentGroup : Component, INotifyPropertyChanged
             WidthMicrometers = WidthMicrometers,
             HeightMicrometers = HeightMicrometers,
             Rotation90CounterClock = Rotation90CounterClock,
+            // Immutable record — sharing the reference is safe.
+            ProcessBinding = ProcessBinding,
             // Immutable records — sharing the list is safe (same rule as Component.DeepCopy).
             OutlinePolygons = OutlinePolygons
         };

--- a/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/GroupProcessPolicy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using CAP_Core.Components.Core;
 
 namespace CAP_Core.Components.Process;
 
@@ -8,7 +9,9 @@ namespace CAP_Core.Components.Process;
 /// Extends <see cref="SingleProcessPolicy"/> to component groups (issue #653). A group carries
 /// no <c>PdkSource</c> of its own, so its process membership is derived from its child
 /// components' PDK sources: the group is placeable only when every child passes the
-/// per-component placement check (member / built-in / process-agnostic).
+/// per-component placement check (member / built-in / process-agnostic). Since issue #935 a
+/// group may additionally act as a chiplet with its own process scope — see
+/// <see cref="DeriveProcessBinding"/> and <see cref="ComponentGroup.ProcessBinding"/>.
 /// </summary>
 public static class GroupProcessPolicy
 {
@@ -29,12 +32,17 @@ public static class GroupProcessPolicy
     /// authority; null falls back to the snapshot.
     /// </param>
     /// <param name="groupName">Display name of the group, used in the block message.</param>
+    /// <param name="chipletName">
+    /// Name of the target chiplet when the check runs against a chiplet's process scope
+    /// (issue #935) instead of the canvas lock; changes the block message's wording only.
+    /// </param>
     public static (bool IsAllowed, string? BlockReason) CheckGroupPlacement(
         ActiveProcessSelection? active,
         IEnumerable<string?> childPdkSources,
         IReadOnlyCollection<string>? processAgnosticPdkNames = null,
         IReadOnlyCollection<string>? liveMemberPdkNames = null,
-        string? groupName = null)
+        string? groupName = null,
+        string? chipletName = null)
     {
         var blockedPdkNames = childPdkSources
             .Where(pdk => !SingleProcessPolicy.CheckPlacement(active, pdk, processAgnosticPdkNames, liveMemberPdkNames).IsAllowed)
@@ -46,9 +54,50 @@ public static class GroupProcessPolicy
             return (true, null);
 
         var groupLabel = string.IsNullOrWhiteSpace(groupName) ? "This group" : $"Group '{groupName}'";
+        if (!string.IsNullOrWhiteSpace(chipletName))
+        {
+            return (false,
+                $"{groupLabel} contains component(s) from '{string.Join("', '", blockedPdkNames)}', but " +
+                $"chiplet '{chipletName}' fabricates in the process '{active!.DisplayName}' — a chiplet " +
+                "uses one process. Place the group outside the chiplet, or use Playground to mix processes.");
+        }
         return (false,
             $"{groupLabel} contains component(s) from '{string.Join("', '", blockedPdkNames)}', but the " +
             $"chip is locked to the process '{active!.DisplayName}'. A monolithic design uses one process — " +
-            "start a new design (or use Playground) to mix processes.");
+            "start a new design (or use Playground) to mix processes. A group whose components all " +
+            "belong to one other process can be placed as its own chiplet.");
+    }
+
+    /// <summary>
+    /// Derives a group's chiplet process binding (issue #935) from its children's PDK
+    /// sources: when every non-exempt child belongs to exactly one process of the live
+    /// <paramref name="processCatalog"/>, the group is a chiplet fabricated in that
+    /// process. Returns null when the group carries no process content (built-in/tool
+    /// children only) or its children span PDKs no single catalog process covers — such
+    /// a group cannot be fabricated as one chiplet.
+    /// </summary>
+    /// <param name="childPdkSources">PDK source of every child component (null = built-in/unknown).</param>
+    /// <param name="processCatalog">The live process catalog over all loaded PDKs.</param>
+    /// <param name="processAgnosticPdkNames">Names of PDKs flagged process-agnostic (tool libraries).</param>
+    public static ActiveProcessSelection? DeriveProcessBinding(
+        IEnumerable<string?> childPdkSources,
+        IReadOnlyList<ProcessGroup> processCatalog,
+        IReadOnlyCollection<string>? processAgnosticPdkNames = null)
+    {
+        var sources = childPdkSources
+            .Where(pdk => !SingleProcessPolicy.IsExempt(pdk, processAgnosticPdkNames))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (sources.Count == 0)
+            return null;
+
+        var coveringProcesses = processCatalog
+            .Where(group => sources.All(source =>
+                group.MemberPdkNames.Contains(source, StringComparer.OrdinalIgnoreCase)))
+            .ToList();
+
+        return coveringProcesses.Count == 1
+            ? ActiveProcessSelection.ForGroup(coveringProcesses[0])
+            : null;
     }
 }

--- a/Connect-A-Pic-Core/Components/Process/PlacementPolicyContext.cs
+++ b/Connect-A-Pic-Core/Components/Process/PlacementPolicyContext.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using CAP_Core.Components.Core;
 
 namespace CAP_Core.Components.Process;
 
 /// <summary>
-/// Shared, live-evaluated context for the single-process placement policy (issues #570/#653/#737).
+/// Shared, live-evaluated context for the single-process placement policy (issues #570/#653/#737)
+/// and its per-chiplet scoping (#935).
 /// Built once by <c>MainViewModel</c> and handed as one reference to every placement consumer
 /// (manual canvas interaction, AI grid service, …), replacing four per-consumer duplicated
 /// nullable funcs whose wiring could silently diverge. Accessors evaluate lazily so the context
@@ -17,6 +19,7 @@ public sealed class PlacementPolicyContext
     private readonly Func<IReadOnlyCollection<string>> _getProcessAgnosticPdkNames;
     private readonly Func<Component, string?> _resolveComponentPdkSource;
     private readonly Func<IReadOnlyCollection<string>?> _resolveLiveMemberPdkNames;
+    private readonly Func<IReadOnlyList<ProcessGroup>> _getProcessCatalog;
 
     /// <summary>
     /// Creates a context from live accessors.
@@ -27,16 +30,21 @@ public sealed class PlacementPolicyContext
     /// <param name="resolveLiveMemberPdkNames">Returns by-value-compatible member PDK names for
     /// the active process, computed live against the current PDK catalog; null falls back to the
     /// persisted snapshot.</param>
+    /// <param name="getProcessCatalog">Returns the live process catalog over all loaded PDKs,
+    /// used to derive chiplet process bindings (issue #935); null disables chiplet scoping
+    /// and keeps the canvas-global behavior.</param>
     public PlacementPolicyContext(
         Func<ActiveProcessSelection?> getActiveProcess,
         Func<IReadOnlyCollection<string>> getProcessAgnosticPdkNames,
         Func<Component, string?> resolveComponentPdkSource,
-        Func<IReadOnlyCollection<string>?>? resolveLiveMemberPdkNames = null)
+        Func<IReadOnlyCollection<string>?>? resolveLiveMemberPdkNames = null,
+        Func<IReadOnlyList<ProcessGroup>>? getProcessCatalog = null)
     {
         _getActiveProcess = getActiveProcess ?? throw new ArgumentNullException(nameof(getActiveProcess));
         _getProcessAgnosticPdkNames = getProcessAgnosticPdkNames ?? throw new ArgumentNullException(nameof(getProcessAgnosticPdkNames));
         _resolveComponentPdkSource = resolveComponentPdkSource ?? throw new ArgumentNullException(nameof(resolveComponentPdkSource));
         _resolveLiveMemberPdkNames = resolveLiveMemberPdkNames ?? (() => null);
+        _getProcessCatalog = getProcessCatalog ?? (() => Array.Empty<ProcessGroup>());
     }
 
     /// <summary>
@@ -76,4 +84,88 @@ public sealed class PlacementPolicyContext
     public (bool IsAllowed, string? BlockReason) CheckGroupPlacement(
         IEnumerable<string?> childPdkSources, string? groupName = null) =>
         GroupProcessPolicy.CheckGroupPlacement(ActiveProcess, childPdkSources, ProcessAgnosticPdkNames, LiveMemberPdkNames, groupName);
+
+    /// <summary>The live process catalog over all loaded PDKs (empty when unwired).</summary>
+    public IReadOnlyList<ProcessGroup> ProcessCatalog => _getProcessCatalog();
+
+    /// <summary>
+    /// The process scope a chiplet enforces on content placed into or onto it (issue #935):
+    /// the group's explicit <see cref="ComponentGroup.ProcessBinding"/> when set, else the
+    /// binding derived live from its children. Null = unbound group — the canvas-level
+    /// process applies.
+    /// </summary>
+    public ActiveProcessSelection? ResolveChipletProcess(ComponentGroup group) =>
+        group.ProcessBinding ?? GroupProcessPolicy.DeriveProcessBinding(
+            ChildPdkSources(group), ProcessCatalog, ProcessAgnosticPdkNames);
+
+    /// <summary>
+    /// Checks a component placement against the process scope at the drop target: the target
+    /// chiplet's process when placing into/onto a bound chiplet (issue #935), the
+    /// canvas-level active process otherwise.
+    /// </summary>
+    public (bool IsAllowed, string? BlockReason) CheckPlacementAt(string? componentPdkName, ComponentGroup? targetGroup)
+    {
+        if (targetGroup != null && ResolveChipletProcess(targetGroup) is { } chipletProcess)
+        {
+            return SingleProcessPolicy.CheckPlacement(
+                chipletProcess, componentPdkName, ProcessAgnosticPdkNames,
+                chipletName: targetGroup.GroupName);
+        }
+        return CheckPlacement(componentPdkName);
+    }
+
+    /// <summary>
+    /// Checks a group's placement at the drop target (issue #935). Onto a bound chiplet the
+    /// chiplet's process is the scope. At canvas level a group that fails the design-wide
+    /// check is still placeable as its own chiplet when all its children belong to exactly
+    /// one catalog process; that binding comes back as <c>DerivedBinding</c> for the caller
+    /// to pin onto the placed instance.
+    /// </summary>
+    public (bool IsAllowed, string? BlockReason, ActiveProcessSelection? DerivedBinding) CheckGroupPlacementAt(
+        ComponentGroup group, ComponentGroup? targetGroup, string? groupName = null)
+    {
+        var childSources = ChildPdkSources(group).ToList();
+        if (targetGroup != null && ResolveChipletProcess(targetGroup) is { } chipletProcess)
+        {
+            var chipletCheck = GroupProcessPolicy.CheckGroupPlacement(
+                chipletProcess, childSources, ProcessAgnosticPdkNames,
+                groupName: groupName, chipletName: targetGroup.GroupName);
+            return chipletCheck.IsAllowed
+                ? (true, null, group.ProcessBinding)
+                : (false, chipletCheck.BlockReason, null);
+        }
+
+        var check = CheckGroupPlacement(childSources, groupName);
+        if (check.IsAllowed)
+        {
+            return (true, null,
+                group.ProcessBinding ?? GroupProcessPolicy.DeriveProcessBinding(
+                    childSources, ProcessCatalog, ProcessAgnosticPdkNames));
+        }
+
+        var derived = GroupProcessPolicy.DeriveProcessBinding(childSources, ProcessCatalog, ProcessAgnosticPdkNames);
+        return derived != null
+            ? (true, null, derived)
+            : (false, check.BlockReason, null);
+    }
+
+    /// <summary>
+    /// Paste guard for one top-level clipboard entry (issues #653/#935): a loose component is
+    /// checked against the canvas process; a copied group is additionally admitted as its own
+    /// chiplet when its children uniformly belong to one catalog process.
+    /// </summary>
+    public bool IsPasteEntryAllowed(bool isGroupEntry, IReadOnlyList<string?> entryPdkSources)
+    {
+        if (GroupProcessPolicy.CheckGroupPlacement(
+                ActiveProcess, entryPdkSources, ProcessAgnosticPdkNames, LiveMemberPdkNames).IsAllowed)
+            return true;
+        return isGroupEntry &&
+            GroupProcessPolicy.DeriveProcessBinding(entryPdkSources, ProcessCatalog, ProcessAgnosticPdkNames) != null;
+    }
+
+    /// <summary>Resolved PDK source of every recursive non-group child of <paramref name="group"/>.</summary>
+    private IEnumerable<string?> ChildPdkSources(ComponentGroup group) =>
+        group.GetAllComponentsRecursive()
+            .Where(child => child is not ComponentGroup)
+            .Select(ResolveComponentPdkSource);
 }

--- a/Connect-A-Pic-Core/Components/Process/SingleProcessPolicy.cs
+++ b/Connect-A-Pic-Core/Components/Process/SingleProcessPolicy.cs
@@ -51,10 +51,15 @@ public static class SingleProcessPolicy
     /// snapshot when the active process has no computable fingerprint. Null (unwired caller)
     /// falls back to the snapshot, preserving prior behavior.
     /// </param>
+    /// <param name="chipletName">
+    /// Name of the target chiplet when the check runs against a chiplet's process scope
+    /// (issue #935) instead of the canvas lock; changes the block message's wording only.
+    /// </param>
     public static (bool IsAllowed, string? BlockReason) CheckPlacement(
         ActiveProcessSelection? active, string? componentPdkName,
         IReadOnlyCollection<string>? processAgnosticPdkNames = null,
-        IReadOnlyCollection<string>? liveMemberPdkNames = null)
+        IReadOnlyCollection<string>? liveMemberPdkNames = null,
+        string? chipletName = null)
     {
         if (IsExempt(componentPdkName, processAgnosticPdkNames))
             return (true, null);
@@ -66,9 +71,17 @@ public static class SingleProcessPolicy
         if (effectiveMembers.Contains(componentPdkName!, StringComparer.OrdinalIgnoreCase))
             return (true, null);
 
+        if (!string.IsNullOrWhiteSpace(chipletName))
+        {
+            return (false,
+                $"This component belongs to '{componentPdkName}', but chiplet '{chipletName}' " +
+                $"fabricates in the process '{active.DisplayName}' — a chiplet uses one process. " +
+                "Place the component outside the chiplet, or use Playground to mix processes.");
+        }
+
         return (false,
             $"This component belongs to '{componentPdkName}', but the chip is locked to the process " +
             $"'{active.DisplayName}'. A monolithic design uses one process — start a new design (or use " +
-            "Playground) to mix processes.");
+            "Playground) to mix processes. Content grouped as its own chiplet carries its own process.");
     }
 }

--- a/Connect-A-Pic-Core/Routing/RoutedPath.cs
+++ b/Connect-A-Pic-Core/Routing/RoutedPath.cs
@@ -36,8 +36,10 @@ public class RoutedPath
     public bool IsPlaceholderGeometry { get; set; } = false;
 
     /// <summary>
-    /// True when the path could only be routed with a bend radius below the active
-    /// fabrication process' minimum (<see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>).
+    /// True when the path could only be routed with a bend radius below the fabrication
+    /// process' minimum for THIS connection (<see cref="WaveguideRouter.ResolveProcessFloorFor"/>:
+    /// the endpoint chiplets' process when a per-connection provider is wired, else the
+    /// canvas-wide <see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>).
     /// The geometry itself is clean, but the design violates the process rule; the
     /// design checks surface it as a <c>BendRadiusBelowProcessMinimum</c> issue.
     /// </summary>

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.ProcessFloor.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.ProcessFloor.cs
@@ -1,0 +1,34 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Routing;
+
+/// <summary>
+/// Process bend-radius floor members of <see cref="WaveguideRouter"/>: the per-connection
+/// override provider and the floor resolution for one pin pair (issue #937).
+/// </summary>
+public partial class WaveguideRouter
+{
+    /// <summary>
+    /// Optional per-connection process bend-radius floor provider (µm), consulted with the
+    /// connection's endpoint pins. On a multi-process canvas (e.g. a Cornerstone SiN chiplet
+    /// next to a SiEPIC SOI chiplet) each connection is floored by its own endpoints' process
+    /// instead of one canvas-wide value, so the stricter chiplet's foundry minimum is enforced
+    /// and the looser one is not over-constrained (issue #937). A null return means "no
+    /// per-connection opinion" — the canvas-wide <see cref="ProcessMinBendRadiusMicrometers"/>
+    /// governs. Invoked on the routing thread, so the provider must only read pass-start
+    /// snapshots, never live UI collections.
+    /// </summary>
+    public Func<PhysicalPin, PhysicalPin, double?>? ConnectionProcessFloorProvider { get; set; }
+
+    /// <summary>
+    /// Resolves the process bend-radius floor (µm) for one connection: the metal floor for
+    /// electrical pins (RF traces must bend at the metal cross-section radius — checking one
+    /// pin is authoritative, cross-kind pairs are rejected at connection creation time),
+    /// the per-connection provider's value when wired and resolvable for these endpoints,
+    /// otherwise the canvas-wide <see cref="ProcessMinBendRadiusMicrometers"/>.
+    /// </summary>
+    public double ResolveProcessFloorFor(PhysicalPin startPin, PhysicalPin endPin) =>
+        startPin.MatterType == MatterType.Electricity || endPin.MatterType == MatterType.Electricity
+            ? MetalProcessMinBendRadiusMicrometers
+            : ConnectionProcessFloorProvider?.Invoke(startPin, endPin) ?? ProcessMinBendRadiusMicrometers;
+}

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
@@ -20,7 +20,8 @@ public partial class WaveguideRouter
     /// this floor and <see cref="MinBendRadiusMicrometers"/>; when no clean path exists at the
     /// floor it retries at the connection radius and marks the result with
     /// <see cref="RoutedPath.ViolatesProcessMinBendRadius"/> so the design checks surface the
-    /// violation. 0 means no process constraint.
+    /// violation. 0 means no process constraint. This is the canvas-wide value —
+    /// <see cref="ConnectionProcessFloorProvider"/> can override it per connection.
     /// </summary>
     public double ProcessMinBendRadiusMicrometers { get; set; }
 
@@ -216,7 +217,9 @@ public partial class WaveguideRouter
     /// default) the DIRECT styled geometry is tried first and A* only runs when obstacles
     /// actually block the styled path (issue #860). The A* attempt itself is two-phase.
     /// The first attempt honors the process bend-radius floor
-    /// (<see cref="ProcessMinBendRadiusMicrometers"/>); when no clean path exists at the floor,
+    /// (<see cref="ResolveProcessFloorFor"/> — per-connection when
+    /// <see cref="ConnectionProcessFloorProvider"/> is wired, else the canvas-wide
+    /// <see cref="ProcessMinBendRadiusMicrometers"/>); when no clean path exists at the floor,
     /// it retries at the connection radius and marks the result with
     /// <see cref="RoutedPath.ViolatesProcessMinBendRadius"/>. Falls back to Manhattan routing
     /// if all A* attempts fail; a self-intersecting or blocked fallback at the floor radius
@@ -248,7 +251,8 @@ public partial class WaveguideRouter
         double endInputAngle = AngleUtilities.NormalizeAngle(endAngle + 180);
 
         double connectionRadius = MinBendRadiusMicrometers;
-        double effectiveRadius = Math.Max(connectionRadius, ProcessFloorFor(startPin, endPin));
+        double processFloor = ResolveProcessFloorFor(startPin, endPin);
+        double effectiveRadius = Math.Max(connectionRadius, processFloor);
         bool floorRaisesRadius = effectiveRadius > connectionRadius + RadiusToleranceMicrometers;
 
         if (PreferDirectStyledRoutes)
@@ -286,17 +290,6 @@ public partial class WaveguideRouter
         return RouteManhattanFallback(startX, startY, startAngle, endX, endY, endInputAngle,
                                       connectionRadius, effectiveRadius, floorRaisesRadius);
     }
-
-    /// <summary>
-    /// The process bend-radius floor governing this pin pair: the metal floor for
-    /// electrical pins (RF traces must bend at the metal cross-section radius),
-    /// the optical floor otherwise. Checking one pin is authoritative — cross-kind
-    /// pairs are rejected at connection creation time.
-    /// </summary>
-    private double ProcessFloorFor(PhysicalPin startPin, PhysicalPin endPin) =>
-        startPin.MatterType == MatterType.Electricity || endPin.MatterType == MatterType.Electricity
-            ? MetalProcessMinBendRadiusMicrometers
-            : ProcessMinBendRadiusMicrometers;
 
     /// <summary>
     /// The route for a perfect abutment: both pins sit at the same point, so the honest

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
@@ -10,9 +10,12 @@ namespace UnitTests.Components;
 
 /// <summary>
 /// Green "today" pins for the documented-red stations of the multi-process journey:
-/// each test proves the current single-process behavior the red steps 3 (#935), 5
-/// (#937) and 8 (#939) describe, so a future per-chiplet fix turns the pin red as a
-/// tripwire. See <see cref="MultiProcessChipletJourneyTests"/> for the full journey.
+/// each test proves the current single-process behavior the red steps 5 (#937) and 8
+/// (#939) describe, so a future per-chiplet fix turns the pin red as a tripwire.
+/// See <see cref="MultiProcessChipletJourneyTests"/> for the full journey. The step-3
+/// pin now guards the canvas-level half of the shipped per-chiplet scope (#935):
+/// ungrouped foreign content stays rejected even though chiplets may carry a second
+/// process.
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
@@ -20,10 +23,12 @@ public partial class MultiProcessChipletJourneyTests
     private const double SiepicMinBendRadiusUm = 5.0;
 
     [Fact]
-    public void Placement_ProcessLockedCanvas_RejectsSecondChipletProcess_Today()
+    public void Placement_ProcessLockedCanvas_RejectsUngroupedForeignComponent()
     {
-        // Companion to red step 3 (#935): the canvas-global lock really rejects the
-        // second chiplet's process today — only Playground admits both.
+        // Companion to green step 3 (#935): at the raw canvas scope the lock still
+        // rejects the second chiplet's process — only chiplets (groups bound to their
+        // own process) cross the boundary; loose components and Playground behave as
+        // before.
         var (cornerstone, siepic, catalog) = LoadProcessCatalog();
         var cornerstoneLock = ActiveProcessSelection.ForGroup(
             catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name)));
@@ -32,14 +37,14 @@ public partial class MultiProcessChipletJourneyTests
             .IsAllowed.ShouldBeTrue("chiplet A's own process must stay placeable");
 
         var (allowed, blockReason) = SingleProcessPolicy.CheckPlacement(cornerstoneLock, siepic.Name);
-        allowed.ShouldBeFalse("today the design-global lock rejects chiplet B's process (#935)");
+        allowed.ShouldBeFalse("ungrouped foreign content stays rejected at canvas scope (#935)");
         blockReason.ShouldNotBeNull();
         blockReason!.ShouldContain("monolithic");
 
         SingleProcessPolicy.CheckPlacement(ActiveProcessSelection.Playground(), cornerstone.Name)
             .IsAllowed.ShouldBeTrue();
         SingleProcessPolicy.CheckPlacement(ActiveProcessSelection.Playground(), siepic.Name)
-            .IsAllowed.ShouldBeTrue("Playground is the only mode that can hold both chiplets today");
+            .IsAllowed.ShouldBeTrue("Playground still admits both chiplets without any checks");
     }
 
     [Fact]

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
@@ -14,42 +14,13 @@ using Xunit;
 namespace UnitTests.Components;
 
 /// <summary>
-/// Documented-red inventory stations of the multi-process journey (steps 3–5, 7–8) —
+/// Documented-red inventory stations of the multi-process journey (steps 4–5, 7–8) —
 /// each Skip links the issue filed for that exact single-process assumption. See
 /// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
+/// (Step 3 turned green with the per-chiplet placement scope, issue #935.)
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
-    [Fact(Skip = "Single-process assumption (#933 inventory): the placement policy is canvas-global — a process-locked canvas rejects the second chiplet's process; per-chiplet process scope is https://github.com/aignermax/Lunima/issues/935")]
-    public void Step3_ProcessLockedCanvas_AcceptsSecondProcessChiplet()
-    {
-        var cornerstone = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.CornerstonePdkFile);
-        var siepic = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.SiepicPdkFile);
-        var catalog = ProcessCatalog.BuildGroups(new[]
-        {
-            new PdkProcessEntry(cornerstone.Name, ProcessFingerprintFactory.From(cornerstone)),
-            new PdkProcessEntry(siepic.Name, ProcessFingerprintFactory.From(siepic)),
-        });
-        var active = ActiveProcessSelection.ForGroup(
-            catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name)));
-
-        var canvas = new DesignCanvasViewModel();
-        var interaction = new CanvasInteractionViewModel(canvas, new CommandManager());
-        interaction.PlacementContext = new PlacementPolicyContext(
-            () => active, () => Array.Empty<string>(), _ => null);
-
-        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(cornerstone, "Coupler");
-        interaction.CanvasClicked(100, 100);
-        canvas.Components.Count.ShouldBe(1, "the Cornerstone chiplet's process owns the canvas");
-
-        // Rung 6: a SiEPIC chiplet must be placeable NEXT TO the Cornerstone chiplet,
-        // carrying its own process — today the canvas-global lock rejects it.
-        interaction.SelectedTemplate = MultiProcessChipletJourneyDesign.TemplateFor(siepic, "Y-Branch 1550");
-        interaction.CanvasClicked(500, 100);
-        canvas.Components.Count.ShouldBe(2,
-            "rung 6: the second chiplet's process must be placeable as a chiplet-scoped process (#935)");
-    }
-
     [Fact(Skip = "Single-process assumption (#933 inventory): DRC-lite derives its whole rule set from the single active process (first member PDK) — per-chiplet limits are https://github.com/aignermax/Lunima/issues/936")]
     public void Step4_DrcLite_ChecksEachChipletAgainstItsOwnProcess()
     {

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -9,6 +9,7 @@ using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP_Core.Analysis;
 using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
 using CAP_Core.Components.Process;
 using CAP_Core.ExternalPorts;
 using CAP_Core.Grid;
@@ -40,8 +41,9 @@ namespace UnitTests.Components;
 ///         process boundary; pins carry their own PDK's width/layer stamps.
 ///   Step 2 (green): S-matrix simulation delivers physically correct power across
 ///         the chiplet boundary (value assertions from the bundled PDK data).
-///   Step 3 (RED, #935): placement policy is canvas-global — a process-locked
-///         canvas cannot take a second-process chiplet; only Playground can mix.
+///   Step 3 (green, #935): placement is chiplet-scoped — a process-locked canvas
+///         accepts a second-process chiplet (bound to its own process) while
+///         ungrouped foreign content stays rejected.
 ///   Step 4 (RED, #936): DRC-lite rules come from the single active process — a
 ///         two-process design checks nothing PDK-dependent at all.
 ///   Step 5 (RED, #937): the router's bend-radius floor is one canvas-wide value.
@@ -52,11 +54,12 @@ namespace UnitTests.Components;
 ///   Step 8 (RED, #939): GDS export routes every waveguide through one global
 ///         interconnect (width/radius/layer), not each chiplet's own stack.
 ///
-/// The red steps 3, 5 and 8 additionally carry GREEN "today" pins in the
-/// CurrentBehavior partial: the canvas-global lock really does reject the second
-/// process, the Playground bend floor really is one fallback for everything, and
-/// GDS export really does size every route with one majority cross-section — so a
-/// future per-chiplet fix turns those pins red as a tripwire.
+/// The red steps 5 and 8 additionally carry GREEN "today" pins in the
+/// CurrentBehavior partial: the Playground bend floor really is one fallback for
+/// everything, and GDS export really does size every route with one majority
+/// cross-section — so a future per-chiplet fix turns those pins red as a tripwire.
+/// The step-3 pin now guards the canvas-level half of the shipped #935 behavior:
+/// ungrouped foreign content must stay rejected.
 /// </summary>
 public partial class MultiProcessChipletJourneyTests : IDisposable
 {
@@ -151,6 +154,99 @@ public partial class MultiProcessChipletJourneyTests : IDisposable
             "Step 2: the Y-branch's free arm carries its physical share — the boundary is truly crossed");
         leakage.ShouldBeLessThan(0.02,
             "Step 2: only the Y-branch's port-1 reflection leaks back to the unexcited coupler input");
+    }
+
+    [Fact]
+    public void Step3_ProcessLockedCanvas_AcceptsSecondProcessChiplet()
+    {
+        var cornerstone = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.CornerstonePdkFile);
+        var siepic = MultiProcessChipletJourneyDesign.LoadPdk(MultiProcessChipletJourneyDesign.SiepicPdkFile);
+        var catalog = ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(cornerstone.Name, ProcessFingerprintFactory.From(cornerstone)),
+            new PdkProcessEntry(siepic.Name, ProcessFingerprintFactory.From(siepic)),
+        });
+        ActiveProcessSelection? active = ActiveProcessSelection.ForGroup(
+            catalog.Single(g => g.MemberPdkNames.Contains(cornerstone.Name)));
+        var templates = new List<ComponentTemplate>
+        {
+            MultiProcessChipletJourneyDesign.TemplateFor(cornerstone, "Coupler"),
+            MultiProcessChipletJourneyDesign.TemplateFor(siepic, "Y-Branch 1550"),
+            MultiProcessChipletJourneyDesign.TemplateFor(siepic, "Taper TE 1550"),
+        };
+
+        var libraryPath = Path.Combine(Path.GetTempPath(), $"chiplet_step3_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(libraryPath);
+        try
+        {
+            var canvas = new DesignCanvasViewModel();
+            var interaction = new CanvasInteractionViewModel(
+                canvas, new CommandManager(),
+                new ComponentLibraryViewModel(new GroupLibraryManager(libraryPath)));
+            interaction.PlacementContext = new PlacementPolicyContext(
+                () => active,
+                () => Array.Empty<string>(),
+                component => ComponentPdkSourceResolver.Resolve(component, templates),
+                getProcessCatalog: () => catalog);
+
+            interaction.SelectedTemplate = templates[0];
+            interaction.CanvasClicked(100, 100);
+            canvas.Components.Count.ShouldBe(1, "the Cornerstone chiplet's process owns the canvas");
+
+            // Ungrouped foreign content stays rejected — the lock's protection against
+            // accidental mixing is unchanged; only chiplets carry a second process.
+            string? status = null;
+            interaction.UpdateStatus = s => status = s;
+            interaction.SelectedTemplate = templates[1];
+            interaction.CanvasClicked(500, 100);
+            canvas.Components.Count.ShouldBe(1,
+                "a loose SiEPIC component is ungrouped content — the canvas lock still rejects it");
+            status.ShouldNotBeNull();
+            status!.ShouldContain("monolithic");
+
+            // Rung 6: the same components grouped as a chiplet ARE placeable next to the
+            // Cornerstone chiplet — the group carries the SiEPIC process as its binding.
+            interaction.SelectedTemplate = null;
+            SelectSiepicChipletTemplate(interaction, libraryPath, templates);
+            interaction.CanvasClicked(1500, 100);
+
+            canvas.Components.Count.ShouldBe(2,
+                "the second chiplet places as a chiplet-scoped process on the locked canvas (#935)");
+            var chipletB = (ComponentGroup)canvas.Components.Last().Component;
+            chipletB.ProcessBinding.ShouldNotBeNull(
+                "the placed chiplet is pinned to its own fabrication process");
+            chipletB.ProcessBinding!.IsPlayground.ShouldBeFalse(
+                "a bound chiplet is a first-class manufacturable state, not Playground");
+            chipletB.ProcessBinding.MemberPdkNames.ShouldContain(siepic.Name);
+
+            // The chiplet scopes what may join it: SiEPIC content passes, Cornerstone
+            // content — though it owns the canvas — is foreign to the chiplet.
+            interaction.PlacementContext.CheckPlacementAt(siepic.Name, chipletB).IsAllowed
+                .ShouldBeTrue("the chiplet's own process scopes drops onto it");
+            interaction.PlacementContext.CheckPlacementAt(cornerstone.Name, chipletB).IsAllowed
+                .ShouldBeFalse("the canvas owner is foreign to the chiplet");
+        }
+        finally
+        {
+            if (Directory.Exists(libraryPath)) Directory.Delete(libraryPath, true);
+        }
+    }
+
+    /// <summary>
+    /// Saves chiplet B (Y-branch + taper, built from the real SiEPIC templates) as a group
+    /// template and selects it for placement — the production "Saved Groups" flow.
+    /// </summary>
+    private static void SelectSiepicChipletTemplate(
+        CanvasInteractionViewModel interaction, string libraryPath, List<ComponentTemplate> templates)
+    {
+        var group = new ComponentGroup(MultiProcessChipletJourneyDesign.ChipletBName);
+        group.AddChild(ComponentTemplates.CreateFromTemplate(templates[1], 0, 0));
+        group.AddChild(ComponentTemplates.CreateFromTemplate(templates[2], 200, 0));
+
+        var libraryManager = new GroupLibraryManager(libraryPath);
+        var template = libraryManager.SaveTemplate(group, MultiProcessChipletJourneyDesign.ChipletBName);
+        template.TemplateGroup = group;
+        interaction.SelectedGroupTemplate = template;
     }
 
     // ── Journey helpers ─────────────────────────────────────────────────────────

--- a/UnitTests/Components/Process/ChipletProcessScopeTests.cs
+++ b/UnitTests/Components/Process/ChipletProcessScopeTests.cs
@@ -1,0 +1,280 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_Core.LightCalculation;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.Process;
+
+/// <summary>
+/// Per-chiplet process scoping (issue #935): a component group can act as a chiplet with
+/// its own fabrication process — pinned explicitly via <see cref="ComponentGroup.ProcessBinding"/>
+/// or derived live from its children (<see cref="GroupProcessPolicy.DeriveProcessBinding"/>).
+/// Placement and paste checks resolve against the target chiplet's process; ungrouped
+/// content stays checked against the canvas-level active process.
+/// </summary>
+public class ChipletProcessScopeTests
+{
+    private static readonly ProcessGroup SoiGroup = new(
+        "SOI 220", new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"), new[] { "Demo" });
+    private static readonly ProcessGroup InPGroup = new(
+        "InP", new ProcessFingerprint("InP", 300, "SiO2", 1550, "InP"), new[] { "HHI-InP" });
+    private static readonly IReadOnlyList<ProcessGroup> Catalog = new[] { SoiGroup, InPGroup };
+
+    private static ActiveProcessSelection Soi() => ActiveProcessSelection.ForGroup(SoiGroup);
+    private static ActiveProcessSelection InP() => ActiveProcessSelection.ForGroup(InPGroup);
+
+    /// <summary>Maps a child's NazcaFunctionName to a PDK source, mimicking the library lookup.</summary>
+    private static string? Resolve(Component component) => component.NazcaFunctionName switch
+    {
+        "member_func" => "Demo",
+        "foreign_func" => "HHI-InP",
+        _ => null
+    };
+
+    private static PlacementPolicyContext Context(ActiveProcessSelection? active) =>
+        new(() => active,
+            () => Array.Empty<string>(),
+            component => Resolve(component),
+            getProcessCatalog: () => Catalog);
+
+    private static ComponentGroup BuildGroup(string name, params string[] childNazcaFunctions)
+    {
+        var group = new ComponentGroup(name) { PhysicalX = 0, PhysicalY = 0 };
+        for (int i = 0; i < childNazcaFunctions.Length; i++)
+        {
+            group.AddChild(new Component(
+                new Dictionary<int, SMatrix>(),
+                new List<Slider>(),
+                childNazcaFunctions[i],
+                "",
+                new Part[1, 1] { { new Part() } },
+                -1,
+                $"comp_{i}_{Guid.NewGuid():N}",
+                DiscreteRotation.R0,
+                new List<PhysicalPin>())
+            {
+                PhysicalX = i * 100,
+                PhysicalY = 0,
+                WidthMicrometers = 50,
+                HeightMicrometers = 30
+            });
+        }
+        return group;
+    }
+
+    // ── DeriveProcessBinding ────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeriveProcessBinding_UniformChildren_BindsToTheirProcess()
+    {
+        var binding = GroupProcessPolicy.DeriveProcessBinding(new[] { "HHI-InP", "HHI-InP" }, Catalog);
+
+        binding.ShouldNotBeNull();
+        binding!.DisplayName.ShouldBe("InP");
+        binding.IsPlayground.ShouldBeFalse();
+        binding.MemberPdkNames.ShouldBe(new[] { "HHI-InP" });
+    }
+
+    [Fact]
+    public void DeriveProcessBinding_ChildrenSpanningTwoProcesses_ReturnsNull()
+    {
+        GroupProcessPolicy.DeriveProcessBinding(new[] { "Demo", "HHI-InP" }, Catalog)
+            .ShouldBeNull("no single process can fabricate a mixed group — it is no chiplet");
+    }
+
+    [Fact]
+    public void DeriveProcessBinding_OnlyExemptChildren_ReturnsNull()
+    {
+        GroupProcessPolicy.DeriveProcessBinding(new string?[] { null, "Built-in" }, Catalog)
+            .ShouldBeNull("built-in/tool content carries no process");
+
+        GroupProcessPolicy.DeriveProcessBinding(new[] { "Analysis Tools" }, Catalog, new[] { "Analysis Tools" })
+            .ShouldBeNull("process-agnostic tool PDKs carry no process");
+    }
+
+    [Fact]
+    public void DeriveProcessBinding_EmptyCatalog_ReturnsNull()
+    {
+        GroupProcessPolicy.DeriveProcessBinding(new[] { "HHI-InP" }, Array.Empty<ProcessGroup>())
+            .ShouldBeNull("an unwired catalog must not fabricate bindings (legacy behavior)");
+    }
+
+    [Fact]
+    public void DeriveProcessBinding_MatchesCaseInsensitively()
+    {
+        GroupProcessPolicy.DeriveProcessBinding(new[] { "hhi-inp" }, Catalog)
+            .ShouldNotBeNull();
+    }
+
+    // ── ResolveChipletProcess ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveChipletProcess_ExplicitBindingWinsOverChildren()
+    {
+        var chiplet = BuildGroup("Chiplet", "foreign_func");
+        chiplet.ProcessBinding = Soi();
+
+        Context(active: null).ResolveChipletProcess(chiplet)!.DisplayName.ShouldBe("SOI 220");
+    }
+
+    [Fact]
+    public void ResolveChipletProcess_UnboundGroup_DerivesFromChildren()
+    {
+        var chiplet = BuildGroup("Chiplet", "foreign_func", "foreign_func");
+
+        Context(active: null).ResolveChipletProcess(chiplet)!.DisplayName.ShouldBe("InP");
+    }
+
+    [Fact]
+    public void ResolveChipletProcess_MixedOrProcesslessGroup_IsUnbound()
+    {
+        Context(active: null).ResolveChipletProcess(BuildGroup("Mixed", "member_func", "foreign_func"))
+            .ShouldBeNull();
+        Context(active: null).ResolveChipletProcess(BuildGroup("Tools", "unknown_func"))
+            .ShouldBeNull();
+    }
+
+    // ── CheckPlacementAt ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckPlacementAt_OntoBoundChiplet_ResolvesAgainstChipletProcess()
+    {
+        var context = Context(Soi());
+        var chiplet = BuildGroup("InP Chiplet", "foreign_func");
+
+        context.CheckPlacementAt("HHI-InP", chiplet).IsAllowed
+            .ShouldBeTrue("the chiplet's own process scopes the drop, not the canvas lock");
+
+        var (allowed, reason) = context.CheckPlacementAt("Demo", chiplet);
+        allowed.ShouldBeFalse("the canvas process is foreign TO THE CHIPLET");
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("InP Chiplet");
+        reason.ShouldContain("chiplet");
+    }
+
+    [Fact]
+    public void CheckPlacementAt_OngroundedCanvas_KeepsCanvasLock()
+    {
+        var context = Context(Soi());
+
+        context.CheckPlacementAt("HHI-InP", targetGroup: null).IsAllowed
+            .ShouldBeFalse("ungrouped foreign content stays rejected by the canvas lock");
+        context.CheckPlacementAt("Demo", targetGroup: null).IsAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CheckPlacementAt_OntoUnboundGroup_UsesCanvasLock()
+    {
+        var context = Context(Soi());
+        var toolGroup = BuildGroup("Tool Group", "unknown_func");
+
+        context.CheckPlacementAt("HHI-InP", toolGroup).IsAllowed
+            .ShouldBeFalse("an unbound group has no process scope of its own");
+    }
+
+    // ── CheckGroupPlacementAt ───────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckGroupPlacementAt_UniformForeignGroup_OnLockedCanvas_PlacesAsChiplet()
+    {
+        var context = Context(Soi());
+        var chiplet = BuildGroup("InP Chiplet", "foreign_func", "foreign_func");
+
+        var (allowed, reason, derivedBinding) = context.CheckGroupPlacementAt(chiplet, targetGroup: null, "InP Chiplet");
+
+        allowed.ShouldBeTrue("a uniformly foreign group is placeable as its own chiplet");
+        reason.ShouldBeNull();
+        derivedBinding.ShouldNotBeNull("the caller must pin the derived binding onto the placed instance");
+        derivedBinding!.DisplayName.ShouldBe("InP");
+    }
+
+    [Fact]
+    public void CheckGroupPlacementAt_MixedGroup_OnLockedCanvas_StaysBlocked()
+    {
+        var context = Context(Soi());
+        var mixed = BuildGroup("Mixed", "member_func", "foreign_func");
+
+        var (allowed, reason, derivedBinding) = context.CheckGroupPlacementAt(mixed, targetGroup: null, "Mixed");
+
+        allowed.ShouldBeFalse("a group no single process can fabricate is no chiplet");
+        derivedBinding.ShouldBeNull();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("HHI-InP");
+        reason.ShouldContain("monolithic");
+    }
+
+    [Fact]
+    public void CheckGroupPlacementAt_MemberGroup_OnLockedCanvas_PlacesAndBindsToCanvasProcess()
+    {
+        var context = Context(Soi());
+        var group = BuildGroup("SOI Pair", "member_func", "member_func");
+
+        var (allowed, _, derivedBinding) = context.CheckGroupPlacementAt(group, targetGroup: null, "SOI Pair");
+
+        allowed.ShouldBeTrue();
+        derivedBinding.ShouldNotBeNull("a member group is pinned to the process it belongs to");
+        derivedBinding!.DisplayName.ShouldBe("SOI 220");
+    }
+
+    [Fact]
+    public void CheckGroupPlacementAt_OntoBoundChiplet_ResolvesAgainstChipletProcess()
+    {
+        var context = Context(Soi());
+        var chiplet = BuildGroup("InP Chiplet", "foreign_func");
+
+        var matching = BuildGroup("InP Add-on", "foreign_func");
+        context.CheckGroupPlacementAt(matching, chiplet, "InP Add-on").IsAllowed
+            .ShouldBeTrue("same-process content may join the chiplet");
+
+        var (allowed, reason, _) = context.CheckGroupPlacementAt(BuildGroup("SOI Add-on", "member_func"), chiplet, "SOI Add-on");
+        allowed.ShouldBeFalse("canvas-member content is foreign to the chiplet");
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("InP Chiplet");
+    }
+
+    // ── IsPasteEntryAllowed ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsPasteEntryAllowed_LooseForeignComponent_StaysBlocked()
+    {
+        Context(Soi()).IsPasteEntryAllowed(isGroupEntry: false, new[] { "HHI-InP" })
+            .ShouldBeFalse("a loose foreign component must not slip through as a pseudo-chiplet");
+    }
+
+    [Fact]
+    public void IsPasteEntryAllowed_CopiedUniformForeignGroup_PastesAsChiplet()
+    {
+        Context(Soi()).IsPasteEntryAllowed(isGroupEntry: true, new[] { "HHI-InP", "HHI-InP" })
+            .ShouldBeTrue("a copied chiplet keeps its own process scope across paste");
+    }
+
+    [Fact]
+    public void IsPasteEntryAllowed_CopiedMixedGroup_StaysBlocked()
+    {
+        Context(Soi()).IsPasteEntryAllowed(isGroupEntry: true, new[] { "Demo", "HHI-InP" })
+            .ShouldBeFalse("a mixed group is no chiplet and contains a foreign child");
+    }
+
+    [Fact]
+    public void IsPasteEntryAllowed_MemberContent_AlwaysAllowed()
+    {
+        Context(Soi()).IsPasteEntryAllowed(isGroupEntry: false, new[] { "Demo" }).ShouldBeTrue();
+        Context(Soi()).IsPasteEntryAllowed(isGroupEntry: true, new[] { "Demo", null }).ShouldBeTrue();
+    }
+
+    // ── DeepCopy carries the binding ────────────────────────────────────────────
+
+    [Fact]
+    public void DeepCopy_CarriesProcessBinding()
+    {
+        var chiplet = BuildGroup("InP Chiplet", "foreign_func");
+        chiplet.ProcessBinding = InP();
+
+        var copy = chiplet.DeepCopy();
+
+        copy.ProcessBinding.ShouldNotBeNull();
+        copy.ProcessBinding!.DisplayName.ShouldBe("InP");
+    }
+}

--- a/UnitTests/Routing/InterconnectRouting/PerConnectionProcessFloorTests.cs
+++ b/UnitTests/Routing/InterconnectRouting/PerConnectionProcessFloorTests.cs
@@ -1,0 +1,254 @@
+using CAP_Core.Components;
+using CAP_Core.Components.ComponentHelpers;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Tiles;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing.InterconnectRouting;
+
+/// <summary>
+/// Tests for the per-connection process bend-radius floor (issue #937):
+/// <see cref="WaveguideRouter.ConnectionProcessFloorProvider"/> resolves the floor from the
+/// connection's endpoint pins, so on a multi-process canvas (a Cornerstone SiN chiplet at
+/// 30 µm next to a SiEPIC SOI chiplet at 5 µm) each connection is floored by its own
+/// chiplet's process. The stricter chiplet is no longer under-enforced by one canvas-wide
+/// value, the looser one is no longer over-constrained, and
+/// <see cref="RoutedPath.ViolatesProcessMinBendRadius"/> means "below THIS chiplet's
+/// process minimum". A null provider result keeps the canvas-wide
+/// <see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>.
+/// </summary>
+public class PerConnectionProcessFloorTests
+{
+    private const double CornerstoneSinMinRadius = 30.0;
+    private const double SiepicSoiMinRadius = 5.0;
+    private const double PlaygroundFallback = 10.0;
+
+    [Fact]
+    public void ResolveProcessFloorFor_ProviderNotWired_ReturnsCanvasWideFloor()
+    {
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = CornerstoneSinMinRadius };
+        var (startPin, endPin) = FacingPinPair();
+
+        router.ResolveProcessFloorFor(startPin, endPin).ShouldBe(CornerstoneSinMinRadius);
+    }
+
+    [Fact]
+    public void ResolveProcessFloorFor_ProviderReturnsNull_ReturnsCanvasWideFloor()
+    {
+        var router = new WaveguideRouter
+        {
+            ProcessMinBendRadiusMicrometers = CornerstoneSinMinRadius,
+            ConnectionProcessFloorProvider = (_, _) => null,
+        };
+        var (startPin, endPin) = FacingPinPair();
+
+        router.ResolveProcessFloorFor(startPin, endPin).ShouldBe(CornerstoneSinMinRadius);
+    }
+
+    [Fact]
+    public void ResolveProcessFloorFor_ProviderReturnsValue_OverridesCanvasWideFloorBothWays()
+    {
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = PlaygroundFallback };
+        var (startPin, endPin) = FacingPinPair();
+
+        // Stricter than the canvas-wide value (Cornerstone on a playground canvas)…
+        router.ConnectionProcessFloorProvider = (_, _) => CornerstoneSinMinRadius;
+        router.ResolveProcessFloorFor(startPin, endPin).ShouldBe(CornerstoneSinMinRadius);
+
+        // …and looser (SiEPIC below the generic 10 µm fallback).
+        router.ConnectionProcessFloorProvider = (_, _) => SiepicSoiMinRadius;
+        router.ResolveProcessFloorFor(startPin, endPin).ShouldBe(SiepicSoiMinRadius);
+    }
+
+    [Fact]
+    public void TwoChipletCanvas_EachConnectionKeepsItsOwnChipletsFloor()
+    {
+        // The #937 finding: one canvas, a Cornerstone SiN chiplet pair and a SiEPIC SOI
+        // chiplet pair, canvas-wide floor at the playground fallback (10 µm). Before the
+        // fix the Cornerstone route was silently routed below its 30 µm foundry floor and
+        // the SiEPIC route was over-constrained at 10 µm.
+        var cornerstoneA = CreateTestComponent("Cornerstone_a", 0, 0);
+        var cornerstoneB = CreateTestComponent("Cornerstone_b", 300, 100);
+        var siepicA = CreateTestComponent("SiEPIC_a", 0, 400);
+        var siepicB = CreateTestComponent("SiEPIC_b", 300, 500);
+
+        // Direct-first is disabled: the styled candidates use generous fitting radii that
+        // would mask which floor was applied — the A* pipeline builds arcs at exactly the
+        // effective radius (same rationale as ProcessMinRadiusDegradationTests). The discrete
+        // allowed-radii list is cleared for the same reason: with it, smoothing and the
+        // post-routing BendRadiusUpsizer would grow the loose chiplet's bends past the
+        // canvas-wide value and hide which floor governed.
+        var router = new WaveguideRouter
+        {
+            ProcessMinBendRadiusMicrometers = PlaygroundFallback,
+            PreferDirectStyledRoutes = false,
+            AllowedBendRadii = new List<double>(),
+            ConnectionProcessFloorProvider = (startPin, _) =>
+                startPin.ParentComponent.Identifier.StartsWith("Cornerstone") ? CornerstoneSinMinRadius
+                : startPin.ParentComponent.Identifier.StartsWith("SiEPIC") ? SiepicSoiMinRadius
+                : null,
+        };
+        router.InitializePathfindingGrid(-100, -100, 600, 700,
+            new Component[] { cornerstoneA, cornerstoneB, siepicA, siepicB });
+
+        var manager = new WaveguideConnectionManager(router);
+        var cornerstoneConnection = new WaveguideConnection
+        {
+            StartPin = CreatePin("output", cornerstoneA, offsetX: 50, angleDegrees: 0),
+            EndPin = CreatePin("input", cornerstoneB, offsetX: 0, angleDegrees: 180),
+        };
+        var siepicConnection = new WaveguideConnection
+        {
+            BendRadiusMicrometers = SiepicSoiMinRadius,
+            StartPin = CreatePin("output", siepicA, offsetX: 50, angleDegrees: 0),
+            EndPin = CreatePin("input", siepicB, offsetX: 0, angleDegrees: 180),
+        };
+        manager.AddExistingConnection(cornerstoneConnection);
+        manager.AddExistingConnection(siepicConnection);
+        manager.RecalculateAllTransmissions();
+
+        // Cornerstone: raised to its 30 µm foundry floor although the canvas-wide value is 10.
+        var cornerstoneBends = cornerstoneConnection.GetPathSegments().OfType<BendSegment>().ToList();
+        cornerstoneBends.ShouldNotBeEmpty();
+        cornerstoneBends.ShouldAllBe(b => b.RadiusMicrometers >= CornerstoneSinMinRadius - 1e-6);
+        cornerstoneConnection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse();
+
+        // SiEPIC: routed at its own 5 µm process minimum, not dragged up to the
+        // canvas-wide 10 µm fallback or the neighbour's 30 µm.
+        var siepicBends = siepicConnection.GetPathSegments().OfType<BendSegment>().ToList();
+        siepicBends.ShouldNotBeEmpty();
+        siepicBends.ShouldAllBe(b => b.RadiusMicrometers >= SiepicSoiMinRadius - 1e-6);
+        siepicBends.ShouldContain(b => b.RadiusMicrometers < PlaygroundFallback - 1e-6);
+        siepicConnection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TightNeighbors_PerConnectionFloor_DegradesToConnectionRadiusWithViolationFlag()
+    {
+        // The violation flag now means "below THIS chiplet's process minimum": the floor
+        // comes from the provider (30 µm), the canvas-wide value is 0.
+        var connection = RouteTightNeighbors(
+            new WaveguideRouter
+            {
+                ProcessMinBendRadiusMicrometers = 0.0,
+                ConnectionProcessFloorProvider = (_, _) => CornerstoneSinMinRadius,
+            });
+
+        connection.IsPathValid.ShouldBeTrue();
+        connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeTrue();
+        PathIntersectionDetector.HasSelfIntersection(connection.RoutedPath).ShouldBeFalse();
+
+        var bends = connection.GetPathSegments().OfType<BendSegment>().ToList();
+        bends.ShouldNotBeEmpty();
+        bends.ShouldAllBe(b => b.RadiusMicrometers >= connection.BendRadiusMicrometers - 1e-6);
+    }
+
+    [Fact]
+    public void TightNeighbors_ProviderHasNoOpinion_NoViolationFlag()
+    {
+        var connection = RouteTightNeighbors(
+            new WaveguideRouter
+            {
+                ProcessMinBendRadiusMicrometers = 0.0,
+                ConnectionProcessFloorProvider = (_, _) => null,
+            });
+
+        connection.IsPathValid.ShouldBeTrue();
+        connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void StyledBend_PerConnectionFloor_RaisesArcRadiusToTheFloor()
+    {
+        // Styled curves take the same per-connection floor (the WaveguideConnection
+        // effective-radius path): a 29 µm floor still fits the 30 µm maximum here.
+        var connection = new WaveguideConnection
+        {
+            Type = WaveguideType.Bend,
+            StartPin = CreatePin("output", CreateTestComponent("styled_start", 0, 0), offsetX: 50, angleDegrees: 0),
+            EndPin = CreatePin("input", CreateTestComponent("styled_end", 100, 30), offsetX: 0, angleDegrees: 270),
+        };
+        var router = new WaveguideRouter
+        {
+            ProcessMinBendRadiusMicrometers = 0.0,
+            ConnectionProcessFloorProvider = (_, _) => 29.0,
+        };
+
+        connection.RecalculateTransmission(router);
+
+        var bend = connection.GetPathSegments().OfType<BendSegment>().ShouldHaveSingleItem();
+        bend.RadiusMicrometers.ShouldBe(29.0, 0.01);
+    }
+
+    /// <summary>
+    /// Two components whose facing pins are only ~40 µm apart in X and Y — too tight for a
+    /// 30 µm bend radius (the degradation layout from <c>ProcessMinRadiusDegradationTests</c>).
+    /// </summary>
+    private static WaveguideConnection RouteTightNeighbors(WaveguideRouter router)
+    {
+        var left = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        left.PhysicalX = 60;
+        left.PhysicalY = 60;
+        var right = TestComponentFactory.CreateStraightWaveGuideWithPhysicalPins();
+        right.PhysicalX = 350;
+        right.PhysicalY = 100;
+
+        router.InitializePathfindingGrid(-100, -100, 1100, 900, new[] { left, right });
+
+        var manager = new WaveguideConnectionManager(router);
+        var connection = new WaveguideConnection
+        {
+            StartPin = left.PhysicalPins.First(p => p.Name == "out"),
+            EndPin = right.PhysicalPins.First(p => p.Name == "in"),
+        };
+        manager.AddExistingConnection(connection);
+        manager.RecalculateAllTransmissions();
+        return connection;
+    }
+
+    private static (PhysicalPin Start, PhysicalPin End) FacingPinPair()
+    {
+        var start = CreateTestComponent("pair_start", 0, 0);
+        var end = CreateTestComponent("pair_end", 300, 100);
+        return (CreatePin("output", start, offsetX: 50, angleDegrees: 0),
+                CreatePin("input", end, offsetX: 0, angleDegrees: 180));
+    }
+
+    private static PhysicalPin CreatePin(string name, Component parent, double offsetX, double angleDegrees)
+    {
+        return new PhysicalPin
+        {
+            Name = name,
+            OffsetXMicrometers = offsetX,
+            OffsetYMicrometers = 25,
+            AngleDegrees = angleDegrees,
+            ParentComponent = parent,
+        };
+    }
+
+    private static Component CreateTestComponent(string identifier, double x, double y)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+
+        return new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: "test",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: identifier,
+            rotationCounterClock: DiscreteRotation.R0)
+        {
+            WidthMicrometers = 50,
+            HeightMicrometers = 50,
+            PhysicalX = x,
+            PhysicalY = y,
+        };
+    }
+}

--- a/UnitTests/Routing/InterconnectRouting/WaveguideBendRadiusResolverTests.cs
+++ b/UnitTests/Routing/InterconnectRouting/WaveguideBendRadiusResolverTests.cs
@@ -124,4 +124,115 @@ public class WaveguideBendRadiusResolverTests
             active, new List<PdkDraft> { customPdk }, effectiveMemberPdkNames: new[] { "MyCustomFab" })
             .ShouldBe(25);
     }
+
+    [Fact]
+    public void ResolveForEndpointPdkNames_TwoChipletProcesses_StricterEndpointGoverns()
+    {
+        // The #937 scenario: a Cornerstone SiN chiplet (30 µm foundry floor) next to a
+        // SiEPIC SOI chiplet (5 µm). A cross-chiplet connection must keep the stricter
+        // floor — the canvas-wide minimum-over-members (5 µm) under-enforced Cornerstone.
+        var drafts = new List<PdkDraft> { CornerstoneSinPdk(), SiepicSoiPdk() };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("Cornerstone SiN", "SiEPIC SOI", drafts)
+            .ShouldBe(30);
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("SiEPIC SOI", "Cornerstone SiN", drafts)
+            .ShouldBe(30);
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdkNames_SameChipletEndpoints_UsesThatChipletsFloor()
+    {
+        var drafts = new List<PdkDraft> { CornerstoneSinPdk(), SiepicSoiPdk() };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("Cornerstone SiN", "Cornerstone SiN", drafts)
+            .ShouldBe(30);
+        // SiEPIC-to-SiEPIC resolves BELOW the generic 10 µm fallback: the foundry declares
+        // 5 µm legal, so the canvas-wide fallback no longer over-constrains the route.
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("SiEPIC SOI", "SiEPIC SOI", drafts)
+            .ShouldBe(5);
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdkNames_OneEndpointUnresolvable_UsesTheOtherEndpointsFloor()
+    {
+        var drafts = new List<PdkDraft> { CornerstoneSinPdk() };
+
+        // Built-in / group / PDK-less components carry no PDK source (null).
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("Cornerstone SiN", null, drafts)
+            .ShouldBe(30);
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames(null, "Cornerstone SiN", drafts)
+            .ShouldBe(30);
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdkNames_NeitherEndpointResolvable_ReturnsNull()
+    {
+        var drafts = new List<PdkDraft> { CornerstoneSinPdk() };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames(null, null, drafts).ShouldBeNull();
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("Unknown PDK", "Also Unknown", drafts)
+            .ShouldBeNull();
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("Cornerstone SiN", "Cornerstone SiN", null)
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdkNames_PdkWithoutOpticalMinimum_HasNoOpinion()
+    {
+        var noOpticalMin = new PdkDraft
+        {
+            Name = "NoMin PDK",
+            Process = new ProcessDefinition
+            {
+                Name = "NoMin",
+                Xsections = new List<ProcessXsection>
+                {
+                    new() { Name = "E200", Kind = XsectionKind.Optical, MinRadiusUm = 0 },
+                    new() { Name = "MetalDC", Kind = XsectionKind.Metal, MinRadiusUm = 8 }
+                }
+            }
+        };
+        var drafts = new List<PdkDraft> { noOpticalMin, CornerstoneSinPdk() };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("NoMin PDK", "NoMin PDK", drafts)
+            .ShouldBeNull();
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("NoMin PDK", "Cornerstone SiN", drafts)
+            .ShouldBe(30);
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdkNames_PdkNameMatchesCaseInsensitive()
+    {
+        var drafts = new List<PdkDraft> { CornerstoneSinPdk() };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdkNames("cornerstone sin", "CORNERSTONE SIN", drafts)
+            .ShouldBe(30);
+    }
+
+    private static PdkDraft CornerstoneSinPdk() => new()
+    {
+        Name = "Cornerstone SiN",
+        Process = new ProcessDefinition
+        {
+            Name = "Cornerstone SiN",
+            Xsections = new List<ProcessXsection>
+            {
+                new() { Name = "sin300", Kind = XsectionKind.Optical, MinRadiusUm = 30 },
+                new() { Name = "MetalDC", Kind = XsectionKind.Metal, MinRadiusUm = 5 }
+            }
+        }
+    };
+
+    private static PdkDraft SiepicSoiPdk() => new()
+    {
+        Name = "SiEPIC SOI",
+        Process = new ProcessDefinition
+        {
+            Name = "SiEPIC SOI",
+            Xsections = new List<ProcessXsection>
+            {
+                new() { Name = "strip", Kind = XsectionKind.Optical, MinRadiusUm = 5 }
+            }
+        }
+    };
 }

--- a/UnitTests/ViewModels/Canvas/RoutingOrchestratorProcessFloorTests.cs
+++ b/UnitTests/ViewModels/Canvas/RoutingOrchestratorProcessFloorTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Canvas.Services;
+using CAP_Core.Components.Connections;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels.Canvas;
+
+/// <summary>
+/// Tests for the per-connection process bend-floor wiring (issue #937): at the start of
+/// every routing pass the <see cref="RoutingOrchestrator"/> builds the pass-scoped provider
+/// through <see cref="RoutingOrchestrator.BuildConnectionProcessFloorProvider"/> and pushes
+/// it onto the router, so the router floors each connection by its own endpoints' process.
+/// An unwired factory clears the provider and the canvas-wide floor governs.
+/// </summary>
+public class RoutingOrchestratorProcessFloorTests
+{
+    [Fact]
+    public async Task RecalculateRoutesAsync_FactoryWired_PushesProviderOntoTheRouter()
+    {
+        var router = new WaveguideRouter();
+        var orchestrator = CreateOrchestrator(router);
+        orchestrator.BuildConnectionProcessFloorProvider = () => (_, _) => 30.0;
+
+        await orchestrator.RecalculateRoutesAsync();
+
+        router.ConnectionProcessFloorProvider.ShouldNotBeNull();
+        router.ConnectionProcessFloorProvider!(null!, null!).ShouldBe(30.0);
+    }
+
+    [Fact]
+    public async Task RecalculateRoutesAsync_FactoryNotWired_ClearsStaleProvider()
+    {
+        var router = new WaveguideRouter
+        {
+            ConnectionProcessFloorProvider = (_, _) => 5.0,
+        };
+        var orchestrator = CreateOrchestrator(router);
+
+        await orchestrator.RecalculateRoutesAsync();
+
+        router.ConnectionProcessFloorProvider.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RecalculateRoutesAsync_FactoryReturnsNull_ClearsProvider()
+    {
+        var router = new WaveguideRouter
+        {
+            ConnectionProcessFloorProvider = (_, _) => 5.0,
+        };
+        var orchestrator = CreateOrchestrator(router);
+        orchestrator.BuildConnectionProcessFloorProvider = () => null;
+
+        await orchestrator.RecalculateRoutesAsync();
+
+        router.ConnectionProcessFloorProvider.ShouldBeNull();
+    }
+
+    private static RoutingOrchestrator CreateOrchestrator(WaveguideRouter router) =>
+        new(router,
+            new WaveguideConnectionManager(router),
+            new ObservableCollection<ComponentViewModel>(),
+            new ObservableCollection<WaveguideConnectionViewModel>());
+}

--- a/UnitTests/ViewModels/Panels/ChipletPlacementTests.cs
+++ b/UnitTests/ViewModels/Panels/ChipletPlacementTests.cs
@@ -1,0 +1,236 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_Core.LightCalculation;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels.Panels;
+
+/// <summary>
+/// Per-chiplet process scoping at the placement surfaces (issue #935): on a canvas locked
+/// to one process, a uniformly foreign-process group places as its own chiplet (and gets
+/// the derived process pinned as its <see cref="ComponentGroup.ProcessBinding"/>), drops
+/// onto a bound chiplet resolve against the chiplet's process, and a copied chiplet pastes
+/// across the process boundary — while loose foreign components and mixed groups stay
+/// blocked by the canvas lock.
+/// </summary>
+public class ChipletPlacementTests : IDisposable
+{
+    private static readonly ProcessGroup SoiGroup = new(
+        "SOI 220", new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"), new[] { "Demo" });
+    private static readonly ProcessGroup InPGroup = new(
+        "InP", new ProcessFingerprint("InP", 300, "SiO2", 1550, "InP"), new[] { "HHI-InP" });
+    private static readonly IReadOnlyList<ProcessGroup> Catalog = new[] { SoiGroup, InPGroup };
+
+    private readonly string _testLibraryPath;
+    private readonly GroupLibraryManager _libraryManager;
+    private readonly DesignCanvasViewModel _canvas;
+    private readonly CanvasInteractionViewModel _interaction;
+
+    public ChipletPlacementTests()
+    {
+        _testLibraryPath = Path.Combine(Path.GetTempPath(), $"ChipletPlacementTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testLibraryPath);
+
+        _libraryManager = new GroupLibraryManager(_testLibraryPath);
+        _canvas = new DesignCanvasViewModel();
+        _interaction = new CanvasInteractionViewModel(
+            _canvas, new CommandManager(), new ComponentLibraryViewModel(_libraryManager));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testLibraryPath))
+            Directory.Delete(_testLibraryPath, true);
+    }
+
+    private static ActiveProcessSelection Soi() => ActiveProcessSelection.ForGroup(SoiGroup);
+
+    /// <summary>Maps a child's NazcaFunctionName to a PDK source, mimicking the library lookup.</summary>
+    private static string? ResolveByNazcaFunction(Component component) => component.NazcaFunctionName switch
+    {
+        "member_func" => "Demo",
+        "foreign_func" => "HHI-InP",
+        _ => null
+    };
+
+    private void LockToSoi()
+    {
+        _interaction.PlacementContext = new PlacementPolicyContext(
+            () => Soi(),
+            () => Array.Empty<string>(),
+            component => ResolveByNazcaFunction(component),
+            getProcessCatalog: () => Catalog);
+        _canvas.Clipboard.PdkSourceResolver = ResolveByNazcaFunction;
+    }
+
+    private static ComponentTemplate BuildTemplate(string pdkSource) => new()
+    {
+        Name = "TestComp",
+        Category = "Test",
+        PdkSource = pdkSource,
+        WidthMicrometers = 10,
+        HeightMicrometers = 10,
+        PinDefinitions = new[] { new PinDefinition("a", 0, 5, 180) },
+        CreateSMatrix = pins =>
+        {
+            var ids = pins.SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+            return new SMatrix(ids, new List<(Guid, double)>());
+        }
+    };
+
+    private void SelectGroupTemplate(string name, params string[] childNazcaFunctions)
+    {
+        var group = BuildGroup(name, childNazcaFunctions);
+        var template = _libraryManager.SaveTemplate(group, name);
+        template.TemplateGroup = group;
+        _interaction.SelectedGroupTemplate = template;
+    }
+
+    private static ComponentGroup BuildGroup(string name, params string[] childNazcaFunctions)
+    {
+        var group = new ComponentGroup(name) { PhysicalX = 0, PhysicalY = 0 };
+        for (int i = 0; i < childNazcaFunctions.Length; i++)
+        {
+            group.AddChild(new Component(
+                new Dictionary<int, SMatrix>(),
+                new List<Slider>(),
+                childNazcaFunctions[i],
+                "",
+                new Part[1, 1] { { new Part() } },
+                -1,
+                $"comp_{i}_{Guid.NewGuid():N}",
+                DiscreteRotation.R0,
+                new List<PhysicalPin>())
+            {
+                PhysicalX = i * 100,
+                PhysicalY = 0,
+                WidthMicrometers = 50,
+                HeightMicrometers = 30
+            });
+        }
+        return group;
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_UniformForeignGroup_OnLockedCanvas_PlacesAsBoundChiplet()
+    {
+        LockToSoi();
+        SelectGroupTemplate("InP Chiplet", "foreign_func", "foreign_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1,
+            "a uniformly foreign-process group is placeable as its own chiplet");
+        var placed = (ComponentGroup)_canvas.Components.Single().Component;
+        placed.ProcessBinding.ShouldNotBeNull("the placed instance carries its chiplet process binding");
+        placed.ProcessBinding!.DisplayName.ShouldBe("InP");
+        placed.ProcessBinding.IsPlayground.ShouldBeFalse("a bound chiplet is manufacturable, not Playground");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_MixedGroup_OnLockedCanvas_StaysBlocked()
+    {
+        LockToSoi();
+        SelectGroupTemplate("Mixed", "member_func", "foreign_func");
+
+        string? status = null;
+        _interaction.UpdateStatus = s => status = s;
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(0, "a group no single process can fabricate is no chiplet");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("HHI-InP");
+    }
+
+    [Fact]
+    public void PlaceGroupTemplate_MemberGroup_GetsPinnedToCanvasProcess()
+    {
+        LockToSoi();
+        SelectGroupTemplate("SOI Pair", "member_func", "member_func");
+
+        _interaction.CanvasClicked(500, 500);
+
+        _canvas.Components.Count.ShouldBe(1);
+        var placed = (ComponentGroup)_canvas.Components.Single().Component;
+        placed.ProcessBinding.ShouldNotBeNull();
+        placed.ProcessBinding!.DisplayName.ShouldBe("SOI 220");
+    }
+
+    [Fact]
+    public void PlaceComponent_OntoBoundChiplet_ResolvesAgainstChipletProcess()
+    {
+        LockToSoi();
+        SelectGroupTemplate("InP Chiplet", "foreign_func", "foreign_func");
+        _interaction.CanvasClicked(500, 500);
+        _canvas.Components.Count.ShouldBe(1);
+
+        var chipletVm = _canvas.Components.Single();
+        double cx = chipletVm.X + chipletVm.Width / 2;
+        double cy = chipletVm.Y + chipletVm.Height / 2;
+
+        // Canvas member, but foreign to the chiplet: the chiplet's process rejects it.
+        string? status = null;
+        _interaction.UpdateStatus = s => status = s;
+        _interaction.SelectedTemplate = BuildTemplate("Demo");
+        _interaction.CanvasClicked(cx, cy);
+
+        _canvas.Components.Count.ShouldBe(1, "canvas-member content is foreign to the chiplet");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("InP Chiplet");
+
+        // Foreign to the canvas, but matching the chiplet: the process check must pass
+        // (geometry may still displace the drop — only the policy verdict is asserted here).
+        _interaction.SelectedTemplate = BuildTemplate("HHI-InP");
+        _interaction.CanvasClicked(cx, cy);
+
+        status.ShouldNotBeNull();
+        status!.Contains("fabricates").ShouldBeFalse(
+            "the chiplet's own process must accept the drop at the policy level");
+    }
+
+    [Fact]
+    public void PasteSelected_CopiedForeignChiplet_OnLockedCanvas_PastesAsChiplet()
+    {
+        var group = BuildGroup("InP Chiplet", "foreign_func", "foreign_func");
+        var vm = _canvas.AddComponent(group);
+        _canvas.Selection.SelectSingle(vm);
+        _interaction.CopySelectedCommand.Execute(null);
+
+        LockToSoi();
+
+        int countBefore = _canvas.Components.Count;
+        _interaction.PasteSelected();
+
+        _canvas.Components.Count.ShouldBe(countBefore + 1,
+            "a copied chiplet keeps its own process scope across paste");
+    }
+
+    [Fact]
+    public void PasteSelected_LooseForeignComponent_OnLockedCanvas_StaysBlocked()
+    {
+        var group = BuildGroup("carrier", "foreign_func");
+        var looseChild = group.ChildComponents.Single();
+        var vm = _canvas.AddComponent(looseChild, "TestTemplate", "HHI-InP");
+        _canvas.Selection.SelectSingle(vm);
+        _interaction.CopySelectedCommand.Execute(null);
+
+        LockToSoi();
+        string? status = null;
+        _interaction.UpdateStatus = s => status = s;
+
+        int countBefore = _canvas.Components.Count;
+        _interaction.PasteSelected();
+
+        _canvas.Components.Count.ShouldBe(countBefore,
+            "a loose foreign component must not slip through as a pseudo-chiplet");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("SOI 220");
+    }
+}


### PR DESCRIPTION
## What & why

**#935 — Multi-chiplet: placement policy was canvas-global; it now has a per-chiplet process scope (#537 rung 6).**

Until now the single-process enforcement (#570/#653) knew exactly one scope: the whole design. A canvas locked to process A rejected every component/group of process B at placement and paste time; the only way to hold two processes on one canvas was Playground — explicitly "not manufacturable", with all PDK-dependent checks switched off.

This PR gives `ComponentGroup` (= chiplet) an optional process identity and makes placement/paste checks resolve against the *target chiplet's* process:

- `ComponentGroup.ProcessBinding` (new, optional, in-memory): the fabrication process the chiplet belongs to. Carried through `DeepCopy` (copy/paste, template instantiation). **Persisting it in .lun files is deliberately left to #938** (journey step 7) — the property is `[JsonIgnore]`d, so the file format and the step-6 round-trip pin are untouched.
- `GroupProcessPolicy.DeriveProcessBinding(children, catalog)`: when every non-exempt child belongs to exactly one process of the live catalog, the group is a chiplet of that process. Mixed groups (no single process can fabricate them) get no binding — they stay blocked on a foreign-locked canvas, exactly as before.
- `PlacementPolicyContext` gains a live catalog accessor (wired in `MainViewModel` from `LeftPanel.GetLoadedPdkProcessEntries()`; unwired = empty catalog = legacy canvas-global behavior) and chiplet-aware checks:
  - `CheckPlacementAt` — dropping a component onto a bound chiplet checks it against the *chiplet's* process; ungrouped canvas keeps the design lock.
  - `CheckGroupPlacementAt` — onto a bound chiplet the chiplet's process decides; at canvas level a uniformly foreign-process group is placeable **as its own chiplet** and the derived binding is pinned onto the placed instance (`PlaceGroupTemplateCommand.GroupToPlace`).
  - `IsPasteEntryAllowed` — the paste guard works per top-level clipboard entry (`ComponentClipboard.PeekEntryPdkSources`): loose foreign components stay blocked; a copied chiplet pastes across the process boundary with its scope intact.
- Block messages extended (still containing the asserted "monolithic" wording): the canvas message now hints that content grouped as its own chiplet carries its own process, and chiplet-scope rejections name the chiplet ("chiplet 'X' fabricates in the process 'Y'"). These are status-bar/policy strings, hardcoded English like all existing policy messages — no new i18n keys (Core has no localization dependency).

Two chiplets with different processes on one canvas are now a first-class, manufacturable state instead of Playground. The monolithic protection is preserved: loose foreign components and mixed groups are still rejected, and the journey's "today" pin was converted to guard exactly that canvas-level half.

## How it was tested

- **26 new tests**, all green:
  - `UnitTests/Components/Process/ChipletProcessScopeTests.cs` (18): binding derivation (uniform/mixed/exempt/empty-catalog/case), explicit-vs-derived resolution, scope checks at placement/group-placement/paste level, `DeepCopy` carrying the binding.
  - `UnitTests/ViewModels/Panels/ChipletPlacementTests.cs` (6→8): group template places as bound chiplet on a locked canvas, mixed group stays blocked, member group pins to the canvas process, drop-onto-chiplet resolves against the chiplet's process, copied chiplet pastes, loose foreign component stays blocked.
- **Journey step 3 un-skipped and green** (`MultiProcessChipletJourneyTests.Step3_ProcessLockedCanvas_AcceptsSecondProcessChiplet`) on the real bundled CornerStone SiN + SiEPIC EBeam PDKs: locked canvas accepts the second-process chiplet, rejects loose foreign content, pins the binding, scopes drops. Steps 4/5/7/8 stay documented-red under their own issues (#936–#939).
- Existing enforcement suites (`GroupProcessEnforcementTests`, `CanvasInteractionProcessEnforcementTests`, policy/context/catalog tests) all still green — they wire no catalog, proving legacy behavior is unchanged when the feature is unwired.

Local suite: 5647 passed, 0 failed

## Known boundaries (deliberate, for review)

- The binding is **in-memory only**; saving/loading it is #938 (journey step 7, still red).
- **Ungrouping** a foreign chiplet on a locked canvas scatters its children as ungrouped foreign content — placement checks don't apply to ungroup. If unwanted, that's a follow-up guard.
- The **AI grid service** path keeps the conservative canvas-global check (it can't create chiplets yet).
- DRC-lite (#936), router bend floors (#937) and GDS export stacks (#939) remain canvas-global per their own issues.

## Manual verification after vacation

All paths above are covered headlessly; one visual smoke pass is still worthwhile because real hit-testing/pixel bounds differ from test doubles:

1. Open a design, lock it to a process (process panel), place a component of that process.
2. From "Saved Groups", place a group whose children all belong to a *different* process → it places; select it and confirm the status bar reports the placement (no process error).
3. Try placing a single component of the other process on empty canvas → status bar shows the monolithic-lock message with the chiplet hint.
4. Copy the chiplet (Ctrl+C / Ctrl+V) → paste succeeds; copy one child out of it (ungrouped) → paste is blocked with the "another process" message.

✅ Complete! Tools: dotnet test filtered runs (~100K output chars avoided via grep/tail); smart_test.py not installed on this machine.


---

## #937 — Router bend-radius floor is now per-connection (added on rebase)

**The canvas-wide bend-radius floor under-enforced the stricter chiplet's process (#537 rung 6).** With two chiplets on one canvas (e.g. Cornerstone SiN at 30 µm next to SiEPIC SOI at 5 µm), one canvas-wide floor either under-enforced the stricter chiplet or over-constrained the looser one.

- `WaveguideRouter.ConnectionProcessFloorProvider` (new, optional): resolves the floor from the connection's endpoint pins per routing pass. Wired in `MainViewModel` via a UI-thread factory that snapshots library templates + PDK drafts, so the routing thread never enumerates live ViewModel collections.
- `ResolveProcessFloorFor(startPin, endPin)` consolidates floor selection: electrical pins → metal cross-section floor (#854, unchanged); optical pins → per-connection provider value, else the canvas-wide `ProcessMinBendRadiusMicrometers` fallback. Used by both the A* `Route` path and the styled-curve effective radius in `WaveguideConnection`.
- `RoutedPath.ViolatesProcessMinBendRadius` now means "below THIS connection's process minimum" — the design checks surface a cross-chiplet violation against the stricter chiplet's foundry minimum.
- Unresolvable endpoints (built-ins, groups, PDK-less drafts) yield null → canvas-wide floor governs, so single-process and playground canvases behave exactly as before.

**Rebase note:** this commit was rebased onto the parallel session's tip (37 commits incl. #935, #900, #869). Semantic merge with #854's electrical/metal floor (both kept: metal short-circuit inside `ResolveProcessFloorFor`). One test updated: the two-chiplet routing test clears `AllowedBendRadii`, because the new post-routing `BendRadiusUpsizer` (#869) legitimately grows the loose chiplet's bends past the canvas-wide value and would mask which floor governed.

**Tests:** 10 new tests (`PerConnectionProcessFloorTests`, `WaveguideBendRadiusResolverTests` endpoint-name resolution, `RoutingOrchestratorProcessFloorTests`) — full suite green: 5663 passed, 0 failed (Slow category excluded locally, CI runs all).
