### PR TITLE
Agent: Bias inputs in TruthTableExtractor + NOT/NAND example via MZI interference (#964)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTable.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTable.cs
@@ -10,7 +10,7 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 /// </summary>
 public sealed class TruthTable
 {
-    /// <summary>Assembles an immutable extraction result.</summary>
+    /// <summary>Assembles an immutable extraction result without bias pins.</summary>
     public TruthTable(
         string groupName,
         IReadOnlyList<string> inputPinNames,
@@ -18,10 +18,24 @@ public sealed class TruthTable
         double powerThreshold,
         int wavelengthNm,
         IReadOnlyList<TruthTableRow> rows)
+        : this(groupName, inputPinNames, outputPinNames, [], powerThreshold, wavelengthNm, rows)
+    {
+    }
+
+    /// <summary>Assembles an immutable extraction result including the bias-pin assignment.</summary>
+    public TruthTable(
+        string groupName,
+        IReadOnlyList<string> inputPinNames,
+        IReadOnlyList<string> outputPinNames,
+        IReadOnlyList<string> biasPinNames,
+        double powerThreshold,
+        int wavelengthNm,
+        IReadOnlyList<TruthTableRow> rows)
     {
         GroupName = groupName;
         InputPinNames = inputPinNames;
         OutputPinNames = outputPinNames;
+        BiasPinNames = biasPinNames;
         PowerThreshold = powerThreshold;
         WavelengthNm = wavelengthNm;
         Rows = rows;
@@ -35,6 +49,9 @@ public sealed class TruthTable
 
     /// <summary>Logic output pin names.</summary>
     public IReadOnlyList<string> OutputPinNames { get; }
+
+    /// <summary>Bias pin names — constantly "on" in every row, so they never appear as input-bit columns.</summary>
+    public IReadOnlyList<string> BiasPinNames { get; }
 
     /// <summary>Normalized power threshold used for classification (power ≥ threshold is logic 1).</summary>
     public double PowerThreshold { get; }

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTableExtractor.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/TruthTableExtractor.cs
@@ -19,6 +19,11 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 /// The group is always simulated in isolation; canvas connections around the group
 /// are irrelevant for its gate behavior.
 ///
+/// An optional set of bias pins can be declared on the bias-aware overload: they
+/// are constantly "on" in every row (coherent, like an active input) but never
+/// appear as input-bit columns — the ingredient inversion needs, since power-only
+/// thresholds cannot make an output bright while the signal input is dark.
+///
 /// Boundaries: at most <see cref="MaxLogicInputs"/> logic inputs (the combination
 /// count grows as 2^n and each combination is a full simulation run), the power
 /// threshold is a mandatory parameter (no guessing), and the whole table is
@@ -37,7 +42,8 @@ public sealed class TruthTableExtractor
 
     /// <summary>
     /// Simulates every binary input combination of <paramref name="group"/> and
-    /// classifies each output against <paramref name="powerThreshold"/>.
+    /// classifies each output against <paramref name="powerThreshold"/>, with no bias
+    /// pins — equivalent to the bias-aware overload with an empty bias list.
     /// </summary>
     /// <param name="group">The grouped circuit under test; its external pins form the gate interface.</param>
     /// <param name="inputPinNames">
@@ -60,18 +66,63 @@ public sealed class TruthTableExtractor
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="powerThreshold"/> lies outside (0, 1), or <paramref name="wavelengthNm"/> is not positive.
     /// </exception>
-    public async Task<TruthTable> ExtractAsync(
+    public Task<TruthTable> ExtractAsync(
         ComponentGroup group,
         IReadOnlyList<string> inputPinNames,
         IReadOnlyList<string> outputPinNames,
         double powerThreshold,
         int wavelengthNm,
+        CancellationToken cancellationToken = default) =>
+        ExtractAsync(group, inputPinNames, outputPinNames, [], powerThreshold, wavelengthNm, cancellationToken);
+
+    /// <summary>
+    /// Simulates every binary input combination of <paramref name="group"/> and
+    /// classifies each output against <paramref name="powerThreshold"/>, with
+    /// <paramref name="biasPins"/> constantly "on" in every row — coherent, same
+    /// wavelength and field as the enumerated logic inputs, but absent from the
+    /// table's input bits. Bias is what inversion needs physically: a reference
+    /// input whose destructive interference with the signal input can turn the
+    /// output dark.
+    /// </summary>
+    /// <param name="group">The grouped circuit under test; its external pins form the gate interface.</param>
+    /// <param name="inputPinNames">
+    /// Names of the group's external pins to drive as logic inputs
+    /// (1 to <see cref="MaxLogicInputs"/> entries, no duplicates, disjoint from the outputs and the bias pins).
+    /// </param>
+    /// <param name="outputPinNames">Names of the group's external pins to observe as logic outputs.</param>
+    /// <param name="biasPins">
+    /// Names of the group's external pins held constantly "on" (coherent, like an
+    /// active input) in every row. Not a column in the table's input bits.
+    /// </param>
+    /// <param name="powerThreshold">
+    /// Normalized power threshold in the open interval (0, 1): an output is logic 1 when
+    /// its power is ≥ threshold. Each active input injects power 1.
+    /// </param>
+    /// <param name="wavelengthNm">Laser wavelength in nm shared by all inputs (the active laser).</param>
+    /// <param name="cancellationToken">Cancels the extraction between combinations.</param>
+    /// <returns>The truth table, including the raw simulated power behind every output bit.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="group"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// A pin list is empty, contains duplicates, overlaps another list, exceeds
+    /// <see cref="MaxLogicInputs"/> inputs, or names a pin the group does not expose.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="powerThreshold"/> lies outside (0, 1), or <paramref name="wavelengthNm"/> is not positive.
+    /// </exception>
+    public async Task<TruthTable> ExtractAsync(
+        ComponentGroup group,
+        IReadOnlyList<string> inputPinNames,
+        IReadOnlyList<string> outputPinNames,
+        IReadOnlyList<string> biasPins,
+        double powerThreshold,
+        int wavelengthNm,
         CancellationToken cancellationToken = default)
     {
         if (group == null) throw new ArgumentNullException(nameof(group));
-        ValidateArguments(inputPinNames, outputPinNames, powerThreshold, wavelengthNm);
+        ValidateArguments(inputPinNames, outputPinNames, biasPins, powerThreshold, wavelengthNm);
         var inputs = ResolvePins(group, inputPinNames, nameof(inputPinNames));
         var outputs = ResolvePins(group, outputPinNames, nameof(outputPinNames));
+        var biases = ResolvePins(group, biasPins, nameof(biasPins));
 
         // Compute the group closure once up front: a group that cannot simulate at
         // all fails before the first row, and the per-combination runs reuse it.
@@ -83,13 +134,14 @@ public sealed class TruthTableExtractor
         {
             cancellationToken.ThrowIfCancellationRequested();
             rows.Add(await SimulateCombinationAsync(
-                group, inputs, outputs, pattern, powerThreshold, wavelengthNm, cancellationToken));
+                group, inputs, biases, outputs, pattern, powerThreshold, wavelengthNm, cancellationToken));
         }
 
         return new TruthTable(
             group.GroupName,
             inputPinNames.ToArray(),
             outputPinNames.ToArray(),
+            biasPins.ToArray(),
             powerThreshold,
             wavelengthNm,
             rows);
@@ -99,6 +151,7 @@ public sealed class TruthTableExtractor
     private static async Task<TruthTableRow> SimulateCombinationAsync(
         ComponentGroup group,
         IReadOnlyList<GroupPin> inputs,
+        IReadOnlyList<GroupPin> biases,
         IReadOnlyList<GroupPin> outputs,
         int pattern,
         double powerThreshold,
@@ -106,6 +159,13 @@ public sealed class TruthTableExtractor
         CancellationToken cancellationToken)
     {
         var portManager = new PhysicalExternalPortManager();
+        // Bias pins are always "on" — the same coherent field as an active input,
+        // just not enumerated as a table column.
+        foreach (var bias in biases)
+        {
+            portManager.AddLightSource(CreateOnInput(bias, wavelengthNm), InFlowIdOf(bias));
+        }
+
         var inputBits = new Dictionary<string, bool>(inputs.Count);
         for (var i = 0; i < inputs.Count; i++)
         {
@@ -171,6 +231,7 @@ public sealed class TruthTableExtractor
     private static void ValidateArguments(
         IReadOnlyList<string> inputPinNames,
         IReadOnlyList<string> outputPinNames,
+        IReadOnlyList<string> biasPins,
         double powerThreshold,
         int wavelengthNm)
     {
@@ -185,10 +246,10 @@ public sealed class TruthTableExtractor
 
         ThrowOnDuplicates(inputPinNames, nameof(inputPinNames));
         ThrowOnDuplicates(outputPinNames, nameof(outputPinNames));
-        var overlap = inputPinNames.Intersect(outputPinNames).FirstOrDefault();
-        if (overlap != null)
-            throw new ArgumentException(
-                $"Pin '{overlap}' is declared as both a logic input and a logic output.", nameof(outputPinNames));
+        ThrowOnDuplicates(biasPins, nameof(biasPins));
+        ThrowOnOverlap(inputPinNames, outputPinNames, nameof(outputPinNames));
+        ThrowOnOverlap(inputPinNames, biasPins, nameof(biasPins));
+        ThrowOnOverlap(biasPins, outputPinNames, nameof(biasPins));
 
         if (double.IsNaN(powerThreshold) || powerThreshold <= 0.0 || powerThreshold >= 1.0)
             throw new ArgumentOutOfRangeException(
@@ -227,5 +288,13 @@ public sealed class TruthTableExtractor
         var duplicate = pinNames.GroupBy(n => n).FirstOrDefault(g => g.Count() > 1)?.Key;
         if (duplicate != null)
             throw new ArgumentException($"Pin '{duplicate}' is listed more than once.", parameterName);
+    }
+
+    /// <summary>Rejects pins claimed for two roles — a pin is exactly one of input, output, or bias.</summary>
+    private static void ThrowOnOverlap(IReadOnlyList<string> first, IReadOnlyList<string> second, string parameterName)
+    {
+        var overlap = first.Intersect(second).FirstOrDefault();
+        if (overlap != null)
+            throw new ArgumentException($"Pin '{overlap}' is assigned two roles in one extraction.", parameterName);
     }
 }

--- a/UnitTests/Analysis/LogicAnalysis/TruthTableExtractorBiasTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/TruthTableExtractorBiasTests.cs
@@ -1,0 +1,103 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Bias-pin behavior of <see cref="TruthTableExtractor"/> (rung 4 of the NAND game):
+/// a bias pin is constantly "on" in every row — coherent like an active input — but
+/// never appears as an input-bit column. On the combiner fixture a bias alone puts
+/// half its power (0.5) at the output; a bias plus a single enumerated input
+/// recombine coherently into full power (1.0), exactly as the coupler S-matrix
+/// dictates.
+/// </summary>
+public class TruthTableExtractorBiasTests
+{
+    private static readonly string[] Inputs = { "a" };
+    private static readonly string[] Biases = { "b" };
+    private static readonly string[] Outputs = { "y" };
+    private const double Threshold = 0.75;
+    private const double PowerTolerance = 1e-6;
+
+    [Fact]
+    public async Task ExtractAsync_BiasAlone_DeliversRestingPowerWithoutBitColumn()
+    {
+        var table = await Extract();
+
+        table.BiasPinNames.ShouldBe(Biases);
+        var row = table.Rows[0];
+        row.InputBits.Keys.ShouldBe(Inputs, "bias pins never become input-bit columns");
+        row.InputBits["a"].ShouldBeFalse();
+        row.Outputs["y"].Power.ShouldBe(0.5, PowerTolerance,
+            "one always-on bias source through the 50/50 coupler rests at half power");
+        row.Outputs["y"].IsOne.ShouldBeFalse(
+            "at threshold 0.75 the resting power is below the gate threshold");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_BiasPlusInput_InterferePerSMatrix()
+    {
+        var table = await Extract();
+
+        var row = table.Rows[1];
+        row.Outputs["y"].Power.ShouldBe(1.0, PowerTolerance,
+            "|through·a + cross·b|² = |√0.5 + i·√0.5|² = 1.0 by the coupler S-matrix");
+        row.Outputs["y"].IsOne.ShouldBeTrue("both sources together cross the threshold");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyBiasList_MatchesTheClassicOverload()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group, Inputs, Outputs, Array.Empty<string>(), Threshold, LogicGateFixtureFactory.WavelengthNm);
+
+        table.BiasPinNames.ShouldBeEmpty();
+        table.Rows[0].Outputs["y"].Power.ShouldBe(0.0, PowerTolerance);
+        table.Rows[1].Outputs["y"].Power.ShouldBe(0.5, PowerTolerance);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_BiasOverlapsInput_ThrowsArgumentException()
+    {
+        var exception = await Should.ThrowAsync<ArgumentException>(() => ToTask(new[] { "a" }));
+        exception.Message.ShouldContain("'a'");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_BiasOverlapsOutput_ThrowsArgumentException()
+    {
+        var exception = await Should.ThrowAsync<ArgumentException>(() => ToTask(new[] { "y" }));
+        exception.Message.ShouldContain("'y'");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_DuplicateBias_ThrowsArgumentException()
+    {
+        var exception = await Should.ThrowAsync<ArgumentException>(() => ToTask(new[] { "b", "b" }));
+        exception.Message.ShouldContain("'b'");
+    }
+
+    [Fact]
+    public async Task ExtractAsync_UnknownBias_ThrowsArgumentExceptionNamingThePin()
+    {
+        var exception = await Should.ThrowAsync<ArgumentException>(() => ToTask(new[] { "no-such-pin" }));
+        exception.Message.ShouldContain("'no-such-pin'");
+    }
+
+    private static async Task<TruthTable> Extract()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        return await new TruthTableExtractor().ExtractAsync(
+            group, Inputs, Outputs, Biases, Threshold, LogicGateFixtureFactory.WavelengthNm);
+    }
+
+    private static Task<TruthTable> ToTask(string[] biases)
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        return new TruthTableExtractor().ExtractAsync(
+            group, Inputs, Outputs, biases, Threshold, LogicGateFixtureFactory.WavelengthNm);
+    }
+}

--- a/UnitTests/Integration/LogicGateNotNandExampleTests.cs
+++ b/UnitTests/Integration/LogicGateNotNandExampleTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Headless load test for the shipped logic-gate example
+/// <c>examples/Logic Gate NOT-NAND.lun</c> (issue #964, rung 4 of the NAND game):
+/// the file loads through the real load path as a single "NOT/NAND Gate" group
+/// built only from bundled Demo PDK components. The BIAS pin — 'on' in every row and
+/// shifted 135° against the combined A·B beam — cancels it in the recombination
+/// coupler exactly when both inputs are on (raw power 0). Enumerate only A at
+/// threshold 0.375 for NOT (resting 0.5 bright, single-input 0.25 dark), enumerate
+/// A and B at threshold 0.125 for NAND: raw powers 0.5 / 0.25 / 0.25 / 0.0.
+/// </summary>
+public class LogicGateNotNandExampleTests
+{
+    private const string ExampleFileName = "Logic Gate NOT-NAND.lun";
+    private const string GroupName = "NOT/NAND Gate";
+    private const double PowerTolerance = 1e-6;
+    private const double NotThreshold = 0.375;
+    private const double NandThreshold = 0.125;
+    private const double RestingPower = 0.5;
+    private const double SingleInputPower = 0.25;
+    private const int WavelengthNm = 1550;
+
+    private static readonly string[] InputA = { "A" };
+    private static readonly string[] InputsAb = { "A", "B" };
+    private static readonly string[] Biases = { "BIAS" };
+    private static readonly string[] Outputs = { "Y" };
+
+    [Fact]
+    public async Task Example_LoadsAsSingleGroup_WithCleanExternalPins()
+    {
+        var group = await LoadGateGroup();
+
+        group.GroupName.ShouldBe(GroupName);
+        // The group description carries both thresholds plus the phase lesson.
+        group.Description.ShouldContain("0.375");
+        group.Description.ShouldContain("0.125");
+        group.Description.ShouldContain("135");
+        group.ChildComponents.Select(c => c.Identifier)
+            .ShouldBe(new[] { "input_a", "input_b", "combine", "phase", "recombine", "output" }, ignoreOrder: true);
+        group.InternalPaths.Count.ShouldBe(5,
+            "both inputs, the stage link, the phase result, and the output are routed inside the group");
+        group.ExternalPins.Select(p => p.Name)
+            .ShouldBe(new[] { "A", "B", "BIAS", "Y" }, ignoreOrder: true);
+        group.ExternalPins.ShouldAllBe(p => p.InternalPin != null && p.InternalPin.LogicalPin != null,
+            "every external pin stays bound to a simulatable component pin");
+    }
+
+    [Fact]
+    public async Task TruthTable_InputAOnlyAtThreshold0375_ProducesNotBitsWithRawPowers()
+    {
+        var table = await Extract(InputA, NotThreshold);
+
+        table.BiasPinNames.ShouldBe(Biases);
+        table.Rows.Count.ShouldBe(2, "one logic input produces two rows");
+        AssertRow(table, 0, expectedBit: true, expectedPower: RestingPower);
+        AssertRow(table, 1, expectedBit: false, expectedPower: SingleInputPower);
+    }
+
+    [Fact]
+    public async Task TruthTable_InputsAbAtThreshold0125_ProducesNandBitsWithRawPowers()
+    {
+        var table = await Extract(InputsAb, NandThreshold);
+
+        table.Rows.Count.ShouldBe(4, "two logic inputs produce four rows");
+        AssertRow(table, 0, expectedBit: true, expectedPower: RestingPower);
+        AssertRow(table, 1, expectedBit: true, expectedPower: SingleInputPower);
+        AssertRow(table, 2, expectedBit: true, expectedPower: SingleInputPower);
+        AssertRow(table, 3, expectedBit: false, expectedPower: 0.0);
+    }
+
+    [Fact]
+    public async Task TruthTable_WithoutBias_CannotInvert()
+    {
+        var group = await LoadGateGroup();
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group, InputA, Outputs, Array.Empty<string>(), NotThreshold, WavelengthNm);
+
+        table.BiasPinNames.ShouldBeEmpty();
+        // Without the reference light the signal just passes — bright when A is on,
+        // dark when A is off; an inversion needs the bias to take light away.
+        AssertRow(table, 0, expectedBit: false, expectedPower: 0.0);
+        AssertRow(table, 1, expectedBit: false, expectedPower: SingleInputPower);
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns its group.</summary>
+    private static async Task<ComponentGroup> LoadGateGroup()
+    {
+        var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!);
+
+        var examplePath = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+        (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+            $"the shipped example '{ExampleFileName}' must load through the real load path");
+
+        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+    }
+
+    /// <summary>Extracts the gate's truth table at the given analog→digital threshold.</summary>
+    private static async Task<TruthTable> Extract(string[] inputs, double threshold)
+    {
+        var group = await LoadGateGroup();
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group, inputs, Outputs, Biases, threshold, WavelengthNm);
+        table.GroupName.ShouldBe(GroupName);
+        table.InputPinNames.ShouldBe(inputs);
+        table.OutputPinNames.ShouldBe(Outputs);
+        return table;
+    }
+
+    /// <summary>Asserts one row's output bit and its raw simulated power behind it.</summary>
+    private static void AssertRow(TruthTable table, int pattern, bool expectedBit, double expectedPower)
+    {
+        var row = table.Rows[pattern];
+        var output = row.Outputs["Y"];
+        output.IsOne.ShouldBe(expectedBit,
+            $"threshold {table.PowerThreshold}: output bit for input pattern {pattern}");
+        output.Power.ShouldBe(expectedPower, PowerTolerance,
+            $"threshold {table.PowerThreshold}: raw power for input pattern {pattern}");
+    }
+}

--- a/examples/Logic Gate NOT-NAND.lun
+++ b/examples/Logic Gate NOT-NAND.lun
@@ -1,0 +1,329 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "NOT/NAND Gate",
+        "Description": "NOT and NAND from one circuit, unlocked by the extractor's bias feature. Power-only thresholds pass what they receive, so inversion — output bright while every input is dark — needs a constant reference light (BIAS) that takes power away through interference. The combine coupler turns A·B into one beam that reaches it with a +45° phase (A rests on the 0° through path, B on the +90° cross path). BIAS passes a 135° Phase Shifter into recombine.in2; the coupler's cross path to out1 adds another +90°, so BIAS arrives at +225° — exactly anti-phase to A·B — and cancels it whenever both inputs are on (raw power 0 → bit 0 at threshold 0.125). A single input on leaves only a quarter power at Y (0.25 → still bit 1), and with both inputs off the BIAS alone rests at half power (0.5 → bit 1): the NAND table. Enumerate only A at threshold 0.375 and the same circuit reads NOT: A=0 rests at 0.5 (bit 1), A=1 drops to 0.25 (bit 0). Mark BIAS as a bias pin so it stays 'on' in every row without getting its own column.",
+        "Identifier": "group_9f4c1b2a8e6d4a05bed2",
+        "IdGuid": "64c5dd1f-24b9-46fd-9167-ccd85f9483d8",
+        "ChildComponentGuids": [
+          "00e3cb00-c383-4362-b2a1-468d03c68741",
+          "da50c91c-f655-4398-b965-17ff8e423ec8",
+          "34005875-4565-4ee1-babd-0d4ef474c26e",
+          "9d224da5-ee30-4f84-8023-dfaae5e37a31",
+          "6403f3cd-ce1c-4a55-962d-585a1591338c",
+          "8a41fd80-5fa5-445e-a037-e8aff7c9b62f"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 95,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_a",
+          "input_b",
+          "combine",
+          "phase",
+          "recombine",
+          "output"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "8306b770-ee6d-4167-8e24-d234c7300d60",
+            "StartComponentId": "input_a",
+            "StartComponentGuid": "00e3cb00-c383-4362-b2a1-468d03c68741",
+            "StartPinName": "b0",
+            "EndComponentId": "combine",
+            "EndComponentGuid": "34005875-4565-4ee1-babd-0d4ef474c26e",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "80de4cd2-a36c-4e42-a7f7-65bf1cd0b0dd",
+            "StartComponentId": "input_b",
+            "StartComponentGuid": "da50c91c-f655-4398-b965-17ff8e423ec8",
+            "StartPinName": "b0",
+            "EndComponentId": "combine",
+            "EndComponentGuid": "34005875-4565-4ee1-babd-0d4ef474c26e",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "0edd332c-5811-4878-8ca2-e22bc35bd2bf",
+            "StartComponentId": "combine",
+            "StartComponentGuid": "34005875-4565-4ee1-babd-0d4ef474c26e",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine",
+            "EndComponentGuid": "6403f3cd-ce1c-4a55-962d-585a1591338c",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "d2e7c50f-41da-47e9-ba08-ad96dd0c5921",
+            "StartComponentId": "phase",
+            "StartComponentGuid": "9d224da5-ee30-4f84-8023-dfaae5e37a31",
+            "StartPinName": "out",
+            "EndComponentId": "recombine",
+            "EndComponentGuid": "6403f3cd-ce1c-4a55-962d-585a1591338c",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "2948dbc8-2568-4da5-b55f-37451f5b602c",
+            "StartComponentId": "recombine",
+            "StartComponentGuid": "6403f3cd-ce1c-4a55-962d-585a1591338c",
+            "StartPinName": "out1",
+            "EndComponentId": "output",
+            "EndComponentGuid": "8a41fd80-5fa5-445e-a037-e8aff7c9b62f",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "8efeb3ce-40de-4a7d-9cf2-7664d58101f2",
+            "Name": "A",
+            "InternalComponentId": "input_a",
+            "InternalComponentGuid": "00e3cb00-c383-4362-b2a1-468d03c68741",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "bce76a36-83fc-41d4-8659-9cc0df59a5c5",
+            "Name": "B",
+            "InternalComponentId": "input_b",
+            "InternalComponentGuid": "da50c91c-f655-4398-b965-17ff8e423ec8",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "6266a9d4-1bde-45d4-87a0-cd636d86f5a4",
+            "Name": "BIAS",
+            "InternalComponentId": "phase",
+            "InternalComponentGuid": "9d224da5-ee30-4f84-8023-dfaae5e37a31",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8b1d3205-2910-44b9-ba31-6cd90fa0a2f4",
+            "Name": "Y",
+            "InternalComponentId": "output",
+            "InternalComponentGuid": "8a41fd80-5fa5-445e-a037-e8aff7c9b62f",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_a",
+          "ComponentGuid": "00e3cb00-c383-4362-b2a1-468d03c68741",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_b",
+          "ComponentGuid": "da50c91c-f655-4398-b965-17ff8e423ec8",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine",
+          "ComponentGuid": "34005875-4565-4ee1-babd-0d4ef474c26e",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase",
+          "ComponentGuid": "9d224da5-ee30-4f84-8023-dfaae5e37a31",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine",
+          "ComponentGuid": "6403f3cd-ce1c-4a55-962d-585a1591338c",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output",
+          "ComponentGuid": "8a41fd80-5fa5-445e-a037-e8aff7c9b62f",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 95,
+      "CanvasY": 100
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-16",
+      "Modified": "2026-08-16T12:00:00.0000000Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}


### PR DESCRIPTION
## What & why

Issue #964 (rung 4 of the NAND game): the ladder stops at inversion today — OR/AND per threshold (#946/#962) cannot make an output bright while its input is dark. Photonically that needs a constant **bias/reference input** plus destructive interference, exactly the gap PR #962 delegated to rung 4.

- **`TruthTableExtractor`: bias pins.** New overload `ExtractAsync(group, inputPinNames, outputPinNames, biasPins, ...)` — purely additive; the classic six-argument signature stays and delegates with an empty bias list. Bias pins are 'on' in every row (coherent: same wavelength, amplitude 1, phase 0, exactly like enumerated inputs) but never appear as input-bit columns. Validation: disjoint from inputs/outputs, no duplicates, resolvable pins — same exception style as before.
- **`TruthTable`** now carries `BiasPinNames` (empty via the classic constructor) so results are self-describing.
- **Shipped example `examples/Logic Gate NOT-NAND.lun`** — one "NOT/NAND Gate" group, Demo PDK only (two input waveguides, combine MMI, one 135° Phase Shifter on the BIAS arm, recombine MMI, output waveguide). The combine coupler ends A·B with a +45° phase; the recombine coupler's cross port adds +90°, so BIAS arrives anti-phase at +225° and cancels A·B exactly at (1,1). Education text lives in the group description: why inversion needs a reference light, which threshold reads which gate.

## How it was tested

- New unit tests `TruthTableExtractorBiasTests` (fixture coupler): bias alone rests at 0.5, bias+input interfere to 1.0 per S-matrix, empty bias matches the classic overload, overlap/duplicate/unknown-pin validation.
- New integration tests `LogicGateNotNandExampleTests`: the example loads through the real load path (`FileOperationsViewModel.LoadDesignFromPathAsync`), then
  - NOT: enumerate A only, threshold 0.375 → bits [1, 0] with raw powers 0.5 / 0.25 (±1e-6).
  - NAND: enumerate A+B, threshold 0.125 → bits [1, 1, 1, 0] with raw powers 0.5 / 0.25 / 0.25 / 0.0 (±1e-6) — (1,1) cancels to exactly zero.
  - Without bias the same circuit cannot invert — pinned by a negative test.
- Existing extractor signatures/tests (OR/AND, journey #955) untouched and green.
- Follow-up for the panel-side bias selection filed as #968.

Local suite: 5719 passed, 0 failed

## Manual verification after vacation

No UI in this PR, so interactive verification needs the panel follow-up #968 (bias-pin selection in the Truth Table panel) first. Then:

1. Open `examples/Logic Gate NOT-NAND.lun`.
2. Select the `NOT/NAND Gate` group, open the Truth Table panel.
3. Mark **A** as input, **Y** as output, **BIAS** as bias, threshold **0.375** → NOT table `1, 0`.
4. Additionally mark **B** as input, threshold **0.125** → NAND table `1, 1, 1, 0`, with the (1,1) row dark (raw power 0).
