### PR TITLE
Agent: Multi-process journey step 5 un-skipped — per-connection bend-radius floor (#957)

### DIFF
--- a/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.CurrentBehavior.cs
@@ -10,9 +10,11 @@ namespace UnitTests.Components;
 
 /// <summary>
 /// Green "today" pins for the documented-red stations of the multi-process journey:
-/// each test proves the current single-process behavior the red steps 5 (#937) and 8
-/// (#939) describe, so a future per-chiplet fix turns the pin red as a tripwire.
-/// See <see cref="MultiProcessChipletJourneyTests"/> for the full journey. The step-3
+/// the step-8 (#939) pin proves the current single-process behavior so a future
+/// per-chiplet fix turns it red as a tripwire, while the step-5 (#937) pins guard
+/// the canvas-wide bend-floor fallback layer that remains underneath the
+/// per-connection floors shipped in #948. See
+/// <see cref="MultiProcessChipletJourneyTests"/> for the full journey. The step-3
 /// pin now guards the canvas-level half of the shipped per-chiplet scope (#935):
 /// ungrouped foreign content stays rejected even though chiplets may carry a second
 /// process.
@@ -50,8 +52,8 @@ public partial class MultiProcessChipletJourneyTests
     [Fact]
     public void BendRadius_LockedProcess_ResolvesEachProcessMinimum_Today()
     {
-        // Companion to red step 5 (#937): per-process limits exist and are honored —
-        // but only while the whole design is locked to that one process.
+        // Companion to green step 5 (#937/#948): the canvas-wide floor still resolves
+        // each process minimum while the whole design is locked to that one process.
         var (cornerstone, siepic, catalog) = LoadProcessCatalog();
         var pdks = new List<PdkDraft> { cornerstone, siepic };
 
@@ -70,9 +72,11 @@ public partial class MultiProcessChipletJourneyTests
     [Fact]
     public void BendRadius_Playground_OneFallbackForBothChiplets_Today()
     {
-        // Companion to red step 5 (#937): Playground is the only mode that can hold both
-        // chiplets — and there the resolver knows neither chiplet's limit; one global
-        // fallback silently covers every route in the design.
+        // Companion to green step 5 (#937/#948): Playground is the only mode that can
+        // hold both chiplets — and there the canvas-wide resolver knows neither
+        // chiplet's limit. This fallback is now only the layer underneath the
+        // per-connection floors: connections whose endpoint PDKs resolve get their
+        // own floor (step 5), and this value governs the rest.
         var (cornerstone, siepic, _) = LoadProcessCatalog();
         var pdks = new List<PdkDraft> { cornerstone, siepic };
 

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.RedInventory.cs
@@ -5,7 +5,6 @@ using CAP.Avalonia.ViewModels.Diagnostics;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP_Core.Analysis;
-using CAP_Core.Components.Process;
 using CAP_DataAccess.Components.ComponentDraftMapper;
 using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
 using Moq;
@@ -15,11 +14,12 @@ using Xunit;
 namespace UnitTests.Components;
 
 /// <summary>
-/// Documented-red inventory stations of the multi-process journey (steps 5, 7–8) —
+/// Documented-red inventory stations of the multi-process journey (steps 7–8) —
 /// each Skip links the issue filed for that exact single-process assumption. See
 /// <see cref="MultiProcessChipletJourneyTests"/> for the full journey description.
 /// (Step 3 turned green with the per-chiplet placement scope, issue #935; step 4
-/// with the per-connection DRC rule sets, issue #936.)
+/// with the per-connection DRC rule sets, issue #936; step 5 with the per-connection
+/// bend-radius floors, issue #937 shipped in #948.)
 /// </summary>
 public partial class MultiProcessChipletJourneyTests
 {
@@ -65,15 +65,54 @@ public partial class MultiProcessChipletJourneyTests
             "chiplet B must stay silent: SiEPIC declares no minWidthUm — no invented values (#926)");
     }
 
-    [Fact(Skip = "Single-process assumption (#933 inventory): the router bend-radius floor is one canvas-wide value (Playground fallback 10 µm) — per-chiplet floors are https://github.com/aignermax/Lunima/issues/937")]
+    [Fact]
     public void Step5_BendRadiusFloor_FollowsEachChipletsProcess()
     {
-        // What production applies on a two-process (Playground) canvas: no member PDKs,
-        // so the resolver falls back to the generic 10 µm for EVERY route.
-        var floorForChipletA = WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[0]);
+        var design = MultiProcessChipletJourneyDesign.BuildComposed();
 
-        floorForChipletA.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
-            "chiplet A's routes must honor the Cornerstone 30 µm floor, not the fallback (#937)");
+        // The #948 production wiring, mirrored exactly like MainViewModel wires
+        // RoutingOrchestrator.BuildConnectionProcessFloorProvider (#937): pass-start
+        // snapshots of the templates and drafts, endpoint PDK sources resolved through
+        // the production resolver. RecalculateRoutesAsync pushes the built provider onto
+        // the router before every pass; the Playground canvas-wide floor (10 µm fallback)
+        // only governs connections the per-connection provider has no opinion on.
+        var templates = design.Templates.ToList();
+        var drafts = new List<PdkDraft> { design.Cornerstone, design.Siepic };
+        string? PdkSourceOf(CAP_Core.Components.Core.PhysicalPin pin) =>
+            pin.ParentComponent is { } component
+                ? ComponentPdkSourceResolver.Resolve(component, templates)
+                : null;
+        design.Canvas.Routing.BuildConnectionProcessFloorProvider = () =>
+            (startPin, endPin) => WaveguideBendRadiusResolver.ResolveForEndpointPdkNames(
+                PdkSourceOf(startPin), PdkSourceOf(endPin), drafts);
+
+        var router = design.Canvas.Router;
+        router.ProcessMinBendRadiusMicrometers = WaveguideBendRadiusResolver.FallbackMinimumMicrometers;
+        router.ConnectionProcessFloorProvider = design.Canvas.Routing.BuildConnectionProcessFloorProvider();
+
+        // A route inside chiplet A keeps the Cornerstone 30 µm foundry floor instead of
+        // dropping to the Playground fallback.
+        router.ResolveProcessFloorFor(
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o1"),
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_coupler_o2"))
+            .ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+                "a connection inside chiplet A must honor Cornerstone's 30 µm floor (#937/#948)");
+
+        // The cross-chiplet abutment is governed by the stricter side: Cornerstone's
+        // 30 µm wins over SiEPIC's 5 µm.
+        router.ResolveProcessFloorFor(
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o2"),
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 1"))
+            .ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneMinBendRadiusUm,
+                "the stricter endpoint process governs a cross-chiplet connection (#937/#948)");
+
+        // A route inside chiplet B gets SiEPIC's declared 5 µm — the looser chiplet is
+        // neither over-constrained to 30 µm nor under-floored by the 10 µm fallback.
+        router.ResolveProcessFloorFor(
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 3"),
+                MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_taper_port 2"))
+            .ShouldBe(SiepicMinBendRadiusUm,
+                "a connection inside chiplet B resolves SiEPIC's own 5 µm minimum (#937/#948)");
     }
 
     [Fact(Skip = "Single-process assumption (#933 inventory): .lun persists one design-level ActiveProcess and no per-chiplet process binding — https://github.com/aignermax/Lunima/issues/938")]

--- a/UnitTests/Components/MultiProcessChipletJourneyTests.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyTests.cs
@@ -47,7 +47,10 @@ namespace UnitTests.Components;
 ///   Step 4 (green, #936): DRC-lite checks each chiplet against its OWN process —
 ///         a deliberately narrow Cornerstone route is flagged even in Playground
 ///         while the SiEPIC chiplet (no declared minWidthUm) stays silent.
-///   Step 5 (RED, #937): the router's bend-radius floor is one canvas-wide value.
+///   Step 5 (green, #937 shipped in #948): the router floors each connection by its
+///         own endpoint PDKs — a Cornerstone route keeps its 30 µm foundry floor,
+///         the stricter side governs the cross-chiplet abutment, and SiEPIC routes
+///         use their declared 5 µm instead of the 10 µm Playground fallback.
 ///   Step 6 (green): .lun round-trip — both per-component PDK assignments, the
 ///         groups, the abutment and the physics survive (the design reloads as
 ///         Playground: pinned here as current behavior, #938 is the fix).
@@ -55,10 +58,12 @@ namespace UnitTests.Components;
 ///   Step 8 (RED, #939): GDS export routes every waveguide through one global
 ///         interconnect (width/radius/layer), not each chiplet's own stack.
 ///
-/// The red steps 5 and 8 additionally carry GREEN "today" pins in the
-/// CurrentBehavior partial: the Playground bend floor really is one fallback for
-/// everything, and GDS export really does size every route with one majority
-/// cross-section — so a future per-chiplet fix turns those pins red as a tripwire.
+/// The red step 8 additionally carries a GREEN "today" pin in the CurrentBehavior
+/// partial: GDS export really does size every route with one majority cross-section —
+/// so a future per-chiplet fix turns that pin red as a tripwire. The step-5 pins in
+/// the same partial survived the #948 fix unchanged: the canvas-wide fallback they
+/// pin is still the layer underneath the per-connection floors (a null per-connection
+/// opinion falls back to it), so they now guard that fallback layer.
 /// The step-3 pin now guards the canvas-level half of the shipped #935 behavior:
 /// ungrouped foreign content must stay rejected.
 /// </summary>


### PR DESCRIPTION
## What & Why

Issue #957: Step 5 of the multi-process chiplet journey (`Step5_BendRadiusFloor_FollowsEachChipletsProcess`) was still skipped as documented-red with a link to #937 — but #937 was implemented and closed by #948. The station was **stale**: its body called the old canvas-wide API `WaveguideBendRadiusResolver.Resolve(new ProcessDefinition?[0])` and expected 30 µm, which could never go green under the #948 design (the fix lives in the per-connection API `ResolveForEndpointPdkNames`).

## How (test-only, Recipe B)

The station was rewritten to the #948 reality, mirroring Step 4's (#936) pattern of wiring the provider exactly like production (`MainViewModel.BuildConnectionProcessFloorProvider` → `RoutingOrchestrator` → `WaveguideRouter.ConnectionProcessFloorProvider`), then asserting through the router's real resolution point `ResolveProcessFloorFor` on the real bundled PDKs (Cornerstone SiN + SiEPIC):

- A route **inside chiplet A** resolves the Cornerstone **30 µm** foundry floor (not the 10 µm Playground fallback).
- The **cross-chiplet abutment** is governed by the stricter side: Cornerstone 30 µm wins over SiEPIC 5 µm.
- A route **inside chiplet B** resolves SiEPIC's declared **5 µm** — the looser chiplet is neither over-constrained nor under-floored.

Journey headers updated in `MultiProcessChipletJourneyTests.cs` and `...RedInventory.cs` (only Step 8 / #939 stays documented-red). The step-5 "today" pins in the CurrentBehavior partial survived unchanged and their comments now state why: the canvas-wide fallback they pin is still the layer underneath the per-connection floors.

No production-code change — the real wiring delivers the floor, so no defect issue was needed.

## Testing

- Step 5 un-skipped and green on the real bundled PDKs.
- Full filtered suite (`Category!=Slow`) run before opening this PR.

Local suite: 5699 passed, 0 failed