### PR TITLE
Agent: Persist per-chiplet process binding in .lun round-trip (#938)

### DIFF
--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -1355,6 +1355,15 @@ public class DesignGroupData
     /// Canvas Y position of the group ViewModel.
     /// </summary>
     public double CanvasY { get; set; }
+
+    /// <summary>
+    /// Per-chiplet process binding of a top-level group (issue #938): the fabrication
+    /// process the chiplet's contents belong to. Null for unbound groups, nested groups
+    /// (their scope is the top-level chiplet's), and files saved before per-chiplet
+    /// bindings existed — the design-level <see cref="DesignFileData.ActiveProcess"/>
+    /// remains the default for those and for ungrouped components.
+    /// </summary>
+    public ActiveProcessData? ProcessBinding { get; set; }
 }
 
 /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/ActiveProcessResolver.cs
+++ b/CAP.Avalonia/ViewModels/Panels/ActiveProcessResolver.cs
@@ -75,6 +75,30 @@ public static class ActiveProcessResolver
     }
 
     /// <summary>
+    /// Derives the design-level default for a loaded design that carries no own process
+    /// record but whose chiplets restored per-group bindings (issue #938): a single
+    /// distinct chiplet process becomes the design default; several distinct processes
+    /// yield Playground — the canvas genuinely mixes processes there, and the
+    /// manufacturability information lives in the per-chiplet bindings. No warning is
+    /// needed either way: the file fully describes the state, nothing was migrated.
+    /// Returns null when no chiplet carries a real process binding.
+    /// </summary>
+    /// <param name="chipletBindings">Restored bindings of the top-level groups.</param>
+    public static ActiveProcessSelection? FromChipletBindings(IEnumerable<ActiveProcessSelection?> chipletBindings)
+    {
+        var distinct = chipletBindings
+            .Where(b => b is { IsPlayground: false })
+            .GroupBy(b => b!.DisplayName, System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return distinct.Count switch
+        {
+            0 => null,
+            1 => distinct[0].First(),
+            _ => ActiveProcessSelection.Playground(),
+        };
+    }
+
+    /// <summary>
     /// Infers the active process for a legacy design from the PDK sources of its placed
     /// components. One matching group → that process; several → Playground + a warning;
     /// none → null (empty / built-ins only).

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -658,8 +658,31 @@ public partial class FileOperationsViewModel : ObservableObject
             GroupDto = groupDto,
             ChildComponents = childDataList,
             CanvasX = groupVm.X,
-            CanvasY = groupVm.Y
+            CanvasY = groupVm.Y,
+            // Only top-level groups act as chiplets (issue #938); a nested group's
+            // process scope is its top-level parent's.
+            ProcessBinding = group.ParentGroup == null ? ResolveGroupBindingForSave(group) : null
         });
+    }
+
+    /// <summary>
+    /// Serialized form of a top-level group's chiplet process binding (issue #938): the
+    /// explicitly set binding, or — for groups built without one (e.g. in Playground) —
+    /// the binding derived from the children's PDK sources when they unanimously belong
+    /// to one catalog process. Null when the group has no process content, its children
+    /// span processes, or no catalog is available.
+    /// </summary>
+    private ActiveProcessData? ResolveGroupBindingForSave(ComponentGroup group)
+    {
+        var binding = group.ProcessBinding;
+        if (binding == null && ProcessCatalogProvider?.Invoke() is { Count: > 0 } catalog)
+        {
+            binding = GroupProcessPolicy.DeriveProcessBinding(
+                group.GetAllComponentsRecursive().Select(FindTemplatePdkSource),
+                catalog,
+                ProcessAgnosticPdkNamesProvider?.Invoke() ?? Array.Empty<string>());
+        }
+        return ActiveProcessResolver.ToData(binding);
     }
 
     /// <summary>
@@ -1101,12 +1124,25 @@ public partial class FileOperationsViewModel : ObservableObject
                 else
                 {
                     var catalog = ProcessCatalogProvider?.Invoke() ?? Array.Empty<ProcessGroup>();
+                    // Chiplets with a restored binding carry their own process (issue
+                    // #938): their children stay out of the design-level inference,
+                    // which is only the default for ungrouped and unbound content.
                     var pdkSources = designData.Components.Select(c => c.PdkSource)
-                        .Concat(designData.Groups?.SelectMany(g => g.ChildComponents.Select(ch => ch.PdkSource))
+                        .Concat(designData.Groups?
+                                .Where(g => g.ProcessBinding == null)
+                                .SelectMany(g => g.ChildComponents.Select(ch => ch.PdkSource))
                                 ?? Enumerable.Empty<string?>());
                     ActiveProcess = ActiveProcessResolver.Migrate(pdkSources, catalog, out var warning,
                         ProcessAgnosticPdkNamesProvider?.Invoke() ?? System.Array.Empty<string>());
                     if (warning != null) OnProcessMigrationWarning?.Invoke(warning);
+
+                    // No unbound process content: the design default follows the
+                    // chiplets themselves — one shared process, or Playground for a
+                    // genuine multi-process carrier (no migration, hence no warning).
+                    ActiveProcess ??= ActiveProcessResolver.FromChipletBindings(
+                        _canvas.Components.Select(vm => vm.Component)
+                            .OfType<ComponentGroup>()
+                            .Select(g => g.ProcessBinding));
                 }
 
                 // Restore imported S-matrices from PIR section
@@ -1482,6 +1518,7 @@ public partial class FileOperationsViewModel : ObservableObject
             // Only add top-level groups (groups without a parent) to the canvas
             if (groupData.GroupDto.ParentGroupId == null)
             {
+                group.ProcessBinding = RestoreGroupBinding(groupData);
                 var groupVm = _canvas.AddComponent(group);
                 groupVm.X = groupData.CanvasX;
                 groupVm.Y = groupData.CanvasY;
@@ -1491,6 +1528,29 @@ public partial class FileOperationsViewModel : ObservableObject
         }
 
         return orderedGroups.Count;
+    }
+
+    /// <summary>
+    /// Restores a top-level group's persisted chiplet process binding (issue #938),
+    /// re-anchored to the installed process catalog exactly like the design-level
+    /// record: newly installed compatible PDKs join the binding, and a chiplet whose
+    /// PDKs are all missing warns instead of silently pinning a nonexistent process.
+    /// Null for unbound groups and legacy files.
+    /// </summary>
+    private ActiveProcessSelection? RestoreGroupBinding(DesignGroupData groupData)
+    {
+        var binding = ActiveProcessResolver.FromData(groupData.ProcessBinding);
+        if (binding is not { IsPlayground: false })
+            return binding;
+
+        var catalog = ProcessCatalogProvider?.Invoke() ?? Array.Empty<ProcessGroup>();
+        var revalidated = ActiveProcessResolver.Revalidate(binding, catalog, out var warning);
+        if (warning != null)
+        {
+            OnProcessMigrationWarning?.Invoke(
+                $"Chiplet '{groupData.GroupDto.GroupName}': {warning}");
+        }
+        return revalidated;
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -82,8 +82,8 @@ public class ComponentGroup : Component, INotifyPropertyChanged
     /// Optional process binding of this group as a chiplet (issue #935): the fabrication
     /// process the group's contents belong to. Null = unbound — placement checks then
     /// derive the scope live from the children (see
-    /// <see cref="GroupProcessPolicy.DeriveProcessBinding"/>). Held in memory only;
-    /// persisting the binding in .lun files is issue #938.
+    /// <see cref="GroupProcessPolicy.DeriveProcessBinding"/>). Persisted in .lun files
+    /// for top-level groups since issue #938.
     /// </summary>
     [JsonIgnore]
     public ActiveProcessSelection? ProcessBinding { get; set; }

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
@@ -1,4 +1,3 @@
-using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Diagnostics;
@@ -7,17 +6,17 @@ using CAP_Core.Analysis;
 using CAP_Core.Components.Process;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
-using Moq;
 using Shouldly;
 using Xunit;
 
 namespace UnitTests.Components;
 
 /// <summary>
-/// Documented-red inventory stations of the multi-process journey (steps 4–5, 7–8) —
+/// Documented-red inventory stations of the multi-process journey (steps 4–5, 8) —
 /// each Skip links the issue filed for that exact single-process assumption. See
 /// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
-/// (Step 3 turned green with the per-chiplet placement scope, issue #935.)
+/// (Step 3 turned green with the per-chiplet placement scope, issue #935; step 7
+/// with the persisted per-chiplet process binding, issue #938.)
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
@@ -63,33 +62,6 @@ public partial class MultiProcessChipletJourneyTests
 
         floorForChipletA.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
             "chiplet A's routes must honor the Cornerstone 30 µm floor, not the fallback (#937)");
-    }
-
-    [Fact(Skip = "Single-process assumption (#933 inventory): .lun persists one design-level ActiveProcess and no per-chiplet process binding — https://github.com/aignermax/Lunima/issues/938")]
-    public async Task Step7_LunRoundTrip_PerChipletProcessBindingSurvives()
-    {
-        var design = MultiProcessChipletJourneyDesign.BuildComposed();
-        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
-        var saveDialog = new Mock<IFileDialogService>();
-        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(_designFilePath);
-        saveVm.FileDialogService = saveDialog.Object;
-        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
-
-        var loadedCanvas = new DesignCanvasViewModel();
-        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
-        var loadDialog = new Mock<IFileDialogService>();
-        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(_designFilePath);
-        loadVm.FileDialogService = loadDialog.Object;
-        await loadVm.LoadDesignCommand.ExecuteAsync(null);
-
-        // Rung 6: chiplet A must reload bound to the Cornerstone process and chiplet B
-        // to the SiEPIC process — the design as a whole is not one process.
-        loadVm.ActiveProcess.ShouldNotBeNull();
-        loadVm.ActiveProcess!.IsPlayground.ShouldBeFalse(
-            "each chiplet's process binding must survive the round-trip (#938)");
     }
 
     [Fact(Skip = "Single-process assumption (#933 inventory): GDS export routes every waveguide through one global interconnect (width/radius/layer from a user preference) — per-chiplet stacks are https://github.com/aignermax/Lunima/issues/939")]

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RoundTrip.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RoundTrip.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace UnitTests.Components;
 
 /// <summary>
-/// Green .lun round-trip station of the multi-process journey (step 6) — see
+/// Green .lun round-trip stations of the multi-process journey (steps 6–7) — see
 /// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
@@ -25,6 +25,7 @@ public partial class MultiProcessChipletJourneyTests
             MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2").LogicalPin!.IDOutFlow);
 
         var saveVm = CreateFileOperations(design.Canvas, design.Templates);
+        saveVm.ProcessCatalogProvider = () => BuildProcessCatalog(design);
         var saveDialog = new Mock<IFileDialogService>();
         saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
@@ -40,11 +41,7 @@ public partial class MultiProcessChipletJourneyTests
 
         var loadedCanvas = new DesignCanvasViewModel();
         var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
-        loadVm.ProcessCatalogProvider = () => ProcessCatalog.BuildGroups(new[]
-        {
-            new PdkProcessEntry(design.Cornerstone.Name, ProcessFingerprintFactory.From(design.Cornerstone)),
-            new PdkProcessEntry(design.Siepic.Name, ProcessFingerprintFactory.From(design.Siepic)),
-        });
+        loadVm.ProcessCatalogProvider = () => BuildProcessCatalog(design);
         string? migrationWarning = null;
         loadVm.OnProcessMigrationWarning = w => migrationWarning = w;
         var loadDialog = new Mock<IFileDialogService>();
@@ -78,15 +75,16 @@ public partial class MultiProcessChipletJourneyTests
         ReferenceEquals(startGroup, endGroup).ShouldBeFalse(
             "Step 6: the abutment must keep bridging the two chiplets");
 
-        // Current behavior, pinned honestly: the design-level process record cannot
-        // represent two processes, so the reloaded design collapses to Playground
-        // ("not manufacturable"). The desired per-chiplet binding is step 7 (#938).
+        // Since #938 the round-trip is lossless: the per-chiplet bindings fully describe
+        // the two-process state, so nothing migrates and no "not manufacturable" warning
+        // fires. The canvas-level default stays Playground — the honest state for a
+        // carrier that genuinely mixes two processes (step 7 proves the bindings).
         loadVm.ActiveProcess.ShouldNotBeNull();
         loadVm.ActiveProcess!.IsPlayground.ShouldBeTrue(
-            "Step 6: today a two-process design reloads as Playground — the single design-level " +
-            "ActiveProcess cannot hold both processes (#938)");
-        migrationWarning.ShouldNotBeNull();
-        migrationWarning!.ShouldContain("multiple processes");
+            "Step 6: a two-process carrier's canvas-level default is Playground — " +
+            "manufacturability lives in the per-chiplet bindings (#938)");
+        migrationWarning.ShouldBeNull(
+            "Step 6: with per-chiplet bindings persisted, the reload has nothing to migrate (#938)");
 
         var loadedFields = await SimulateAsync(loadedCanvas,
             InjectLight("source", MultiProcessChipletJourneyDesign.ExposedPin(loadedA, "cs_coupler_o1")));
@@ -95,4 +93,113 @@ public partial class MultiProcessChipletJourneyTests
             .ShouldBe(outputBefore, AmplitudeTolerance,
                 "Step 6: the reloaded two-process system delivers the same output power");
     }
+
+    [Fact]
+    public async Task Step7_LunRoundTrip_PerChipletProcessBindingSurvives()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
+        saveVm.ProcessCatalogProvider = () => BuildProcessCatalog(design);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+
+        // The binding of each top-level group is persisted inside the file itself.
+        var fileText = File.ReadAllText(_designFilePath);
+        fileText.ShouldContain("\"ProcessBinding\"", Case.Sensitive,
+            "Step 7: each chiplet's process binding must be written into the .lun (#938)");
+
+        var loadedCanvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
+        loadVm.ProcessCatalogProvider = () => BuildProcessCatalog(design);
+        string? migrationWarning = null;
+        loadVm.OnProcessMigrationWarning = w => migrationWarning = w;
+        var loadDialog = new Mock<IFileDialogService>();
+        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        loadVm.FileDialogService = loadDialog.Object;
+        await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+        var loadedGroups = loadedCanvas.Components
+            .Where(c => c.Component is ComponentGroup)
+            .Select(c => (ComponentGroup)c.Component)
+            .ToList();
+        var loadedA = loadedGroups.Single(g => g.Identifier == design.ChipletA.Identifier);
+        var loadedB = loadedGroups.Single(g => g.Identifier == design.ChipletB.Identifier);
+
+        // Rung 6: chiplet A reloads bound to the Cornerstone process and chiplet B to
+        // the SiEPIC process — the design as a whole is not one process.
+        loadedA.ProcessBinding.ShouldNotBeNull("Step 7: chiplet A's process binding survives (#938)");
+        loadedA.ProcessBinding!.IsPlayground.ShouldBeFalse(
+            "Step 7: a bound chiplet is a first-class manufacturable state, not Playground");
+        loadedA.ProcessBinding.MemberPdkNames.ShouldContain(design.Cornerstone.Name);
+        loadedB.ProcessBinding.ShouldNotBeNull("Step 7: chiplet B's process binding survives (#938)");
+        loadedB.ProcessBinding!.IsPlayground.ShouldBeFalse(
+            "Step 7: a bound chiplet is a first-class manufacturable state, not Playground");
+        loadedB.ProcessBinding.MemberPdkNames.ShouldContain(design.Siepic.Name);
+
+        migrationWarning.ShouldBeNull(
+            "Step 7: the persisted bindings describe the design completely — no Playground migration");
+        loadVm.ActiveProcess.ShouldNotBeNull(
+            "Step 7: a loaded design never falls back to the unset state (that would re-open the process picker)");
+        loadVm.ActiveProcess!.IsPlayground.ShouldBeTrue(
+            "Step 7: the canvas-level default for a genuine two-process carrier is Playground; " +
+            "the per-chiplet bindings above carry the manufacturability (#938)");
+    }
+
+    /// <summary>
+    /// Backward compatibility (#938 acceptance): a .lun saved before per-chiplet
+    /// bindings existed (no catalog at save time → no bindings in the file) loads
+    /// exactly as today — Playground plus the multi-process migration warning.
+    /// </summary>
+    [Fact]
+    public async Task Step7_LegacyFileWithoutBindings_LoadsExactlyAsBefore()
+    {
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var saveVm = CreateFileOperations(design.Canvas, design.Templates);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+
+        var fileText = File.ReadAllText(_designFilePath);
+        fileText.ShouldNotContain("\"ProcessBinding\"", Case.Sensitive,
+            "a pre-#938 save carries no per-chiplet binding — this test pins that legacy shape");
+
+        var loadedCanvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(loadedCanvas, design.Templates);
+        loadVm.ProcessCatalogProvider = () => BuildProcessCatalog(design);
+        string? migrationWarning = null;
+        loadVm.OnProcessMigrationWarning = w => migrationWarning = w;
+        var loadDialog = new Mock<IFileDialogService>();
+        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        loadVm.FileDialogService = loadDialog.Object;
+        await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+        var loadedGroups = loadedCanvas.Components
+            .Where(c => c.Component is ComponentGroup)
+            .Select(c => (ComponentGroup)c.Component)
+            .ToList();
+        loadedGroups.ShouldAllBe(g => g.ProcessBinding == null,
+            "legacy files restore no bindings — placement derives the scope live as before (#935)");
+        loadVm.ActiveProcess.ShouldNotBeNull();
+        loadVm.ActiveProcess!.IsPlayground.ShouldBeTrue(
+            "legacy two-process designs still migrate to Playground");
+        migrationWarning.ShouldNotBeNull();
+        migrationWarning!.ShouldContain("multiple processes");
+    }
+
+    /// <summary>The production process catalog over the journey's two bundled PDKs.</summary>
+    private static IReadOnlyList<ProcessGroup> BuildProcessCatalog(MultiProcessChipletJourneyDesign design) =>
+        ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(design.Cornerstone.Name, ProcessFingerprintFactory.From(design.Cornerstone)),
+            new PdkProcessEntry(design.Siepic.Name, ProcessFingerprintFactory.From(design.Siepic)),
+        });
 }

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -48,9 +48,11 @@ namespace UnitTests.Components;
 ///         two-process design checks nothing PDK-dependent at all.
 ///   Step 5 (RED, #937): the router's bend-radius floor is one canvas-wide value.
 ///   Step 6 (green): .lun round-trip — both per-component PDK assignments, the
-///         groups, the abutment and the physics survive (the design reloads as
-///         Playground: pinned here as current behavior, #938 is the fix).
-///   Step 7 (RED, #938): no per-chiplet process binding exists to persist.
+///         groups, the abutment and the physics survive; since #938 the reload
+///         migrates nothing (the per-chiplet bindings describe the state).
+///   Step 7 (green, #938): the per-chiplet process binding is persisted per
+///         top-level group and restored on load — no Playground migration.
+///         Legacy files without bindings load exactly as before.
 ///   Step 8 (RED, #939): GDS export routes every waveguide through one global
 ///         interconnect (width/radius/layer), not each chiplet's own stack.
 ///

--- a/UnitTests/ViewModels/Panels/ActiveProcessResolverTests.cs
+++ b/UnitTests/ViewModels/Panels/ActiveProcessResolverTests.cs
@@ -100,6 +100,59 @@ public class ActiveProcessResolverTests
         warning!.ShouldContain("Ghost PDK");
     }
 
+    // ─── FromChipletBindings (design default derived from restored chiplet bindings, #938) ─────
+
+    [Fact]
+    public void FromChipletBindings_NoBindings_ReturnsNull()
+    {
+        ActiveProcessResolver.FromChipletBindings(new ActiveProcessSelection?[] { null, null })
+            .ShouldBeNull();
+        ActiveProcessResolver.FromChipletBindings(Array.Empty<ActiveProcessSelection?>())
+            .ShouldBeNull();
+    }
+
+    [Fact]
+    public void FromChipletBindings_AllChipletsShareOneProcess_AdoptsThatProcess()
+    {
+        var chipletA = ActiveProcessSelection.ForGroup(Soi);
+        var chipletB = ActiveProcessSelection.ForGroup(Soi);
+
+        var result = ActiveProcessResolver.FromChipletBindings(
+            new ActiveProcessSelection?[] { chipletA, chipletB, null });
+
+        result.ShouldNotBeNull();
+        result!.IsPlayground.ShouldBeFalse();
+        result.DisplayName.ShouldBe("SOI 220");
+    }
+
+    [Fact]
+    public void FromChipletBindings_ChipletsSpanProcesses_YieldsPlayground()
+    {
+        var result = ActiveProcessResolver.FromChipletBindings(new ActiveProcessSelection?[]
+        {
+            ActiveProcessSelection.ForGroup(Soi),
+            ActiveProcessSelection.ForGroup(Inp),
+        });
+
+        result.ShouldNotBeNull();
+        result!.IsPlayground.ShouldBeTrue(
+            "a carrier of two chiplet processes has no single design-level process");
+    }
+
+    [Fact]
+    public void FromChipletBindings_PlaygroundBinding_DoesNotCountAsProcess()
+    {
+        var result = ActiveProcessResolver.FromChipletBindings(new ActiveProcessSelection?[]
+        {
+            ActiveProcessSelection.ForGroup(Soi),
+            ActiveProcessSelection.Playground(),
+        });
+
+        result.ShouldNotBeNull();
+        result!.DisplayName.ShouldBe("SOI 220",
+            "a Playground-bound group carries no process — the one real binding decides");
+    }
+
     // ─── Revalidate (stored processes re-anchored to the installed catalog) ─────
 
     [Fact]


### PR DESCRIPTION
## What & why

Fixes #938 (#537 rung 6). The .lun format persisted exactly one process record per design (`DesignFileData.ActiveProcess`), so a two-chiplet design reloaded into **Playground** with a "not manufacturable" migration warning and every chiplet's process binding was lost.

This PR persists an optional process binding per **top-level group** (chiplet) — the serialized form of the in-memory `ComponentGroup.ProcessBinding` that landed with #935:

- **Save:** `DesignGroupData.ProcessBinding` (new optional field) carries the group's explicit binding, or — for groups built without one (e.g. composed in Playground) — the binding derived from the children's PDK sources via `GroupProcessPolicy.DeriveProcessBinding` when they unanimously belong to one catalog process. Null bindings are omitted from the JSON, so legacy files keep their exact shape. Nested groups carry no own record; their scope is the top-level chiplet's.
- **Load:** each top-level group's binding is restored and re-anchored to the installed catalog with the same `ActiveProcessResolver.Revalidate` semantics as the design-level record (newly installed compatible PDKs join; a chiplet whose PDKs are all missing warns instead of silently pinning a nonexistent process).
- **Design-level inference:** chiplet-bound content no longer feeds `Migrate` — the design-level `ActiveProcess` stays the default for ungrouped/legacy content only. When no own record and no unbound content exist, the default follows the restored bindings (`ActiveProcessResolver.FromChipletBindings`): one shared chiplet process → that process; several distinct processes → Playground (the canvas genuinely mixes processes; manufacturability now lives in the per-chiplet bindings). No migration warning fires in either case — the file fully describes the state, nothing was lost. Playground rather than null so a loaded design never re-triggers the initial process picker.

Backward compatibility: a legacy .lun without bindings loads exactly as before (Playground + "multiple processes" migration warning), pinned by a dedicated test.

Out of scope per the issue's guardrails: per-chiplet DRC (#936) and per-chiplet GDS export stacks (#939) are untouched.

## How it was tested

- Journey step 7 un-skipped and green on the real bundled Cornerstone SiN + SiEPIC EBeam PDKs: save two-chiplet design → `ProcessBinding` records present in the file → reload → chiplet A bound to the Cornerstone process, chiplet B to the SiEPIC process, **no Playground migration warning**.
- Journey step 6's documented-collapse pin updated to the new lossless behavior (round-trip still bit-identical in physics: simulated output power unchanged after reload).
- New backward-compat test: a pre-#938-shaped file (no bindings) loads exactly as today — Playground + migration warning, groups unbound.
- New `ActiveProcessResolverTests` unit tests for `FromChipletBindings` (none / unanimous / split / Playground-binding cases).

Local suite: 5685 passed, 0 failed

## Manual verification after vacation

Headless tests cover the round-trip; the only user-visible delta worth a click-through:

1. Open Lunima, choose **Playground** as the design process.
2. Place a Cornerstone Coupler + Mmi1x2, select both, Ctrl+G → group "Chiplet A". Place a SiEPIC Y-Branch + Taper, group them → "Chiplet B".
3. Save the design as .lun, close it (File → New Design), reload the .lun.
4. Expected: **no** "multiple processes / not manufacturable" migration warning appears (previously it did). The process badge shows Playground (the canvas genuinely mixes two processes).
5. Optional: open the .lun in a text editor — each top-level group carries a `ProcessBinding` record naming its process's member PDK.
6. Regression check: open any legacy single-process .lun — it loads locked to its process exactly as before.