### PR TITLE
Agent: Truth Table panel: pin-role mutual exclusion at the checkbox (#975)

### DIFF
--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/PinSelectionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/PinSelectionViewModel.cs
@@ -4,7 +4,7 @@ namespace CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
 
 /// <summary>
 /// One external group pin offered as a checkbox in the Truth Table panel's
-/// input or output list.
+/// input, output, or bias list.
 /// </summary>
 public partial class PinSelectionViewModel : ObservableObject
 {
@@ -17,7 +17,7 @@ public partial class PinSelectionViewModel : ObservableObject
     /// <summary>Name of the external group pin this checkbox assigns.</summary>
     public string PinName { get; }
 
-    /// <summary>True when the pin is assigned to the corresponding role (input/output).</summary>
+    /// <summary>True when the pin is assigned to the corresponding role (input/output/bias).</summary>
     [ObservableProperty]
     private bool _isChecked;
 }

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
@@ -15,7 +15,8 @@ namespace CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
 /// <see cref="TruthTableExtractor.MaxLogicInputs"/>), outputs, or bias pins (constantly
 /// "on" in every row — the ingredient inversion gates need), and the panel extracts
 /// the group's truth table via <see cref="TruthTableExtractor"/> — every output bit shown
-/// together with the raw simulated power behind it.
+/// together with the raw simulated power behind it. A pin is exactly one of input, output,
+/// or bias: checking it in one list revokes it in the other two.
 /// </summary>
 public partial class TruthTableViewModel : ObservableObject
 {
@@ -25,7 +26,7 @@ public partial class TruthTableViewModel : ObservableObject
     private ComponentGroup? _group;
     private DesignCanvasViewModel? _canvas;
     private CancellationTokenSource? _extractCts;
-    private bool _revertingInputCheck;
+    private bool _revertingPinCheck;
 
     /// <summary>True while exactly one group is selected and the panel is active.</summary>
     [ObservableProperty]
@@ -100,8 +101,7 @@ public partial class TruthTableViewModel : ObservableObject
 
     private void RebuildPinLists()
     {
-        foreach (var pin in InputPins)
-            pin.PropertyChanged -= OnInputPinPropertyChanged;
+        DetachPinHandlers();
         InputPins.Clear();
         OutputPins.Clear();
         BiasPins.Clear();
@@ -110,27 +110,72 @@ public partial class TruthTableViewModel : ObservableObject
 
         foreach (var pin in _group.ExternalPins)
         {
-            var input = new PinSelectionViewModel(pin.Name);
-            input.PropertyChanged += OnInputPinPropertyChanged;
-            InputPins.Add(input);
-            OutputPins.Add(new PinSelectionViewModel(pin.Name));
-            BiasPins.Add(new PinSelectionViewModel(pin.Name));
+            InputPins.Add(CreatePin(pin.Name));
+            OutputPins.Add(CreatePin(pin.Name));
+            BiasPins.Add(CreatePin(pin.Name));
         }
     }
 
-    /// <summary>Enforces the extractor's input limit directly at the checkbox.</summary>
-    private void OnInputPinPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    /// <summary>Builds one checkbox entry and wires the pin-role invariant handler.</summary>
+    private PinSelectionViewModel CreatePin(string pinName)
     {
-        if (_revertingInputCheck || e.PropertyName != nameof(PinSelectionViewModel.IsChecked))
+        var pin = new PinSelectionViewModel(pinName);
+        pin.PropertyChanged += OnPinPropertyChanged;
+        return pin;
+    }
+
+    private void DetachPinHandlers()
+    {
+        foreach (var pin in InputPins.Concat(OutputPins).Concat(BiasPins))
+            pin.PropertyChanged -= OnPinPropertyChanged;
+    }
+
+    /// <summary>
+    /// Enforces the pin-role invariants directly at the checkbox: a pin is at most one
+    /// of input, output, or bias (checking it in one list revokes it in the other two),
+    /// and at most <see cref="TruthTableExtractor.MaxLogicInputs"/> inputs may be checked.
+    /// </summary>
+    private void OnPinPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_revertingPinCheck || e.PropertyName != nameof(PinSelectionViewModel.IsChecked))
             return;
         if (sender is not PinSelectionViewModel pin || !pin.IsChecked)
+            return;
+
+        _revertingPinCheck = true;
+        try
+        {
+            UncheckSamePinInOtherLists(pin);
+            EnforceInputLimit(pin);
+        }
+        finally
+        {
+            _revertingPinCheck = false;
+        }
+    }
+
+    /// <summary>Unchecks the same pin name in the two lists the just-checked pin does not belong to.</summary>
+    private void UncheckSamePinInOtherLists(PinSelectionViewModel checkedPin)
+    {
+        foreach (var list in new[] { InputPins, OutputPins, BiasPins })
+        {
+            if (list.Contains(checkedPin))
+                continue;
+            var twin = list.FirstOrDefault(p => p.PinName == checkedPin.PinName);
+            if (twin != null)
+                twin.IsChecked = false;
+        }
+    }
+
+    /// <summary>Reverts a fresh input check that would exceed the extractor's input limit.</summary>
+    private void EnforceInputLimit(PinSelectionViewModel checkedPin)
+    {
+        if (!InputPins.Contains(checkedPin))
             return;
         if (InputPins.Count(p => p.IsChecked) <= TruthTableExtractor.MaxLogicInputs)
             return;
 
-        _revertingInputCheck = true;
-        pin.IsChecked = false;
-        _revertingInputCheck = false;
+        checkedPin.IsChecked = false;
         StatusText = string.Format(Translate("Analysis.TruthTable.TooManyInputs"), TruthTableExtractor.MaxLogicInputs);
     }
 

--- a/UnitTests/Analysis/LogicAnalysis/TruthTableViewModelTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/TruthTableViewModelTests.cs
@@ -8,7 +8,8 @@ namespace UnitTests.Analysis.LogicAnalysis;
 
 /// <summary>
 /// ViewModel tests for the Truth Table panel: activation only for exactly one
-/// selected group, the 4-input limit at the checkboxes, extraction on the
+/// selected group, the 4-input limit at the checkboxes, pin-role mutual exclusion
+/// across input/output/bias at the checkbox, extraction on the
 /// <see cref="LogicGateFixtureFactory"/> fixtures (OR table at threshold 0.25 including
 /// raw powers), extractor validation shown as a message instead of a crash, and cancel.
 /// </summary>
@@ -33,6 +34,12 @@ public class TruthTableViewModelTests
             vm.InputPins.Single(p => p.PinName == name).IsChecked = true;
         foreach (var name in outputs)
             vm.OutputPins.Single(p => p.PinName == name).IsChecked = true;
+    }
+
+    private static void CheckBiasPins(TruthTableViewModel vm, params string[] biases)
+    {
+        foreach (var name in biases)
+            vm.BiasPins.Single(p => p.PinName == name).IsChecked = true;
     }
 
     [Fact]
@@ -171,15 +178,18 @@ public class TruthTableViewModelTests
     }
 
     [Fact]
-    public async Task Extract_PinDeclaredAsInputAndBias_ShowsMessage()
+    public async Task Extract_PinCheckedAsBias_RevokesItsInputTwin()
     {
         var (vm, _) = ConfigureForGroup(LogicGateFixtureFactory.CreateCombinerGroup());
         CheckPins(vm, new[] { "a" }, new[] { "y" });
-        vm.BiasPins.Single(p => p.PinName == "a").IsChecked = true;
+        CheckBiasPins(vm, "a");
 
         await vm.ExtractCommand.ExecuteAsync(null);
 
-        vm.StatusText.ShouldContain("'a'");
+        vm.InputPins.Single(p => p.PinName == "a").IsChecked.ShouldBeFalse(
+            "checking 'a' as bias revokes its input role — a pin has exactly one role");
+        vm.StatusText.ShouldBe(Translate("Analysis.TruthTable.SelectPins"),
+            "with the sole input revoked, no input bit remains — the panel asks for one");
         vm.HasResult.ShouldBeFalse();
         vm.IsProcessing.ShouldBeFalse();
     }
@@ -214,14 +224,17 @@ public class TruthTableViewModelTests
     }
 
     [Fact]
-    public async Task Extract_PinDeclaredAsInputAndOutput_ShowsMessage()
+    public async Task Extract_PinCheckedAsOutput_RevokesItsInputTwin()
     {
         var (vm, _) = ConfigureForGroup(LogicGateFixtureFactory.CreateCombinerGroup());
         CheckPins(vm, new[] { "a" }, new[] { "a" });
 
         await vm.ExtractCommand.ExecuteAsync(null);
 
-        vm.StatusText.ShouldContain("'a'");
+        vm.InputPins.Single(p => p.PinName == "a").IsChecked.ShouldBeFalse(
+            "checking 'a' as output revokes its input role — a pin has exactly one role");
+        vm.StatusText.ShouldBe(Translate("Analysis.TruthTable.SelectPins"),
+            "with the input role revoked, no input remains — the panel asks for one");
         vm.HasResult.ShouldBeFalse();
         vm.IsProcessing.ShouldBeFalse();
     }
@@ -279,5 +292,32 @@ public class TruthTableViewModelTests
         vm.HasResult.ShouldBeFalse();
         vm.IsProcessing.ShouldBeFalse();
         vm.Rows.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void PinRoles_CheckingOneRole_UnchecksTheSamePinInTheOtherTwoLists()
+    {
+        var (vm, _) = ConfigureForGroup(LogicGateFixtureFactory.CreateCombinerGroup());
+        CheckPins(vm, new[] { "a", "b" }, new[] { "y" });
+        CheckBiasPins(vm, "a");
+
+        vm.InputPins.Single(p => p.PinName == "a").IsChecked.ShouldBeFalse(
+            "checking 'a' as bias revokes its input role — a pin has exactly one role");
+        vm.InputPins.Single(p => p.PinName == "b").IsChecked.ShouldBeTrue(
+            "an unrelated pin keeps its role");
+
+        vm.BiasPins.Single(p => p.PinName == "b").IsChecked = true;
+        vm.InputPins.Single(p => p.PinName == "b").IsChecked.ShouldBeFalse(
+            "the bias check takes over from both roles at once");
+
+        vm.OutputPins.Single(p => p.PinName == "a").IsChecked = true;
+        vm.BiasPins.Single(p => p.PinName == "a").IsChecked.ShouldBeFalse(
+            "re-checking as output revokes the bias role");
+        vm.OutputPins.Single(p => p.PinName == "a").IsChecked.ShouldBeTrue();
+
+        vm.InputPins.Single(p => p.PinName == "a").IsChecked = true;
+        vm.OutputPins.Single(p => p.PinName == "a").IsChecked.ShouldBeFalse(
+            "re-checking as input revokes the output role");
+        vm.InputPins.Single(p => p.PinName == "a").IsChecked.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
## Summary

- Checking a pin in one Truth Table role list now revokes it in the other two (input/output/bias) — invalid overlaps unreachable at the checkbox.
- Ports the closed PR #974 interaction (`OnPinPropertyChanged` / `UncheckSamePinInOtherLists` / `EnforceInputLimit`) onto the merged #972 state; extractor-side validation kept as safety net.
- Max-4-input revert stays intact, re-entrancy guarded with try/finally; no new strings, no panel layout change.
- Overlap tests now assert mutual exclusion instead of the post-extract error message; dedicated test cycles a pin through all three roles in both directions.

## Verification

- Build clean, 0 warnings (build_errors.py).
- `TruthTableViewModel` tests: 16/16 green; all `TruthTable` tests: 60/60 green.
- Full non-Slow suite: 5733 passed, 0 failed, 16 skipped.

Manual check after vacation: tick the same pin across the three lists in the panel and watch the roles swap.

## Test plan

- [ ] `PinRoles_CheckingOneRole_UnchecksTheSamePinInTheOtherTwoLists` — all three pairings, both directions
- [ ] `Extract_PinCheckedAsBias_RevokesItsInputTwin` / `Extract_PinCheckedAsOutput_RevokesItsInputTwin` — overlap scenario now asserts exclusion + SelectPins hint
- [ ] `InputPins_FifthCheck_IsRevertedWithMessage` — max-4-input revert unchanged
- [ ] Existing bias extraction tests (bias summary, NOT/NAND example) stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)