### PR TITLE
Agent: LogicNetworkBuilder derives logic networks from canvas gate wiring (#982)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/GateRoleAssignment.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/GateRoleAssignment.cs
@@ -1,0 +1,33 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The role each external pin of a gate group plays in a logic network: which pins
+/// are logic inputs, which are logic outputs, which are constantly-on bias pins,
+/// and the power threshold the gate's truth table was extracted at. Until role
+/// persistence (#981) lands, callers and tests construct this record directly;
+/// afterwards its data feeds this parameter.
+/// </summary>
+/// <param name="InputPinNames">External pin names driven as logic inputs.</param>
+/// <param name="OutputPinNames">External pin names observed as logic outputs.</param>
+/// <param name="BiasPinNames">External pin names held constantly "on" — they take no part in wiring.</param>
+/// <param name="PowerThreshold">Normalized power threshold the gate's truth table was extracted at.</param>
+public sealed record GateRoleAssignment(
+    IReadOnlyList<string> InputPinNames,
+    IReadOnlyList<string> OutputPinNames,
+    IReadOnlyList<string> BiasPinNames,
+    double PowerThreshold);
+
+/// <summary>
+/// One top-level gate group on the canvas together with its logic-level model and
+/// its role assignment — the unit of input a <see cref="LogicNetworkBuilder"/>
+/// derives a network from.
+/// </summary>
+/// <param name="Group">The placed gate group; its name becomes the network-local gate id.</param>
+/// <param name="Model">The evaluable logic model extracted from the group.</param>
+/// <param name="Roles">The pin roles matching the extraction the model came from.</param>
+public sealed record LogicGateInstance(
+    ComponentGroup Group,
+    LogicGateModel Model,
+    GateRoleAssignment Roles);

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.Validation.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.Validation.cs
@@ -1,0 +1,148 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Structural validation half of <see cref="LogicNetworkBuilder"/>: every gate
+/// instance is checked against its group and model before any wiring is derived,
+/// so an inconsistent input never reaches network assembly.
+/// </summary>
+public sealed partial class LogicNetworkBuilder
+{
+    /// <summary>The wiring role of one external pin of a gate group.</summary>
+    private enum PinRole
+    {
+        Input,
+        Output,
+        Bias,
+    }
+
+    /// <summary>One resolved connection endpoint: a gate pin together with its role.</summary>
+    private readonly record struct Endpoint(LogicPinRef Pin, PinRole Role);
+
+    /// <summary>Rejects duplicated gate ids — network inputs and taps are named by gate id.</summary>
+    private static void ThrowOnDuplicateGateIds(IReadOnlyList<GateContext> contexts)
+    {
+        var duplicate = contexts.GroupBy(c => c.GateId).FirstOrDefault(g => g.Count() > 1)?.Key;
+        if (duplicate != null)
+            throw new ArgumentException(
+                $"Two gate groups are named '{duplicate}'. Gate ids come from the group name " +
+                "and must be unique — rename one of the groups.",
+                nameof(contexts));
+    }
+
+    /// <summary>One gate group with its prevalidated logic interface.</summary>
+    private sealed class GateContext
+    {
+        private GateContext(LogicGateInstance instance)
+        {
+            Instance = instance;
+        }
+
+        /// <summary>The gate instance this context wraps.</summary>
+        public LogicGateInstance Instance { get; }
+
+        /// <summary>The network-local gate id: the group name.</summary>
+        public string GateId => Instance.Group.GroupName;
+
+        /// <summary>The placed gate group.</summary>
+        public ComponentGroup Group => Instance.Group;
+
+        /// <summary>The gate's evaluable logic model.</summary>
+        public LogicGateModel Model => Instance.Model;
+
+        /// <summary>Validates one gate instance and wraps it as a context.</summary>
+        /// <exception cref="ArgumentException">The instance is incomplete or inconsistent.</exception>
+        public static GateContext Create(LogicGateInstance? instance)
+        {
+            if (instance == null)
+                throw new ArgumentException("A gate instance is null.", nameof(instance));
+            if (instance.Group == null)
+                throw new ArgumentException("A gate instance has no group.", nameof(instance));
+            if (instance.Model == null)
+                throw new ArgumentException($"Gate '{instance.Group.GroupName}' has no logic model.", nameof(instance));
+            if (instance.Roles == null)
+                throw new ArgumentException($"Gate '{instance.Group.GroupName}' has no role assignment.", nameof(instance));
+
+            var context = new GateContext(instance);
+            context.ThrowOnDuplicateRolePins();
+            context.ThrowOnOverlappingRoles();
+            context.ThrowOnRoleModelMismatch();
+            context.ThrowOnUnknownRolePins();
+            return context;
+        }
+
+        /// <summary>The wiring role of one external pin name, or null when the pin has no role.</summary>
+        public PinRole? RoleOf(string pinName)
+        {
+            if (Instance.Roles.InputPinNames.Contains(pinName)) return PinRole.Input;
+            if (Instance.Roles.OutputPinNames.Contains(pinName)) return PinRole.Output;
+            if (Instance.Roles.BiasPinNames.Contains(pinName)) return PinRole.Bias;
+            return null;
+        }
+
+        /// <summary>Rejects pins listed twice within one role list.</summary>
+        private void ThrowOnDuplicateRolePins()
+        {
+            var duplicate = Instance.Roles.InputPinNames
+                .Concat(Instance.Roles.OutputPinNames)
+                .Concat(Instance.Roles.BiasPinNames)
+                .GroupBy(name => name).FirstOrDefault(g => g.Count() > 1)?.Key;
+            if (duplicate != null)
+                throw new ArgumentException(
+                    $"Gate '{GateId}' lists pin '{duplicate}' more than once in its role assignment.",
+                    nameof(Instance));
+        }
+
+        /// <summary>Rejects pins claimed for two roles — a pin is exactly one of input, output, or bias.</summary>
+        private void ThrowOnOverlappingRoles()
+        {
+            var roles = Instance.Roles;
+            var overlap = roles.InputPinNames.Intersect(roles.OutputPinNames)
+                .Concat(roles.InputPinNames.Intersect(roles.BiasPinNames))
+                .Concat(roles.BiasPinNames.Intersect(roles.OutputPinNames))
+                .FirstOrDefault();
+            if (overlap != null)
+                throw new ArgumentException(
+                    $"Gate '{GateId}' assigns pin '{overlap}' two roles — a pin is exactly one of input, output, or bias.",
+                    nameof(Instance));
+        }
+
+        /// <summary>Rejects a role assignment that does not match the gate model's interface.</summary>
+        private void ThrowOnRoleModelMismatch()
+        {
+            ThrowOnSetMismatch("input", Instance.Roles.InputPinNames, Model.InputPinNames);
+            ThrowOnSetMismatch("output", Instance.Roles.OutputPinNames, Model.OutputPinNames);
+        }
+
+        /// <summary>Compares one role list against the model's pin list, ignoring order.</summary>
+        private void ThrowOnSetMismatch(string role, IReadOnlyList<string> rolePins, IReadOnlyList<string> modelPins)
+        {
+            if (rolePins.ToHashSet().SetEquals(modelPins))
+                return;
+            throw new ArgumentException(
+                $"Gate '{GateId}' assigns {role} pins [{string.Join(", ", rolePins)}] but its logic model " +
+                $"declares [{string.Join(", ", modelPins)}] — the roles must match the extraction the model came from.",
+                nameof(Instance));
+        }
+
+        /// <summary>
+        /// Rejects role pins the group does not expose. External pins without a role are
+        /// fine — a group read as a smaller gate (the NOT reading of the NOT/NAND example
+        /// leaves pin B unused) simply keeps them out of the logic network.
+        /// </summary>
+        private void ThrowOnUnknownRolePins()
+        {
+            var externalNames = Group.ExternalPins.Select(p => p.Name).ToList();
+            var unknown = Instance.Roles.InputPinNames
+                .Concat(Instance.Roles.OutputPinNames)
+                .Concat(Instance.Roles.BiasPinNames)
+                .FirstOrDefault(name => !externalNames.Contains(name));
+            if (unknown != null)
+                throw new ArgumentException(
+                    $"Gate '{GateId}' assigns a role to pin '{unknown}', which the group does not expose. " +
+                    $"Available pins: {string.Join(", ", externalNames)}.",
+                    nameof(Instance));
+        }
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
@@ -1,0 +1,153 @@
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Derives a <see cref="LogicNetworkEvaluator"/> from the gate groups placed on the
+/// canvas, making the canvas the source of truth for the wiring: a connection from
+/// one group's external output pin to another group's external input pin becomes a
+/// logic wire (fan-out of one output to several inputs is allowed). Unconnected
+/// gate input pins become network-level inputs named <c>&lt;group&gt;.&lt;pin&gt;</c>,
+/// and every gate output pin becomes a network-level output tap under the same
+/// naming — also when it additionally drives another gate. Bias pins take no part
+/// in wiring (they are constantly on — the extraction contract); a connection into
+/// a bias pin, a connection between two input pins, and a gate input driven by two
+/// different outputs are rejected with messages naming the pins.
+/// </summary>
+public sealed partial class LogicNetworkBuilder
+{
+    /// <summary>
+    /// Derives and validates the logic network behind the given gate groups and the
+    /// design's connections between their external pins.
+    /// </summary>
+    /// <param name="gates">
+    /// The top-level gate groups, each with its logic model and role assignment.
+    /// Gate ids come from the group names and must be unique.
+    /// </param>
+    /// <param name="connections">
+    /// The design's waveguide connections. Only connections joining external pins of
+    /// two gate groups take part in wiring; connections towards anything else (a laser,
+    /// an external port, an ungrouped component) are ignored — an unconnected gate
+    /// input simply becomes a network-level input.
+    /// </param>
+    /// <returns>The validated, evaluation-ready network.</returns>
+    /// <exception cref="ArgumentException">
+    /// A gate id is duplicated, a role assignment does not match its model or group,
+    /// or a connection is logically invalid. The message names the offending pins.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">The derived wiring forms a cycle.</exception>
+    public LogicNetworkEvaluator Build(
+        IReadOnlyList<LogicGateInstance> gates,
+        IReadOnlyList<WaveguideConnection> connections)
+    {
+        if (gates == null) throw new ArgumentNullException(nameof(gates));
+        if (connections == null) throw new ArgumentNullException(nameof(connections));
+        if (gates.Count == 0)
+            throw new ArgumentException("A logic network needs at least one gate group.", nameof(gates));
+
+        var contexts = gates.Select(GateContext.Create).ToList();
+        ThrowOnDuplicateGateIds(contexts);
+
+        var drivers = new Dictionary<LogicPinRef, LogicPinRef>();
+        foreach (var connection in connections)
+        {
+            AddConnectionDrivers(contexts, connection, drivers);
+        }
+
+        return AssembleNetwork(contexts, drivers);
+    }
+
+    /// <summary>Classifies one design connection and records the logic driver it implies, if any.</summary>
+    private static void AddConnectionDrivers(
+        IReadOnlyList<GateContext> contexts,
+        WaveguideConnection connection,
+        IDictionary<LogicPinRef, LogicPinRef> drivers)
+    {
+        var start = ResolveEndpoint(contexts, connection.StartPin);
+        var end = ResolveEndpoint(contexts, connection.EndPin);
+        if (start == null || end == null)
+            return;
+
+        var (source, load) = Classify(start.Value, end.Value);
+        if (drivers.TryGetValue(load, out var existing) && !existing.Equals(source))
+            throw new ArgumentException(
+                $"Gate input '{Format(load)}' is driven by two different gate outputs: " +
+                $"'{Format(existing)}' and '{Format(source)}'. One logic wire needs exactly one driver.");
+        drivers[load] = source;
+    }
+
+    /// <summary>Determines which endpoint drives which, rejecting logically invalid pairings.</summary>
+    private static (LogicPinRef Source, LogicPinRef Load) Classify(Endpoint first, Endpoint second)
+    {
+        if (first.Role == PinRole.Bias || second.Role == PinRole.Bias)
+            throw new ArgumentException(
+                $"Connection between '{Format(first.Pin)}' and '{Format(second.Pin)}' touches a bias pin. " +
+                "Bias pins are constantly on and take no part in wiring — remove the connection.");
+        if (first.Role == PinRole.Output && second.Role == PinRole.Input)
+            return (first.Pin, second.Pin);
+        if (second.Role == PinRole.Output && first.Role == PinRole.Input)
+            return (second.Pin, first.Pin);
+        if (first.Role == PinRole.Input)
+            throw new ArgumentException(
+                $"Connection joins two gate input pins: '{Format(first.Pin)}' and '{Format(second.Pin)}'. " +
+                "A gate input must be driven by a gate output or left unconnected to become a network input.");
+        throw new ArgumentException(
+            $"Connection joins two gate output pins: '{Format(first.Pin)}' and '{Format(second.Pin)}'. " +
+            "A gate output drives gate inputs; it cannot be driven itself.");
+    }
+
+    /// <summary>Renders a gate pin the way network inputs and taps are named: <c>group.pin</c>.</summary>
+    private static string Format(LogicPinRef pin) => $"{pin.GateId}.{pin.PinName}";
+
+    /// <summary>Maps one connection endpoint onto its gate pin and role, or null when no gate group is involved.</summary>
+    private static Endpoint? ResolveEndpoint(IReadOnlyList<GateContext> contexts, PhysicalPin? pin)
+    {
+        if (pin?.ParentComponent == null)
+            return null;
+        var context = contexts.FirstOrDefault(c => ReferenceEquals(c.Group, pin.ParentComponent));
+        var role = context?.RoleOf(pin.Name);
+        return role == null ? null : new Endpoint(new LogicPinRef(context!.GateId, pin.Name), role.Value);
+    }
+
+    /// <summary>
+    /// Assembles the evaluator: unconnected gate inputs become network-level inputs
+    /// named <c>&lt;group&gt;.&lt;pin&gt;</c>, and every gate output pin becomes a
+    /// network-level output tap under the same naming.
+    /// </summary>
+    private static LogicNetworkEvaluator AssembleNetwork(
+        IReadOnlyList<GateContext> contexts,
+        IReadOnlyDictionary<LogicPinRef, LogicPinRef> drivers)
+    {
+        var networkInputs = new List<string>();
+        var wiring = new Dictionary<LogicPinRef, LogicNetDriver>();
+        var outputTaps = new Dictionary<string, LogicPinRef>();
+        var models = new Dictionary<string, LogicGateModel>();
+
+        foreach (var context in contexts)
+        {
+            models[context.GateId] = context.Model;
+            foreach (var pinName in context.Model.InputPinNames)
+            {
+                var load = new LogicPinRef(context.GateId, pinName);
+                wiring[load] = drivers.TryGetValue(load, out var source)
+                    ? new LogicNetDriver.GateOutput(source)
+                    : new LogicNetDriver.NetworkInput(NetworkInputName(networkInputs, load));
+            }
+            foreach (var pinName in context.Model.OutputPinNames)
+            {
+                outputTaps[$"{context.GateId}.{pinName}"] = new LogicPinRef(context.GateId, pinName);
+            }
+        }
+
+        return new LogicNetworkEvaluator(networkInputs, models, wiring, outputTaps);
+    }
+
+    /// <summary>Registers and returns the network-level input name of an unconnected gate input.</summary>
+    private static string NetworkInputName(ICollection<string> networkInputs, LogicPinRef load)
+    {
+        var name = Format(load);
+        networkInputs.Add(name);
+        return name;
+    }
+}

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkBuilderTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkBuilderTests.cs
@@ -1,0 +1,227 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The canvas-driven network builder: synthetic gate groups wired through design
+/// connections become a <see cref="LogicNetworkEvaluator"/> — linear chains, fan-out,
+/// and unconnected inputs turning into network-level inputs named <c>group.pin</c> —
+/// while logically invalid wirings (input–input, double-driven input, bias targets)
+/// are rejected with messages naming the pins.
+/// </summary>
+public class LogicNetworkBuilderTests
+{
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, true)]
+    public void Build_NandFeedingNot_DerivesTheAndNetworkFromTheCanvasConnection(bool a, bool b, bool expected)
+    {
+        var nand = NandInstance("NAND");
+        var inv = NotInstance("INV");
+        var connections = new[] { Connect(nand, "Y", inv, "A") };
+
+        var network = new LogicNetworkBuilder().Build(new[] { nand, inv }, connections);
+
+        network.InputPinNames.ShouldBe(new[] { "NAND.A", "NAND.B" });
+        network.OutputPinNames.ShouldBe(new[] { "NAND.Y", "INV.Y" },
+            "every gate output pin becomes a network-level output tap, also when it drives another gate");
+        network.Evaluate(Bits(("NAND.A", a), ("NAND.B", b)))["INV.Y"].ShouldBe(expected);
+        network.Evaluate(Bits(("NAND.A", a), ("NAND.B", b)))["NAND.Y"].ShouldBe(!(a && b),
+            "the intermediate gate output stays readable as a tap");
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void Build_OutputFannedOutToTwoInputs_DrivesBothLoads(bool a, bool expected)
+    {
+        var source = NotInstance("SRC");
+        var nand = NandInstance("NAND");
+        var connections = new[] { Connect(source, "Y", nand, "A"), Connect(source, "Y", nand, "B") };
+
+        var network = new LogicNetworkBuilder().Build(new[] { source, nand }, connections);
+
+        network.InputPinNames.ShouldBe(new[] { "SRC.A" });
+        network.Evaluate(Bits(("SRC.A", a)))["NAND.Y"].ShouldBe(expected,
+            "NAND(!a, !a) restores the input bit");
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void Build_UnconnectedGateInput_BecomesANetworkInputNamedGroupDotPin(bool a, bool expected)
+    {
+        var inv = NotInstance("INV");
+
+        var network = new LogicNetworkBuilder().Build(new[] { inv }, Array.Empty<WaveguideConnection>());
+
+        network.InputPinNames.ShouldBe(new[] { "INV.A" });
+        network.OutputPinNames.ShouldBe(new[] { "INV.Y" });
+        network.Evaluate(Bits(("INV.A", a))).ShouldBe(Bits(("INV.Y", expected)));
+    }
+
+    [Fact]
+    public void Build_ConnectionBetweenTwoInputPins_ThrowsNamingThePins()
+    {
+        var nand = NandInstance("NAND");
+        var inv = NotInstance("INV");
+        var connections = new[] { Connect(nand, "A", inv, "A") };
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { nand, inv }, connections));
+
+        error.Message.ShouldContain("two gate input pins");
+        error.Message.ShouldContain("NAND.A");
+        error.Message.ShouldContain("INV.A");
+    }
+
+    [Fact]
+    public void Build_InputDrivenByTwoDifferentOutputs_ThrowsNamingThePins()
+    {
+        var first = NotInstance("NOT1");
+        var second = NotInstance("NOT2");
+        var nand = NandInstance("NAND");
+        var connections = new[] { Connect(first, "Y", nand, "A"), Connect(second, "Y", nand, "A") };
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { first, second, nand }, connections));
+
+        error.Message.ShouldContain("NAND.A");
+        error.Message.ShouldContain("NOT1.Y");
+        error.Message.ShouldContain("NOT2.Y");
+    }
+
+    [Fact]
+    public void Build_ConnectionIntoBiasPin_ThrowsNamingThePins()
+    {
+        var inv = NotInstance("INV");
+        var nand = NandInstance("NAND");
+        var connections = new[] { Connect(inv, "Y", nand, "BIAS") };
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { inv, nand }, connections));
+
+        error.Message.ShouldContain("bias pin");
+        error.Message.ShouldContain("NAND.BIAS");
+        error.Message.ShouldContain("constantly on");
+    }
+
+    [Fact]
+    public void Build_ConnectionBetweenTwoOutputPins_ThrowsNamingThePins()
+    {
+        var nand = NandInstance("NAND");
+        var inv = NotInstance("INV");
+        var connections = new[] { Connect(nand, "Y", inv, "Y") };
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { nand, inv }, connections));
+
+        error.Message.ShouldContain("two gate output pins");
+        error.Message.ShouldContain("NAND.Y");
+        error.Message.ShouldContain("INV.Y");
+    }
+
+    [Fact]
+    public void Build_DuplicateGroupNames_ThrowsNamingTheDuplicate()
+    {
+        var first = NotInstance("INV");
+        var second = NotInstance("INV");
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { first, second }, Array.Empty<WaveguideConnection>()));
+
+        error.Message.ShouldContain("'INV'");
+        error.Message.ShouldContain("must be unique");
+    }
+
+    [Fact]
+    public void Build_RoleAssignmentMismatchingTheModel_ThrowsNamingTheGate()
+    {
+        var inv = new LogicGateInstance(
+            CreateGateGroup("INV", "A", "B", "BIAS", "Y"),
+            PinnedGateTables.NotGate(),
+            new GateRoleAssignment(new[] { "A", "B" }, new[] { "Y" }, new[] { "BIAS" }, PinnedGateTables.NotThreshold));
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { inv }, Array.Empty<WaveguideConnection>()));
+
+        error.Message.ShouldContain("INV");
+        error.Message.ShouldContain("input pins [A, B]");
+        error.Message.ShouldContain("declares [A]");
+    }
+
+    [Fact]
+    public void Build_ExternalPinWithoutRole_StaysOutOfTheLogicNetwork()
+    {
+        // The NOT reading of the NOT/NAND example: the same physical group, pin B unused.
+        var inv = new LogicGateInstance(
+            CreateGateGroup("INV", "A", "B", "BIAS", "Y"),
+            PinnedGateTables.NotGate(),
+            new GateRoleAssignment(new[] { "A" }, new[] { "Y" }, new[] { "BIAS" }, PinnedGateTables.NotThreshold));
+
+        var network = new LogicNetworkBuilder().Build(new[] { inv }, Array.Empty<WaveguideConnection>());
+
+        network.InputPinNames.ShouldBe(new[] { "INV.A" });
+        network.OutputPinNames.ShouldBe(new[] { "INV.Y" });
+    }
+
+    [Fact]
+    public void Build_RolePinTheGroupDoesNotExpose_ThrowsNamingThePin()
+    {
+        var inv = new LogicGateInstance(
+            CreateGateGroup("INV", "A", "Y"),
+            PinnedGateTables.NotGate(),
+            new GateRoleAssignment(new[] { "A" }, new[] { "Y" }, new[] { "BIAS" }, PinnedGateTables.NotThreshold));
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { inv }, Array.Empty<WaveguideConnection>()));
+
+        error.Message.ShouldContain("'BIAS'");
+        error.Message.ShouldContain("does not expose");
+    }
+
+    /// <summary>A NAND gate instance on a synthetic group exposing the example's pin interface.</summary>
+    private static LogicGateInstance NandInstance(string groupName) =>
+        new(
+            CreateGateGroup(groupName, "A", "B", "BIAS", "Y"),
+            PinnedGateTables.NandGate(),
+            new GateRoleAssignment(new[] { "A", "B" }, new[] { "Y" }, new[] { "BIAS" }, PinnedGateTables.NandThreshold));
+
+    /// <summary>A NOT gate instance on a synthetic group exposing the example's pin interface.</summary>
+    private static LogicGateInstance NotInstance(string groupName) =>
+        new(
+            CreateGateGroup(groupName, "A", "BIAS", "Y"),
+            PinnedGateTables.NotGate(),
+            new GateRoleAssignment(new[] { "A" }, new[] { "Y" }, new[] { "BIAS" }, PinnedGateTables.NotThreshold));
+
+    /// <summary>A bare group whose external pins are connectable like canvas-synced group pins.</summary>
+    private static ComponentGroup CreateGateGroup(string groupName, params string[] externalPinNames)
+    {
+        var group = new ComponentGroup(groupName);
+        foreach (var pinName in externalPinNames)
+        {
+            var physicalPin = new PhysicalPin { Name = pinName, ParentComponent = group };
+            group.PhysicalPins.Add(physicalPin);
+            group.AddExternalPin(new GroupPin { Name = pinName, InternalPin = physicalPin });
+        }
+        return group;
+    }
+
+    /// <summary>A design connection between two gate groups' external pins.</summary>
+    private static WaveguideConnection Connect(LogicGateInstance from, string fromPin, LogicGateInstance to, string toPin) =>
+        new() { StartPin = Pin(from.Group, fromPin), EndPin = Pin(to.Group, toPin) };
+
+    /// <summary>Looks up a group's connectable external pin.</summary>
+    private static PhysicalPin Pin(ComponentGroup group, string name) =>
+        group.PhysicalPins.Single(p => p.Name == name);
+
+    /// <summary>Builds an input-bit dictionary from (name, bit) pairs.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}

--- a/UnitTests/Integration/LogicNetworkBuilderExampleTests.cs
+++ b/UnitTests/Integration/LogicNetworkBuilderExampleTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Rung-4 canvas-to-logic integration: two instances of the shipped
+/// <c>examples/Logic Gate NOT-NAND.lun</c> gate are placed as top-level groups and
+/// wired NAND→NOT through a design connection between their external pins, exactly
+/// as Jonas routes them on the canvas. <see cref="LogicNetworkBuilder"/> derives the
+/// network from those connections — the role assignments stand in for the #981
+/// persistence data — and the evaluator reads the AND truth table by pure table
+/// lookup: no re-simulation of the cascade, ideal level restoration at both stages.
+/// </summary>
+public class LogicNetworkBuilderExampleTests
+{
+    private const string ExampleFileName = "Logic Gate NOT-NAND.lun";
+    private const string NandGateId = "NAND";
+    private const string NotGateId = "NOT";
+    private const double NandThreshold = 0.125;
+    private const double NotThreshold = 0.375;
+    private const int WavelengthNm = 1550;
+
+    private static readonly string[] NandInputs = { "A", "B" };
+    private static readonly string[] NotInputs = { "A" };
+    private static readonly string[] Biases = { "BIAS" };
+    private static readonly string[] Outputs = { "Y" };
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, true)]
+    public async Task CanvasWiring_NandGroupFeedingNotGroup_EvaluatesTheAndTruthTable(
+        bool a, bool b, bool expected)
+    {
+        var nand = await LoadGateInstance(NandGateId, NandInputs, NandThreshold);
+        var inv = await LoadGateInstance(NotGateId, NotInputs, NotThreshold);
+        var connections = new[] { ConnectGroups(nand.Group, "Y", inv.Group, "A") };
+
+        var network = new LogicNetworkBuilder().Build(new[] { nand, inv }, connections);
+
+        network.InputPinNames.ShouldBe(new[] { "NAND.A", "NAND.B" },
+            "the unconnected NAND inputs become the network-level inputs");
+        network.OutputPinNames.ShouldBe(new[] { "NAND.Y", "NOT.Y" },
+            "every gate output pin becomes a network-level output tap");
+        var inputBits = new Dictionary<string, bool> { ["NAND.A"] = a, ["NAND.B"] = b };
+        network.Evaluate(inputBits)["NOT.Y"].ShouldBe(expected, "AND = NOT(NAND(A, B))");
+        network.Evaluate(inputBits)["NAND.Y"].ShouldBe(!(a && b),
+            "the driving gate output stays readable as a tap");
+    }
+
+    /// <summary>
+    /// Loads the shipped example through the real load path, renames the group to its
+    /// network-local gate id, and extracts its logic model through the real simulation.
+    /// </summary>
+    private static async Task<LogicGateInstance> LoadGateInstance(
+        string gateId, string[] inputPinNames, double threshold)
+    {
+        var group = await LoadGateGroup();
+        group.GroupName = gateId;
+        var table = await new TruthTableExtractor().ExtractAsync(
+            group, inputPinNames, Outputs, Biases, threshold, WavelengthNm);
+        return new LogicGateInstance(
+            group,
+            LogicGateModel.FromTruthTable(table),
+            new GateRoleAssignment(inputPinNames, Outputs, Biases, threshold));
+    }
+
+    /// <summary>The canvas wiring between two gate groups' external pins: NAND.Y → NOT.A.</summary>
+    private static WaveguideConnection ConnectGroups(
+        ComponentGroup from, string fromPin, ComponentGroup to, string toPin) =>
+        new() { StartPin = ExternalPin(from, fromPin), EndPin = ExternalPin(to, toPin) };
+
+    /// <summary>The group's connectable external pin, synced onto the group by the extraction.</summary>
+    private static PhysicalPin ExternalPin(ComponentGroup group, string name) =>
+        group.PhysicalPins.Single(p => p.Name == name);
+
+    /// <summary>Loads the shipped example through the real load path and returns its group.</summary>
+    private static async Task<ComponentGroup> LoadGateGroup()
+    {
+        var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!);
+
+        var examplePath = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+        (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+            $"the shipped example '{ExampleFileName}' must load through the real load path");
+
+        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+    }
+}


### PR DESCRIPTION
## What & why

Rung 4 of the NAND game (#982): the canvas becomes the source of truth for logic networks. `LogicNetworkBuilder` (in `Connect-A-Pic-Core/Analysis/LogicAnalysis/`) derives a `LogicNetworkEvaluator` from the top-level gate groups and the design's connections between their external pins — no more hand-wired netlists in code.

- **Input:** `LogicGateInstance` records — the placed `ComponentGroup`, its `LogicGateModel`, and a `GateRoleAssignment` (input/output/bias pin names + threshold) passed in as a parameter, so #981's persistence data can feed it later without blocking this rung.
- **Wiring:** a connection from a gate's external output pin to another gate's external input pin becomes a logic wire; fan-out of one output to several inputs is allowed. Gate ids come from the group names (duplicates rejected).
- **Unconnected gate inputs** become network-level inputs named `<group>.<pin>`; **every gate output pin** becomes a network-level output tap under the same naming, also when it additionally drives another gate.
- **Bias pins** take no part in wiring (constantly on — the #969 extraction contract); a connection into a bias pin, a connection between two input pins, two outputs joined, or a gate input driven by two different outputs are all rejected with messages naming the pins (same style as the evaluator). Connections towards non-gate components (lasers, external ports) are ignored.
- External pins without a role stay out of the logic network — that is what reading the same physical group as NOT (pin B unused) needs.

Core-only (Recipe B): no ViewModel/View, no new user-visible strings.

## How it was tested

- `UnitTests/Analysis/LogicAnalysis/LogicNetworkBuilderTests.cs` — synthetic groups/connections: linear chain NAND→NOT reads AND, fan-out drives both loads, unconnected inputs become `group.pin` network inputs, and the bad wirings (input–input, double-driven input, bias target, output–output, duplicate gate ids, role/model mismatch, unknown role pin) are rejected naming the pins.
- `UnitTests/Integration/LogicNetworkBuilderExampleTests.cs` — two instances of the shipped `examples/Logic Gate NOT-NAND.lun` gate loaded through the real load path, tables extracted via the real simulation, wired NAND→NOT with a design connection; the built network evaluates the AND truth table by pure table lookup — no re-simulation of the cascade.

Local suite: 5800 passed, 0 failed

No manual UI verification needed — headless core change only.