### PR TITLE
Agent: Logic-level gate model + network evaluator — rung 4 behavioral layer (#977)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicGateModel.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicGateModel.cs
@@ -1,0 +1,141 @@
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Immutable logic-level model of one gate: its input pin names, its output pin
+/// names, and the <see cref="Analysis.LogicAnalysis.TruthTable"/> a
+/// <see cref="TruthTableExtractor"/> produced for the grouped photonic circuit.
+/// Evaluating the model is a pure table lookup — no re-simulation — and every
+/// output is a clean bit, so a network of these models restores ideal logic
+/// levels at every stage by construction.
+/// </summary>
+public sealed class LogicGateModel
+{
+    private LogicGateModel(TruthTable table)
+    {
+        TruthTable = table;
+        GateName = table.GroupName;
+        InputPinNames = table.InputPinNames;
+        OutputPinNames = table.OutputPinNames;
+    }
+
+    /// <summary>Name of the gate — the group the truth table was extracted from.</summary>
+    public string GateName { get; }
+
+    /// <summary>Logic input pin names, in the bit order of the truth table rows.</summary>
+    public IReadOnlyList<string> InputPinNames { get; }
+
+    /// <summary>Logic output pin names.</summary>
+    public IReadOnlyList<string> OutputPinNames { get; }
+
+    /// <summary>The extracted truth table backing this model, raw powers included.</summary>
+    public TruthTable TruthTable { get; }
+
+    /// <summary>
+    /// Wraps an extracted truth table as an evaluable gate model, verifying the
+    /// table is complete and self-consistent: exactly 2^input rows in binary
+    /// counting order, every row carrying exactly the declared input and output pins.
+    /// </summary>
+    /// <param name="table">The truth table as produced by <see cref="TruthTableExtractor"/>.</param>
+    /// <returns>The immutable gate model.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="table"/> is null.</exception>
+    /// <exception cref="ArgumentException">The table is incomplete or inconsistent.</exception>
+    public static LogicGateModel FromTruthTable(TruthTable table)
+    {
+        if (table == null) throw new ArgumentNullException(nameof(table));
+        ValidatePinNames(table);
+        ValidateRows(table);
+        return new LogicGateModel(table);
+    }
+
+    /// <summary>
+    /// Looks up the gate's output bits for one input combination — a pure table
+    /// read, so the results are clean bits with ideal level restoration.
+    /// </summary>
+    /// <param name="inputBits">One bit per declared input pin name.</param>
+    /// <returns>The output bit per declared output pin name.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="inputBits"/> is null.</exception>
+    /// <exception cref="ArgumentException">A declared input bit is missing or an unknown pin is passed.</exception>
+    public IReadOnlyDictionary<string, bool> Evaluate(IReadOnlyDictionary<string, bool> inputBits)
+    {
+        if (inputBits == null) throw new ArgumentNullException(nameof(inputBits));
+
+        var pattern = 0;
+        for (var i = 0; i < InputPinNames.Count; i++)
+        {
+            if (!inputBits.TryGetValue(InputPinNames[i], out var bit))
+                throw new ArgumentException(
+                    $"Gate '{GateName}' is missing a bit for input pin '{InputPinNames[i]}'. " +
+                    $"Required inputs: {string.Join(", ", InputPinNames)}.",
+                    nameof(inputBits));
+            if (bit) pattern |= 1 << i;
+        }
+
+        var unknown = inputBits.Keys.Except(InputPinNames).FirstOrDefault();
+        if (unknown != null)
+            throw new ArgumentException(
+                $"Gate '{GateName}' has no input pin named '{unknown}'. " +
+                $"Available inputs: {string.Join(", ", InputPinNames)}.",
+                nameof(inputBits));
+
+        return TruthTable.Rows[pattern].Outputs.ToDictionary(
+            pair => pair.Key, pair => pair.Value.IsOne);
+    }
+
+    /// <summary>Rejects empty or duplicated pin declarations before any row is inspected.</summary>
+    private static void ValidatePinNames(TruthTable table)
+    {
+        if (table.InputPinNames.Count == 0)
+            throw new ArgumentException(
+                $"Truth table of group '{table.GroupName}' declares no input pins.", nameof(table));
+        if (table.OutputPinNames.Count == 0)
+            throw new ArgumentException(
+                $"Truth table of group '{table.GroupName}' declares no output pins.", nameof(table));
+
+        var duplicate = table.InputPinNames.Concat(table.OutputPinNames)
+            .GroupBy(name => name).FirstOrDefault(group => group.Count() > 1)?.Key;
+        if (duplicate != null)
+            throw new ArgumentException(
+                $"Truth table of group '{table.GroupName}' declares pin '{duplicate}' more than once.",
+                nameof(table));
+    }
+
+    /// <summary>
+    /// Verifies the row count matches 2^inputs and that every row sits at its
+    /// binary-counting index with exactly the declared pins — the ordering
+    /// contract <see cref="Evaluate"/> relies on for its direct index lookup.
+    /// </summary>
+    private static void ValidateRows(TruthTable table)
+    {
+        var expectedRows = 1 << table.InputPinNames.Count;
+        if (table.Rows.Count != expectedRows)
+            throw new ArgumentException(
+                $"Truth table of group '{table.GroupName}' has {table.Rows.Count} rows but " +
+                $"{table.InputPinNames.Count} inputs require exactly {expectedRows}.",
+                nameof(table));
+
+        for (var pattern = 0; pattern < expectedRows; pattern++)
+        {
+            var row = table.Rows[pattern];
+            if (row.InputBits.Count != table.InputPinNames.Count)
+                throw new ArgumentException(
+                    $"Row {pattern} of group '{table.GroupName}' carries {row.InputBits.Count} input bits " +
+                    $"but the table declares {table.InputPinNames.Count} input pins.",
+                    nameof(table));
+            for (var i = 0; i < table.InputPinNames.Count; i++)
+            {
+                var pin = table.InputPinNames[i];
+                if (!row.InputBits.TryGetValue(pin, out var bit) || bit != ((pattern & (1 << i)) != 0))
+                    throw new ArgumentException(
+                        $"Row {pattern} of group '{table.GroupName}' does not carry input pin '{pin}' " +
+                        "at its binary-counting level — rows must be in binary counting order.",
+                        nameof(table));
+            }
+
+            var missingOutput = table.OutputPinNames.FirstOrDefault(pin => !row.Outputs.ContainsKey(pin));
+            if (missingOutput != null)
+                throw new ArgumentException(
+                    $"Row {pattern} of group '{table.GroupName}' carries no value for output pin '{missingOutput}'.",
+                    nameof(table));
+        }
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNet.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNet.cs
@@ -1,0 +1,22 @@
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>One endpoint of a logic net: one pin of one gate instance in the network.</summary>
+/// <param name="GateId">The network-local id of the gate instance.</param>
+/// <param name="PinName">The pin name on that gate.</param>
+public sealed record LogicPinRef(string GateId, string PinName);
+
+/// <summary>The driver of a gate input pin: a network-level input or another gate's output.</summary>
+public abstract record LogicNetDriver
+{
+    private LogicNetDriver()
+    {
+    }
+
+    /// <summary>A network-level input pin drives the gate input.</summary>
+    /// <param name="PinName">The network input pin name.</param>
+    public sealed record NetworkInput(string PinName) : LogicNetDriver;
+
+    /// <summary>An output pin of another gate instance drives the gate input.</summary>
+    /// <param name="Pin">The driving gate output pin.</param>
+    public sealed record GateOutput(LogicPinRef Pin) : LogicNetDriver;
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Validation.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Validation.cs
@@ -1,0 +1,128 @@
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Structural validation half of <see cref="LogicNetworkEvaluator"/>: every check
+/// runs once at construction, so an invalid network never reaches evaluation.
+/// </summary>
+public sealed partial class LogicNetworkEvaluator
+{
+    /// <summary>Rejects an empty network input list or duplicated input names.</summary>
+    private void ValidateNetworkInputs()
+    {
+        if (InputPinNames.Count == 0)
+            throw new ArgumentException("A logic network needs at least one input pin.", nameof(InputPinNames));
+        var duplicate = InputPinNames.GroupBy(name => name).FirstOrDefault(group => group.Count() > 1)?.Key;
+        if (duplicate != null)
+            throw new ArgumentException($"Network input '{duplicate}' is declared more than once.", nameof(InputPinNames));
+    }
+
+    /// <summary>Rejects an empty gate list or null gate instances.</summary>
+    private void ValidateGates()
+    {
+        if (Gates.Count == 0)
+            throw new ArgumentException("A logic network needs at least one gate.", nameof(Gates));
+        var nullGate = Gates.FirstOrDefault(pair => pair.Value == null).Key;
+        if (nullGate != null)
+            throw new ArgumentException($"Gate '{nullGate}' is null.", nameof(Gates));
+    }
+
+    /// <summary>
+    /// Verifies every wiring endpoint: loads must be real input pins of real gates,
+    /// drivers must be declared network inputs or real output pins of real gates,
+    /// and every gate input pin must be driven exactly once.
+    /// </summary>
+    private void ValidateWiring()
+    {
+        foreach (var (load, driver) in _inputWiring)
+        {
+            var gate = LookupGate(load.GateId, "Wiring targets");
+            if (!gate.InputPinNames.Contains(load.PinName))
+                throw new ArgumentException(
+                    $"Gate '{load.GateId}' has no input pin '{load.PinName}'. " +
+                    $"Available inputs: {string.Join(", ", gate.InputPinNames)}.",
+                    nameof(_inputWiring));
+            ValidateDriver(driver);
+        }
+
+        foreach (var (gateId, gate) in Gates)
+        {
+            var undriven = gate.InputPinNames
+                .Where(pin => !_inputWiring.ContainsKey(new LogicPinRef(gateId, pin)))
+                .ToList();
+            if (undriven.Count > 0)
+                throw new ArgumentException(
+                    $"Gate '{gateId}' has undriven input pins: {string.Join(", ", undriven)}. " +
+                    "Every gate input must be wired exactly once.",
+                    nameof(_inputWiring));
+        }
+    }
+
+    /// <summary>Verifies one driver endpoint against the declared network inputs and gates.</summary>
+    private void ValidateDriver(LogicNetDriver driver)
+    {
+        switch (driver)
+        {
+            case LogicNetDriver.NetworkInput input:
+                if (!InputPinNames.Contains(input.PinName))
+                    throw new ArgumentException(
+                        $"The network has no input pin '{input.PinName}'. " +
+                        $"Declared inputs: {string.Join(", ", InputPinNames)}.",
+                        nameof(_inputWiring));
+                break;
+            case LogicNetDriver.GateOutput source:
+                var gate = LookupGate(source.Pin.GateId, "Wiring drives from");
+                if (!gate.OutputPinNames.Contains(source.Pin.PinName))
+                    throw new ArgumentException(
+                        $"Gate '{source.Pin.GateId}' has no output pin '{source.Pin.PinName}'. " +
+                        $"Available outputs: {string.Join(", ", gate.OutputPinNames)}.",
+                        nameof(_inputWiring));
+                break;
+            default:
+                throw new ArgumentException(
+                    $"Unsupported driver type '{driver.GetType().Name}'.", nameof(_inputWiring));
+        }
+    }
+
+    /// <summary>Verifies every network output taps a real output pin of a real gate.</summary>
+    private void ValidateOutputTaps()
+    {
+        if (_outputTaps.Count == 0)
+            throw new ArgumentException("A logic network needs at least one output.", nameof(_outputTaps));
+        foreach (var (outputName, tap) in _outputTaps)
+        {
+            var gate = LookupGate(tap.GateId, $"Network output '{outputName}' taps");
+            if (!gate.OutputPinNames.Contains(tap.PinName))
+                throw new ArgumentException(
+                    $"Network output '{outputName}' taps pin '{tap.PinName}' of gate '{tap.GateId}', " +
+                    $"which is not an output of that gate. Available outputs: {string.Join(", ", gate.OutputPinNames)}.",
+                    nameof(_outputTaps));
+        }
+    }
+
+    /// <summary>Returns the gate behind an id or throws a readable error naming the lookup context.</summary>
+    private LogicGateModel LookupGate(string gateId, string context)
+    {
+        if (Gates.TryGetValue(gateId, out var gate))
+            return gate;
+        throw new ArgumentException(
+            $"{context} unknown gate '{gateId}'. Known gates: {string.Join(", ", Gates.Keys)}.",
+            nameof(_inputWiring));
+    }
+
+    /// <summary>Rejects missing or unknown network input bits before any gate fires.</summary>
+    private void ValidateInputBits(IReadOnlyDictionary<string, bool> inputBits)
+    {
+        var missing = InputPinNames.FirstOrDefault(name => !inputBits.ContainsKey(name));
+        if (missing != null)
+            throw new ArgumentException(
+                $"No bit provided for network input '{missing}'. " +
+                $"Required inputs: {string.Join(", ", InputPinNames)}.",
+                nameof(inputBits));
+        var unknown = inputBits.Keys.Except(InputPinNames).FirstOrDefault();
+        if (unknown != null)
+            throw new ArgumentException(
+                $"The network has no input pin '{unknown}'. " +
+                $"Declared inputs: {string.Join(", ", InputPinNames)}.",
+                nameof(inputBits));
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
@@ -1,0 +1,139 @@
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Evaluates a combinational network of <see cref="LogicGateModel"/> instances:
+/// gates wired output→input as a simple net list of (gateId, pin) pairs. The
+/// network is validated and topologically ordered once at construction — cycles
+/// are rejected with a clear exception, since sequential logic is a later rung —
+/// and <see cref="Evaluate"/> then walks the gates in dependency order. Every
+/// stage output is a clean bit taken from the gate's truth table, so the network
+/// has ideal level restoration by construction: arbitrary cascade depth works,
+/// exactly what the passive-linear layer cannot do.
+/// </summary>
+public sealed partial class LogicNetworkEvaluator
+{
+    private readonly IReadOnlyDictionary<LogicPinRef, LogicNetDriver> _inputWiring;
+    private readonly IReadOnlyDictionary<string, LogicPinRef> _outputTaps;
+    private readonly IReadOnlyList<string> _evaluationOrder;
+
+    /// <summary>
+    /// Assembles and validates a combinational logic network.
+    /// </summary>
+    /// <param name="inputPinNames">Network-level input pin names (at least one, no duplicates).</param>
+    /// <param name="gates">The gate instances of the network, keyed by their network-local id.</param>
+    /// <param name="inputWiring">
+    /// The driver of every gate input pin, keyed by (gateId, inputPin). Every input pin of
+    /// every gate must appear exactly once; fan-out of a driver to several loads is allowed.
+    /// </param>
+    /// <param name="outputTaps">Network-level output names, each tapping one gate output pin.</param>
+    /// <exception cref="ArgumentException">
+    /// A gate, pin, or network input is unknown; a gate input is left undriven; or the
+    /// wiring is otherwise inconsistent. The message names the offending element.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">The wiring forms a cycle.</exception>
+    public LogicNetworkEvaluator(
+        IReadOnlyList<string> inputPinNames,
+        IReadOnlyDictionary<string, LogicGateModel> gates,
+        IReadOnlyDictionary<LogicPinRef, LogicNetDriver> inputWiring,
+        IReadOnlyDictionary<string, LogicPinRef> outputTaps)
+    {
+        InputPinNames = inputPinNames ?? throw new ArgumentNullException(nameof(inputPinNames));
+        Gates = gates ?? throw new ArgumentNullException(nameof(gates));
+        _inputWiring = inputWiring ?? throw new ArgumentNullException(nameof(inputWiring));
+        _outputTaps = outputTaps ?? throw new ArgumentNullException(nameof(outputTaps));
+
+        ValidateNetworkInputs();
+        ValidateGates();
+        ValidateWiring();
+        ValidateOutputTaps();
+        _evaluationOrder = TopologicalOrder();
+    }
+
+    /// <summary>Network-level input pin names.</summary>
+    public IReadOnlyList<string> InputPinNames { get; }
+
+    /// <summary>The gate instances of the network, keyed by their network-local id.</summary>
+    public IReadOnlyDictionary<string, LogicGateModel> Gates { get; }
+
+    /// <summary>Network-level output names, in declaration order.</summary>
+    public IReadOnlyList<string> OutputPinNames => _outputTaps.Keys.ToList();
+
+    /// <summary>
+    /// Evaluates the network for one input combination: every gate fires exactly
+    /// once in topological order, reading clean bits and producing clean bits.
+    /// </summary>
+    /// <param name="inputBits">One bit per network-level input pin name.</param>
+    /// <returns>The bit of every network-level output.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="inputBits"/> is null.</exception>
+    /// <exception cref="ArgumentException">A network input bit is missing or an unknown pin is passed.</exception>
+    public IReadOnlyDictionary<string, bool> Evaluate(IReadOnlyDictionary<string, bool> inputBits)
+    {
+        if (inputBits == null) throw new ArgumentNullException(nameof(inputBits));
+        ValidateInputBits(inputBits);
+
+        var gateOutputs = new Dictionary<LogicPinRef, bool>();
+        foreach (var gateId in _evaluationOrder)
+        {
+            var gate = Gates[gateId];
+            var gateInputBits = new Dictionary<string, bool>(gate.InputPinNames.Count);
+            foreach (var pinName in gate.InputPinNames)
+            {
+                gateInputBits[pinName] = ResolveDriverBit(
+                    _inputWiring[new LogicPinRef(gateId, pinName)], inputBits, gateOutputs);
+            }
+
+            foreach (var (pinName, bit) in gate.Evaluate(gateInputBits))
+            {
+                gateOutputs[new LogicPinRef(gateId, pinName)] = bit;
+            }
+        }
+
+        return _outputTaps.ToDictionary(tap => tap.Key, tap => gateOutputs[tap.Value]);
+    }
+
+    /// <summary>Resolves one driver to its current bit: a network input bit or an already-evaluated gate output.</summary>
+    private static bool ResolveDriverBit(
+        LogicNetDriver driver,
+        IReadOnlyDictionary<string, bool> inputBits,
+        IReadOnlyDictionary<LogicPinRef, bool> gateOutputs) =>
+        driver switch
+        {
+            LogicNetDriver.NetworkInput input => inputBits[input.PinName],
+            LogicNetDriver.GateOutput source => gateOutputs[source.Pin],
+            _ => throw new InvalidOperationException($"Unsupported driver type '{driver.GetType().Name}'."),
+        };
+
+    /// <summary>
+    /// Orders the gates so every gate fires only after all gates driving its inputs
+    /// have fired (Kahn's algorithm). A network that cannot be fully ordered contains
+    /// a cycle — sequential logic, which this combinational evaluator rejects.
+    /// </summary>
+    private IReadOnlyList<string> TopologicalOrder()
+    {
+        var dependencies = Gates.Keys.ToDictionary(id => id, _ => new HashSet<string>());
+        foreach (var (load, driver) in _inputWiring)
+        {
+            if (driver is LogicNetDriver.GateOutput source)
+                dependencies[load.GateId].Add(source.Pin.GateId);
+        }
+
+        var order = new List<string>(Gates.Count);
+        var resolved = new HashSet<string>();
+        var remaining = Gates.Keys.ToList();
+        while (remaining.Count > 0)
+        {
+            var ready = remaining.Where(id => dependencies[id].IsSubsetOf(resolved)).ToList();
+            if (ready.Count == 0)
+                throw new InvalidOperationException(
+                    $"The logic network contains a cycle involving gates: {string.Join(", ", remaining)}. " +
+                    "Only combinational networks (DAGs) can be evaluated; sequential logic is not supported.");
+            foreach (var id in ready)
+            {
+                order.Add(id);
+                resolved.Add(id);
+                remaining.Remove(id);
+            }
+        }
+        return order;
+    }
+}

--- a/UnitTests/Analysis/LogicAnalysis/LogicGateModelTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicGateModelTests.cs
@@ -1,0 +1,136 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The logic-level gate model: a truth table wrapped as an evaluable gate whose
+/// outputs are clean bits by construction. Covers the pinned NAND table, the
+/// table-consistency validation, and the input-bit error paths.
+/// </summary>
+public class LogicGateModelTests
+{
+    [Fact]
+    public void FromTruthTable_PinnedNandTable_ExposesTheGateInterface()
+    {
+        var table = PinnedGateTables.Nand();
+
+        var gate = LogicGateModel.FromTruthTable(table);
+
+        gate.GateName.ShouldBe("NOT/NAND Gate");
+        gate.InputPinNames.ShouldBe(new[] { "A", "B" });
+        gate.OutputPinNames.ShouldBe(new[] { "Y" });
+        gate.TruthTable.ShouldBeSameAs(table);
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, false)]
+    public void Evaluate_PinnedNandGate_ReturnsCleanBitsForEveryCombination(bool a, bool b, bool expected)
+    {
+        var gate = PinnedGateTables.NandGate();
+
+        var outputs = gate.Evaluate(new Dictionary<string, bool> { ["A"] = a, ["B"] = b });
+
+        outputs.ShouldBe(new Dictionary<string, bool> { ["Y"] = expected });
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void Evaluate_PinnedNotGate_InvertsTheInput(bool a, bool expected)
+    {
+        var gate = PinnedGateTables.NotGate();
+
+        gate.Evaluate(new Dictionary<string, bool> { ["A"] = a })["Y"].ShouldBe(expected);
+    }
+
+    [Fact]
+    public void FromTruthTable_NullTable_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => LogicGateModel.FromTruthTable(null!));
+    }
+
+    [Fact]
+    public void FromTruthTable_RowCountMismatch_Throws()
+    {
+        var table = PinnedGateTables.Nand();
+        var broken = new TruthTable(
+            table.GroupName, table.InputPinNames, table.OutputPinNames, table.BiasPinNames,
+            table.PowerThreshold, table.WavelengthNm, table.Rows.Take(3).ToArray());
+
+        var error = Should.Throw<ArgumentException>(() => LogicGateModel.FromTruthTable(broken));
+
+        error.Message.ShouldContain("3 rows");
+        error.Message.ShouldContain("require exactly 4");
+    }
+
+    [Fact]
+    public void FromTruthTable_RowOutOfBinaryCountingOrder_Throws()
+    {
+        var table = PinnedGateTables.Nand();
+        var swapped = new[] { table.Rows[0], table.Rows[2], table.Rows[1], table.Rows[3] };
+        var broken = new TruthTable(
+            table.GroupName, table.InputPinNames, table.OutputPinNames, table.BiasPinNames,
+            table.PowerThreshold, table.WavelengthNm, swapped);
+
+        var error = Should.Throw<ArgumentException>(() => LogicGateModel.FromTruthTable(broken));
+
+        error.Message.ShouldContain("binary counting order");
+    }
+
+    [Fact]
+    public void FromTruthTable_RowMissingAnOutput_Throws()
+    {
+        var table = PinnedGateTables.Nand();
+        var rowWithoutOutput = new TruthTableRow(
+            table.Rows[0].InputBits, new Dictionary<string, LogicOutputValue>());
+        var brokenRows = new[] { rowWithoutOutput, table.Rows[1], table.Rows[2], table.Rows[3] };
+        var broken = new TruthTable(
+            table.GroupName, table.InputPinNames, table.OutputPinNames, table.BiasPinNames,
+            table.PowerThreshold, table.WavelengthNm, brokenRows);
+
+        var error = Should.Throw<ArgumentException>(() => LogicGateModel.FromTruthTable(broken));
+
+        error.Message.ShouldContain("output pin 'Y'");
+    }
+
+    [Fact]
+    public void FromTruthTable_DuplicatePinDeclaration_Throws()
+    {
+        var table = PinnedGateTables.Not();
+        var broken = new TruthTable(
+            table.GroupName, new[] { "A", "A" }, table.OutputPinNames, table.BiasPinNames,
+            table.PowerThreshold, table.WavelengthNm, table.Rows);
+
+        var error = Should.Throw<ArgumentException>(() => LogicGateModel.FromTruthTable(broken));
+
+        error.Message.ShouldContain("'A' more than once");
+    }
+
+    [Fact]
+    public void Evaluate_MissingInputBit_ThrowsNamingThePin()
+    {
+        var gate = PinnedGateTables.NandGate();
+
+        var error = Should.Throw<ArgumentException>(
+            () => gate.Evaluate(new Dictionary<string, bool> { ["A"] = true }));
+
+        error.Message.ShouldContain("'B'");
+        error.Message.ShouldContain("Required inputs: A, B");
+    }
+
+    [Fact]
+    public void Evaluate_UnknownInputPin_ThrowsNamingThePin()
+    {
+        var gate = PinnedGateTables.NandGate();
+
+        var error = Should.Throw<ArgumentException>(
+            () => gate.Evaluate(new Dictionary<string, bool> { ["A"] = true, ["B"] = false, ["C"] = true }));
+
+        error.Message.ShouldContain("no input pin named 'C'");
+    }
+}

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkEvaluatorTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkEvaluatorTests.cs
@@ -1,0 +1,280 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The logic-level network evaluator: gates from the pinned NAND/NOT tables
+/// composed into bigger circuits — AND = NOT(NAND), OR = NAND(NOT a, NOT b), and
+/// a four-stage inverter chain. Every stage output is a clean bit, so arbitrary
+/// cascade depth works at the logic layer, exactly what the passive-linear layer
+/// cannot do (its margin tops out at 2× after two stages). Also covers cycle
+/// detection and the wiring error paths.
+/// </summary>
+public class LogicNetworkEvaluatorTests
+{
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, true)]
+    public void Evaluate_AndFromNandFeedingNot_MatchesTheAndTruthTable(bool a, bool b, bool expected)
+    {
+        var network = new LogicNetworkEvaluator(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["nand"] = PinnedGateTables.NandGate(),
+                ["inv"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("nand", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "Y") });
+
+        network.Evaluate(Bits(("a", a), ("b", b))).ShouldBe(Bits(("y", expected)));
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public void Evaluate_OrFromNandWithInvertedInputs_MatchesTheOrTruthTable(bool a, bool b, bool expected)
+    {
+        var network = new LogicNetworkEvaluator(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["notA"] = PinnedGateTables.NotGate(),
+                ["notB"] = PinnedGateTables.NotGate(),
+                ["nand"] = PinnedGateTables.NandGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("notA", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("notB", "A")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("notA", "Y")),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("notB", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") });
+
+        network.Evaluate(Bits(("a", a), ("b", b))).ShouldBe(Bits(("y", expected)));
+    }
+
+    [Theory]
+    [InlineData(false, new[] { true, false, true, false })]
+    [InlineData(true, new[] { false, true, false, true })]
+    public void Evaluate_FourStageNotChain_RestoresCleanLevelsAtEveryStage(bool x, bool[] expectedStages)
+    {
+        var wiring = new Dictionary<LogicPinRef, LogicNetDriver>
+        {
+            [new LogicPinRef("stage1", "A")] = new LogicNetDriver.NetworkInput("x"),
+        };
+        var taps = new Dictionary<string, LogicPinRef>();
+        for (var stage = 1; stage <= 4; stage++)
+        {
+            if (stage > 1)
+                wiring[new LogicPinRef($"stage{stage}", "A")] =
+                    new LogicNetDriver.GateOutput(new LogicPinRef($"stage{stage - 1}", "Y"));
+            taps[$"y{stage}"] = new LogicPinRef($"stage{stage}", "Y");
+        }
+
+        var network = new LogicNetworkEvaluator(
+            new[] { "x" },
+            Enumerable.Range(1, 4).ToDictionary(stage => $"stage{stage}", _ => PinnedGateTables.NotGate()),
+            wiring,
+            taps);
+
+        var outputs = network.Evaluate(Bits(("x", x)));
+
+        for (var stage = 1; stage <= 4; stage++)
+            outputs[$"y{stage}"].ShouldBe(expectedStages[stage - 1],
+                $"stage {stage} output is a clean bit — ideal level restoration at any cascade depth");
+        outputs["y4"].ShouldBe(x, "four inversions restore the input exactly");
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void Evaluate_NetworkInputFannedOutToBothNandInputs_ActsAsNot(bool a, bool expected)
+    {
+        var network = new LogicNetworkEvaluator(
+            new[] { "a" },
+            new Dictionary<string, LogicGateModel> { ["nand"] = PinnedGateTables.NandGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.NetworkInput("a"),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") });
+
+        network.Evaluate(Bits(("a", a))).ShouldBe(Bits(("y", expected)));
+    }
+
+    [Fact]
+    public void Constructor_CrossWiredGates_ThrowsCycleErrorInsteadOfHanging()
+    {
+        var error = Should.Throw<InvalidOperationException>(() => new LogicNetworkEvaluator(
+            new[] { "x" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["n1"] = PinnedGateTables.NotGate(),
+                ["n2"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("n1", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("n2", "Y")),
+                [new LogicPinRef("n2", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("n1", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("n1", "Y") }));
+
+        error.Message.ShouldContain("cycle");
+        error.Message.ShouldContain("n1");
+        error.Message.ShouldContain("n2");
+        error.Message.ShouldContain("sequential logic is not supported");
+    }
+
+    [Fact]
+    public void Constructor_WiringTargetsUnknownGate_ThrowsNamingTheGate()
+    {
+        var error = Should.Throw<ArgumentException>(() => new LogicNetworkEvaluator(
+            new[] { "a" },
+            new Dictionary<string, LogicGateModel> { ["nand"] = PinnedGateTables.NandGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("ghost", "A")] = new LogicNetDriver.NetworkInput("a"),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") }));
+
+        error.Message.ShouldContain("unknown gate 'ghost'");
+        error.Message.ShouldContain("Known gates: nand");
+    }
+
+    [Fact]
+    public void Constructor_WiringTargetsUnknownInputPin_ThrowsListingAvailablePins()
+    {
+        var error = Should.Throw<ArgumentException>(() => new LogicNetworkEvaluator(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel> { ["nand"] = PinnedGateTables.NandGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("nand", "C")] = new LogicNetDriver.NetworkInput("b"),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") }));
+
+        error.Message.ShouldContain("Gate 'nand' has no input pin 'C'");
+        error.Message.ShouldContain("Available inputs: A, B");
+    }
+
+    [Fact]
+    public void Constructor_DriverFromUnknownNetworkInput_ThrowsListingDeclaredInputs()
+    {
+        var error = Should.Throw<ArgumentException>(() => new LogicNetworkEvaluator(
+            new[] { "a" },
+            new Dictionary<string, LogicGateModel> { ["inv"] = PinnedGateTables.NotGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.NetworkInput("c"),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "Y") }));
+
+        error.Message.ShouldContain("no input pin 'c'");
+        error.Message.ShouldContain("Declared inputs: a");
+    }
+
+    [Fact]
+    public void Constructor_DriverFromNonOutputPin_ThrowsListingAvailableOutputs()
+    {
+        var error = Should.Throw<ArgumentException>(() => new LogicNetworkEvaluator(
+            new[] { "a" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["nand"] = PinnedGateTables.NandGate(),
+                ["inv"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("nand", "A")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "Y") }));
+
+        error.Message.ShouldContain("Gate 'nand' has no output pin 'A'");
+        error.Message.ShouldContain("Available outputs: Y");
+    }
+
+    [Fact]
+    public void Constructor_UndrivenGateInput_ThrowsNamingThePin()
+    {
+        var error = Should.Throw<ArgumentException>(() => new LogicNetworkEvaluator(
+            new[] { "a" },
+            new Dictionary<string, LogicGateModel> { ["nand"] = PinnedGateTables.NandGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") }));
+
+        error.Message.ShouldContain("Gate 'nand' has undriven input pins: B");
+    }
+
+    [Fact]
+    public void Constructor_OutputTapOnNonOutputPin_Throws()
+    {
+        var error = Should.Throw<ArgumentException>(() => new LogicNetworkEvaluator(
+            new[] { "a" },
+            new Dictionary<string, LogicGateModel> { ["inv"] = PinnedGateTables.NotGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.NetworkInput("a"),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "A") }));
+
+        error.Message.ShouldContain("Network output 'y'");
+        error.Message.ShouldContain("not an output");
+    }
+
+    [Fact]
+    public void Evaluate_MissingNetworkInputBit_ThrowsNamingTheInput()
+    {
+        var network = SingleNotNetwork();
+
+        var error = Should.Throw<ArgumentException>(
+            () => network.Evaluate(new Dictionary<string, bool>()));
+
+        error.Message.ShouldContain("No bit provided for network input 'a'");
+    }
+
+    [Fact]
+    public void Evaluate_UnknownNetworkInputBit_ThrowsNamingTheInput()
+    {
+        var network = SingleNotNetwork();
+
+        var error = Should.Throw<ArgumentException>(
+            () => network.Evaluate(Bits(("a", true), ("c", false))));
+
+        error.Message.ShouldContain("no input pin 'c'");
+    }
+
+    /// <summary>The smallest valid network: one inverter driven by one network input.</summary>
+    private static LogicNetworkEvaluator SingleNotNetwork() =>
+        new(
+            new[] { "a" },
+            new Dictionary<string, LogicGateModel> { ["inv"] = PinnedGateTables.NotGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.NetworkInput("a"),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "Y") });
+
+    /// <summary>Builds an input-bit dictionary from (name, bit) pairs.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}

--- a/UnitTests/Analysis/LogicAnalysis/PinnedGateTables.cs
+++ b/UnitTests/Analysis/LogicAnalysis/PinnedGateTables.cs
@@ -1,0 +1,76 @@
+using CAP_Core.Analysis.LogicAnalysis;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The pinned NAND/NOT truth tables of the shipped <c>Logic Gate NOT-NAND.lun</c>
+/// example, rebuilt by value: extracted at 1550 nm with the BIAS pin constantly
+/// on, NAND at threshold 0.125 reads 1/1/1/0 with raw powers 0.5/0.25/0.25/0.0,
+/// NOT at threshold 0.375 reads 1/0 with raw powers 0.5/0.25. Logic-layer unit
+/// tests use these value-built copies to stay fast and deterministic; the
+/// integration tests re-derive the same tables from the real simulation.
+/// </summary>
+internal static class PinnedGateTables
+{
+    /// <summary>Normalized power threshold at which the example reads NAND.</summary>
+    public const double NandThreshold = 0.125;
+
+    /// <summary>Normalized power threshold at which the example reads NOT.</summary>
+    public const double NotThreshold = 0.375;
+
+    /// <summary>Laser wavelength the pinned tables were extracted at.</summary>
+    public const int WavelengthNm = 1550;
+
+    private const string GroupName = "NOT/NAND Gate";
+    private const double RestingPower = 0.5;
+    private const double SingleInputPower = 0.25;
+
+    private static readonly string[] NandInputs = { "A", "B" };
+    private static readonly string[] NotInputs = { "A" };
+    private static readonly string[] Outputs = { "Y" };
+    private static readonly string[] Biases = { "BIAS" };
+
+    /// <summary>The pinned NAND table: rows in binary counting order, bit 0 = A.</summary>
+    public static TruthTable Nand() =>
+        new(
+            GroupName,
+            NandInputs,
+            Outputs,
+            Biases,
+            NandThreshold,
+            WavelengthNm,
+            new[]
+            {
+                Row(NandInputs, new[] { false, false }, true, RestingPower),
+                Row(NandInputs, new[] { true, false }, true, SingleInputPower),
+                Row(NandInputs, new[] { false, true }, true, SingleInputPower),
+                Row(NandInputs, new[] { true, true }, false, 0.0),
+            });
+
+    /// <summary>The pinned NOT table: row 0 = input off, row 1 = input on.</summary>
+    public static TruthTable Not() =>
+        new(
+            GroupName,
+            NotInputs,
+            Outputs,
+            Biases,
+            NotThreshold,
+            WavelengthNm,
+            new[]
+            {
+                Row(NotInputs, new[] { false }, true, RestingPower),
+                Row(NotInputs, new[] { true }, false, SingleInputPower),
+            });
+
+    /// <summary>The pinned NAND table wrapped as an evaluable gate model.</summary>
+    public static LogicGateModel NandGate() => LogicGateModel.FromTruthTable(Nand());
+
+    /// <summary>The pinned NOT table wrapped as an evaluable gate model.</summary>
+    public static LogicGateModel NotGate() => LogicGateModel.FromTruthTable(Not());
+
+    /// <summary>Builds one table row: the input bits per pin name plus the single Y output.</summary>
+    private static TruthTableRow Row(string[] inputNames, bool[] bits, bool y, double power) =>
+        new(
+            inputNames.Select((name, i) => (name, bit: bits[i])).ToDictionary(pair => pair.name, pair => pair.bit),
+            new Dictionary<string, LogicOutputValue> { ["Y"] = new(y, power) });
+}

--- a/UnitTests/Integration/LogicNetworkEvaluationExampleTests.cs
+++ b/UnitTests/Integration/LogicNetworkEvaluationExampleTests.cs
@@ -1,0 +1,124 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Rung-4 logic-layer evaluation over the real extracted tables of the shipped
+/// <c>examples/Logic Gate NOT-NAND.lun</c> gate: the NAND and NOT truth tables
+/// come out of the actual S-matrix simulation via <see cref="TruthTableExtractor"/>,
+/// then <see cref="LogicGateModel"/> and <see cref="LogicNetworkEvaluator"/>
+/// compose them into AND = NOT(NAND) and OR = NAND(NOT a, NOT b) — pure table
+/// lookups, no re-simulation. Where the passive-linear two-stage cascade of the
+/// AND-from-NAND example tops out at a 2× margin, the logic layer restores clean
+/// bits at every stage, so the composed gates read exact truth tables.
+/// </summary>
+public class LogicNetworkEvaluationExampleTests
+{
+    private const string ExampleFileName = "Logic Gate NOT-NAND.lun";
+    private const double NandThreshold = 0.125;
+    private const double NotThreshold = 0.375;
+    private const int WavelengthNm = 1550;
+
+    private static readonly string[] InputsAb = { "A", "B" };
+    private static readonly string[] InputA = { "A" };
+    private static readonly string[] Biases = { "BIAS" };
+    private static readonly string[] Outputs = { "Y" };
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, true)]
+    public async Task LogicLayer_AndFromExtractedNandAndNot_MatchesTheAndTruthTable(
+        bool a, bool b, bool expected)
+    {
+        var network = new LogicNetworkEvaluator(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["nand"] = await ExtractGate(InputsAb, NandThreshold),
+                ["inv"] = await ExtractGate(InputA, NotThreshold),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("nand", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "Y") });
+
+        network.Evaluate(new Dictionary<string, bool> { ["a"] = a, ["b"] = b })["y"].ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public async Task LogicLayer_OrFromExtractedGates_MatchesTheOrTruthTable(bool a, bool b, bool expected)
+    {
+        var network = new LogicNetworkEvaluator(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["notA"] = await ExtractGate(InputA, NotThreshold),
+                ["notB"] = await ExtractGate(InputA, NotThreshold),
+                ["nand"] = await ExtractGate(InputsAb, NandThreshold),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("notA", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("notB", "A")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("notA", "Y")),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("notB", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") });
+
+        network.Evaluate(new Dictionary<string, bool> { ["a"] = a, ["b"] = b })["y"].ShouldBe(expected);
+    }
+
+    /// <summary>
+    /// Extracts the shipped example's truth table through the real simulation and
+    /// wraps it as an evaluable logic-level gate model.
+    /// </summary>
+    private static async Task<LogicGateModel> ExtractGate(string[] inputs, double threshold)
+    {
+        var group = await LoadGateGroup();
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group, inputs, Outputs, Biases, threshold, WavelengthNm);
+        return LogicGateModel.FromTruthTable(table);
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns its group.</summary>
+    private static async Task<ComponentGroup> LoadGateGroup()
+    {
+        var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!);
+
+        var examplePath = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+        (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+            $"the shipped example '{ExampleFileName}' must load through the real load path");
+
+        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+    }
+}


### PR DESCRIPTION
## What & why

Rung 4 seed of the roadmap's behavioral layer (guiding principle 4, layered simulation). #973 pinned the physical limit: passive linear cascades reach their honest edge at two stages (margin ratio 2×). This PR adds the minimal evaluable **logic layer** the NAND-game endgame (half-adder, ALU) will sit on: grouped gates are evaluated as truth tables with ideal level restoration, instead of stacking fragile S-matrix cascades.

Core only (Recipe B — no UI), all in `Connect-A-Pic-Core/Analysis/LogicAnalysis/`:

- **`LogicGateModel.cs`** — immutable model of one gate: input pin names, output pin names, and its `TruthTable` as produced by `TruthTableExtractor`. Factory `FromTruthTable(TruthTable)` validates the table is complete and self-consistent (exactly 2^n rows in binary counting order, every row carrying exactly the declared pins). `Evaluate(inputBits)` is a pure table lookup — no re-simulation — returning clean bits.
- **`LogicNet.cs`** — the net-list primitives: `LogicPinRef` (gateId, pin) and `LogicNetDriver` (network input | gate output).
- **`LogicNetworkEvaluator.cs`** (+ `.Validation.cs` partial) — evaluates a DAG of gate models wired output→input. The network is validated and topologically ordered (Kahn) once at construction; every stage output is a clean bit, so ideal level restoration holds by construction and arbitrary cascade depth works — exactly what the passive-linear layer cannot do. Combinational only: cycles are rejected with a clear exception naming the looping gates (sequential logic is a later rung); unknown gates/pins, undriven inputs, and bad output taps all fail with readable messages.

No changes to existing simulation code. No new user-visible strings (no i18n impact).

## How it was tested

- **Unit tests** (`UnitTests/Analysis/LogicAnalysis/`): NAND built as a `LogicGateModel` from the pinned #969 table (rebuilt by value: threshold 0.125, powers 0.5/0.25/0.25/0.0; NOT at 0.375) and composed at the logic layer into **AND = NOT(NAND)** and **OR = NAND(NOT a, NOT b)** with full truth tables asserted; a **4-stage inverter chain** asserts clean alternating bits at every tapped stage (arbitrary cascade depth). Cycle detection throws a clear error instead of hanging; unknown-pin wiring, undriven inputs, non-output drivers/taps, and missing/unknown network input bits are all rejected with readable messages.
- **Integration test** (`UnitTests/Integration/LogicNetworkEvaluationExampleTests.cs`): extracts the NAND and NOT tables from the shipped `Logic Gate NOT-NAND.lun` through the real simulation + load path, then composes AND and OR at the logic layer — exact truth tables, no re-simulation of the cascade.
- `dotnet build CAP.Desktop/CAP.Desktop.csproj` — 0 errors.

Local suite: 5775 passed, 0 failed

## Manual verification after vacation

None needed — core-only change, fully covered headless. The visualizer/UI wiring for this layer is a later rung by design.

Tools: smart_test.py not present in this clone (`tools/` missing); used `dotnet test --filter "Category!=Slow"` with output redirected to a log file (~100K saved).