### PR TITLE
Agent: Per-connection router bend-radius floor from endpoint chiplet process (#937)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/WaveguideBendRadiusResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/WaveguideBendRadiusResolver.cs
@@ -70,20 +70,72 @@ namespace CAP_DataAccess.Components.ComponentDraftMapper
             double? smallest = null;
             foreach (var process in processes)
             {
-                var xsections = process?.Xsections;
-                if (xsections == null)
-                    continue;
-
-                foreach (var xsection in xsections)
-                {
-                    if (xsection.Kind != XsectionKind.Optical || xsection.MinRadiusUm <= 0)
-                        continue;
-                    if (smallest == null || xsection.MinRadiusUm < smallest.Value)
-                        smallest = xsection.MinRadiusUm;
-                }
+                var declared = DeclaredOpticalMinimum(process);
+                if (declared != null && (smallest == null || declared.Value < smallest.Value))
+                    smallest = declared;
             }
 
             return smallest ?? FallbackMinimumMicrometers;
+        }
+
+        /// <summary>
+        /// Resolves the bend-radius floor for ONE connection from the PDK names of its two
+        /// endpoint components (issue #937): each endpoint contributes the optical minimum of
+        /// its own PDK's process and the STRICTER of the two governs the whole route — a
+        /// cross-process connection must never undercut the tighter chiplet's foundry floor,
+        /// and a same-chiplet pair is no longer diluted by a second member PDK's looser
+        /// minimum. Endpoints whose PDK is unknown (null name, not loaded, built-in) or whose
+        /// process declares no optical minimum contribute nothing; when neither endpoint
+        /// resolves, <paramref name="fallback"/> (typically the design-wide
+        /// <see cref="Resolve(ActiveProcessSelection, IReadOnlyList{PdkDraft}, IReadOnlyCollection{string}?)"/>
+        /// result) applies.
+        /// </summary>
+        /// <param name="startPdkName">PDK source name of the start pin's component, or null.</param>
+        /// <param name="endPdkName">PDK source name of the end pin's component, or null.</param>
+        /// <param name="loadedPdks">All currently loaded PDK drafts.</param>
+        /// <param name="fallback">Floor to use when neither endpoint resolves a minimum.</param>
+        public static double ResolveForEndpointPdks(
+            string? startPdkName, string? endPdkName,
+            IReadOnlyList<PdkDraft>? loadedPdks, double fallback)
+        {
+            double? startMinimum = EndpointMinimum(startPdkName, loadedPdks);
+            double? endMinimum = EndpointMinimum(endPdkName, loadedPdks);
+
+            if (startMinimum == null) return endMinimum ?? fallback;
+            if (endMinimum == null) return startMinimum.Value;
+            return Math.Max(startMinimum.Value, endMinimum.Value);
+        }
+
+        /// <summary>The declared optical minimum of the named PDK's process, or null.</summary>
+        private static double? EndpointMinimum(string? pdkName, IReadOnlyList<PdkDraft>? loadedPdks)
+        {
+            if (string.IsNullOrEmpty(pdkName) || loadedPdks == null)
+                return null;
+
+            var process = loadedPdks.FirstOrDefault(
+                d => string.Equals(d.Name, pdkName, StringComparison.OrdinalIgnoreCase))?.Process;
+            return DeclaredOpticalMinimum(process);
+        }
+
+        /// <summary>
+        /// The smallest positive optical <see cref="ProcessXsection.MinRadiusUm"/> of one
+        /// process definition, or null when it declares none.
+        /// </summary>
+        private static double? DeclaredOpticalMinimum(ProcessDefinition? process)
+        {
+            if (process?.Xsections == null)
+                return null;
+
+            double? smallest = null;
+            foreach (var xsection in process.Xsections)
+            {
+                if (xsection.Kind != XsectionKind.Optical || xsection.MinRadiusUm <= 0)
+                    continue;
+                if (smallest == null || xsection.MinRadiusUm < smallest.Value)
+                    smallest = xsection.MinRadiusUm;
+            }
+
+            return smallest;
         }
     }
 }

--- a/CAP.Avalonia/ViewModels/Canvas/Services/RoutingOrchestrator.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/Services/RoutingOrchestrator.cs
@@ -65,6 +65,18 @@ public class RoutingOrchestrator
     public Func<CAP_Core.Routing.MetalRouting.MetalRoutingSpec>? GetMetalRoutingSpec { get; set; }
 
     /// <summary>
+    /// Factory for the per-connection optical bend-radius floor (issue #937), wired by
+    /// <c>MainViewModel</c> to <c>WaveguideBendRadiusResolver.ResolveForEndpointPdks</c>.
+    /// The FACTORY runs on the caller's UI thread at the start of every routing pass (it
+    /// snapshots library and PDK state); the returned pin-pair lookup is pure and safe to
+    /// invoke from the routing thread, and is pushed onto
+    /// <see cref="WaveguideRouter.ProcessMinBendRadiusForPinPair"/>. When unwired, the
+    /// router keeps the canvas-wide <see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>.
+    /// </summary>
+    public Func<Func<CAP_Core.Components.Core.PhysicalPin, CAP_Core.Components.Core.PhysicalPin, double>>?
+        CreateProcessMinBendRadiusForPinPair { get; set; }
+
+    /// <summary>
     /// Raised when IsRouting or RoutingStatusText changes.
     /// </summary>
     public event Action? StateChanged;
@@ -124,6 +136,8 @@ public class RoutingOrchestrator
         // UI thread — the provider reads ViewModel state).
         if (GetProcessMinBendRadiusMicrometers != null)
             _router.ProcessMinBendRadiusMicrometers = GetProcessMinBendRadiusMicrometers();
+        if (CreateProcessMinBendRadiusForPinPair != null)
+            _router.ProcessMinBendRadiusForPinPair = CreateProcessMinBendRadiusForPinPair();
         if (GetMetalRoutingSpec != null)
         {
             var metalSpec = GetMetalRoutingSpec();

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -388,6 +388,27 @@ public partial class MainViewModel : ObservableObject
         // the orchestrator refreshes the router before every routing pass, so AUTO cannot
         // bend tighter than the active process allows.
         _canvas.Routing.GetProcessMinBendRadiusMicrometers = resolveMinBendRadiusMicrometers;
+        // Per-connection floor (issue #937): on a multi-process canvas each optical
+        // connection floors at the stricter of its two endpoint components' chiplet
+        // process instead of the one canvas-wide value. The factory runs on the UI
+        // thread and snapshots library + PDK state, so the returned pin-pair lookup is
+        // safe to call from the routing thread; pins whose PDK is unknown fall back to
+        // the canvas-wide value.
+        _canvas.Routing.CreateProcessMinBendRadiusForPinPair = () =>
+        {
+            var drafts = LeftPanel.GetLoadedPdkDrafts();
+            var templates = LeftPanel.AllTemplates.ToList();
+            double canvasWideFallback = resolveMinBendRadiusMicrometers();
+            return (startPin, endPin) =>
+            {
+                string? startPdk = ViewModels.Library.ComponentPdkSourceResolver.Resolve(
+                    startPin.ParentComponent, templates);
+                string? endPdk = ViewModels.Library.ComponentPdkSourceResolver.Resolve(
+                    endPin.ParentComponent, templates);
+                return CAP_DataAccess.Components.ComponentDraftMapper.WaveguideBendRadiusResolver
+                    .ResolveForEndpointPdks(startPdk, endPdk, drafts, canvasWideFallback);
+            };
+        };
         // Metal traces are curved like waveguides (#854): the metal spec's bend radius floors
         // the router for electrical connections and its trace width pads their grid obstacles.
         // The bend-handle drag clamp for metal traces uses the same source.

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -167,10 +167,9 @@ namespace CAP_Core.Components.Connections
             // The effective bend radius honors both the connection's own setting and the
             // fabrication process' minimum: the larger of the two governs the geometry.
             // Electrical connections use the metal floor (RF traces bend at the metal
-            // cross-section radius, issue #854), optical ones the waveguide floor.
-            double processFloor = IsElectrical
-                ? router.MetalProcessMinBendRadiusMicrometers
-                : router.ProcessMinBendRadiusMicrometers;
+            // cross-section radius, issue #854), optical ones the floor of their endpoint
+            // components' chiplet process (issue #937).
+            double processFloor = router.ProcessFloorFor(StartPin, EndPin);
             double effectiveBendRadius = Math.Max(BendRadiusMicrometers, processFloor);
 
             if (Type != WaveguideType.Auto)

--- a/Connect-A-Pic-Core/Routing/RoutedPath.cs
+++ b/Connect-A-Pic-Core/Routing/RoutedPath.cs
@@ -36,8 +36,10 @@ public class RoutedPath
     public bool IsPlaceholderGeometry { get; set; } = false;
 
     /// <summary>
-    /// True when the path could only be routed with a bend radius below the active
-    /// fabrication process' minimum (<see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>).
+    /// True when the path could only be routed with a bend radius below the governing
+    /// fabrication process' minimum — the endpoint chiplet's per-connection floor
+    /// (<see cref="WaveguideRouter.ProcessMinBendRadiusForPinPair"/>) when wired, else the
+    /// canvas-wide <see cref="WaveguideRouter.ProcessMinBendRadiusMicrometers"/>.
     /// The geometry itself is clean, but the design violates the process rule; the
     /// design checks surface it as a <c>BendRadiusBelowProcessMinimum</c> issue.
     /// </summary>

--- a/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
+++ b/Connect-A-Pic-Core/Routing/WaveguideRouter.cs
@@ -20,9 +20,20 @@ public partial class WaveguideRouter
     /// this floor and <see cref="MinBendRadiusMicrometers"/>; when no clean path exists at the
     /// floor it retries at the connection radius and marks the result with
     /// <see cref="RoutedPath.ViolatesProcessMinBendRadius"/> so the design checks surface the
-    /// violation. 0 means no process constraint.
+    /// violation. 0 means no process constraint. For optical pin pairs this canvas-wide value
+    /// is superseded by <see cref="ProcessMinBendRadiusForPinPair"/> when that is wired.
     /// </summary>
     public double ProcessMinBendRadiusMicrometers { get; set; }
+
+    /// <summary>
+    /// Optional per-connection optical bend-radius floor (issue #937): given the routed pin
+    /// pair, returns the floor imposed by the endpoint components' own chiplet process, so a
+    /// multi-process canvas enforces each chiplet's foundry minimum instead of one
+    /// canvas-wide value. When unwired, optical pairs use
+    /// <see cref="ProcessMinBendRadiusMicrometers"/>; electrical pairs always use
+    /// <see cref="MetalProcessMinBendRadiusMicrometers"/>.
+    /// </summary>
+    public Func<PhysicalPin, PhysicalPin, double>? ProcessMinBendRadiusForPinPair { get; set; }
 
     /// <summary>
     /// Bend-radius floor (µm) for ELECTRICAL (metal trace) connections, sourced from the
@@ -290,13 +301,16 @@ public partial class WaveguideRouter
     /// <summary>
     /// The process bend-radius floor governing this pin pair: the metal floor for
     /// electrical pins (RF traces must bend at the metal cross-section radius),
-    /// the optical floor otherwise. Checking one pin is authoritative — cross-kind
-    /// pairs are rejected at connection creation time.
+    /// the optical floor otherwise — per endpoint pair when
+    /// <see cref="ProcessMinBendRadiusForPinPair"/> is wired (issue #937), the
+    /// canvas-wide <see cref="ProcessMinBendRadiusMicrometers"/> otherwise. Checking one
+    /// pin is authoritative — cross-kind pairs are rejected at connection creation time.
     /// </summary>
-    private double ProcessFloorFor(PhysicalPin startPin, PhysicalPin endPin) =>
+    public double ProcessFloorFor(PhysicalPin startPin, PhysicalPin endPin) =>
         startPin.MatterType == MatterType.Electricity || endPin.MatterType == MatterType.Electricity
             ? MetalProcessMinBendRadiusMicrometers
-            : ProcessMinBendRadiusMicrometers;
+            : ProcessMinBendRadiusForPinPair?.Invoke(startPin, endPin)
+              ?? ProcessMinBendRadiusMicrometers;
 
     /// <summary>
     /// The route for a perfect abutment: both pins sit at the same point, so the honest

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
@@ -10,9 +10,10 @@ namespace UnitTests.Components;
 
 /// <summary>
 /// Green "today" pins for the documented-red stations of the multi-process journey:
-/// each test proves the current single-process behavior the red steps 3 (#935), 5
-/// (#937) and 8 (#939) describe, so a future per-chiplet fix turns the pin red as a
-/// tripwire. See <see cref="MultiProcessChipletJourneyTests"/> for the full journey.
+/// each test proves the current single-process behavior the red steps 3 (#935) and 8
+/// (#939) describe, so a future per-chiplet fix turns the pin red as a tripwire.
+/// (Step 5's pin fired with #937 and was replaced by the per-chiplet assertion below.)
+/// See <see cref="MultiProcessChipletJourneyTests"/> for the full journey.
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
@@ -45,8 +46,9 @@ public partial class MultiProcessChipletJourneyTests
     [Fact]
     public void BendRadius_LockedProcess_ResolvesEachProcessMinimum_Today()
     {
-        // Companion to red step 5 (#937): per-process limits exist and are honored —
-        // but only while the whole design is locked to that one process.
+        // Companion to step 5 (#937): the design-wide resolution still exists and
+        // stays honored while the whole design is locked to one process — the
+        // per-connection floor only takes over where endpoint PDKs differ.
         var (cornerstone, siepic, catalog) = LoadProcessCatalog();
         var pdks = new List<PdkDraft> { cornerstone, siepic };
 
@@ -63,19 +65,31 @@ public partial class MultiProcessChipletJourneyTests
     }
 
     [Fact]
-    public void BendRadius_Playground_OneFallbackForBothChiplets_Today()
+    public void BendRadius_Playground_PerChipletFloors_FromEndpointPdks()
     {
-        // Companion to red step 5 (#937): Playground is the only mode that can hold both
-        // chiplets — and there the resolver knows neither chiplet's limit; one global
-        // fallback silently covers every route in the design.
+        // Companion to green step 5 (#937, the fired tripwire): even in Playground —
+        // the only mode that can hold both chiplets — the per-connection resolver
+        // reads each endpoint PDK's own process minimum instead of one global value.
         var (cornerstone, siepic, _) = LoadProcessCatalog();
         var pdks = new List<PdkDraft> { cornerstone, siepic };
+        const double canvasWideFallback = WaveguideBendRadiusResolver.FallbackMinimumMicrometers;
 
-        var resolved = WaveguideBendRadiusResolver.Resolve(ActiveProcessSelection.Playground(), pdks);
-
-        resolved.ShouldBe(WaveguideBendRadiusResolver.FallbackMinimumMicrometers);
-        resolved.ShouldNotBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm);
-        resolved.ShouldNotBe(SiepicMinBendRadiusUm);
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks(
+                cornerstone.Name, cornerstone.Name, pdks, canvasWideFallback)
+            .ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+                "a Cornerstone↔Cornerstone pair floors at xs_nc's 30 µm");
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks(
+                siepic.Name, siepic.Name, pdks, canvasWideFallback)
+            .ShouldBe(SiepicMinBendRadiusUm,
+                "a SiEPIC↔SiEPIC pair floors at the strip 5 µm — no longer over-constrained");
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks(
+                cornerstone.Name, siepic.Name, pdks, canvasWideFallback)
+            .ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+                "a cross-process pair takes the STRICTER floor, not the minimum over member PDKs");
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks(
+                null, null, pdks, canvasWideFallback)
+            .ShouldBe(canvasWideFallback,
+                "endpoints without a resolvable PDK keep the canvas-wide fallback");
     }
 
     [Fact]

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
@@ -14,8 +14,9 @@ using Xunit;
 namespace UnitTests.Components;
 
 /// <summary>
-/// Documented-red inventory stations of the multi-process journey (steps 3–5, 7–8) —
-/// each Skip links the issue filed for that exact single-process assumption. See
+/// Documented-red inventory stations of the multi-process journey (steps 3, 4, 7, 8 —
+/// step 5 landed with #937) — each Skip links the issue filed for that exact
+/// single-process assumption. See
 /// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
@@ -81,17 +82,6 @@ public partial class MultiProcessChipletJourneyTests
         panel.Issues.Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth
                 && i.Description.Contains("si_")).ShouldBe(0,
             "chiplet B must stay silent: SiEPIC declares no minWidthUm — no invented values (#926)");
-    }
-
-    [Fact(Skip = "Single-process assumption (#933 inventory): the router bend-radius floor is one canvas-wide value (Playground fallback 10 µm) — per-chiplet floors are https://github.com/aignermax/Lunima/issues/937")]
-    public void Step5_BendRadiusFloor_FollowsEachChipletsProcess()
-    {
-        // What production applies on a two-process (Playground) canvas: no member PDKs,
-        // so the resolver falls back to the generic 10 µm for EVERY route.
-        var floorForChipletA = WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[0]);
-
-        floorForChipletA.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
-            "chiplet A's routes must honor the Cornerstone 30 µm floor, not the fallback (#937)");
     }
 
     [Fact(Skip = "Single-process assumption (#933 inventory): .lun persists one design-level ActiveProcess and no per-chiplet process binding — https://github.com/aignermax/Lunima/issues/938")]

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -44,7 +44,10 @@ namespace UnitTests.Components;
 ///         canvas cannot take a second-process chiplet; only Playground can mix.
 ///   Step 4 (RED, #936): DRC-lite rules come from the single active process — a
 ///         two-process design checks nothing PDK-dependent at all.
-///   Step 5 (RED, #937): the router's bend-radius floor is one canvas-wide value.
+///   Step 5 (green, #937): the router resolves the bend-radius floor per connection
+///         from the endpoint components' chiplet process — chiplet A routes at
+///         Cornerstone's 30 µm, chiplet B at SiEPIC's 5 µm, cross-process pairs at
+///         the stricter of the two.
 ///   Step 6 (green): .lun round-trip — both per-component PDK assignments, the
 ///         groups, the abutment and the physics survive (the design reloads as
 ///         Playground: pinned here as current behavior, #938 is the fix).
@@ -52,11 +55,11 @@ namespace UnitTests.Components;
 ///   Step 8 (RED, #939): GDS export routes every waveguide through one global
 ///         interconnect (width/radius/layer), not each chiplet's own stack.
 ///
-/// The red steps 3, 5 and 8 additionally carry GREEN "today" pins in the
+/// The red steps 3 and 8 additionally carry GREEN "today" pins in the
 /// CurrentBehavior partial: the canvas-global lock really does reject the second
-/// process, the Playground bend floor really is one fallback for everything, and
-/// GDS export really does size every route with one majority cross-section — so a
-/// future per-chiplet fix turns those pins red as a tripwire.
+/// process, and GDS export really does size every route with one majority
+/// cross-section — so a future per-chiplet fix turns those pins red as a tripwire.
+/// (Step 5's tripwire fired with #937 and was replaced by the green step itself.)
 /// </summary>
 public partial class MultiProcessChipletJourneyTests : IDisposable
 {
@@ -151,6 +154,41 @@ public partial class MultiProcessChipletJourneyTests : IDisposable
             "Step 2: the Y-branch's free arm carries its physical share — the boundary is truly crossed");
         leakage.ShouldBeLessThan(0.02,
             "Step 2: only the Y-branch's port-1 reflection leaks back to the unexcited coupler input");
+    }
+
+    [Fact]
+    public void Step5_BendRadiusFloor_FollowsEachChipletsProcess()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var drafts = new List<PdkDraft> { design.Cornerstone, design.Siepic };
+        double canvasWideFallback = WaveguideBendRadiusResolver.Resolve(
+            ActiveProcessSelection.Playground(), drafts);
+        canvasWideFallback.ShouldBe(WaveguideBendRadiusResolver.FallbackMinimumMicrometers,
+            "Step 5: Playground knows no member PDKs — the canvas-wide value is the bare fallback");
+
+        // The MainViewModel wiring, headless: each endpoint component's own PDK resolves
+        // its optical minimum and the STRICTER of the pair governs the whole route (#937).
+        design.Canvas.Router.ProcessMinBendRadiusForPinPair = (startPin, endPin) =>
+            WaveguideBendRadiusResolver.ResolveForEndpointPdks(
+                ComponentPdkSourceResolver.Resolve(startPin.ParentComponent, design.Templates),
+                ComponentPdkSourceResolver.Resolve(endPin.ParentComponent, design.Templates),
+                drafts, canvasWideFallback);
+
+        var csCoupler = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4");
+        var csMmi = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3");
+        var siYBranch = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 3");
+        var siTaper = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2");
+
+        design.Canvas.Router.ProcessFloorFor(csCoupler, csMmi).ShouldBe(
+            MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+            "Step 5: a route inside chiplet A honors Cornerstone's 30 µm floor, not the fallback");
+        design.Canvas.Router.ProcessFloorFor(siYBranch, siTaper).ShouldBe(
+            SiepicMinBendRadiusUm,
+            "Step 5: a route inside chiplet B honors SiEPIC's 5 µm floor — no longer over-constrained");
+        design.Canvas.Router.ProcessFloorFor(csMmi, siYBranch).ShouldBe(
+            MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+            "Step 5: a cross-process route honors the STRICTER chiplet's floor — " +
+            "anything looser would undercut Cornerstone's foundry minimum");
     }
 
     // ── Journey helpers ─────────────────────────────────────────────────────────

--- a/UnitTests/Routing/InterconnectRouting/ProcessMinBendRadiusFloorTests.cs
+++ b/UnitTests/Routing/InterconnectRouting/ProcessMinBendRadiusFloorTests.cs
@@ -99,6 +99,44 @@ public class ProcessMinBendRadiusFloorTests
         SBendGeometry.ApplyRadiusFloor(30.0, floor).ShouldBe(expected, 1e-9);
     }
 
+    [Fact]
+    public void Auto_PerPinPairFloor_OverridesCanvasWideFloor()
+    {
+        // Issue #937: the per-connection provider (the endpoint components' chiplet
+        // process) supersedes the canvas-wide value for optical pairs.
+        var (router, connection) = CreateAutoLayout(offsetY: 100);
+        router.ProcessMinBendRadiusMicrometers = 5.0;
+        router.ProcessMinBendRadiusForPinPair = (_, _) => CornerstoneSinMinRadius;
+
+        connection.RecalculateTransmission(router);
+
+        var bends = connection.GetPathSegments().OfType<BendSegment>().ToList();
+        bends.ShouldNotBeEmpty();
+        bends.ShouldAllBe(b => b.RadiusMicrometers >= CornerstoneSinMinRadius - 1e-6);
+        connection.RoutedPath!.ViolatesProcessMinBendRadius.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ProcessFloorFor_NoPerPairProvider_KeepsCanvasWideFloor()
+    {
+        var (router, connection) = CreateAutoLayout(offsetY: 100);
+        router.ProcessMinBendRadiusMicrometers = CornerstoneSinMinRadius;
+
+        router.ProcessFloorFor(connection.StartPin, connection.EndPin)
+            .ShouldBe(CornerstoneSinMinRadius);
+    }
+
+    [Fact]
+    public void ProcessFloorFor_ElectricalPair_KeepsMetalFloor()
+    {
+        var (router, connection) = CreateAutoLayout(offsetY: 100);
+        connection.StartPin.LogicalPin = new Pin("output", 0, MatterType.Electricity, RectSide.Right);
+        router.MetalProcessMinBendRadiusMicrometers = 40.0;
+        router.ProcessMinBendRadiusForPinPair = (_, _) => CornerstoneSinMinRadius;
+
+        router.ProcessFloorFor(connection.StartPin, connection.EndPin).ShouldBe(40.0);
+    }
+
     /// <summary>
     /// Two components with laterally offset facing pins and an initialized A* grid, so the
     /// AUTO route must contain bends. The connection keeps its 10 µm default radius.

--- a/UnitTests/Routing/InterconnectRouting/WaveguideBendRadiusResolverTests.cs
+++ b/UnitTests/Routing/InterconnectRouting/WaveguideBendRadiusResolverTests.cs
@@ -124,4 +124,90 @@ public class WaveguideBendRadiusResolverTests
             active, new List<PdkDraft> { customPdk }, effectiveMemberPdkNames: new[] { "MyCustomFab" })
             .ShouldBe(25);
     }
+
+    [Fact]
+    public void ResolveForEndpointPdks_SamePdkPair_ResolvesThatPdksMinimum()
+    {
+        var pdks = new List<PdkDraft>
+        {
+            PdkWithOpticalMinimum("Cornerstone", 30),
+            PdkWithOpticalMinimum("SiEPIC", 5),
+        };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("SiEPIC", "SiEPIC", pdks, fallback: 10)
+            .ShouldBe(5, "a same-chiplet pair is not diluted by the other PDK's looser minimum");
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdks_CrossProcessPair_StricterFloorWins()
+    {
+        var pdks = new List<PdkDraft>
+        {
+            PdkWithOpticalMinimum("Cornerstone", 30),
+            PdkWithOpticalMinimum("SiEPIC", 5),
+        };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("Cornerstone", "SiEPIC", pdks, fallback: 10)
+            .ShouldBe(30, "the cross-process route must never undercut the tighter chiplet's floor");
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("SiEPIC", "Cornerstone", pdks, fallback: 10)
+            .ShouldBe(30, "pin order does not matter");
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdks_OneEndpointUnknown_KeepsTheOthersMinimum()
+    {
+        var pdks = new List<PdkDraft> { PdkWithOpticalMinimum("Cornerstone", 30) };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("Cornerstone", null, pdks, fallback: 10)
+            .ShouldBe(30);
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("Cornerstone", "NotLoaded", pdks, fallback: 10)
+            .ShouldBe(30);
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdks_PdkWithoutOpticalMinimum_ContributesNothing()
+    {
+        var pdks = new List<PdkDraft>
+        {
+            PdkWithOpticalMinimum("Cornerstone", 30),
+            new PdkDraft { Name = "NoMin", Process = new ProcessDefinition { Name = "NoMin" } },
+        };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("NoMin", "Cornerstone", pdks, fallback: 10)
+            .ShouldBe(30, "the endpoint that declares no minimum must not drag the floor down");
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("NoMin", "NoMin", pdks, fallback: 10)
+            .ShouldBe(10, "with no declared minimum on either side the fallback applies");
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdks_NeitherEndpointResolves_ReturnsFallback()
+    {
+        var pdks = new List<PdkDraft> { PdkWithOpticalMinimum("Cornerstone", 30) };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks(null, null, pdks, fallback: 10).ShouldBe(10);
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("A", "B", null, fallback: 10).ShouldBe(10);
+    }
+
+    [Fact]
+    public void ResolveForEndpointPdks_NameMatchIsCaseInsensitive()
+    {
+        var pdks = new List<PdkDraft> { PdkWithOpticalMinimum("Cornerstone", 30) };
+
+        WaveguideBendRadiusResolver.ResolveForEndpointPdks("cornerstone", "CORNERSTONE", pdks, fallback: 10)
+            .ShouldBe(30);
+    }
+
+    private static PdkDraft PdkWithOpticalMinimum(string name, double minRadiusUm) =>
+        new()
+        {
+            Name = name,
+            Process = new ProcessDefinition
+            {
+                Name = name,
+                Xsections = new List<ProcessXsection>
+                {
+                    new() { Name = "Strip", Kind = XsectionKind.Optical, MinRadiusUm = minRadiusUm }
+                }
+            }
+        };
 }


### PR DESCRIPTION
## What & why

The router's process bend-radius floor was one canvas-wide number: on a two-chiplet canvas (Playground) every route got the generic 10 µm fallback — Cornerstone SiN routes were silently routed below their 30 µm foundry floor (cspdk.sin300 `radius_min`, #924) while SiEPIC SOI routes were over-constrained; even with one active process the resolver took the *minimum* over member PDKs, again under-enforcing the stricter chiplet. This is rung 6 of #537, found by the #933 multi-process chiplet journey (its step 5 was documented-red until now).

The floor is now resolved **per connection** from the endpoint components' chiplet process:

- `WaveguideBendRadiusResolver.ResolveForEndpointPdks(startPdk, endPdk, drafts, fallback)` — each endpoint contributes the optical minimum of its own PDK's process; the **stricter** of the two governs the whole route (a cross-process route must never undercut the tighter chiplet's floor). Endpoints whose PDK is unknown or declares no optical minimum contribute nothing; when neither resolves, the canvas-wide value applies.
- `WaveguideRouter.ProcessMinBendRadiusForPinPair` — optional per-pair floor provider; `ProcessFloorFor` (now public) consults it for optical pairs and keeps the metal floor for electrical pairs. `WaveguideConnection` uses the same `ProcessFloorFor`, so `ViolatesProcessMinBendRadius` now means "below *this chiplet's* process minimum".
- `RoutingOrchestrator.CreateProcessMinBendRadiusForPinPair` — a factory wired by `MainViewModel`: it snapshots library + PDK state on the UI thread at the start of every routing pass (via `ComponentPdkSourceResolver` + `WaveguideBendRadiusResolver`), so the returned pin-pair lookup is pure and safe on the routing thread. Unwired contexts keep the exact previous canvas-wide behavior.

Scope note: the in-canvas bend-handle drag clamp (`CanvasInteraction.GetMinBendRadiusMicrometers`) is still the design-wide value — per-connection clamping there is a possible follow-up, not part of this router-focused fix.

## How it was tested

- Journey step 5 turned green: `MultiProcessChipletJourneyTests.Step5_BendRadiusFloor_FollowsEachChipletsProcess` exercises the real bundled Cornerstone + SiEPIC PDKs through the headless MainViewModel wiring — Cornerstone pair floors at 30 µm, SiEPIC pair at 5 µm, cross-process pair at the stricter 30 µm.
- The fired tripwire pin in `CurrentBehavior` was replaced by per-chiplet resolver assertions on the real PDKs; the design-wide locked-process pin stays green.
- New unit tests: 6 for `ResolveForEndpointPdks` (same/cross/unknown/no-minimum/case-insensitive/fallback) and 3 router tests (per-pair provider governs the A* route end-to-end, unwired fallback, electrical pairs keep the metal floor).
- The remaining documented-red journey steps (3, 4, 7, 8) stay skipped with their issue links.

Local suite: 5630 passed, 0 failed

No UI or user-visible strings added (headless routing change only); no manual verification needed.