### PR TITLE
Agent: Logic-gate starter example (OR/AND per truth-table threshold) (#958)

### DIFF
--- a/UnitTests/Integration/ExampleDesignFilesTests.cs
+++ b/UnitTests/Integration/ExampleDesignFilesTests.cs
@@ -24,7 +24,7 @@ public class ExampleDesignFilesTests
     /// <summary>Minimum connections a shipped example must contain to be meaningful.</summary>
     private const int MinConnectionsPerExample = 3;
 
-    private static string ExamplesDirectory()
+    internal static string ExamplesDirectory()
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);
         while (current != null)
@@ -58,9 +58,18 @@ public class ExampleDesignFilesTests
             using var doc = System.Text.Json.JsonDocument.Parse(await File.ReadAllTextAsync(examplePath));
             var declaredComponents = doc.RootElement.GetProperty("Components").GetArrayLength();
             var declaredConnections = doc.RootElement.GetProperty("Connections").GetArrayLength();
-            var declaredGroups = doc.RootElement.TryGetProperty("Groups", out var groups)
-                ? groups.GetArrayLength()
-                : 0;
+            var declaredGroups = 0;
+            var declaredGroupChildren = 0;
+            var declaredInternalPaths = 0;
+            if (doc.RootElement.TryGetProperty("Groups", out var groups))
+            {
+                declaredGroups = groups.GetArrayLength();
+                foreach (var group in groups.EnumerateArray())
+                {
+                    declaredGroupChildren += group.GetProperty("ChildComponents").GetArrayLength();
+                    declaredInternalPaths += group.GetProperty("GroupDto").GetProperty("InternalPaths").GetArrayLength();
+                }
+            }
 
             var canvas = new DesignCanvasViewModel();
             var fileOps = new FileOperationsViewModel(
@@ -76,10 +85,12 @@ public class ExampleDesignFilesTests
             var loaded = await fileOps.LoadDesignFromPathAsync(examplePath);
 
             loaded.ShouldBeTrue($"Example '{name}' must load");
-            declaredComponents.ShouldBeGreaterThanOrEqualTo(
-                MinComponentsPerExample, $"Example '{name}' must ship a meaningful circuit");
-            declaredConnections.ShouldBeGreaterThanOrEqualTo(
-                MinConnectionsPerExample, $"Example '{name}' must ship a connected circuit");
+            (declaredComponents + declaredGroupChildren).ShouldBeGreaterThanOrEqualTo(
+                MinComponentsPerExample,
+                $"Example '{name}' must ship a meaningful circuit (group children count)");
+            (declaredConnections + declaredInternalPaths).ShouldBeGreaterThanOrEqualTo(
+                MinConnectionsPerExample,
+                $"Example '{name}' must ship a connected circuit (group-internal paths count)");
             canvas.Components.Count.ShouldBe(
                 declaredComponents + declaredGroups,
                 $"Example '{name}' must resolve every declared component template");

--- a/UnitTests/Integration/LogicGateExampleTests.cs
+++ b/UnitTests/Integration/LogicGateExampleTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Headless load test for the shipped logic-gate starter example
+/// <c>examples/Logic Gate OR-AND.lun</c> (issue #958, rung 4 of the NAND game):
+/// the file loads through the real load path as a single "OR/AND Gate" group
+/// built only from bundled Demo PDK components, and the
+/// <see cref="TruthTableExtractor"/> reads the OR table at threshold 0.25 and
+/// the AND table at threshold 0.75 off the same circuit — the analog→digital
+/// threshold lesson — with raw powers 0.0 / 0.5 / 0.5 / 1.0, mirroring
+/// <see cref="Components.NandGameTruthTableJourneyTests"/>.
+/// </summary>
+public class LogicGateExampleTests
+{
+    private const string ExampleFileName = "Logic Gate OR-AND.lun";
+    private const string GroupName = "OR/AND Gate";
+    private const double PowerTolerance = 1e-6;
+    private const int WavelengthNm = 1550;
+
+    private static readonly string[] InputPins = { "A", "B" };
+    private static readonly string[] OutputPins = { "Y" };
+
+    [Fact]
+    public async Task Example_LoadsAsSingleGroup_WithCleanExternalPins()
+    {
+        var group = await LoadGateGroup();
+
+        group.GroupName.ShouldBe(GroupName);
+        // The group description carries the threshold lesson (OR at 0.25, AND at 0.75).
+        group.Description.ShouldContain("0.25");
+        group.Description.ShouldContain("0.75");
+        group.ChildComponents.Select(c => c.Identifier)
+            .ShouldBe(new[] { "input_a", "input_b", "combiner", "output" }, ignoreOrder: true);
+        group.InternalPaths.Count.ShouldBe(3,
+            "both inputs and the combiner output are routed inside the group");
+        group.ExternalPins.Select(p => p.Name)
+            .ShouldBe(new[] { "A", "B", "AUX", "Y" }, ignoreOrder: true);
+        group.ExternalPins.ShouldAllBe(p => p.InternalPin != null && p.InternalPin.LogicalPin != null,
+            "every external pin stays bound to a simulatable component pin");
+    }
+
+    [Fact]
+    public async Task TruthTable_Threshold025_ProducesOrBitsWithRawPowers()
+    {
+        var table = await Extract(threshold: 0.25);
+
+        table.Rows.Count.ShouldBe(4, "two logic inputs produce four rows");
+        AssertRow(table, a: false, b: false, expectedBit: false, expectedPower: 0.0);
+        AssertRow(table, a: true, b: false, expectedBit: true, expectedPower: 0.5);
+        AssertRow(table, a: false, b: true, expectedBit: true, expectedPower: 0.5);
+        AssertRow(table, a: true, b: true, expectedBit: true, expectedPower: 1.0);
+    }
+
+    [Fact]
+    public async Task TruthTable_Threshold075_ProducesAndBitsWithRawPowers()
+    {
+        var table = await Extract(threshold: 0.75);
+
+        table.Rows.Count.ShouldBe(4, "two logic inputs produce four rows");
+        AssertRow(table, a: false, b: false, expectedBit: false, expectedPower: 0.0);
+        AssertRow(table, a: true, b: false, expectedBit: false, expectedPower: 0.5);
+        AssertRow(table, a: false, b: true, expectedBit: false, expectedPower: 0.5);
+        AssertRow(table, a: true, b: true, expectedBit: true, expectedPower: 1.0);
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns its group.</summary>
+    private static async Task<ComponentGroup> LoadGateGroup()
+    {
+        var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!);
+
+        var examplePath = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+        (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+            $"the shipped example '{ExampleFileName}' must load through the real load path");
+
+        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+    }
+
+    /// <summary>Extracts the gate's truth table at the given analog→digital threshold.</summary>
+    private static async Task<TruthTable> Extract(double threshold)
+    {
+        var group = await LoadGateGroup();
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group, InputPins, OutputPins, threshold, WavelengthNm);
+        table.GroupName.ShouldBe(GroupName);
+        table.InputPinNames.ShouldBe(InputPins);
+        table.OutputPinNames.ShouldBe(OutputPins);
+        return table;
+    }
+
+    /// <summary>Asserts one row's output bit and its raw simulated power behind it.</summary>
+    private static void AssertRow(
+        TruthTable table, bool a, bool b, bool expectedBit, double expectedPower)
+    {
+        var row = table.Rows.Single(r => r.InputBits["A"] == a && r.InputBits["B"] == b);
+        var output = row.Outputs["Y"];
+        var pattern = $"A={(a ? 1 : 0)} B={(b ? 1 : 0)}";
+        output.IsOne.ShouldBe(expectedBit,
+            $"threshold {table.PowerThreshold}: output bit for {pattern}");
+        output.Power.ShouldBe(expectedPower, PowerTolerance,
+            $"threshold {table.PowerThreshold}: raw power for {pattern}");
+    }
+}

--- a/examples/Logic Gate OR-AND.lun
+++ b/examples/Logic Gate OR-AND.lun
@@ -1,0 +1,236 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "OR/AND Gate",
+        "Description": "One circuit, two gates: inputs A and B feed a 50/50 combiner (2x2 MMI Coupler), the combined light leaves at Y. A single active input delivers half the power (0.5); both inputs together recombine coherently into full power (1.0). The Truth Table panel\u0027s analog-to-digital threshold decides which gate this is: at threshold 0.25 any single input crosses it (OR), at 0.75 only both inputs together reach it (AND). Select the group, open the Truth Table panel, check A \u002B B as inputs and Y as output, and extract once per threshold. AUX is the combiner\u0027s unused cross port.",
+        "Identifier": "group_7430827127f24fa4b6ef40f35bb04de9",
+        "IdGuid": "e64eade6-cb61-43b0-9561-f69a42518be7",
+        "ChildComponentGuids": [
+          "f1bf6956-b843-411a-ae23-9979586ce673",
+          "f11b78e6-f43d-4537-a34c-1c79bed49ebb",
+          "f32d1140-2ef3-47ca-bb9e-1b43cffbf983",
+          "8be927b4-c62d-4023-b479-563caaa77655"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 95,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_a",
+          "input_b",
+          "combiner",
+          "output"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "0941d502-8e86-45f7-8801-7ee65e25f73d",
+            "StartComponentId": "input_a",
+            "StartComponentGuid": "f1bf6956-b843-411a-ae23-9979586ce673",
+            "StartPinName": "b0",
+            "EndComponentId": "combiner",
+            "EndComponentGuid": "f32d1140-2ef3-47ca-bb9e-1b43cffbf983",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 126,
+                "EndX": 200,
+                "EndY": 126,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "324237ad-f5fa-45e8-9f3e-af51c9919aee",
+            "StartComponentId": "input_b",
+            "StartComponentGuid": "f11b78e6-f43d-4537-a34c-1c79bed49ebb",
+            "StartPinName": "b0",
+            "EndComponentId": "combiner",
+            "EndComponentGuid": "f32d1140-2ef3-47ca-bb9e-1b43cffbf983",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 134,
+                "EndX": 200,
+                "EndY": 134,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "5f410808-7871-41f6-9bc9-8c40ba92b0e9",
+            "StartComponentId": "combiner",
+            "StartComponentGuid": "f32d1140-2ef3-47ca-bb9e-1b43cffbf983",
+            "StartPinName": "out1",
+            "EndComponentId": "output",
+            "EndComponentGuid": "8be927b4-c62d-4023-b479-563caaa77655",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 450,
+                "StartY": 126,
+                "EndX": 455,
+                "EndY": 126,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "04054e18-9da7-478e-84cc-517d40cbdf27",
+            "Name": "A",
+            "InternalComponentId": "input_a",
+            "InternalComponentGuid": "f1bf6956-b843-411a-ae23-9979586ce673",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 26,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "e64d73d0-f01b-4452-ab46-82e756fe6ee6",
+            "Name": "B",
+            "InternalComponentId": "input_b",
+            "InternalComponentGuid": "f11b78e6-f43d-4537-a34c-1c79bed49ebb",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 34,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "91d4c2e5-cd1f-4587-bbef-bb6ca6280ac8",
+            "Name": "AUX",
+            "InternalComponentId": "combiner",
+            "InternalComponentGuid": "f32d1140-2ef3-47ca-bb9e-1b43cffbf983",
+            "InternalPinName": "out2",
+            "RelativeX": 355,
+            "RelativeY": 34,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "4eeb3cd3-c15d-41ff-9a9d-8b26d8d66196",
+            "Name": "Y",
+            "InternalComponentId": "output",
+            "InternalComponentGuid": "8be927b4-c62d-4023-b479-563caaa77655",
+            "InternalPinName": "b0",
+            "RelativeX": 460,
+            "RelativeY": 26,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_a",
+          "ComponentGuid": "f1bf6956-b843-411a-ae23-9979586ce673",
+          "TemplateName": "Straight Waveguide 100\u00B5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 121,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00B5m"
+        },
+        {
+          "Identifier": "input_b",
+          "ComponentGuid": "f11b78e6-f43d-4537-a34c-1c79bed49ebb",
+          "TemplateName": "Straight Waveguide 100\u00B5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 129,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00B5m"
+        },
+        {
+          "Identifier": "combiner",
+          "ComponentGuid": "f32d1140-2ef3-47ca-bb9e-1b43cffbf983",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 200,
+          "Y": 100,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output",
+          "ComponentGuid": "8be927b4-c62d-4023-b479-563caaa77655",
+          "TemplateName": "Straight Waveguide 100\u00B5m",
+          "PdkSource": "Demo PDK",
+          "X": 455,
+          "Y": 121,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00B5m"
+        }
+      ],
+      "CanvasX": 95,
+      "CanvasY": 100
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-16",
+      "Modified": "2026-08-16T08:27:06.8520159Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}


### PR DESCRIPTION
## What & why

Rung 4 of the NAND game shipped this week (`TruthTableExtractor` #946, Truth-Table-Panel #951, E2E journey #955), but `examples/` only contained the MZI — a student (Jonas) opening Lunima fresh found no logic example at all. This PR adds a ready-to-open gate design, which also serves the demo path (Ingrid).

- **`examples/Logic Gate OR-AND.lun`** — a small gate built only from bundled Demo PDK components (available in a fresh installation): two input waveguides → 2x2 MMI Coupler as 50/50 combiner → output waveguide, grouped as **"OR/AND Gate"** with cleanly named external pins `A`, `B`, `Y`, `AUX` (the combiner's unused cross port). The group's Description field carries the education core: one active input delivers half the power (0.5), both inputs recombine coherently into full power (1.0), so the analog→digital threshold decides the gate — **0.25 reads OR, 0.75 reads AND**. The file was generated through the real build → group → save path (not hand-written), with waveguides/routes lossless so the teaching values stay clean.
- **`UnitTests/Integration/LogicGateExampleTests.cs`** (new, Recipe B, no UI) — loads the example through the real load path (`FileOperationsViewModel.LoadDesignFromPathAsync`), asserts the group, its children, and its external pins, then runs `TruthTableExtractor` directly: OR bits (00→0, 01→1, 10→1, 11→1) at threshold 0.25 and AND bits at 0.75, with raw-power assertions 0.0 / 0.5 / 0.5 / 1.0 (±1e-6), mirroring `NandGameTruthTableJourneyTests`.
- **`ExampleDesignFilesTests`** — group child components and group-internal frozen paths now count toward the existing "meaningful circuit" minimums (a group-based example declares 0 top-level components/connections by construction); top-level count assertions unchanged.

**Deliberately out of scope:** a real NAND/NOT (needs interferometric inversion/bias — separate rung-4 issue), and any new UI. The example is discovered dynamically by the Home screen's `ExampleDesignsService`, so no code change was needed there; bundling examples into release packages stays with #768.

## How it was tested

- New headless integration tests: load path + group shape + both truth tables with raw powers.
- Existing `ExampleDesignFilesTests.EveryExample_LoadsExactlyWhatItDeclares` now also validates the new example (every declared template resolves, nothing dropped).
- `dotnet build CAP.Desktop/CAP.Desktop.csproj` — clean, 0 warnings.

Local suite: 5701 passed, 0 failed

## Manual verification after vacation

1. Start Lunima → Home screen → **Examples** → open "Logic Gate OR-AND".
2. Single-click the **OR/AND Gate** group → the Truth Table panel activates.
3. Check `A` and `B` as inputs, `Y` as output; set threshold **0.25** → Extract → expect OR (0/1/1/1) with powers 0.00/0.50/0.50/1.00.
4. Set threshold **0.75** → Extract → expect AND (0/0/0/1) with the same raw powers.
5. Read the group description (properties) for the threshold explanation.

Depends on #768 for examples/ shipping inside release bundles.