### PR TITLE
Agent: Ship examples/ in all release bundles (MSI/dmg/portable) (#768)

### DIFF
--- a/.github/workflows/Build_Exe.yaml
+++ b/.github/workflows/Build_Exe.yaml
@@ -102,6 +102,13 @@ jobs:
           fi
         shell: bash
 
+      # Ship the repo's example designs beside the binary so the Home screen's
+      # Examples section (walk-up discovery from the app base directory) also
+      # works in the portable zip/tar layout, not just the dev tree.
+      - name: Bundle example designs
+        run: cp -r examples publish/examples
+        shell: bash
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -158,6 +165,12 @@ jobs:
           --self-contained false
           -p:Version=${{ steps.version.outputs.version }}
           -o publish/win-x64-msi
+
+      # Examples must land in the publish dir BEFORE harvesting so the MSI
+      # installs them next to CAP.Desktop.exe (same discovery as portable).
+      - name: Bundle example designs
+        run: cp -r examples publish/win-x64-msi/examples
+        shell: bash
 
       - name: Generate HarvestedFiles.wxs
         shell: pwsh

--- a/UnitTests/Architecture/ExamplesPackagingTests.cs
+++ b/UnitTests/Architecture/ExamplesPackagingTests.cs
@@ -1,0 +1,79 @@
+using Shouldly;
+
+namespace UnitTests.Architecture;
+
+/// <summary>
+/// Guards that the shipped example designs (<c>examples/*.lun</c>) are bundled
+/// into every release artifact. The app discovers them by walking up from its
+/// base directory (<see cref="CAP.Avalonia.Services.ExampleDesignsService"/>),
+/// so each packaging path must place an <c>examples/</c> folder beside the
+/// executable — otherwise the Home screen's Examples section is silently empty
+/// in installed builds (issue #768).
+/// </summary>
+public class ExamplesPackagingTests
+{
+    private static readonly string RepoRoot = FindRepoRoot();
+
+    [Fact]
+    public void RepositoryExamplesDirectory_ContainsAtLeastOneDesign()
+    {
+        var examplesDir = Path.Combine(RepoRoot, "examples");
+
+        Directory.Exists(examplesDir).ShouldBeTrue(
+            "examples/ is missing — the release bundles would ship an empty Examples section.");
+        Directory.GetFiles(examplesDir, "*.lun").ShouldNotBeEmpty(
+            "examples/ contains no .lun designs — the release bundles would ship an empty Examples section.");
+    }
+
+    [Fact]
+    public void PortableBuildJob_CopiesExamplesIntoPublishOutput()
+    {
+        var workflow = ReadWorkflow();
+
+        workflow.Contains("cp -r examples publish/examples").ShouldBeTrue(
+            "The portable win-x64/linux-x64 artifacts must contain examples/ beside the binary.");
+    }
+
+    [Fact]
+    public void MsiBuildJob_CopiesExamplesIntoPublishOutput_BeforeHarvesting()
+    {
+        var workflow = ReadWorkflow();
+
+        var copyIndex = workflow.IndexOf("cp -r examples publish/win-x64-msi/examples", StringComparison.Ordinal);
+        copyIndex.ShouldBeGreaterThanOrEqualTo(0,
+            "The MSI job must copy examples/ into publish/win-x64-msi so harvesting picks it up.");
+
+        var harvestIndex = workflow.IndexOf("Generate-HarvestedFiles.ps1", StringComparison.Ordinal);
+        harvestIndex.ShouldBeGreaterThan(copyIndex,
+            "examples/ must be copied before Generate-HarvestedFiles.ps1 runs, otherwise the MSI misses them.");
+    }
+
+    [Fact]
+    public void MacOsBundleScript_CopiesExamplesBesideTheExecutable()
+    {
+        var script = File.ReadAllText(Path.Combine(RepoRoot, "scripts", "build_macos_bundle.sh"));
+
+        script.Contains("\"${MACOS_DIR}/examples\"").ShouldBeTrue(
+            "The .app bundle must contain examples/ in Contents/MacOS (the app base directory).");
+    }
+
+    private static string ReadWorkflow()
+    {
+        return File.ReadAllText(Path.Combine(RepoRoot, ".github", "workflows", "Build_Exe.yaml"));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var gitPath = Path.Combine(dir.FullName, ".git");
+            // In a normal clone .git is a directory; in a git worktree it is a file.
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root (.git directory or file).");
+    }
+}

--- a/scripts/build_macos_bundle.sh
+++ b/scripts/build_macos_bundle.sh
@@ -133,6 +133,15 @@ else
   exit 1
 fi
 
+# Ship the repo's example designs beside the executable: the app discovers
+# examples/ by walking up from its base directory (Contents/MacOS/).
+if [[ -d "${REPO_ROOT}/examples" ]]; then
+  cp -R "${REPO_ROOT}/examples" "${MACOS_DIR}/examples"
+  echo "      Bundled examples/ into Contents/MacOS/."
+else
+  echo "      NOTE: No examples/ directory at ${REPO_ROOT}; skipping examples."
+fi
+
 # ---------------------------------------------------------------------------
 # Step 3 — Write Contents/Info.plist
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

**#768 — Home screen: `examples/` in die Release-Bundles packen (MSI/dmg/portable, alle 3 OS)**

PR #694 shipped `examples/*.lun` (Demo-MZI, Logic-Gate) discovered by `ExampleDesignsService`'s walk-up from the app base directory. That works in the dev tree, but the release artifacts never bundled the folder — so in an installed Lunima the Home screen's Examples section is silently empty.

This PR puts `examples/` into all three packaging paths (repo rule: all 3 OS together):

- **Portable zip/tar** (`.github/workflows/Build_Exe.yaml`, `build` job): copies `examples/` into `publish/` so the archives carry it beside `Lunima`/`Lunima.exe`.
- **MSI** (same workflow, `build-msi` job): copies `examples/` into `publish/win-x64-msi/` **before** `Generate-HarvestedFiles.ps1` runs, so the harvested WiX fragment installs it under `[INSTALLDIR]examples\` next to `CAP.Desktop.exe`.
- **macOS .app / .dmg** (`scripts/build_macos_bundle.sh`): copies `examples/` into `Contents/MacOS/`, which is the app base directory the discovery walk starts from.

Guarded by a new architecture test (`UnitTests/Architecture/ExamplesPackagingTests.cs`) that fails if any of the three packaging paths stops bundling `examples/`, or if the repo folder loses its last `.lun` design.

## How it was tested

- `UnitTests/Architecture/ExamplesPackagingTests.cs` — 4 new tests (portable copy step, MSI copy-before-harvest ordering, macOS bundle copy, repo `examples/` non-empty).
- `bash -n scripts/build_macos_bundle.sh` + YAML parse check.
- Full filtered local suite (as required): `Local suite: 5712 passed, 0 failed` (16 conditionally skipped, as on dev-ki).

Cross-platform reasoning per CLAUDE.md §1.2: for single-file portable builds `AppContext.BaseDirectory` is the exe's own directory; for the MSI it's `[INSTALLDIR]`; for the `.app` it's `Contents/MacOS`. In all three layouts the walk-up now finds `examples/` on the first hop.

## Manual verification after vacation

Headless CI can't install its own artifacts, so please sanity-check one artifact per OS:

1. **MSI:** install `Lunima-Setup-*.msi`, open `%ProgramFiles%\Lunima\examples\` with the `.lun` files present, start Lunima → Home shows the *Mach-Zehnder Interferometer* and *Logic Gate OR-AND* examples.
2. **Portable (win/linux):** unzip/untar, confirm `examples/` sits beside `Lunima(.exe)`, run → Examples section populated.
3. **macOS:** open the `.dmg`, drag to Applications, `xattr -dr com.apple.quarantine`, confirm `Contents/MacOS/examples/` exists via `ls`, launch → Examples section populated.