### PR TITLE
docs: ROADMAP status sync - rungs 1/2/3/4/6/7 reflect merged reality

### DIFF
--- a/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
@@ -40,6 +40,8 @@ internal sealed class MultiProcessChipletJourneyDesign
     public const double CornerstoneMinWidthUm = 0.25;
     /// <summary>Cornerstone xs_nc: cspdk.sin300 radius_min tech constant (#924).</summary>
     public const double CornerstoneMinBendRadiusUm = 30.0;
+    /// <summary>SiEPIC strip (WG) minimum bend radius (µm) from the bundled PDK.</summary>
+    public const double SiepicMinBendRadiusUm = 5.0;
     /// <summary>Cornerstone NITRIDE waveguide layer.</summary>
     public const int CornerstoneGdsLayer = 203;
     /// <summary>SiEPIC WG waveguide layer.</summary>

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
@@ -10,17 +10,17 @@ namespace UnitTests.Components;
 
 /// <summary>
 /// Green "today" pins for the documented-red stations of the multi-process journey:
-/// each test proves the current single-process behavior the red steps 5 (#937) and 8
-/// (#939) describe, so a future per-chiplet fix turns the pin red as a tripwire.
+/// the pin proves the current single-process behavior the red step 8 (#939)
+/// describes, so a future per-chiplet fix turns the pin red as a tripwire.
 /// See <see cref="MultiProcessChipletJourneyTests"/> for the full journey. The step-3
 /// pin now guards the canvas-level half of the shipped per-chiplet scope (#935):
 /// ungrouped foreign content stays rejected even though chiplets may carry a second
-/// process.
+/// process. The bend pins are companions of green step 5 (#937): they pin what the
+/// canvas-wide resolver still contributes beneath the per-connection floors —
+/// locked-process resolution and the Playground fallback.
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
-    /// <summary>SiEPIC strip minimum bend radius (µm) from the bundled PDK.</summary>
-    private const double SiepicMinBendRadiusUm = 5.0;
 
     [Fact]
     public void Placement_ProcessLockedCanvas_RejectsUngroupedForeignComponent()
@@ -50,8 +50,9 @@ public partial class MultiProcessChipletJourneyTests
     [Fact]
     public void BendRadius_LockedProcess_ResolvesEachProcessMinimum_Today()
     {
-        // Companion to red step 5 (#937): per-process limits exist and are honored —
-        // but only while the whole design is locked to that one process.
+        // Companion to green step 5 (#937): the canvas-wide resolver keeps resolving a
+        // process-locked design's minimum — single-process designs still floor through
+        // it, while the multi-process canvas layers the per-connection provider on top.
         var (cornerstone, siepic, catalog) = LoadProcessCatalog();
         var pdks = new List<PdkDraft> { cornerstone, siepic };
 
@@ -63,16 +64,17 @@ public partial class MultiProcessChipletJourneyTests
         WaveguideBendRadiusResolver.Resolve(
                 ActiveProcessSelection.ForGroup(
                     catalog.Single(g => g.MemberPdkNames.Contains(siepic.Name))), pdks)
-            .ShouldBe(SiepicMinBendRadiusUm,
+            .ShouldBe(MultiProcessChipletJourneyDesign.SiepicMinBendRadiusUm,
                 "a SiEPIC-locked design resolves the strip 5 µm minimum");
     }
 
     [Fact]
     public void BendRadius_Playground_OneFallbackForBothChiplets_Today()
     {
-        // Companion to red step 5 (#937): Playground is the only mode that can hold both
-        // chiplets — and there the resolver knows neither chiplet's limit; one global
-        // fallback silently covers every route in the design.
+        // Companion to green step 5 (#937): Playground is the only mode that can hold both
+        // chiplets — and there the canvas-wide resolver alone still knows neither chiplet's
+        // limit; one global fallback covers it. Routes with resolvable endpoints escape that
+        // fallback only through the per-connection floors step 5 asserts.
         var (cornerstone, siepic, _) = LoadProcessCatalog();
         var pdks = new List<PdkDraft> { cornerstone, siepic };
 
@@ -80,7 +82,7 @@ public partial class MultiProcessChipletJourneyTests
 
         resolved.ShouldBe(WaveguideBendRadiusResolver.FallbackMinimumMicrometers);
         resolved.ShouldNotBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm);
-        resolved.ShouldNotBe(SiepicMinBendRadiusUm);
+        resolved.ShouldNotBe(MultiProcessChipletJourneyDesign.SiepicMinBendRadiusUm);
     }
 
     [Fact]

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
@@ -5,7 +5,6 @@ using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP_Core.Analysis;
-using CAP_Core.Components.Process;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using Moq;
@@ -15,11 +14,12 @@ using Xunit;
 namespace UnitTests.Components;
 
 /// <summary>
-/// Documented-red inventory stations of the multi-process journey (steps 5, 7–8) —
+/// Documented-red inventory stations of the multi-process journey (steps 7–8) —
 /// each Skip links the issue filed for that exact single-process assumption. See
 /// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
 /// (Step 3 turned green with the per-chiplet placement scope, issue #935; step 4
-/// with the per-connection DRC rule sets, issue #936.)
+/// with the per-connection DRC rule sets, issue #936; step 5 with the per-connection
+/// bend-radius floors, issue #937.)
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
@@ -65,15 +65,50 @@ public partial class MultiProcessChipletJourneyTests
             "chiplet B must stay silent: SiEPIC declares no minWidthUm — no invented values (#926)");
     }
 
-    [Fact(Skip = "Single-process assumption (#933 inventory): the router bend-radius floor is one canvas-wide value (Playground fallback 10 µm) — per-chiplet floors are https://github.com/aignermax/Lunima/issues/937")]
+    [Fact]
     public void Step5_BendRadiusFloor_FollowsEachChipletsProcess()
     {
-        // What production applies on a two-process (Playground) canvas: no member PDKs,
-        // so the resolver falls back to the generic 10 µm for EVERY route.
-        var floorForChipletA = WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[0]);
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
+        var abutment = design.Canvas.ConnectionManager.Connections.Single();
 
-        floorForChipletA.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
-            "chiplet A's routes must honor the Cornerstone 30 µm floor, not the fallback (#937)");
+        // One more route inside each chiplet, so all three endpoint combinations
+        // exist on the canvas: A–A, B–B and the cross-process A–B abutment.
+        var intraA = design.Canvas.ConnectPinsWithCachedRoute(
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3"),
+            MultiProcessChipletJourneyDesign.StraightPath(
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o4"),
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o3")));
+        intraA.ShouldNotBeNull();
+        var intraB = design.Canvas.ConnectPinsWithCachedRoute(
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 3"),
+            MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2"),
+            MultiProcessChipletJourneyDesign.StraightPath(
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 3"),
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2")));
+        intraB.ShouldNotBeNull();
+
+        // #937: the floor is per connection now — each endpoint component's PDK process
+        // contributes its minimum and the stricter side governs. The provider is wired
+        // exactly like MainViewModel wires RoutingOrchestrator.BuildConnectionProcessFloorProvider.
+        var drafts = new List<PdkDraft> { design.Cornerstone, design.Siepic };
+        string? PdkSourceOf(CAP_Core.Components.Core.PhysicalPin? pin) =>
+            pin?.ParentComponent is { } component
+                ? ComponentPdkSourceResolver.Resolve(component, design.Templates)
+                : null;
+        double? FloorBetween(CAP_Core.Components.Core.PhysicalPin start, CAP_Core.Components.Core.PhysicalPin end) =>
+            WaveguideBendRadiusResolver.ResolveForEndpointPdkNames(
+                PdkSourceOf(start), PdkSourceOf(end), drafts);
+
+        FloorBetween(intraA!.Connection.StartPin, intraA!.Connection.EndPin)
+            .ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+                "an intra-chiplet-A route honors the Cornerstone 30 µm floor, not the fallback (#937)");
+        FloorBetween(intraB!.Connection.StartPin, intraB!.Connection.EndPin)
+            .ShouldBe(MultiProcessChipletJourneyDesign.SiepicMinBendRadiusUm,
+                "an intra-chiplet-B route uses SiEPIC's declared 5 µm — below the generic 10 µm fallback (#937)");
+        FloorBetween(abutment.StartPin, abutment.EndPin)
+            .ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+                "the cross-chiplet abutment keeps the stricter side: Cornerstone 30 µm over SiEPIC 5 µm (#937)");
     }
 
     [Fact(Skip = "Single-process assumption (#933 inventory): .lun persists one design-level ActiveProcess and no per-chiplet process binding — https://github.com/aignermax/Lunima/issues/938")]

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -47,7 +47,9 @@ namespace UnitTests.Components;
 ///   Step 4 (green, #936): DRC-lite checks each chiplet against its OWN process —
 ///         a deliberately narrow Cornerstone route is flagged even in Playground
 ///         while the SiEPIC chiplet (no declared minWidthUm) stays silent.
-///   Step 5 (RED, #937): the router's bend-radius floor is one canvas-wide value.
+///   Step 5 (green, #937): the router's bend-radius floor is per connection — an
+///         intra-chiplet route honors its own chiplet's process floor and a
+///         cross-chiplet route keeps the stricter endpoint's floor.
 ///   Step 6 (green): .lun round-trip — both per-component PDK assignments, the
 ///         groups, the abutment and the physics survive (the design reloads as
 ///         Playground: pinned here as current behavior, #938 is the fix).
@@ -55,10 +57,9 @@ namespace UnitTests.Components;
 ///   Step 8 (RED, #939): GDS export routes every waveguide through one global
 ///         interconnect (width/radius/layer), not each chiplet's own stack.
 ///
-/// The red steps 5 and 8 additionally carry GREEN "today" pins in the
-/// CurrentBehavior partial: the Playground bend floor really is one fallback for
-/// everything, and GDS export really does size every route with one majority
-/// cross-section — so a future per-chiplet fix turns those pins red as a tripwire.
+/// The red step 8 additionally carries a GREEN "today" pin in the CurrentBehavior
+/// partial: GDS export really does size every route with one majority
+/// cross-section — so a future per-chiplet fix turns that pin red as a tripwire.
 /// The step-3 pin now guards the canvas-level half of the shipped #935 behavior:
 /// ungrouped foreign content must stay rejected.
 /// </summary>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,29 +34,20 @@ is the product.
 | # | Rung | Status | Notes |
 |---|------|--------|-------|
 | 0 | PIC canvas, S-matrix sim, light propagation, GDS export (Nazca), S-param import, metal routing, component groups | ✅ exists | |
-| 1 | **GDS import with pin detection + optional auto-connect** | 🔜 next | Load a GDS cell as a black-box component; detect ports from port layers/labels, fall back to edge heuristics. Import option "auto-connect all pins": after placement, route all pin pairs with the existing A* router + crossing insertion (runs a while on large imports). No separate "bake" step needed — manual geometry stays the default (#807), auto-connect is opt-in per import. Depends on routing rework #704/#725. Serves external users (Peter) and the vision (cells as reusable building blocks). |
-| 2 | **DRC-lite** | planned | Entry point exists: Design Validation ("check conflicts", Diagnostics panel) already covers bend radius, blocked paths, waveguide overlaps, component bounds, PDK compatibility (`DesignValidator`). Extend with: min spacing, unconnected pins / pin mismatch, width + layer rules with PDK-driven values. Promote from panel button to a menu item. Only the rules that kill real tapeouts — not a full foundry DRC. |
-| 3 | Hierarchy done right | partially there (`ComponentGroup`) | Group any circuit → reusable component with exposed pins, library, instances. Gates, chips, systems = same operation nested. |
-| 4 | Behavioral / gate layer | seed exists (Verilog-A export) | Gates with transfer-function models, thresholds, delays; logic-level animation instead of field propagation. |
+| 1 | **GDS import with pin detection + optional auto-connect** | 🟡 mostly shipped | Port detection from port layers/labels (#878) and the edge-heuristic fallback (#879) are merged; imported cells arrive as black-box components with real pins. Still open: the opt-in "auto-connect all pins" pass (#880). Manual geometry stays the default (#807). Serves external users (Peter) and the vision (cells as reusable building blocks). |
+| 2 | **DRC-lite** | 🟡 mostly shipped | Design Validation covers bend radius, blocked paths, overlaps, bounds, PDK compatibility — plus min spacing (#899/#915), PDK-driven min width (#926/#931), foundry-cited Cornerstone limits (#920/#924), and per-connection rule sets from each chiplet's own process (#936). Still open: unconnected pins / pin mismatch + menu-item promotion (#897, in review). Only the rules that kill real tapeouts — not a full foundry DRC. |
+| 3 | Hierarchy done right | ✅ core proven | Group → reusable component with exposed pins, prefab library, instances all work; the chiplet-composition journey (#927) proved two group prefabs compose pin-to-pin, simulate and round-trip with correct physics. Gates, chips, systems = same operation nested. |
+| 4 | Behavioral / gate layer | 🟡 started (NAND-game seed) | Truth-table extraction from grouped circuits over the real S-matrix sim (#934), Truth Table panel with threshold + raw powers (#947), and the build→group→extract→save/load E2E journey (#952) are merged. Next: transfer-function models, delays, logic-level animation. |
 | 5 | ISA + assembler + execution visualizer | future | Tiny 4-bit ISA (Hack-computer-style); the assembler is the easy part, the visualizer is the work. |
-| 6 | System / multi-chip layer | future | Boards, fibers between chips, photonic I/O devices, heater/phase control loops (metal routing already exists). |
-| 7 | Manufacturing path | future | MPW tapeout. First target: Cornerstone SiN (open PDK, open KLayout DRC deck — validate our exported GDS against it, then reach out with a concrete artifact). SiEPIC is a consortium, not a fab — fabrication runs via partner fabs (openEBL/AMF et al.). **Optical transistor additionally needs saturable absorbers (SA), i.e. an InP platform** (Fraunhofer HHI / Smart Photonics JePPIX, NDA-based): fab provides data, we build the Lunima PDK JSON and ship it with the software / registry. Connects to #620 (AI-assisted PDK import). |
+| 6 | System / multi-chip layer | 🟡 started (chiplets) | Chiplets carry their own process identity: per-chiplet placement scope + per-connection bend floors (#935/#937), persisted process bindings in .lun (#938), per-chiplet DRC rule sets (#936). Still open: per-chiplet GDS export stacks (#939). Boards, fibers between chips, photonic I/O devices, control loops remain future. |
+| 7 | Manufacturing path | 🟡 validation shipped | MPW tapeout. First target: Cornerstone SiN — the open KLayout pre-DRC deck is vendored with a headless runner and gated proof fixtures (#932), and the bundled SiN PDK carries the foundry-cited gap/width/bend limits (#920/#924). Next: run real exports through it routinely, then reach out to the foundry with a DRC-clean artifact. SiEPIC is a consortium, not a fab — fabrication runs via partner fabs (openEBL/AMF et al.). **Optical transistor additionally needs saturable absorbers (SA), i.e. an InP platform** (Fraunhofer HHI / Smart Photonics JePPIX, NDA-based): fab provides data, we build the Lunima PDK JSON and ship it with the software / registry. Connects to #620 (AI-assisted PDK import). |
 
 ## How open issues map to the rungs
 
-- Rung 1 groundwork: #704 (routing core defects), #725 (routing rework: direct-first, anytime-A*), #801 (grid ownership bug)
+- Rung 1 remainder: #880 (opt-in auto-connect after import); groundwork still open: #704 (routing core defects), #725 (routing rework: direct-first, anytime-A*)
+- Rung 2 remainder: #897 (unconnected-pin check + menu item, in review)
+- Rung 4 (NAND-game): #958 (logic-gate starter example in `examples/`)
 - Rung 4/7 enabler: #753 (waveguide length matching / phase matching)
+- Rung 6 remainder: #939 (per-chiplet GDS export stacks — last red station of the multi-process journey #933); #957 (modernize the journey's stale bend-floor station)
 - PDK strategy (rung 7): #620 (AI-assisted PDK import), #773, #772, #740 (registry/library)
 - Onboarding (principle 1): #769 (first-steps tutorial), #768 (examples in release bundles)
-
-## Next issues to create
-
-1. **GDS import with pin detection (+ optional auto-connect)** — load a GDS cell as
-   a black-box component; ports from port layers/labels with edge-heuristic
-   fallback; import option to route all pins via the existing router.
-2. **DRC-lite: extend Design Validation + menu item** — add min spacing, pin
-   mismatch, width/layer rules (PDK-driven) to `DesignValidator`; promote the
-   check to a menu item.
-3. **Foundry validation: Cornerstone DRC deck** — run our exported GDS through
-   Cornerstone's open KLayout DRC deck; fix what fails; then contact foundry with
-   the DRC-clean demo.


### PR DESCRIPTION
## Was & warum

Status-Sync der Rungs-Tabelle mit dem tatsächlich gemergten Stand (Owner-Pass, 2026-08-16). Die Tabelle behauptete noch "Rung 1 = next / Rung 2 = planned", obwohl beides seit dieser Woche weitgehend in `dev-ki` liegt — für den aus dem Urlaub zurückkehrenden Maintainer (und für Worker, die Scope gegen die ROADMAP judgen) ist das irreführend. Nur Status-Spalte + Notes + Issue-Mapping angefasst; Vision, Prinzipien und Rungs-Struktur unverändert.

## Belege (alles in dev-ki gemergt)

- **Rung 1:** Port-Detection aus Port-Layern/Labels (#878 → PR #883), Edge-Heuristik-Fallback (#879 → PR #889). Offen nur noch Auto-Connect (#880).
- **Rung 2:** Min-Spacing (#899/#915), minWidthUm PDK-getrieben (#926 → #931), Foundry-zitierte Cornerstone-Limits (#920 → #924), per-connection Regelsets (#936 → #956). Offen: #897 (PR #908 in Review).
- **Rung 3:** Chiplet-Kompositions-Journey (#927 → #929) — zwei Gruppen-Prefabs pin-zu-pin, Physik + Round-Trip verifiziert.
- **Rung 4:** TruthTableExtractor (#934 → #946), Panel (#947 → #951), E2E-Journey (#952 → #955).
- **Rung 6:** Prozess-Scope + Bend-Floor (#935/#937 → #948), .lun-Persistenz (#938 → #954), per-chiplet DRC (#936 → #956). Offen: #939.
- **Rung 7:** Gevendortes Cornerstone-Deck + headless Runner (#932 → #940).

Das "Next issues to create"-Kapitel ist entfernt — alle drei dort gelisteten Issues wurden erstellt und sind inzwischen umgesetzt; das Issue-Mapping-Kapitel übernimmt die Rolle (inkl. der offenen Reste #880/#897/#939/#957/#958). #801 aus dem Mapping entfernt (geschlossen via #922).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
