### PR TITLE
Agent: Multi-chiplet: placement policy is canvas-global — no per-chiplet process scope (#537 rung 6)

### DIFF
--- a/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/CanvasInteractionViewModel.cs
@@ -399,7 +399,10 @@ public partial class CanvasInteractionViewModel : ObservableObject
     {
         if (SelectedTemplate == null) return;
 
-        var (isAllowed, blockReason) = PlacementContext.CheckPlacement(SelectedTemplate.PdkSource);
+        // Dropping onto a chiplet scopes the check to that chiplet's fabrication process;
+        // ungrouped canvas content falls back to the design-global active process (#935).
+        var (isAllowed, blockReason) = PlacementContext.CheckPlacementInScope(
+            ChipletScopeAt(x, y), SelectedTemplate.PdkSource);
         if (!isAllowed)
         {
             UpdateStatus?.Invoke(blockReason ?? "Process mismatch — cannot place component.");
@@ -433,7 +436,9 @@ public partial class CanvasInteractionViewModel : ObservableObject
 
         // Single-process enforcement over the group's children (issue #653): a group has no
         // PdkSource of its own, so a foreign-process child must not slip in via grouping.
-        var (isAllowed, blockReason) = PlacementContext.CheckGroupPlacement(
+        // Dropping onto a chiplet scopes the check to that chiplet's process (#935).
+        var (isAllowed, blockReason) = PlacementContext.CheckGroupPlacementInScope(
+            ChipletScopeAt(x, y),
             ChildPdkSources(SelectedGroupTemplate.TemplateGroup),
             SelectedGroupTemplate.Name);
         if (!isAllowed)
@@ -509,6 +514,25 @@ public partial class CanvasInteractionViewModel : ObservableObject
         _canvas.Components
             .Where(c => x >= c.X && x <= c.X + c.Width && y >= c.Y && y <= c.Y + c.Height)
             .LastOrDefault();
+
+    /// <summary>
+    /// Returns the nearest chiplet (a <see cref="ComponentGroup"/> with a
+    /// <see cref="ComponentGroup.FabricationProcess"/>) whose bounds contain the point —
+    /// walking up the parent chain so a drop onto an unbound inner group nested inside a
+    /// bound chiplet defers to that chiplet — or null when no bound chiplet governs the
+    /// point. Placement/paste checks use this to scope enforcement to the chiplet's
+    /// fabrication process (issue #935).
+    /// </summary>
+    private ComponentGroup? ChipletScopeAt(double x, double y)
+    {
+        var hit = ComponentAt(x, y)?.Component;
+        var group = hit as ComponentGroup ?? hit?.ParentGroup as ComponentGroup;
+        while (group != null && group.FabricationProcess == null)
+        {
+            group = group.ParentGroup;
+        }
+        return group;
+    }
 
     private void SelectAt(double x, double y)
     {
@@ -849,17 +873,25 @@ public partial class CanvasInteractionViewModel : ObservableObject
     {
         if (!_canvas.Clipboard.HasContent) return;
 
+        // Paste at an explicit position onto a chiplet scopes the check to that chiplet's
+        // fabrication process (issue #935); a position-less paste (Ctrl+V) keeps the
+        // canvas-global check because the landing spot is not yet known.
+        var scope = (targetX.HasValue && targetY.HasValue)
+            ? ChipletScopeAt(targetX.Value, targetY.Value)
+            : null;
+
         // PeekPdkSources expands groups to their resolved children (the clipboard's
         // PdkSourceResolver is wired by MainViewModel), so a copied group cannot
         // smuggle foreign-process components past the paste guard (issue #653).
         var blockedCount = _canvas.Clipboard.PeekPdkSources()
-            .Count(pdk => !PlacementContext.CheckPlacement(pdk).IsAllowed);
+            .Count(pdk => !PlacementContext.CheckPlacementInScope(scope, pdk).IsAllowed);
         if (blockedCount > 0)
         {
-            // A blocked component implies a non-null, non-Playground active process.
+            // A blocked component implies a non-null, non-Playground effective process.
+            var effective = PlacementContext.EffectiveProcessFor(scope)!;
             UpdateStatus?.Invoke(
                 $"Clipboard has {blockedCount} component(s) from another process; " +
-                $"cannot paste into the '{PlacementContext.ActiveProcess!.DisplayName}' design.");
+                $"cannot paste into the '{effective.DisplayName}' design.");
             return;
         }
 

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
 using CAP_Core.LightCalculation;
 using CAP_Core.Routing;
 
@@ -76,6 +77,15 @@ public class ComponentGroup : Component, INotifyPropertyChanged
     /// Only prefabs appear in the "Saved Groups" panel.
     /// </summary>
     public bool IsPrefab { get; set; }
+
+    /// <summary>
+    /// Optional per-chiplet fabrication process binding (issue #935). When set, this group is
+    /// treated as a chiplet manufactured in <see cref="FabricationProcess"/>; placement and
+    /// paste of components INTO the group are checked against this process instead of the
+    /// canvas-global active process. Null means the group carries no process identity of its
+    /// own — placement into it falls back to the canvas-global check.
+    /// </summary>
+    public ActiveProcessSelection? FabricationProcess { get; set; }
 
     /// <summary>
     /// Reference to parent group if this group is nested within another group.
@@ -576,6 +586,9 @@ public class ComponentGroup : Component, INotifyPropertyChanged
             WidthMicrometers = WidthMicrometers,
             HeightMicrometers = HeightMicrometers,
             Rotation90CounterClock = Rotation90CounterClock,
+            // A chiplet keeps its fabrication-process binding across copy/paste and template
+            // instantiation, else the copy would silently revert to canvas-global enforcement.
+            FabricationProcess = FabricationProcess,
             // Immutable records — sharing the list is safe (same rule as Component.DeepCopy).
             OutlinePolygons = OutlinePolygons
         };

--- a/Connect-A-Pic-Core/Components/Process/PlacementPolicyContext.cs
+++ b/Connect-A-Pic-Core/Components/Process/PlacementPolicyContext.cs
@@ -76,4 +76,39 @@ public sealed class PlacementPolicyContext
     public (bool IsAllowed, string? BlockReason) CheckGroupPlacement(
         IEnumerable<string?> childPdkSources, string? groupName = null) =>
         GroupProcessPolicy.CheckGroupPlacement(ActiveProcess, childPdkSources, ProcessAgnosticPdkNames, LiveMemberPdkNames, groupName);
+
+    /// <summary>
+    /// Checks a component's placement against the process that governs <paramref name="scope"/>:
+    /// the chiplet's <see cref="ComponentGroup.FabricationProcess"/> when the target is a
+    /// chiplet with its own binding, else the canvas-global <see cref="ActiveProcess"/>
+    /// (issue #935). Two chiplets of different processes can then coexist on one canvas
+    /// without dropping to Playground.
+    /// </summary>
+    /// <param name="scope">The chiplet the component would land in, or null for ungrouped canvas content.</param>
+    /// <param name="componentPdkName">PDK source of the component being placed.</param>
+    public (bool IsAllowed, string? BlockReason) CheckPlacementInScope(
+        ComponentGroup? scope, string? componentPdkName) =>
+        SingleProcessPolicy.CheckPlacement(
+            EffectiveProcessFor(scope), componentPdkName, ProcessAgnosticPdkNames, LiveMemberPdkNames);
+
+    /// <summary>
+    /// Group-placement counterpart of <see cref="CheckPlacementInScope"/>: children are checked
+    /// against the target chiplet's process when one is bound, else against the canvas-global
+    /// active process (issue #935).
+    /// </summary>
+    /// <param name="scope">The chiplet the group would land in, or null for ungrouped canvas content.</param>
+    /// <param name="childPdkSources">PDK source of every child component.</param>
+    /// <param name="groupName">Display name of the placed group, used in the block message.</param>
+    public (bool IsAllowed, string? BlockReason) CheckGroupPlacementInScope(
+        ComponentGroup? scope, IEnumerable<string?> childPdkSources, string? groupName = null) =>
+        GroupProcessPolicy.CheckGroupPlacement(
+            EffectiveProcessFor(scope), childPdkSources, ProcessAgnosticPdkNames, LiveMemberPdkNames, groupName);
+
+    /// <summary>
+    /// Resolves the process that governs placement into <paramref name="scope"/>: the chiplet's
+    /// own <see cref="ComponentGroup.FabricationProcess"/> when bound, else the canvas-global
+    /// <see cref="ActiveProcess"/> (issue #935).
+    /// </summary>
+    public ActiveProcessSelection? EffectiveProcessFor(ComponentGroup? scope) =>
+        scope?.FabricationProcess ?? ActiveProcess;
 }

--- a/UnitTests/Components/Process/ChipletPlacementScopeTests.cs
+++ b/UnitTests/Components/Process/ChipletPlacementScopeTests.cs
@@ -1,0 +1,174 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Process;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Components.Process;
+
+/// <summary>
+/// Per-chiplet process scope (issue #935, north-star #537 rung 6): a
+/// <see cref="ComponentGroup"/> may carry its own <see cref="ComponentGroup.FabricationProcess"/>;
+/// placement/paste checks then resolve against that chiplet's process instead of the
+/// canvas-global <see cref="PlacementPolicyContext.ActiveProcess"/>. Two chiplets of
+/// different processes can coexist on one canvas without dropping to Playground.
+/// </summary>
+public class ChipletPlacementScopeTests
+{
+    private static ActiveProcessSelection Soi(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "SOI 220",
+            new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"),
+            memberPdkNames));
+
+    private static ActiveProcessSelection InP(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "HHI-InP",
+            new ProcessFingerprint("InP", 400, "InP", 1550, "HHI-InP"),
+            memberPdkNames));
+
+    private static ComponentGroup Chiplet(ActiveProcessSelection? process, string name = "Chiplet") =>
+        new(name) { FabricationProcess = process };
+
+    private static PlacementPolicyContext ContextFor(ActiveProcessSelection? canvasActive) =>
+        new(() => canvasActive,
+            () => Array.Empty<string>(),
+            _ => null);
+
+    [Fact]
+    public void EffectiveProcess_ChipletWithBinding_WinsOverCanvas()
+    {
+        var context = ContextFor(Soi("Demo"));
+        var chiplet = Chiplet(InP("InP-Lib"));
+
+        context.EffectiveProcessFor(chiplet).ShouldBe(chiplet.FabricationProcess);
+    }
+
+    [Fact]
+    public void EffectiveProcess_ChipletWithoutBinding_FallsBackToCanvas()
+    {
+        var canvas = Soi("Demo");
+        var context = ContextFor(canvas);
+
+        context.EffectiveProcessFor(Chiplet(null)).ShouldBe(canvas);
+        context.EffectiveProcessFor(null).ShouldBe(canvas);
+    }
+
+    [Fact]
+    public void PlaceComponent_MemberOfChipletProcess_AllowedThoughCanvasLockedElsewhere()
+    {
+        // Canvas is locked to SOI, the chiplet is an InP chiplet: an InP component drops
+        // into the InP chiplet even though it would be rejected on the open canvas.
+        var context = ContextFor(Soi("Demo"));
+        var chiplet = Chiplet(InP("InP-Lib"));
+
+        context.CheckPlacementInScope(chiplet, "InP-Lib").IsAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PlaceComponent_ForeignToChipletProcess_BlockedThoughCanvasWouldAllow()
+    {
+        // Canvas is SOI and "Demo" is a member; the chiplet is InP. Dropping a "Demo"
+        // component into the InP chiplet must be rejected against the chiplet, not the
+        // canvas — otherwise a chiplet could be polluted with foreign-process parts.
+        var context = ContextFor(Soi("Demo"));
+        var chiplet = Chiplet(InP("InP-Lib"));
+
+        var (isAllowed, reason) = context.CheckPlacementInScope(chiplet, "Demo");
+
+        isAllowed.ShouldBeFalse();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("Demo");
+        reason.ShouldContain("HHI-InP");
+    }
+
+    [Fact]
+    public void PlaceComponent_NoChipletScope_UsesCanvasGlobal()
+    {
+        var context = ContextFor(Soi("Demo"));
+
+        context.CheckPlacementInScope(null, "Demo").IsAllowed.ShouldBeTrue();
+        context.CheckPlacementInScope(null, "HHI-InP").IsAllowed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PlaceComponent_ChipletWithoutBinding_UsesCanvasGlobal()
+    {
+        var context = ContextFor(Soi("Demo"));
+
+        context.CheckPlacementInScope(Chiplet(null), "Demo").IsAllowed.ShouldBeTrue();
+        context.CheckPlacementInScope(Chiplet(null), "HHI-InP").IsAllowed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PlaceComponent_ChipletBoundToPlayground_AllowsAnything()
+    {
+        var context = ContextFor(Soi("Demo"));
+        var chiplet = Chiplet(ActiveProcessSelection.Playground());
+
+        context.CheckPlacementInScope(chiplet, "AnyForeignPdk").IsAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PlaceGroup_AllChildrenMemberOfChipletProcess_Allowed()
+    {
+        var context = ContextFor(Soi("Demo"));
+        var chiplet = Chiplet(InP("InP-Lib"));
+
+        var (isAllowed, _) = context.CheckGroupPlacementInScope(
+            chiplet, new[] { "InP-Lib", "InP-Lib" }, groupName: "InP pair");
+
+        isAllowed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PlaceGroup_ForeignChildAgainstChiplet_BlockedEvenWhenCanvasMember()
+    {
+        var context = ContextFor(Soi("Demo"));
+        var chiplet = Chiplet(InP("InP-Lib"));
+
+        var (isAllowed, reason) = context.CheckGroupPlacementInScope(
+            chiplet, new[] { "InP-Lib", "Demo" }, groupName: "Mixed");
+
+        isAllowed.ShouldBeFalse();
+        reason.ShouldNotBeNull();
+        reason!.ShouldContain("Demo");
+        reason.ShouldContain("Mixed");
+    }
+
+    [Fact]
+    public void PlaceGroup_NoChipletScope_FallsBackToCanvasGlobal()
+    {
+        var context = ContextFor(Soi("Demo"));
+
+        context.CheckGroupPlacementInScope(null, new[] { "Demo" }).IsAllowed.ShouldBeTrue();
+        context.CheckGroupPlacementInScope(null, new[] { "HHI-InP" }).IsAllowed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TwoChiplets_OfDifferentProcesses_CoexistOnOneCanvas()
+    {
+        // The north-star scenario: one canvas, two chiplets in two processes. Each accepts
+        // only its own members; neither forces the design into Playground.
+        var context = ContextFor(Soi("Demo"));
+        var soiChiplet = Chiplet(Soi("Demo"), "SOI chiplet");
+        var inPChiplet = Chiplet(InP("InP-Lib"), "InP chiplet");
+
+        context.CheckPlacementInScope(soiChiplet, "Demo").IsAllowed.ShouldBeTrue();
+        context.CheckPlacementInScope(soiChiplet, "InP-Lib").IsAllowed.ShouldBeFalse();
+
+        context.CheckPlacementInScope(inPChiplet, "InP-Lib").IsAllowed.ShouldBeTrue();
+        context.CheckPlacementInScope(inPChiplet, "Demo").IsAllowed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FabricationProcess_SurvivesDeepCopy()
+    {
+        // A chiplet copied or instantiated from a template must keep its binding —
+        // otherwise the copy would silently revert to canvas-global enforcement.
+        var chiplet = Chiplet(InP("InP-Lib"));
+
+        var copy = chiplet.DeepCopy();
+
+        copy.FabricationProcess.ShouldBe(chiplet.FabricationProcess);
+    }
+}

--- a/UnitTests/ViewModels/Panels/ChipletScopeEnforcementTests.cs
+++ b/UnitTests/ViewModels/Panels/ChipletScopeEnforcementTests.cs
@@ -1,0 +1,221 @@
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Creation;
+using CAP_Core.Components.Process;
+using CAP_Core.LightCalculation;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.ViewModels.Panels;
+
+/// <summary>
+/// End-to-end wiring for per-chiplet process scope (issue #935): the placement and paste
+/// guards in <see cref="CanvasInteractionViewModel"/> must resolve the chiplet under the
+/// drop point and check against <see cref="ComponentGroup.FabricationProcess"/> when one is
+/// bound, falling back to the canvas-global active process for ungrouped content.
+/// </summary>
+public class ChipletScopeEnforcementTests
+{
+    private static ActiveProcessSelection Soi(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "SOI 220",
+            new ProcessFingerprint("Si", 220, "SiO2", 1550, "SOI 220"),
+            memberPdkNames));
+
+    private static ActiveProcessSelection InP(params string[] memberPdkNames) =>
+        ActiveProcessSelection.ForGroup(new ProcessGroup(
+            "HHI-InP",
+            new ProcessFingerprint("InP", 400, "InP", 1550, "HHI-InP"),
+            memberPdkNames));
+
+    private static ComponentTemplate BuildTemplate(string pdkSource) => new()
+    {
+        Name = "TestComp",
+        Category = "Test",
+        PdkSource = pdkSource,
+        WidthMicrometers = 10,
+        HeightMicrometers = 10,
+        PinDefinitions = new[] { new PinDefinition("a", 0, 5, 180) },
+        CreateSMatrix = pins =>
+        {
+            var ids = pins.SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
+            return new SMatrix(ids, new List<(Guid, double)>());
+        }
+    };
+
+    private static PlacementPolicyContext Context(ActiveProcessSelection? canvasActive) =>
+        new(() => canvasActive,
+            () => Array.Empty<string>(),
+            _ => null);
+
+    private static (DesignCanvasViewModel canvas, CanvasInteractionViewModel interaction) CreateSetup()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var interaction = new CanvasInteractionViewModel(canvas, new CommandManager());
+        return (canvas, interaction);
+    }
+
+    /// <summary>Adds a chiplet covering (0,0)-(200,200) with the given process binding.</summary>
+    private static ComponentGroup AddChiplet(
+        DesignCanvasViewModel canvas, ActiveProcessSelection? process, string name = "Chiplet")
+    {
+        var chiplet = new ComponentGroup(name)
+        {
+            PhysicalX = 0,
+            PhysicalY = 0,
+            WidthMicrometers = 200,
+            HeightMicrometers = 200,
+            FabricationProcess = process
+        };
+        canvas.AddComponent(chiplet);
+        return chiplet;
+    }
+
+    [Fact]
+    public void PlaceComponent_OntoInpChiplet_UnderSoiCanvas_AllowsInpMember()
+    {
+        var (canvas, interaction) = CreateSetup();
+        AddChiplet(canvas, InP("InP-Lib"));
+        interaction.PlacementContext = Context(Soi("Demo"));
+        interaction.SelectedTemplate = BuildTemplate("InP-Lib");
+
+        interaction.CanvasClicked(100, 100);
+
+        canvas.Components.Count.ShouldBe(2,
+            "an InP member must drop into the InP chiplet even though the canvas is locked to SOI");
+    }
+
+    [Fact]
+    public void PlaceComponent_OntoInpChiplet_BlocksCanvasMemberForeignToChiplet()
+    {
+        var (canvas, interaction) = CreateSetup();
+        AddChiplet(canvas, InP("InP-Lib"));
+        interaction.PlacementContext = Context(Soi("Demo"));
+        interaction.SelectedTemplate = BuildTemplate("Demo");
+
+        string? status = null;
+        interaction.UpdateStatus = s => status = s;
+
+        interaction.CanvasClicked(100, 100);
+
+        canvas.Components.Count.ShouldBe(1,
+            "an SOI member must not pollute the InP chiplet, even though the canvas allows it");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("HHI-InP");
+    }
+
+    [Fact]
+    public void PlaceComponent_BesideChiplet_UsesCanvasGlobalRule()
+    {
+        var (canvas, interaction) = CreateSetup();
+        AddChiplet(canvas, InP("InP-Lib"));
+        interaction.PlacementContext = Context(Soi("Demo"));
+        interaction.SelectedTemplate = BuildTemplate("InP-Lib");
+
+        string? status = null;
+        interaction.UpdateStatus = s => status = s;
+
+        // Drop well outside the chiplet bounds (200,200): the canvas-global SOI lock applies.
+        interaction.CanvasClicked(500, 500);
+
+        canvas.Components.Count.ShouldBe(1,
+            "outside the chiplet the InP component is foreign to the SOI canvas and must be blocked");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void PlaceComponent_OntoChipletWithoutBinding_UsesCanvasGlobalRule()
+    {
+        var (canvas, interaction) = CreateSetup();
+        AddChiplet(canvas, process: null);
+        interaction.PlacementContext = Context(Soi("Demo"));
+        interaction.SelectedTemplate = BuildTemplate("InP-Lib");
+
+        string? status = null;
+        interaction.UpdateStatus = s => status = s;
+
+        interaction.CanvasClicked(100, 100);
+
+        canvas.Components.Count.ShouldBe(1,
+            "a chiplet with no process binding falls back to the canvas-global check");
+        status.ShouldNotBeNull();
+        status!.ShouldContain("SOI 220");
+    }
+
+    [Fact]
+    public void PlaceComponent_OntoUnboundInnerGroupNestedInBoundChiplet_UsesOuterChipletScope()
+    {
+        var (canvas, interaction) = CreateSetup();
+
+        // Outer chiplet (InP) contains an unbound inner group; a drop onto the inner group
+        // must still be checked against the outer chiplet's InP process, not the canvas.
+        var outer = new ComponentGroup("Outer InP chiplet")
+        {
+            PhysicalX = 0,
+            PhysicalY = 0,
+            WidthMicrometers = 200,
+            HeightMicrometers = 200,
+            FabricationProcess = InP("InP-Lib")
+        };
+        var inner = new ComponentGroup("Inner unbound group")
+        {
+            PhysicalX = 50,
+            PhysicalY = 50,
+            WidthMicrometers = 100,
+            HeightMicrometers = 100
+        };
+        outer.AddChild(inner);
+        canvas.AddComponent(outer);
+
+        interaction.PlacementContext = Context(Soi("Demo"));
+        interaction.SelectedTemplate = BuildTemplate("InP-Lib");
+
+        interaction.CanvasClicked(100, 100);
+
+        canvas.Components.Count.ShouldBe(2,
+            "a drop onto the unbound inner group must defer to the outer InP chiplet's binding");
+    }
+
+    [Fact]
+    public void PasteSelected_IntoChipletAtTarget_UsesChipletScope()
+    {
+        var (canvas, interaction) = CreateSetup();
+        AddChiplet(canvas, InP("InP-Lib"));
+
+        // Copy a component whose PDK matches the chiplet but not the canvas; without the
+        // chiplet scope the paste guard would reject it under the SOI canvas lock.
+        var template = BuildTemplate("InP-Lib");
+        var component = new Component(
+            new Dictionary<int, SMatrix>(),
+            new List<Slider>(),
+            "inp_func",
+            "",
+            new Part[1, 1] { { new Part() } },
+            -1,
+            $"comp_{Guid.NewGuid():N}",
+            DiscreteRotation.R0,
+            new List<PhysicalPin>())
+        {
+            PhysicalX = 500,
+            PhysicalY = 500,
+            WidthMicrometers = 10,
+            HeightMicrometers = 10
+        };
+        var vm = canvas.AddComponent(component, template.Name, template.PdkSource);
+        canvas.Selection.SelectSingle(vm);
+        interaction.CopySelectedCommand.Execute(null);
+
+        interaction.PlacementContext = Context(Soi("Demo"));
+        canvas.Clipboard.PdkSourceResolver = _ => "InP-Lib";
+
+        int countBefore = canvas.Components.Count;
+        interaction.PasteSelected(targetX: 100, targetY: 100);
+
+        canvas.Components.Count.ShouldBe(countBefore + 1,
+            "pasting an InP member into the InP chiplet must succeed even under an SOI canvas");
+    }
+}


### PR DESCRIPTION
Automated implementation for #935

Acknowledged — that's the same `make test` background run I already retrieved: 5337 passed, 0 failed (exit 0). Work is complete; PR summary above stands.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 103,300
- **Estimated cost:** $0.0578 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>