### PR TITLE
Agent: AND-from-NAND two-stage cascade example, margins pinned headless (#971)

### DIFF
--- a/UnitTests/Integration/LogicGateAndFromNandExampleTests.cs
+++ b/UnitTests/Integration/LogicGateAndFromNandExampleTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Headless load test for the shipped logic-gate example
+/// <c>examples/Logic Gate AND-from-NAND.lun</c> (issue #971, rung 4 of the NAND game):
+/// the file loads through the real load path as a single "AND from NAND Gate" group —
+/// the NAND stage of <c>Logic Gate NOT-NAND.lun</c> feeding a second inverter stage
+/// with its own bias (AND = NOT(NAND(A,B))). Cascaded passive linear optics has no
+/// level restoration, so the inverter bias is weighted to the weakened NAND levels:
+/// BIAS2 (315° phase, coupling ratio 33.3%) arrives anti-phase to the resting NAND
+/// output and cancels it exactly (raw power 0 at (0,0)), while the single-input rows
+/// rest at 1/6 and (1,1) lets BIAS2 pass at 1/3. At threshold 0.25 the table reads
+/// AND: 0,0,0,1 — with the darkest 1 exactly 2× the brightest 0.
+/// </summary>
+public class LogicGateAndFromNandExampleTests
+{
+    private const string ExampleFileName = "Logic Gate AND-from-NAND.lun";
+    private const string GroupName = "AND from NAND Gate";
+    private const double PowerTolerance = 1e-6;
+    private const double AndThreshold = 0.25;
+    private const double ExtinguishedPower = 0.0;
+    private const double SingleInputPower = 1.0 / 6.0;
+    private const double BothInputsPower = 1.0 / 3.0;
+    private const int WavelengthNm = 1550;
+
+    private static readonly string[] InputsAb = { "A", "B" };
+    private static readonly string[] Biases = { "BIAS", "BIAS2" };
+    private static readonly string[] Outputs = { "Y" };
+
+    [Fact]
+    public async Task Example_LoadsAsSingleGroup_WithCleanExternalPins()
+    {
+        var group = await LoadGateGroup();
+
+        group.GroupName.ShouldBe(GroupName);
+        // The group description carries the threshold, the second bias weighting,
+        // and the cascade lesson.
+        group.Description.ShouldContain("0.25");
+        group.Description.ShouldContain("315");
+        group.Description.ShouldContain("33.3");
+        group.ChildComponents.Select(c => c.Identifier)
+            .ShouldBe(new[]
+            {
+                "input_a", "input_b", "combine", "phase_nand", "recombine",
+                "link", "phase_inv", "invert", "output"
+            }, ignoreOrder: true);
+        group.InternalPaths.Count.ShouldBe(8,
+            "both inputs, both stage links, both phase results, and the output are routed inside the group");
+        group.ExternalPins.Select(p => p.Name)
+            .ShouldBe(new[] { "A", "B", "BIAS", "BIAS2", "Y" }, ignoreOrder: true);
+        group.ExternalPins.ShouldAllBe(p => p.InternalPin != null && p.InternalPin.LogicalPin != null,
+            "every external pin stays bound to a simulatable component pin");
+    }
+
+    [Fact]
+    public async Task TruthTable_InputsAbAtThreshold025_ProducesAndBitsWithRawPowers()
+    {
+        var table = await Extract(InputsAb, Biases, AndThreshold);
+
+        table.BiasPinNames.ShouldBe(Biases);
+        table.Rows.Count.ShouldBe(4, "two logic inputs produce four rows");
+        AssertRow(table, 0, expectedBit: false, expectedPower: ExtinguishedPower);
+        AssertRow(table, 1, expectedBit: false, expectedPower: SingleInputPower);
+        AssertRow(table, 2, expectedBit: false, expectedPower: SingleInputPower);
+        AssertRow(table, 3, expectedBit: true, expectedPower: BothInputsPower);
+    }
+
+    [Fact]
+    public async Task TruthTable_CascadeMargin_DarkestOneIsTwiceTheBrightestZero()
+    {
+        var table = await Extract(InputsAb, Biases, AndThreshold);
+
+        var brightestZero = table.Rows.Take(3).Max(r => r.Outputs["Y"].Power);
+        var darkestOne = table.Rows[3].Outputs["Y"].Power;
+        (darkestOne / brightestZero).ShouldBeGreaterThanOrEqualTo(2.0,
+            "the cascade's honesty bound: without level restoration the margin tops out at exactly 2×");
+    }
+
+    [Fact]
+    public async Task TruthTable_WithoutSecondBias_PassesLevelInsteadOfInverting()
+    {
+        var table = await Extract(InputsAb, new[] { "BIAS" }, AndThreshold);
+
+        table.BiasPinNames.ShouldBe(new[] { "BIAS" });
+        // Without BIAS2 the second stage is a transparent coupler: the weakened NAND
+        // levels just pass through (× 2/3), so the cascade reads NOR, not AND — the
+        // second bias is what turns the passing level into an inversion.
+        AssertRow(table, 0, expectedBit: true, expectedPower: BothInputsPower);
+        AssertRow(table, 1, expectedBit: false, expectedPower: SingleInputPower);
+        AssertRow(table, 2, expectedBit: false, expectedPower: SingleInputPower);
+        AssertRow(table, 3, expectedBit: false, expectedPower: ExtinguishedPower);
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns its group.</summary>
+    private static async Task<ComponentGroup> LoadGateGroup()
+    {
+        var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!);
+
+        var examplePath = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+        (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+            $"the shipped example '{ExampleFileName}' must load through the real load path");
+
+        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+    }
+
+    /// <summary>Extracts the gate's truth table at the given analog→digital threshold.</summary>
+    private static async Task<TruthTable> Extract(string[] inputs, string[] biases, double threshold)
+    {
+        var group = await LoadGateGroup();
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group, inputs, Outputs, biases, threshold, WavelengthNm);
+        table.GroupName.ShouldBe(GroupName);
+        table.InputPinNames.ShouldBe(inputs);
+        table.OutputPinNames.ShouldBe(Outputs);
+        return table;
+    }
+
+    /// <summary>Asserts one row's output bit and its raw simulated power behind it.</summary>
+    private static void AssertRow(TruthTable table, int pattern, bool expectedBit, double expectedPower)
+    {
+        var row = table.Rows[pattern];
+        var output = row.Outputs["Y"];
+        output.IsOne.ShouldBe(expectedBit,
+            $"threshold {table.PowerThreshold}: output bit for input pattern {pattern}");
+        output.Power.ShouldBe(expectedPower, PowerTolerance,
+            $"threshold {table.PowerThreshold}: raw power for input pattern {pattern}");
+    }
+}

--- a/examples/Logic Gate AND-from-NAND.lun
+++ b/examples/Logic Gate AND-from-NAND.lun
@@ -1,0 +1,478 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "AND from NAND Gate",
+        "Description": "AND built from gates, not from a new circuit: the NAND stage of 'Logic Gate NOT-NAND' (A and B combined into one beam at +45°, BIAS shifted 135° so it reaches the recombine coupler at +225° and cancels A·B) feeds a second inverter stage with its own bias — AND = NOT(NAND(A,B)). Cascading is the hard part of the NAND game: passive linear optics has no gain and no level restoration, so a logic 1 leaves stage 1 weakened — resting power 0.5 for (0,0), 0.25 for a single input — and each row at a different phase (225°, 270°, 180°). No single second bias can cancel all three; it can only be weighted toward one compromise. BIAS2 passes a 315° phase shifter into the inverter coupler's cross port (+90°), arriving at +45°, exactly anti-phase to the resting NAND output, and the inverter coupling ratio is set to 33.3% so the BIAS2 amplitude at Y (√(1/3)) exactly matches the weakened resting signal (√(2/3)·√0.5): (0,0) extinguishes to raw power 0. The single-input rows cancel only partially, resting at 1/6 ≈ 0.166667 each, and (1,1) — no signal left at all — lets BIAS2 pass at 1/3 ≈ 0.333333. Threshold 0.25 sits midway between 1/6 and 1/3 and reads the AND table 0,0,0,1. Honesty check: the darkest 1 is exactly 2× the brightest 0 — the best this passive-linear two-stage cascade can reach; wider margins need level restoration between stages (a nonlinear threshold or gain element, roadmap rung 4). Mark BIAS and BIAS2 as bias pins so both stay 'on' in every row without getting their own columns.",
+        "Identifier": "group_acc23971a5da41159f29",
+        "IdGuid": "b9e9f05f-b851-4203-aac9-6527bf8f56ee",
+        "ChildComponentGuids": [
+          "21ea203b-6955-4346-967f-5b9d2d5e06c1",
+          "f1238395-1ffa-4da3-bc87-9c948f1f818d",
+          "8fa47b37-d2d7-47ce-a174-b30c443e0a6f",
+          "9e44a174-10ee-45da-9d3f-ba2224d964fe",
+          "56e46bda-9d4f-43d4-9778-0f31890d87e3",
+          "2e54d388-552e-40d5-945d-8c98591762c6",
+          "f442c843-a568-4c03-b6f1-9771b8a07d97",
+          "b4df13a8-c67e-437e-8f25-52e91b98cc09",
+          "edc2b43f-05be-4f06-b6c5-89f5a4fe7f84"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 95,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_a",
+          "input_b",
+          "combine",
+          "phase_nand",
+          "recombine",
+          "link",
+          "phase_inv",
+          "invert",
+          "output"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "f2663292-6464-4e34-8667-02939f08c380",
+            "StartComponentId": "input_a",
+            "StartComponentGuid": "21ea203b-6955-4346-967f-5b9d2d5e06c1",
+            "StartPinName": "b0",
+            "EndComponentId": "combine",
+            "EndComponentGuid": "8fa47b37-d2d7-47ce-a174-b30c443e0a6f",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "0f80866a-d8fc-48de-a2dc-0889d3155723",
+            "StartComponentId": "input_b",
+            "StartComponentGuid": "f1238395-1ffa-4da3-bc87-9c948f1f818d",
+            "StartPinName": "b0",
+            "EndComponentId": "combine",
+            "EndComponentGuid": "8fa47b37-d2d7-47ce-a174-b30c443e0a6f",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "8a4c010d-c4a5-44b6-85b1-28b075dbd440",
+            "StartComponentId": "combine",
+            "StartComponentGuid": "8fa47b37-d2d7-47ce-a174-b30c443e0a6f",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine",
+            "EndComponentGuid": "56e46bda-9d4f-43d4-9778-0f31890d87e3",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "def3314b-a28d-45d2-ab5d-7224267af857",
+            "StartComponentId": "phase_nand",
+            "StartComponentGuid": "9e44a174-10ee-45da-9d3f-ba2224d964fe",
+            "StartPinName": "out",
+            "EndComponentId": "recombine",
+            "EndComponentGuid": "56e46bda-9d4f-43d4-9778-0f31890d87e3",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "69444577-2a16-47eb-bad2-1d1c570b4268",
+            "StartComponentId": "recombine",
+            "StartComponentGuid": "56e46bda-9d4f-43d4-9778-0f31890d87e3",
+            "StartPinName": "out1",
+            "EndComponentId": "link",
+            "EndComponentGuid": "2e54d388-552e-40d5-945d-8c98591762c6",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "d15cd2ff-28a2-4a9a-bc7a-d595173415e7",
+            "StartComponentId": "link",
+            "StartComponentGuid": "2e54d388-552e-40d5-945d-8c98591762c6",
+            "StartPinName": "b0",
+            "EndComponentId": "invert",
+            "EndComponentGuid": "b4df13a8-c67e-437e-8f25-52e91b98cc09",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1860,
+                "StartY": 123.5,
+                "EndX": 2965,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "564eb7dd-9213-45ac-a2d0-b93df4d2fe68",
+            "StartComponentId": "phase_inv",
+            "StartComponentGuid": "f442c843-a568-4c03-b6f1-9771b8a07d97",
+            "StartPinName": "out",
+            "EndComponentId": "invert",
+            "EndComponentGuid": "b4df13a8-c67e-437e-8f25-52e91b98cc09",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 2960,
+                "StartY": 131.5,
+                "EndX": 2965,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f5ec620e-71b0-4ea8-bd84-6c64233021a8",
+            "StartComponentId": "invert",
+            "StartComponentGuid": "b4df13a8-c67e-437e-8f25-52e91b98cc09",
+            "StartPinName": "out1",
+            "EndComponentId": "output",
+            "EndComponentGuid": "edc2b43f-05be-4f06-b6c5-89f5a4fe7f84",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 3215,
+                "StartY": 123.5,
+                "EndX": 3220,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "5c700c6e-2fa8-4a40-a495-a1284e5ceeed",
+            "Name": "A",
+            "InternalComponentId": "input_a",
+            "InternalComponentGuid": "21ea203b-6955-4346-967f-5b9d2d5e06c1",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "01bc2e53-86aa-43b2-aef4-c9f70984a321",
+            "Name": "B",
+            "InternalComponentId": "input_b",
+            "InternalComponentGuid": "f1238395-1ffa-4da3-bc87-9c948f1f818d",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "31a22cb4-d13f-4a4f-b899-e60ed7d8e02b",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_nand",
+            "InternalComponentGuid": "9e44a174-10ee-45da-9d3f-ba2224d964fe",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "2472004d-3d74-467b-8ee3-5c45c2b36fc1",
+            "Name": "BIAS2",
+            "InternalComponentId": "phase_inv",
+            "InternalComponentGuid": "f442c843-a568-4c03-b6f1-9771b8a07d97",
+            "InternalPinName": "in",
+            "RelativeX": 2365,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "738d46f3-20bc-49b7-b71c-ad61a0e4ed95",
+            "Name": "Y",
+            "InternalComponentId": "output",
+            "InternalComponentGuid": "edc2b43f-05be-4f06-b6c5-89f5a4fe7f84",
+            "InternalPinName": "b0",
+            "RelativeX": 3225,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_a",
+          "ComponentGuid": "21ea203b-6955-4346-967f-5b9d2d5e06c1",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_b",
+          "ComponentGuid": "f1238395-1ffa-4da3-bc87-9c948f1f818d",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine",
+          "ComponentGuid": "8fa47b37-d2d7-47ce-a174-b30c443e0a6f",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_nand",
+          "ComponentGuid": "9e44a174-10ee-45da-9d3f-ba2224d964fe",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine",
+          "ComponentGuid": "56e46bda-9d4f-43d4-9778-0f31890d87e3",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "link",
+          "ComponentGuid": "2e54d388-552e-40d5-945d-8c98591762c6",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "phase_inv",
+          "ComponentGuid": "f442c843-a568-4c03-b6f1-9771b8a07d97",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 2460,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 315,
+          "SliderValues": {
+            "0": 315
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "invert",
+          "ComponentGuid": "b4df13a8-c67e-437e-8f25-52e91b98cc09",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 2965,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 33.33333333333333
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output",
+          "ComponentGuid": "edc2b43f-05be-4f06-b6c5-89f5a4fe7f84",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 3220,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 95,
+      "CanvasY": 100
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-16",
+      "Modified": "2026-08-16T12:00:00.0000000Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}


### PR DESCRIPTION
## What & why

Issue #971 (NAND game #537, rung 4) asks the cascade-honesty question: can a two-stage passive cascade carry a clean AND — AND = NOT(NAND(A,B))?

This PR ships **option 3 from #967**:

- **`examples/Logic Gate AND-from-NAND.lun`** — one outer group "AND from NAND Gate": the NAND stage topology from `Logic Gate NOT-NAND.lun` feeds a second inverter stage with its own bias (BIAS2 → 315° phase shifter → cross port of an inverter coupler whose coupling ratio is set to 33.3%). Nine Demo-PDK components, eight internal routes, external pins A, B, BIAS, BIAS2, Y.
- **Integration test** `UnitTests/Integration/LogicGateAndFromNandExampleTests.cs` over the real load path (pattern: `LogicGateNotNandExampleTests.cs`): structure/pin checks, AND table `0,0,0,1` at threshold **0.25**, **all raw powers pinned ±1e-6** (0, 1/6, 1/6, 1/3), plus the margin assertion and a no-second-bias control (cascade degrades to NOR — the second bias is what inverts).
- **Education text in the group description**: why cascading is hard (no gain / no level restoration in passive linear optics; each NAND row leaves stage 1 at a different amplitude *and* phase: 0.5∠225°, 0.5∠270°, 0.5∠180°), how BIAS2 is weighted (√(1/3) amplitude, arriving at +45°, exactly anti-phase to the resting (0,0) output → full extinction), and why threshold 0.25 (midway between 1/6 and 1/3).

## Honesty check (the important part)

A stable threshold **exists**: the darkest 1 (1/3) is **exactly 2×** the brightest 0 (1/6) — which is the provable optimum for this passive-linear two-stage topology (the margin ratio peaks at coupling ratio 1/3, bias phase 315°; any other weighting does worse). The gate is therefore shipped — not fragile, but at the honest edge of passive linear optics, and the description says so. What the behavioral layer (roadmap rung 4: thresholds / delays / level restoration) must deliver for wider margins: regenerate the level to full amplitude between stages (nonlinear threshold or gain element) so stage 2 sees a restored logic 1 instead of 0.5/0.25 leftovers.

## How it was tested

Fully headless: TruthTableExtractor over the outer group via the real `.lun` load path; no UI changes.

Local suite: 5727 passed, 0 failed

## Manual verification after vacation

1. Open `examples/Logic Gate AND-from-NAND.lun` in the app.
2. Select the "AND from NAND Gate" group and open the Truth-Table panel.
3. Choose inputs A, B, output Y, mark BIAS and BIAS2 as bias pins (bias selection in the panel ships with #968), threshold 0.25.
4. Expected table: `0,0,0,1` with raw powers 0, ≈0.166667, ≈0.166667, ≈0.333333.
5. Repeat with only BIAS as bias pin: the table reads NOR (`1,0,0,0`) — the panel lesson for what the second bias does.