### PR TITLE
Agent: DRC-lite: rule set comes from the single active process — per-chiplet limits impossible (#537 rung 6)

### DIFF
--- a/CAP-DataAccess/Components/ComponentDraftMapper/ConnectionDrcRuleResolver.cs
+++ b/CAP-DataAccess/Components/ComponentDraftMapper/ConnectionDrcRuleResolver.cs
@@ -1,0 +1,64 @@
+using CAP_Core.Analysis;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+
+namespace CAP_DataAccess.Components.ComponentDraftMapper
+{
+    /// <summary>
+    /// Resolves the DRC-lite rule set governing ONE waveguide connection from the PDK
+    /// sources of its endpoint components (issue #936) — the width/spacing counterpart
+    /// of <see cref="WaveguideBendRadiusResolver.ResolveForEndpointPdkNames"/> (issue
+    /// #937). On a multi-process canvas (e.g. a Cornerstone SiN chiplet next to a
+    /// SiEPIC SOI chiplet) this keys every connection to its own endpoints' process
+    /// limits instead of the design-wide rule set taken from the active process' first
+    /// member PDK — and it works in Playground, where no process lock exists at all.
+    /// Only DECLARED values participate: a PDK without <c>minWidthUm</c> /
+    /// <c>minWaveguideSpacingUm</c> contributes nothing (the #926 no-invented-values
+    /// rule). For a cross-chiplet connection both endpoint processes contribute — the
+    /// stricter side governs, same rule as #937.
+    /// </summary>
+    public static class ConnectionDrcRuleResolver
+    {
+        /// <summary>
+        /// Resolves the per-connection DRC-lite rules from the endpoint components' PDK
+        /// sources: the min-width rules are the union of both endpoint processes'
+        /// declared cross-section minimums (the pin-layer association in
+        /// <see cref="WaveguideMinWidthChecker"/> picks each side's own rule), the
+        /// minimum spacing is the stricter (larger) of the two declared process values.
+        /// Returns null when neither endpoint resolves to a loaded PDK process — "no
+        /// PDK opinion"; the caller then falls back to its canvas-wide rule set, the
+        /// same fallback rule as the #937 bend floor.
+        /// </summary>
+        /// <param name="startPdkName">PDK source name of the start endpoint's component (null = unknown).</param>
+        /// <param name="endPdkName">PDK source name of the end endpoint's component (null = unknown).</param>
+        /// <param name="loadedPdks">All currently loaded PDK drafts.</param>
+        public static ConnectionDrcRules? ResolveForEndpointPdkNames(
+            string? startPdkName, string? endPdkName, IReadOnlyList<PdkDraft>? loadedPdks)
+        {
+            if (loadedPdks == null)
+                return null;
+
+            var startProcess = FindProcess(startPdkName, loadedPdks);
+            var endProcess = FindProcess(endPdkName, loadedPdks);
+            if (startProcess == null && endProcess == null)
+                return null;
+
+            var widthRules = new List<WaveguideMinWidthRule>();
+            widthRules.AddRange(startProcess.GetMinWaveguideWidthRules());
+            if (!ReferenceEquals(startProcess, endProcess))
+                widthRules.AddRange(endProcess.GetMinWaveguideWidthRules());
+
+            double minSpacing = Math.Max(
+                startProcess?.MinWaveguideSpacingUm ?? 0,
+                endProcess?.MinWaveguideSpacingUm ?? 0);
+
+            return new ConnectionDrcRules(widthRules, minSpacing);
+        }
+
+        /// <summary>Finds the process definition of the named loaded PDK (null when unknown).</summary>
+        private static ProcessDefinition? FindProcess(string? pdkName, IReadOnlyList<PdkDraft> loadedPdks) =>
+            string.IsNullOrEmpty(pdkName)
+                ? null
+                : loadedPdks.FirstOrDefault(
+                    d => string.Equals(d.Name, pdkName, StringComparison.OrdinalIgnoreCase))?.Process;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Diagnostics/DesignValidationViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Diagnostics/DesignValidationViewModel.cs
@@ -76,6 +76,12 @@ public partial class DesignValidationViewModel : ObservableObject
     /// <param name="externalPortPins">Pins treated as external ports; exempt from the dangling-pin check. Optional.</param>
     /// <param name="minWaveguideSpacingMicrometers">Process minimum edge-to-edge waveguide spacing; ≤0 disables the spacing check. Optional.</param>
     /// <param name="minWaveguideWidthRules">Per-cross-section minimum feature widths of the active process; null/empty disables the min-width check. Optional.</param>
+    /// <param name="connectionDrcRuleProvider">
+    /// Optional per-connection DRC rule-set resolver (issue #936): when wired, each
+    /// connection's width/spacing limits come from its own endpoint PDKs' processes —
+    /// per-chiplet limits on a multi-process canvas and PDK rules even in Playground —
+    /// instead of the design-wide values above. Optional.
+    /// </param>
     public void RunValidation(
         IEnumerable<WaveguideConnection> connections,
         IEnumerable<ComponentGroup>? groups = null,
@@ -88,7 +94,8 @@ public partial class DesignValidationViewModel : ObservableObject
         bool processLockActive = true,
         IEnumerable<PhysicalPin>? externalPortPins = null,
         double minWaveguideSpacingMicrometers = 0,
-        IReadOnlyList<WaveguideMinWidthRule>? minWaveguideWidthRules = null)
+        IReadOnlyList<WaveguideMinWidthRule>? minWaveguideWidthRules = null,
+        Func<WaveguideConnection, ConnectionDrcRules?>? connectionDrcRuleProvider = null)
     {
         Issues.Clear();
         CurrentIndex = -1;
@@ -102,7 +109,8 @@ public partial class DesignValidationViewModel : ObservableObject
             allComponents ?? Array.Empty<Component>(),
             externalPortPins,
             minWaveguideSpacingMicrometers,
-            minWaveguideWidthRules);
+            minWaveguideWidthRules,
+            connectionDrcRuleProvider);
 
         foreach (var issue in results)
             Issues.Add(issue);

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -1199,16 +1199,35 @@ public partial class MainViewModel : ObservableObject
         var processLockActive = FileOperations.ActiveProcess is { IsPlayground: false };
         var compatiblePdkNames = LeftPanel.PdkManager.GetProcessCompatiblePdkNames();
 
-        // DRC-lite min waveguide spacing (#899, wired for #915) and min feature width:
-        // the first member PDK process of the active selection provides the declared
-        // values (spacing falls back to the conservative default); without a real
-        // process (Playground) both checks stay off (0/null = disabled).
+        // DRC-lite per connection (issue #936): each connection's width and spacing
+        // limits come from its OWN endpoint components' PDK processes — the stricter
+        // chiplet governs a cross-chiplet route, same rule as the router's bend floor
+        // (#937) — so a two-process canvas (only possible in Playground, #935) is
+        // checked per chiplet instead of silently skipping every PDK-dependent rule,
+        // and a locked multi-member process no longer checks the other members against
+        // the first member PDK's limits. PDKs that declare no minimum stay silent
+        // (#926). Library and drafts are snapshotted here on the UI thread (same
+        // pattern as the #937 floor provider); connections whose endpoints don't
+        // resolve to a PDK (built-ins) yield null and fall back to the lock-derived
+        // canvas-wide values below, exactly like the #937 floor. Frozen group paths
+        // carry no pins to resolve an owning process from, so they also keep the
+        // canvas-wide spacing (0 in Playground = off, as before).
+        var drcTemplates = LeftPanel.AllTemplates.ToList();
+        var drcDrafts = LeftPanel.GetLoadedPdkDrafts().ToList();
+        string? DrcPdkSourceOf(PhysicalPin? pin) =>
+            pin?.ParentComponent is { } component
+                ? ComponentPdkSourceResolver.Resolve(component, drcTemplates)
+                : null;
+        Func<CAP_Core.Components.Connections.WaveguideConnection, CAP_Core.Analysis.ConnectionDrcRules?> connectionDrcRuleProvider =
+            connection => ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+                DrcPdkSourceOf(connection.StartPin), DrcPdkSourceOf(connection.EndPin), drcDrafts);
+
         double minWaveguideSpacingMicrometers = 0;
         IReadOnlyList<CAP_Core.Analysis.WaveguideMinWidthRule>? minWaveguideWidthRules = null;
         if (processLockActive)
         {
             var memberProcess = LeftPanel.ResolveLiveMemberPdkNames(FileOperations.ActiveProcess!)
-                .Select(name => LeftPanel.GetLoadedPdkDrafts().FirstOrDefault(
+                .Select(name => drcDrafts.FirstOrDefault(
                     d => string.Equals(d.Name, name, StringComparison.OrdinalIgnoreCase))?.Process)
                 .FirstOrDefault(p => p is not null);
             minWaveguideSpacingMicrometers = memberProcess.GetMinWaveguideSpacingMicrometersOrDefault();
@@ -1226,7 +1245,8 @@ public partial class MainViewModel : ObservableObject
             compatiblePdkNames,
             processLockActive,
             minWaveguideSpacingMicrometers: minWaveguideSpacingMicrometers,
-            minWaveguideWidthRules: minWaveguideWidthRules);
+            minWaveguideWidthRules: minWaveguideWidthRules,
+            connectionDrcRuleProvider: connectionDrcRuleProvider);
 
         StatusText = RightPanel.DesignValidation.StatusText;
     }

--- a/Connect-A-Pic-Core/Analysis/ConnectionDrcRules.cs
+++ b/Connect-A-Pic-Core/Analysis/ConnectionDrcRules.cs
@@ -1,0 +1,42 @@
+namespace CAP_Core.Analysis;
+
+/// <summary>
+/// The DRC-lite rule set governing ONE waveguide connection, resolved from the
+/// fabrication processes of the PDKs its endpoint pins belong to (issue #936).
+/// On a multi-process canvas (e.g. a Cornerstone SiN chiplet next to a SiEPIC SOI
+/// chiplet) each connection is checked against its own endpoints' process limits
+/// instead of one design-wide rule set taken from the active process' first member
+/// PDK. Only declared values participate: a PDK that declares no
+/// <c>minWidthUm</c>/<c>minWaveguideSpacingUm</c> contributes nothing and the
+/// connection stays silent for that rule kind — no invented values (the #926 rule).
+/// </summary>
+public sealed class ConnectionDrcRules
+{
+    /// <summary>
+    /// Creates the per-connection rule set.
+    /// </summary>
+    /// <param name="widthRules">
+    /// Union of both endpoint processes' per-cross-section minimum feature widths;
+    /// the pin-layer association in <see cref="WaveguideMinWidthChecker"/> picks the
+    /// rule of the cross-section a pin is drawn on. Empty when neither endpoint PDK
+    /// declares a minimum.
+    /// </param>
+    /// <param name="minSpacingMicrometers">
+    /// The stricter (larger) of the two endpoint processes' declared minimum
+    /// edge-to-edge waveguide spacings; ≤0 when neither declares one (spacing rule
+    /// silent for this connection).
+    /// </param>
+    public ConnectionDrcRules(
+        IReadOnlyList<WaveguideMinWidthRule> widthRules,
+        double minSpacingMicrometers)
+    {
+        WidthRules = widthRules;
+        MinSpacingMicrometers = minSpacingMicrometers;
+    }
+
+    /// <summary>Per-cross-section minimum feature widths of the endpoint processes.</summary>
+    public IReadOnlyList<WaveguideMinWidthRule> WidthRules { get; }
+
+    /// <summary>Governing minimum edge-to-edge spacing in µm; ≤0 means no declared limit.</summary>
+    public double MinSpacingMicrometers { get; }
+}

--- a/Connect-A-Pic-Core/Analysis/DesignValidator.cs
+++ b/Connect-A-Pic-Core/Analysis/DesignValidator.cs
@@ -16,6 +16,7 @@ public class DesignValidator
     private readonly WaveguideOverlapDetector _overlapDetector = new();
     private readonly WaveguideSpacingDetector _spacingDetector = new();
     private readonly WaveguideMinWidthChecker _minWidthChecker = new();
+    private readonly PerConnectionDrcChecker _perConnectionDrcChecker = new();
 
     /// <summary>
     /// Validates all provided waveguide connections and returns any issues found.
@@ -144,11 +145,25 @@ public class DesignValidator
     /// <param name="components">All placed components whose optical pins are checked.</param>
     /// <param name="externalPortPins">Pins that are external ports and should be skipped.</param>
     /// <param name="minWaveguideSpacingMicrometers">
-    /// Minimum required edge-to-edge spacing; ≤0 disables the spacing check.
+    /// Minimum required edge-to-edge spacing; ≤0 disables the spacing check. When a
+    /// per-connection provider is wired this value still governs frozen group paths,
+    /// which carry no pins to resolve an owning process from.
     /// </param>
     /// <param name="minWaveguideWidthRules">
     /// Per-cross-section minimum feature widths of the active process; null/empty disables
-    /// the min-width check (the PDK declares no <c>minWidthUm</c>).
+    /// the min-width check (the PDK declares no <c>minWidthUm</c>). Ignored for
+    /// connections when <paramref name="connectionDrcRuleProvider"/> is wired.
+    /// </param>
+    /// <param name="connectionDrcRuleProvider">
+    /// Optional per-connection rule-set resolver (issue #936): when wired, EACH
+    /// connection's width and spacing limits come from its own endpoint PDKs' processes
+    /// instead of the design-wide values above, so a multi-process (e.g. two-chiplet)
+    /// canvas checks every chiplet against its own foundry limits — including in
+    /// Playground, where no process lock exists at all. A null return means "no PDK
+    /// opinion" (built-ins, PDK-less components): the design-wide values above govern,
+    /// the same fallback rule as the router's per-connection bend floor (#937). A
+    /// non-null but empty rule set means the endpoint PDKs are known and declare no
+    /// minimum — the connection stays silent (no invented values, #926).
     /// </param>
     /// <returns>A list of all design issues found, empty if the design is valid.</returns>
     public List<DesignIssue> Validate(
@@ -157,7 +172,8 @@ public class DesignValidator
         IEnumerable<Component> components,
         IEnumerable<PhysicalPin>? externalPortPins,
         double minWaveguideSpacingMicrometers = 0,
-        IReadOnlyList<WaveguideMinWidthRule>? minWaveguideWidthRules = null)
+        IReadOnlyList<WaveguideMinWidthRule>? minWaveguideWidthRules = null,
+        Func<WaveguideConnection, ConnectionDrcRules?>? connectionDrcRuleProvider = null)
     {
         ArgumentNullException.ThrowIfNull(connections);
         ArgumentNullException.ThrowIfNull(groups);
@@ -165,6 +181,15 @@ public class DesignValidator
 
         var connectionList = connections.ToList();
         var issues = Validate(connectionList, groups, components, externalPortPins);
+
+        if (connectionDrcRuleProvider is not null)
+        {
+            issues.AddRange(_perConnectionDrcChecker.Check(
+                connectionList, groups, minWaveguideSpacingMicrometers,
+                minWaveguideWidthRules, connectionDrcRuleProvider));
+            return issues;
+        }
+
         if (minWaveguideSpacingMicrometers > 0)
         {
             issues.AddRange(_spacingDetector.DetectViolations(

--- a/Connect-A-Pic-Core/Analysis/PerConnectionDrcChecker.cs
+++ b/Connect-A-Pic-Core/Analysis/PerConnectionDrcChecker.cs
@@ -1,0 +1,66 @@
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+
+namespace CAP_Core.Analysis;
+
+/// <summary>
+/// The per-connection DRC-lite aggregation (issue #936): resolves each connection's
+/// rule set once through the caller-provided resolver, then runs the spacing and
+/// min-width checks against those per-connection values instead of one design-wide
+/// rule set — so every chiplet on a multi-process canvas answers to its own foundry
+/// limits, including in Playground where no process lock exists at all. A connection
+/// whose resolver returns null has "no PDK opinion" (built-ins, PDK-less components)
+/// and falls back to the canvas-wide values, the same rule as the router's
+/// per-connection bend floor (#937); a non-null but empty rule set means the endpoint
+/// PDKs are known and declare no minimum — the connection stays silent (#926).
+/// </summary>
+public class PerConnectionDrcChecker
+{
+    private readonly WaveguideSpacingDetector _spacingDetector = new();
+    private readonly WaveguideMinWidthChecker _minWidthChecker = new();
+
+    /// <summary>
+    /// Runs the spacing and min-width checks keyed per connection.
+    /// </summary>
+    /// <param name="connections">The connections to check.</param>
+    /// <param name="groups">ComponentGroups whose frozen internal paths join the spacing check.</param>
+    /// <param name="canvasWideMinSpacingMicrometers">
+    /// Design-wide spacing fallback: governs frozen group paths (no pins to resolve)
+    /// and connections with no PDK opinion.
+    /// </param>
+    /// <param name="canvasWideWidthRules">
+    /// Design-wide min-width fallback for connections with no PDK opinion.
+    /// </param>
+    /// <param name="connectionDrcRuleProvider">
+    /// Resolves the rule set governing one connection from its endpoint PDKs.
+    /// </param>
+    /// <returns>One list with every spacing and min-width finding, empty when compliant.</returns>
+    public List<DesignIssue> Check(
+        IReadOnlyList<WaveguideConnection> connections,
+        IEnumerable<ComponentGroup> groups,
+        double canvasWideMinSpacingMicrometers,
+        IReadOnlyList<WaveguideMinWidthRule>? canvasWideWidthRules,
+        Func<WaveguideConnection, ConnectionDrcRules?> connectionDrcRuleProvider)
+    {
+        ArgumentNullException.ThrowIfNull(connections);
+        ArgumentNullException.ThrowIfNull(groups);
+        ArgumentNullException.ThrowIfNull(connectionDrcRuleProvider);
+
+        var resolved = new Dictionary<WaveguideConnection, ConnectionDrcRules?>();
+        foreach (var connection in connections)
+        {
+            resolved[connection] = connectionDrcRuleProvider(connection);
+        }
+
+        var issues = new List<DesignIssue>();
+        issues.AddRange(_spacingDetector.DetectViolations(
+            connections,
+            groups,
+            canvasWideMinSpacingMicrometers,
+            connection => resolved[connection]?.MinSpacingMicrometers ?? canvasWideMinSpacingMicrometers));
+        issues.AddRange(_minWidthChecker.CheckConnections(
+            connections,
+            connection => resolved[connection]?.WidthRules ?? canvasWideWidthRules));
+        return issues;
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/WaveguideMinWidthChecker.cs
+++ b/Connect-A-Pic-Core/Analysis/WaveguideMinWidthChecker.cs
@@ -49,6 +49,42 @@ public class WaveguideMinWidthChecker
         return issues;
     }
 
+    /// <summary>
+    /// Per-connection counterpart (issue #936): each connection is checked against the
+    /// rule set of its OWN endpoint PDKs — resolved by the caller — instead of one
+    /// design-wide list, so a Cornerstone chiplet on a multi-process canvas is checked
+    /// against the Cornerstone minimum while a SiEPIC chiplet (no declared minimum)
+    /// stays silent, even in Playground where no process lock exists. A connection
+    /// whose rule set resolves to null or empty is skipped (no PDK opinion).
+    /// </summary>
+    /// <param name="connections">The connections to check.</param>
+    /// <param name="rulesForConnection">
+    /// Resolves the min-width rules governing one connection; null/empty return means
+    /// "no declared minimum" and the connection is skipped.
+    /// </param>
+    /// <returns>One issue per violating connection, empty when all are compliant.</returns>
+    public List<DesignIssue> CheckConnections(
+        IEnumerable<WaveguideConnection> connections,
+        Func<WaveguideConnection, IReadOnlyList<WaveguideMinWidthRule>?> rulesForConnection)
+    {
+        ArgumentNullException.ThrowIfNull(connections);
+        ArgumentNullException.ThrowIfNull(rulesForConnection);
+
+        var issues = new List<DesignIssue>();
+        foreach (var connection in connections)
+        {
+            var rules = rulesForConnection(connection);
+            if (rules is not { Count: > 0 })
+                continue;
+
+            var issue = CheckConnection(connection, rules);
+            if (issue is not null)
+                issues.Add(issue);
+        }
+
+        return issues;
+    }
+
     private static DesignIssue? CheckConnection(
         WaveguideConnection connection,
         IReadOnlyList<WaveguideMinWidthRule> rules)

--- a/Connect-A-Pic-Core/Analysis/WaveguideSpacingDetector.cs
+++ b/Connect-A-Pic-Core/Analysis/WaveguideSpacingDetector.cs
@@ -18,37 +18,60 @@ public class WaveguideSpacingDetector
         WaveguideConnection? Connection,
         PathSegment Segment,
         int SegmentIndex,
-        double HalfWidthMicrometers);
+        double HalfWidthMicrometers,
+        double SpacingMicrometers);
 
     /// <summary>
     /// Detects all distinct waveguide segment pairs whose edge-to-edge clearance
-    /// is smaller than <paramref name="minWaveguideSpacingMicrometers"/>.
+    /// is smaller than the governing minimum spacing. Without a per-connection
+    /// provider that is <paramref name="minWaveguideSpacingMicrometers"/> for every
+    /// segment; with one (issue #936) each connection's segments carry the minimum of
+    /// their own endpoint PDKs' processes (≤0 = no declared limit) while frozen group
+    /// paths keep <paramref name="minWaveguideSpacingMicrometers"/>, and a pair is
+    /// governed by the stricter (larger) of its two segments' values — so a
+    /// Cornerstone route enforces its foundry gap even against a SiEPIC neighbour
+    /// that declares no limit of its own.
     /// </summary>
     /// <param name="connections">Regular waveguide connections to check.</param>
     /// <param name="groups">ComponentGroups whose frozen internal paths are checked.</param>
-    /// <param name="minWaveguideSpacingMicrometers">Minimum required edge-to-edge spacing.</param>
+    /// <param name="minWaveguideSpacingMicrometers">
+    /// Minimum required edge-to-edge spacing for frozen group paths and — when no
+    /// per-connection provider is given — for every connection.
+    /// </param>
+    /// <param name="spacingForConnection">
+    /// Optional per-connection minimum spacing resolver (issue #936); a return ≤0
+    /// means the connection's PDKs declare no limit. Null keeps the uniform
+    /// <paramref name="minWaveguideSpacingMicrometers"/> behavior.
+    /// </param>
     /// <returns>A list of spacing design issues, empty if none found.</returns>
     public List<DesignIssue> DetectViolations(
         IEnumerable<WaveguideConnection> connections,
         IEnumerable<ComponentGroup> groups,
-        double minWaveguideSpacingMicrometers)
+        double minWaveguideSpacingMicrometers,
+        Func<WaveguideConnection, double>? spacingForConnection = null)
     {
         ArgumentNullException.ThrowIfNull(connections);
         ArgumentNullException.ThrowIfNull(groups);
 
-        if (minWaveguideSpacingMicrometers <= 0)
-            return new List<DesignIssue>();
-
-        var segments = CollectSegments(connections, groups);
+        var segments = CollectSegments(connections, groups, minWaveguideSpacingMicrometers, spacingForConnection);
         if (segments.Count < 2)
             return new List<DesignIssue>();
 
-        var pairs = FindCandidatePairs(segments, minWaveguideSpacingMicrometers);
+        double maxSpacing = 0.0;
+        foreach (var segment in segments)
+        {
+            if (segment.SpacingMicrometers > maxSpacing)
+                maxSpacing = segment.SpacingMicrometers;
+        }
+        if (maxSpacing <= 0)
+            return new List<DesignIssue>();
+
+        var pairs = FindCandidatePairs(segments, maxSpacing);
         var issues = new List<DesignIssue>();
 
         foreach (var (indexA, indexB) in pairs)
         {
-            var issue = CheckPair(segments[indexA], segments[indexB], minWaveguideSpacingMicrometers);
+            var issue = CheckPair(segments[indexA], segments[indexB]);
             if (issue is not null)
                 issues.Add(issue);
         }
@@ -58,7 +81,9 @@ public class WaveguideSpacingDetector
 
     private static List<SegmentInfo> CollectSegments(
         IEnumerable<WaveguideConnection> connections,
-        IEnumerable<ComponentGroup> groups)
+        IEnumerable<ComponentGroup> groups,
+        double minWaveguideSpacingMicrometers,
+        Func<WaveguideConnection, double>? spacingForConnection)
     {
         var segments = new List<SegmentInfo>();
 
@@ -69,6 +94,7 @@ public class WaveguideSpacingDetector
 
             var label = FormatConnectionLabel(connection);
             double halfWidth = connection.WidthMicrometers / 2.0;
+            double spacing = spacingForConnection?.Invoke(connection) ?? minWaveguideSpacingMicrometers;
 
             for (int i = 0; i < routedSegments.Count; i++)
             {
@@ -78,7 +104,8 @@ public class WaveguideSpacingDetector
                     connection,
                     routedSegments[i],
                     i,
-                    halfWidth));
+                    halfWidth,
+                    spacing));
             }
         }
 
@@ -100,7 +127,8 @@ public class WaveguideSpacingDetector
                         null,
                         frozenSegments[i],
                         i,
-                        halfWidth));
+                        halfWidth,
+                        minWaveguideSpacingMicrometers));
                 }
             }
         }
@@ -110,7 +138,7 @@ public class WaveguideSpacingDetector
 
     private static HashSet<(int IndexA, int IndexB)> FindCandidatePairs(
         List<SegmentInfo> segments,
-        double minSpacing)
+        double maxSpacing)
     {
         double maxHalfWidth = 0.0;
         foreach (var segment in segments)
@@ -119,14 +147,14 @@ public class WaveguideSpacingDetector
                 maxHalfWidth = segment.HalfWidthMicrometers;
         }
 
-        double cellSize = minSpacing + maxHalfWidth * 2.0;
+        double cellSize = maxSpacing + maxHalfWidth * 2.0;
 
         var buckets = new Dictionary<(int X, int Y), List<int>>();
 
         for (int i = 0; i < segments.Count; i++)
         {
             var (minX, minY, maxX, maxY) = WaveguideSpacingGeometry.GetPaddedBounds(
-                segments[i].Segment, segments[i].HalfWidthMicrometers, minSpacing);
+                segments[i].Segment, segments[i].HalfWidthMicrometers, segments[i].SpacingMicrometers);
 
             int bx0 = (int)Math.Floor(minX / cellSize);
             int bx1 = (int)Math.Floor(maxX / cellSize);
@@ -154,7 +182,7 @@ public class WaveguideSpacingDetector
         for (int i = 0; i < segments.Count; i++)
         {
             var (minX, minY, maxX, maxY) = WaveguideSpacingGeometry.GetPaddedBounds(
-                segments[i].Segment, segments[i].HalfWidthMicrometers, minSpacing);
+                segments[i].Segment, segments[i].HalfWidthMicrometers, segments[i].SpacingMicrometers);
 
             int bx0 = (int)Math.Floor(minX / cellSize) - 1;
             int bx1 = (int)Math.Floor(maxX / cellSize) + 1;
@@ -180,9 +208,15 @@ public class WaveguideSpacingDetector
         return pairs;
     }
 
-    private static DesignIssue? CheckPair(SegmentInfo a, SegmentInfo b, double minSpacing)
+    private static DesignIssue? CheckPair(SegmentInfo a, SegmentInfo b)
     {
         if (a.PathId == b.PathId)
+            return null;
+
+        // The stricter side governs: the pair must respect the larger of the two
+        // segments' process minima; a pair where neither side declares one is silent.
+        double minSpacing = Math.Max(a.SpacingMicrometers, b.SpacingMicrometers);
+        if (minSpacing <= 0)
             return null;
 
         if (WaveguideSpacingGeometry.SegmentsShareEndpoint(a.Segment, b.Segment))

--- a/UnitTests/Analysis/ConnectionDrcRuleResolverTests.cs
+++ b/UnitTests/Analysis/ConnectionDrcRuleResolverTests.cs
@@ -1,0 +1,121 @@
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis;
+
+/// <summary>
+/// The per-connection DRC rule resolver (issue #936) keys one connection's width and
+/// spacing limits to the PDK processes of its OWN endpoint components instead of the
+/// design-wide rule set of the active process' first member PDK. Both endpoint
+/// processes contribute — the stricter side governs — and PDKs that declare no
+/// minimum stay silent (the #926 no-invented-values rule). Exercised on the real
+/// bundled PDKs (Cornerstone SiN declares minWidthUm 0.25 + spacing 0.25; SiEPIC
+/// declares neither).
+/// </summary>
+public class ConnectionDrcRuleResolverTests
+{
+    private const string CornerstonePdkFile = "cornerstone-sin-pdk.json";
+    private const string SiepicPdkFile = "siepic-ebeam-pdk.json";
+    private const double CornerstoneDeclaredSpacingUm = 0.25;
+
+    [Fact]
+    public void TwoProcesses_BothContribute_StricterSpacingGoverns()
+    {
+        var (cornerstone, siepic) = LoadBundled();
+
+        var rules = ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+            cornerstone.Name, siepic.Name, new[] { cornerstone, siepic });
+
+        rules.ShouldNotBeNull();
+        rules!.WidthRules.Count.ShouldBe(2,
+            "only Cornerstone declares minWidthUm (xs_nc + xs_no) — SiEPIC contributes nothing");
+        rules.WidthRules.ShouldAllBe(r => r.MinWidthMicrometers == 0.25);
+        rules.MinSpacingMicrometers.ShouldBe(CornerstoneDeclaredSpacingUm,
+            "Cornerstone declares 0.25, SiEPIC declares nothing — the stricter side governs");
+    }
+
+    [Fact]
+    public void SamePdkOnBothEnds_RulesAreNotDuplicated()
+    {
+        var (cornerstone, _) = LoadBundled();
+
+        var rules = ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+            cornerstone.Name, cornerstone.Name, new[] { cornerstone });
+
+        rules.ShouldNotBeNull();
+        rules!.WidthRules.Count.ShouldBe(2,
+            "one process contributes its two cross-section rules exactly once");
+        rules.MinSpacingMicrometers.ShouldBe(CornerstoneDeclaredSpacingUm);
+    }
+
+    [Fact]
+    public void UndeclaringPdk_StaysSilent_ButIsNotNoOpinion()
+    {
+        var (_, siepic) = LoadBundled();
+
+        var rules = ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+            siepic.Name, siepic.Name, new[] { siepic });
+
+        rules.ShouldNotBeNull(
+            "the PDK resolves — it simply declares nothing (distinct from 'no PDK opinion')");
+        rules!.WidthRules.ShouldBeEmpty("SiEPIC declares no minWidthUm — no invented values (#926)");
+        rules.MinSpacingMicrometers.ShouldBe(0, "SiEPIC declares no minWaveguideSpacingUm");
+    }
+
+    [Fact]
+    public void NoResolvableEndpoint_ReturnsNull()
+    {
+        var (cornerstone, siepic) = LoadBundled();
+        var drafts = new PdkDraft[] { cornerstone, siepic };
+
+        ConnectionDrcRuleResolver.ResolveForEndpointPdkNames("deleted-pdk", null, drafts)
+            .ShouldBeNull("unknown PDK names carry no process opinion");
+        ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(null, null, drafts)
+            .ShouldBeNull();
+        ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(cornerstone.Name, siepic.Name, null)
+            .ShouldBeNull("without loaded drafts nothing can resolve");
+    }
+
+    [Fact]
+    public void OneEndpointUnresolvable_OtherSideStillGoverns()
+    {
+        var (cornerstone, _) = LoadBundled();
+
+        var rules = ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+            cornerstone.Name, null, new[] { cornerstone });
+
+        rules.ShouldNotBeNull();
+        rules!.WidthRules.Count.ShouldBe(2);
+        rules.MinSpacingMicrometers.ShouldBe(CornerstoneDeclaredSpacingUm);
+    }
+
+    [Fact]
+    public void Spacing_StricterDeclaredValueWins()
+    {
+        var loose = SyntheticDraft("Loose", spacingUm: 0.3);
+        var strict = SyntheticDraft("Strict", spacingUm: 0.7);
+
+        var rules = ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+            loose.Name, strict.Name, new[] { loose, strict });
+
+        rules.ShouldNotBeNull();
+        rules!.MinSpacingMicrometers.ShouldBe(0.7,
+            "a cross-chiplet connection respects the stricter of the two endpoint processes");
+    }
+
+    private static PdkDraft SyntheticDraft(string name, double spacingUm) =>
+        new()
+        {
+            Name = name,
+            Process = new ProcessDefinition { Name = name, MinWaveguideSpacingUm = spacingUm },
+        };
+
+    private static (PdkDraft Cornerstone, PdkDraft Siepic) LoadBundled() =>
+        (LoadPdk(CornerstonePdkFile), LoadPdk(SiepicPdkFile));
+
+    private static PdkDraft LoadPdk(string fileName) =>
+        new PdkLoader().LoadFromFile(
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PDKs", fileName));
+}

--- a/UnitTests/Analysis/PerConnectionDrcValidationTests.cs
+++ b/UnitTests/Analysis/PerConnectionDrcValidationTests.cs
@@ -1,0 +1,296 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Analysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Creation;
+using CAP_Core.Routing;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis;
+
+/// <summary>
+/// Per-connection DRC keying (issue #936) end-to-end through the validator and the
+/// detectors: each connection's width/spacing limits come from its OWN endpoint pins'
+/// PDKs — wired exactly like <c>MainViewModel.RunDesignChecks</c> wires the
+/// <c>connectionDrcRuleProvider</c> — not from one design-wide rule set taken from the
+/// active process' first member PDK. Complements the resolver-focused
+/// <see cref="ConnectionDrcRuleResolverTests"/> and journey Step 4 in
+/// Components/MultiProcessChipletJourneyTests.
+/// </summary>
+public class PerConnectionDrcValidationTests
+{
+    private const string CornerstonePdkFile = "cornerstone-sin-pdk.json";
+    private const string SiepicPdkFile = "siepic-ebeam-pdk.json";
+    private const int CornerstoneGdsLayer = 203;
+    private const int SyntheticWgLayer = 1;
+
+    [Fact]
+    public void Playground_MixedCanvas_ChecksEachConnectionAgainstItsOwnPdk()
+    {
+        var cornerstone = LoadPdk(CornerstonePdkFile);
+        var siepic = LoadPdk(SiepicPdkFile);
+        var templates = new List<ComponentTemplate>
+        {
+            TemplateFor(cornerstone, "Coupler"),
+            TemplateFor(cornerstone, "Straight"),
+            TemplateFor(siepic, "Y-Branch 1550"),
+        };
+        var drafts = new PdkDraft[] { cornerstone, siepic };
+
+        var coupler = Place(templates[0], 0, 0);
+        var straight = Place(templates[1], 200, 0);
+        var cornerstoneLink = Link(Pin(coupler, "o3"), Pin(straight, "o1"), routeWidthUm: 0.2);
+
+        // Far away so the spacing detector sees no cross-pair interplay.
+        var branchA = Place(templates[2], 0, 2000);
+        var branchB = Place(templates[2], 200, 2000);
+        var siepicLink = Link(Pin(branchA, "port 2"), Pin(branchB, "port 1"), routeWidthUm: 0.2);
+
+        // A two-process canvas only exists in Playground (#935): no lock, no
+        // canvas-wide rules — before #936 nothing was checked at all here.
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            new[] { cornerstoneLink, siepicLink },
+            allComponents: new Component[] { coupler, straight, branchA, branchB },
+            processLockActive: false,
+            connectionDrcRuleProvider: Provider(templates, drafts));
+
+        var findings = panel.Issues.Where(i => i.Type == DesignIssueType.WaveguideBelowMinWidth).ToList();
+        findings.Count.ShouldBe(1, Describe(panel));
+        findings[0].Connection.ShouldBe(cornerstoneLink,
+            "the 0.2 µm Cornerstone route violates its own process' declared 0.25 µm minimum");
+        findings[0].Description.ShouldContain("0.20 µm");
+        findings[0].Description.ShouldContain("0.25 µm");
+    }
+
+    [Fact]
+    public void CrossPdkConnection_FlaggedByTheDeclaringSide()
+    {
+        var cornerstone = LoadPdk(CornerstonePdkFile);
+        var siepic = LoadPdk(SiepicPdkFile);
+        var templates = new List<ComponentTemplate>
+        {
+            TemplateFor(cornerstone, "Straight"),
+            TemplateFor(siepic, "Y-Branch 1550"),
+        };
+        var drafts = new PdkDraft[] { cornerstone, siepic };
+
+        var straight = Place(templates[0], 0, 0);
+        var branch = Place(templates[1], 200, 0);
+        var crossLink = Link(Pin(straight, "o1"), Pin(branch, "port 1"), routeWidthUm: 0.2);
+        crossLink.StartPin.Layer.ShouldBe(CornerstoneGdsLayer,
+            "the Cornerstone pin carries the NITRIDE layer its process' rules cover");
+
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            new[] { crossLink },
+            allComponents: new Component[] { straight, branch },
+            processLockActive: false,
+            connectionDrcRuleProvider: Provider(templates, drafts));
+
+        var findings = panel.Issues.Where(i => i.Type == DesignIssueType.WaveguideBelowMinWidth).ToList();
+        findings.Count.ShouldBe(1, Describe(panel));
+        findings[0].Connection.ShouldBe(crossLink,
+            "the Cornerstone endpoint declares 0.25 µm and covers its pin layer — SiEPIC's silence must not disarm the check");
+    }
+
+    [Fact]
+    public void LockedCanvas_ConnectionNotCheckedAgainstForeignProcessLimits()
+    {
+        var processA = SyntheticProcess("ProcessA", minWidthUm: 0.5);
+        var processB = SyntheticProcess("ProcessB", minWidthUm: 0.25);
+        var drafts = new PdkDraft[]
+        {
+            new() { Name = "PDK-A", Process = processA },
+            new() { Name = "PDK-B", Process = processB },
+        };
+
+        var connA = ConnectionOnSyntheticLayer(y: 0, widthUm: 0.3);
+        var connB = ConnectionOnSyntheticLayer(y: 2000, widthUm: 0.3);
+        var pdkByConnection = new Dictionary<WaveguideConnection, string>
+        {
+            [connA] = "PDK-A",
+            [connB] = "PDK-B",
+        };
+        var canvasWideRules = processA.GetMinWaveguideWidthRules();
+        canvasWideRules.Count.ShouldBe(1, "one optical cross-section declares one minimum");
+
+        // Legacy behavior without the provider: every connection is checked against
+        // the first member PDK's rules — connB is a false positive (the #936 finding).
+        var legacyPanel = new DesignValidationViewModel();
+        legacyPanel.RunValidation(
+            new[] { connA, connB },
+            minWaveguideWidthRules: canvasWideRules);
+        legacyPanel.Issues.Count(i => i.Type == DesignIssueType.WaveguideBelowMinWidth)
+            .ShouldBe(2, "canvas-wide keying checks both connections against process A's 0.5 µm minimum");
+
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            new[] { connA, connB },
+            minWaveguideWidthRules: canvasWideRules,
+            connectionDrcRuleProvider: connection =>
+                ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+                    pdkByConnection[connection], pdkByConnection[connection], drafts));
+
+        var findings = panel.Issues.Where(i => i.Type == DesignIssueType.WaveguideBelowMinWidth).ToList();
+        findings.Count.ShouldBe(1, Describe(panel));
+        findings[0].Connection.ShouldBe(connA,
+            "0.3 µm violates process A's 0.5 µm minimum but respects process B's 0.25 µm — each connection answers to its own process");
+    }
+
+    [Fact]
+    public void UnresolvableConnection_FallsBackToCanvasWideRules()
+    {
+        var cornerstone = LoadPdk(CornerstonePdkFile);
+        var templates = new List<ComponentTemplate>
+        {
+            TemplateFor(cornerstone, "Coupler"),
+            TemplateFor(cornerstone, "Straight"),
+        };
+        var coupler = Place(templates[0], 0, 0);
+        var straight = Place(templates[1], 200, 0);
+        var link = Link(Pin(coupler, "o3"), Pin(straight, "o1"), routeWidthUm: 0.2);
+
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            new[] { link },
+            allComponents: new Component[] { coupler, straight },
+            minWaveguideWidthRules: cornerstone.Process.GetMinWaveguideWidthRules(),
+            connectionDrcRuleProvider: _ => null);
+
+        var findings = panel.Issues.Where(i => i.Type == DesignIssueType.WaveguideBelowMinWidth).ToList();
+        findings.Count.ShouldBe(1, Describe(panel));
+        findings[0].Connection.ShouldBe(link,
+            "no per-connection opinion (e.g. built-in components) keeps the canvas-wide rules — the #937 fallback pattern");
+    }
+
+    [Fact]
+    public void Spacing_StricterSideGovernsThePair()
+    {
+        var detector = new WaveguideSpacingDetector();
+        var connA = ClosePairMember(y: 0);
+        var connB = ClosePairMember(y: 1.1); // edge-to-edge 0.1 µm at width 1.0
+
+        var oneSideDeclares = detector.DetectViolations(
+            new[] { connA, connB },
+            Array.Empty<ComponentGroup>(),
+            minWaveguideSpacingMicrometers: 0,
+            spacingForConnection: c => c == connA ? 0.25 : 0);
+        oneSideDeclares.Count.ShouldBe(1, "edge 0.1 µm violates the one declared 0.25 µm limit");
+        oneSideDeclares[0].Description.ShouldContain("minimum 0.25 µm");
+
+        var bothDeclare = detector.DetectViolations(
+            new[] { connA, connB },
+            Array.Empty<ComponentGroup>(),
+            minWaveguideSpacingMicrometers: 0,
+            spacingForConnection: c => c == connA ? 0.25 : 0.6);
+        bothDeclare.Count.ShouldBe(1);
+        bothDeclare[0].Description.Contains("minimum 0.60 µm").ShouldBeTrue(
+            "the stricter of the two endpoint processes governs the pair");
+
+        detector.DetectViolations(
+            new[] { connA, connB },
+            Array.Empty<ComponentGroup>(),
+            minWaveguideSpacingMicrometers: 0,
+            spacingForConnection: _ => 0.05)
+            .ShouldBeEmpty("edge 0.1 µm respects a declared 0.05 µm limit — declared-looser stays silent too");
+    }
+
+    [Fact]
+    public void Spacing_NoDeclaredLimitOnEitherSide_StaysSilent()
+    {
+        var detector = new WaveguideSpacingDetector();
+        var connA = ClosePairMember(y: 0);
+        var connB = ClosePairMember(y: 1.1);
+
+        detector.DetectViolations(
+            new[] { connA, connB },
+            Array.Empty<ComponentGroup>(),
+            minWaveguideSpacingMicrometers: 0,
+            spacingForConnection: _ => 0)
+            .ShouldBeEmpty("neither endpoint process declares a spacing — no invented values (#926)");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>The production wiring: resolve each endpoint pin's PDK name via the template library.</summary>
+    private static Func<WaveguideConnection, ConnectionDrcRules?> Provider(
+        IReadOnlyList<ComponentTemplate> templates, IReadOnlyList<PdkDraft> drafts)
+    {
+        string? PdkSourceOf(PhysicalPin? pin) =>
+            pin?.ParentComponent is { } component
+                ? ComponentPdkSourceResolver.Resolve(component, templates)
+                : null;
+        return connection => ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+            PdkSourceOf(connection.StartPin), PdkSourceOf(connection.EndPin), drafts);
+    }
+
+    private static WaveguideConnection ConnectionOnSyntheticLayer(double y, double widthUm)
+    {
+        var connection = WaveguideSpacingDetectorTestHelpers.CreateConnectionWithSegment(0, y, 100, y);
+        connection.WidthMicrometers = widthUm;
+        connection.StartPin.Layer = SyntheticWgLayer;
+        connection.EndPin.Layer = SyntheticWgLayer;
+        return connection;
+    }
+
+    private static WaveguideConnection ClosePairMember(double y)
+    {
+        var connection = WaveguideSpacingDetectorTestHelpers.CreateConnectionWithSegment(0, y, 100, y);
+        connection.WidthMicrometers = 1.0;
+        return connection;
+    }
+
+    private static ProcessDefinition SyntheticProcess(string name, double minWidthUm) =>
+        new()
+        {
+            Name = name,
+            Layers = new() { new ProcessLayer { Name = "WG", Layer = SyntheticWgLayer } },
+            Xsections = new()
+            {
+                new ProcessXsection
+                {
+                    Name = "strip",
+                    Kind = XsectionKind.Optical,
+                    WidthUm = 1.0,
+                    MinWidthUm = minWidthUm,
+                    Layers = new() { "WG" },
+                },
+            },
+        };
+
+    private static WaveguideConnection Link(PhysicalPin start, PhysicalPin end, double routeWidthUm)
+    {
+        var (x1, y1) = start.GetAbsolutePosition();
+        var (x2, y2) = end.GetAbsolutePosition();
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(x1, y1, x2, y2, start.GetAbsoluteAngle()));
+        var connection = new WaveguideConnection { StartPin = start, EndPin = end };
+        connection.RestoreCachedPath(path);
+        connection.WidthMicrometers = routeWidthUm;
+        return connection;
+    }
+
+    private static ComponentTemplate TemplateFor(PdkDraft pdk, string componentName) =>
+        PdkTemplateConverter.ConvertToTemplate(
+            pdk.Components.First(c => c.Name == componentName),
+            pdk.Name, pdk.NazcaModuleName, process: pdk.Process);
+
+    private static Component Place(ComponentTemplate template, double x, double y) =>
+        ComponentTemplates.CreateFromTemplate(template, x, y);
+
+    private static PhysicalPin Pin(Component component, string name) =>
+        component.PhysicalPins.First(p => p.Name == name);
+
+    private static PdkDraft LoadPdk(string fileName) =>
+        new PdkLoader().LoadFromFile(
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PDKs", fileName));
+
+    private static string Describe(DesignValidationViewModel panel) =>
+        string.Join(" | ", panel.Issues.Select(i => $"{i.Type}: {i.Description}"));
+}

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
@@ -2,6 +2,7 @@ using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP_Core.Analysis;
 using CAP_Core.Components.Process;
@@ -14,14 +15,15 @@ using Xunit;
 namespace UnitTests.Components;
 
 /// <summary>
-/// Documented-red inventory stations of the multi-process journey (steps 4–5, 7–8) —
+/// Documented-red inventory stations of the multi-process journey (steps 5, 7–8) —
 /// each Skip links the issue filed for that exact single-process assumption. See
 /// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
-/// (Step 3 turned green with the per-chiplet placement scope, issue #935.)
+/// (Step 3 turned green with the per-chiplet placement scope, issue #935; step 4
+/// with the per-connection DRC rule sets, issue #936.)
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
-    [Fact(Skip = "Single-process assumption (#933 inventory): DRC-lite derives its whole rule set from the single active process (first member PDK) — per-chiplet limits are https://github.com/aignermax/Lunima/issues/936")]
+    [Fact]
     public void Step4_DrcLite_ChecksEachChipletAgainstItsOwnProcess()
     {
         var design = MultiProcessChipletJourneyDesign.BuildComposed();
@@ -37,14 +39,23 @@ public partial class MultiProcessChipletJourneyTests
         narrow.ShouldNotBeNull();
         narrow!.Connection.WidthMicrometers = 0.2;
 
-        // Production behavior for a two-process design: it can only exist in Playground
-        // (#935), so RunDesignChecks runs with processLockActive = false and NO process
-        // rules at all — the Cornerstone violation passes silently.
+        // A two-process design can only exist in Playground (#935), so RunDesignChecks
+        // runs with processLockActive = false — and still checks per chiplet (#936):
+        // the per-connection provider keys each connection's rules to its own endpoint
+        // PDKs, wired here exactly like MainViewModel.RunDesignChecks wires it.
+        var drafts = new List<PdkDraft> { design.Cornerstone, design.Siepic };
+        string? PdkSourceOf(CAP_Core.Components.Core.PhysicalPin? pin) =>
+            pin?.ParentComponent is { } component
+                ? ComponentPdkSourceResolver.Resolve(component, design.Templates)
+                : null;
         var panel = new DesignValidationViewModel();
         panel.RunValidation(
             design.Canvas.ConnectionManager.Connections,
             allComponents: design.Canvas.Components.Select(vm => vm.Component),
-            processLockActive: false);
+            processLockActive: false,
+            connectionDrcRuleProvider: connection =>
+                ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+                    PdkSourceOf(connection.StartPin), PdkSourceOf(connection.EndPin), drafts));
 
         panel.Issues.ShouldContain(
             i => i.Type == DesignIssueType.WaveguideBelowMinWidth && ReferenceEquals(i.Connection, narrow.Connection),

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -44,8 +44,9 @@ namespace UnitTests.Components;
 ///   Step 3 (green, #935): placement is chiplet-scoped — a process-locked canvas
 ///         accepts a second-process chiplet (bound to its own process) while
 ///         ungrouped foreign content stays rejected.
-///   Step 4 (RED, #936): DRC-lite rules come from the single active process — a
-///         two-process design checks nothing PDK-dependent at all.
+///   Step 4 (green, #936): DRC-lite checks each chiplet against its OWN process —
+///         a deliberately narrow Cornerstone route is flagged even in Playground
+///         while the SiEPIC chiplet (no declared minWidthUm) stays silent.
 ///   Step 5 (RED, #937): the router's bend-radius floor is one canvas-wide value.
 ///   Step 6 (green): .lun round-trip — both per-component PDK assignments, the
 ///         groups, the abutment and the physics survive (the design reloads as


### PR DESCRIPTION
Automated implementation for #936

Also stale — bhap14d0u was the final full-suite verification I already consumed: 5692 passed, 0 failed, exit 0. The issue #936 work is complete and committed as `0f11a7cb` on `agent/issue-936-1786846723`. All background tasks are now accounted for; nothing pending.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 109,214
- **Estimated cost:** $0.0612 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>