### PR TITLE
Agent: Truth Table pin roles + threshold persist in the .lun — panel prefills after load (rung 4)

### DIFF
--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
 using CommunityToolkit.Mvvm.Input;
 
 namespace CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
@@ -35,6 +36,16 @@ public partial class TruthTableViewModel
             var table = await _extractor.ExtractAsync(
                 _group, inputs, outputs, biases, Threshold, ResolveWavelengthNm(), _extractCts.Token);
             ShowTable(table);
+            // Persist the winning assignment on the group (issue #981) so the next
+            // save → load round trip prefills the panel — a cancelled or failed
+            // extraction must not overwrite the last good one.
+            _group.TruthTablePinAssignment = new TruthTablePinAssignment
+            {
+                InputPinNames = inputs.ToList(),
+                OutputPinNames = outputs.ToList(),
+                BiasPinNames = biases.ToList(),
+                Threshold = Threshold
+            };
             StatusText = string.Format(Translate("Analysis.TruthTable.Complete"), table.Rows.Count);
         }
         catch (OperationCanceledException)

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
@@ -94,9 +94,49 @@ public partial class TruthTableViewModel : ObservableObject
         StatusText = "";
         BiasSummaryText = "";
         RebuildPinLists();
+        PrefillFromPersistedAssignment();
         WavelengthText = IsGroupSelected
             ? string.Format(Translate("TruthTable.Wavelength"), ResolveWavelengthNm())
             : "";
+    }
+
+    /// <summary>
+    /// Re-applies the pin-role assignment the group was last successfully extracted
+    /// with (issue #981 — persisted in the .lun file): ticks the same input/output/
+    /// bias checkboxes and restores the threshold, so a save → load round trip
+    /// brings the panel back exactly as the user left it. Silent for legacy files
+    /// and for groups never extracted; pin names that no longer exist on the group
+    /// are skipped instead of failing.
+    /// </summary>
+    private void PrefillFromPersistedAssignment()
+    {
+        var saved = _group?.TruthTablePinAssignment;
+        if (saved == null)
+            return;
+
+        _revertingPinCheck = true;
+        try
+        {
+            CheckPins(InputPins, saved.InputPinNames);
+            CheckPins(OutputPins, saved.OutputPinNames);
+            CheckPins(BiasPins, saved.BiasPinNames);
+            Threshold = saved.Threshold;
+        }
+        finally
+        {
+            _revertingPinCheck = false;
+        }
+    }
+
+    /// <summary>Ticks the checkbox of every listed pin that still exists on the group.</summary>
+    private static void CheckPins(IEnumerable<PinSelectionViewModel> pins, IEnumerable<string> names)
+    {
+        foreach (var name in names)
+        {
+            var pin = pins.FirstOrDefault(p => p.PinName == name);
+            if (pin != null)
+                pin.IsChecked = true;
+        }
     }
 
     private void RebuildPinLists()

--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -1384,6 +1384,14 @@ public class DesignGroupData
     /// remains the default for those and for ungrouped components.
     /// </summary>
     public ActiveProcessData? ProcessBinding { get; set; }
+
+    /// <summary>
+    /// Truth Table pin-role assignment of a top-level group (issue #981): the input,
+    /// output, and bias pins plus threshold the panel last successfully extracted with.
+    /// Null when the group was never extracted — including every file saved before the
+    /// persistence existed — so legacy .lun files stay clean of unused blocks.
+    /// </summary>
+    public CAP_Core.Components.Core.TruthTablePinAssignment? TruthTablePinAssignment { get; set; }
 }
 
 /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -661,7 +661,9 @@ public partial class FileOperationsViewModel : ObservableObject
             CanvasY = groupVm.Y,
             // Only top-level groups act as chiplets (issue #938); a nested group's
             // process scope is its top-level parent's.
-            ProcessBinding = group.ParentGroup == null ? ResolveGroupBindingForSave(group) : null
+            ProcessBinding = group.ParentGroup == null ? ResolveGroupBindingForSave(group) : null,
+            // Same top-level-only rule for the Truth Table pin roles (issue #981).
+            TruthTablePinAssignment = group.ParentGroup == null ? group.TruthTablePinAssignment : null
         });
     }
 
@@ -1519,6 +1521,9 @@ public partial class FileOperationsViewModel : ObservableObject
             if (groupData.GroupDto.ParentGroupId == null)
             {
                 group.ProcessBinding = RestoreGroupBinding(groupData);
+                // Truth Table pin roles (issue #981): restore as persisted — the panel
+                // silently skips pin names that no longer match a real external pin.
+                group.TruthTablePinAssignment = groupData.TruthTablePinAssignment;
                 var groupVm = _canvas.AddComponent(group);
                 groupVm.X = groupData.CanvasX;
                 groupVm.Y = groupData.CanvasY;

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -89,6 +89,15 @@ public class ComponentGroup : Component, INotifyPropertyChanged
     public ActiveProcessSelection? ProcessBinding { get; set; }
 
     /// <summary>
+    /// Pin-role assignment the Truth Table panel last successfully extracted with for
+    /// this group (issue #981). Null while the panel never extracted the group — nothing
+    /// is persisted in that case, keeping the .lun format free of unused blocks.
+    /// Persisted in .lun files for top-level groups since issue #981.
+    /// </summary>
+    [JsonIgnore]
+    public TruthTablePinAssignment? TruthTablePinAssignment { get; set; }
+
+    /// <summary>
     /// Reference to parent group if this group is nested within another group.
     /// Null if this is a top-level group.
     /// </summary>

--- a/Connect-A-Pic-Core/Components/Core/TruthTablePinAssignment.cs
+++ b/Connect-A-Pic-Core/Components/Core/TruthTablePinAssignment.cs
@@ -1,0 +1,29 @@
+namespace CAP_Core.Components.Core;
+
+/// <summary>
+/// Pin-role assignment the Truth Table panel last successfully extracted with for a
+/// group (issue #981): the logic input pins in bit order, the logic output pins, the
+/// bias pins that are "on" in every row, and the analog→digital power threshold.
+/// Persisted in the .lun design file on top-level groups so the panel can prefill
+/// after a save → load round trip without the user re-assigning roles by hand.
+/// Lives in <c>Components.Core</c> (not <c>Analysis.LogicAnalysis</c>) because the
+/// shared-kernel <see cref="ComponentGroup"/> carries it — the Analysis feature
+/// imports Components, not the other way round.
+/// </summary>
+public sealed class TruthTablePinAssignment
+{
+    /// <summary>Logic input pin names in the truth table's bit order (column order).</summary>
+    public List<string> InputPinNames { get; set; } = new();
+
+    /// <summary>Logic output pin names.</summary>
+    public List<string> OutputPinNames { get; set; } = new();
+
+    /// <summary>Bias pin names — constantly "on" in every row (inversion-gate ingredient).</summary>
+    public List<string> BiasPinNames { get; set; } = new();
+
+    /// <summary>
+    /// Normalized power threshold in the open interval (0, 1) the table was
+    /// extracted at: an output counts as logic 1 at or above it.
+    /// </summary>
+    public double Threshold { get; set; }
+}

--- a/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
+++ b/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Persistence round-trip of the Truth Table pin-role assignment in the .lun file
+/// (issue #981): whatever the panel last successfully extracted with — input pins
+/// in bit order, output pins, bias pins, threshold — survives save → load, the panel
+/// prefills on group selection, and extraction reproduces the pinned table without
+/// any manual role re-assignment. Legacy files without the new block keep loading
+/// exactly as before.
+/// </summary>
+public class TruthTablePinAssignmentPersistenceTests : IDisposable
+{
+    private const string ExampleFileName = "Logic Gate NOT-NAND.lun";
+    private const double NandThreshold = 0.125;
+    private static readonly string[] NandInputs = { "A", "B" };
+    private static readonly string[] NandOutputs = { "Y" };
+    private static readonly string[] NandBiases = { "BIAS" };
+
+    private readonly string _designFilePath =
+        Path.Combine(Path.GetTempPath(), $"truthtable-persist-{Guid.NewGuid():N}.lun");
+
+    public void Dispose()
+    {
+        if (File.Exists(_designFilePath))
+            File.Delete(_designFilePath);
+    }
+
+    [Fact]
+    public async Task RoundTrip_ExtractedAssignmentSurvivesSaveAndReload()
+    {
+        var canvas = await LoadGateOnCanvas();
+        await ExtractNandThroughPanel(canvas);
+
+        await Save(canvas);
+        var fileText = File.ReadAllText(_designFilePath);
+        fileText.ShouldContain("TruthTablePinAssignment", Case.Sensitive,
+            "the persisted .lun carries the truth-table block after an extraction");
+        fileText.ShouldContain("\"Threshold\": 0.125", Case.Sensitive);
+
+        var reloaded = await LoadFromDisk();
+        var group = SingleGateGroup(reloaded);
+        var saved = group.TruthTablePinAssignment.ShouldNotBeNull(
+            "the extracted assignment must be restored on the reloaded group");
+        saved.InputPinNames.ShouldBe(NandInputs);
+        saved.OutputPinNames.ShouldBe(NandOutputs);
+        saved.BiasPinNames.ShouldBe(NandBiases);
+        saved.Threshold.ShouldBe(NandThreshold);
+    }
+
+    [Fact]
+    public async Task LegacyFile_WithoutTruthTableBlock_LoadsWithNullAssignment()
+    {
+        // The shipped example predates the persistence block — it is the legacy case.
+        var canvas = await LoadGateOnCanvas();
+        SingleGateGroup(canvas).TruthTablePinAssignment.ShouldBeNull(
+            "legacy .lun files load with no truth-table assignment attached");
+
+        // Saving and reloading the untouched legacy design must not invent a block:
+        // no assignment → nothing persisted, no format noise.
+        await Save(canvas);
+        var fileText = File.ReadAllText(_designFilePath);
+        fileText.ShouldNotContain("TruthTablePinAssignment", Case.Sensitive,
+            "a never-extracted group persists no truth-table block");
+
+        var reloaded = await LoadFromDisk();
+        SingleGateGroup(reloaded).TruthTablePinAssignment.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ReloadedGroup_PanelPrefillsRoles_AndExtractsNandTableWithoutManualAssignment()
+    {
+        var canvas = await LoadGateOnCanvas();
+        await ExtractNandThroughPanel(canvas);
+        await Save(canvas);
+        var reloaded = await LoadFromDisk();
+
+        // The panel Jonas sees after reopening the file: every role and the threshold
+        // already set, before he touches a single checkbox.
+        var groupVm = reloaded.Components.Single(c => c.Component is ComponentGroup);
+        reloaded.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, reloaded);
+
+        vm.IsGroupSelected.ShouldBeTrue();
+        vm.InputPins.Where(p => p.IsChecked).Select(p => p.PinName).ShouldBe(NandInputs);
+        vm.OutputPins.Where(p => p.IsChecked).Select(p => p.PinName).ShouldBe(NandOutputs);
+        vm.BiasPins.Where(p => p.IsChecked).Select(p => p.PinName).ShouldBe(NandBiases);
+        vm.Threshold.ShouldBe(NandThreshold);
+
+        // Extract with no further interaction — the pinned NAND table must come back.
+        await vm.ExtractCommand.ExecuteAsync(null);
+        vm.HasResult.ShouldBeTrue();
+        vm.InputHeaders.ShouldBe(NandInputs);
+        vm.OutputHeaders.ShouldBe(NandOutputs);
+        vm.BiasSummaryText.ShouldContain("BIAS");
+        vm.Rows.Count.ShouldBe(4);
+        AssertPanelRow(vm, "0 0", expectedBit: true, expectedPowerText: "0.50");
+        AssertPanelRow(vm, "1 0", expectedBit: true, expectedPowerText: "0.25");
+        AssertPanelRow(vm, "0 1", expectedBit: true, expectedPowerText: "0.25");
+        AssertPanelRow(vm, "1 1", expectedBit: false, expectedPowerText: "0.00");
+    }
+
+    /// <summary>Asserts one panel row's output bit and its displayed raw power.</summary>
+    private static void AssertPanelRow(
+        TruthTableViewModel vm, string inputBitsText, bool expectedBit, string expectedPowerText)
+    {
+        var row = vm.Rows.Single(r => r.InputBitsText == inputBitsText);
+        row.OutputCells[0].IsOne.ShouldBe(expectedBit,
+            $"threshold {vm.Threshold}: output bit for input pattern {inputBitsText}");
+        row.OutputCells[0].PowerText.ShouldBe(expectedPowerText,
+            $"threshold {vm.Threshold}: raw power for input pattern {inputBitsText}");
+    }
+
+    /// <summary>
+    /// Drives the loaded example through the Truth Table panel's ViewModel exactly as
+    /// the interactive flow does — this is what populates the persisted assignment.
+    /// </summary>
+    private static async Task ExtractNandThroughPanel(DesignCanvasViewModel canvas)
+    {
+        var groupVm = canvas.Components.Single(c => c.Component is ComponentGroup);
+        canvas.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, canvas);
+        vm.IsGroupSelected.ShouldBeTrue("the loaded gate group must activate the panel");
+        foreach (var name in NandInputs)
+            vm.InputPins.Single(p => p.PinName == name).IsChecked = true;
+        vm.OutputPins.Single(p => p.PinName == "Y").IsChecked = true;
+        vm.BiasPins.Single(p => p.PinName == "BIAS").IsChecked = true;
+        vm.Threshold = NandThreshold;
+        await vm.ExtractCommand.ExecuteAsync(null);
+        vm.HasResult.ShouldBeTrue("the manual extraction that seeds persistence must succeed");
+    }
+
+    /// <summary>Saves the canvas's design through the real save path to the temp file.</summary>
+    private async Task Save(DesignCanvasViewModel canvas)
+    {
+        var saveVm = CreateFileOperations(canvas);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(_designFilePath).ShouldBeTrue("the design file must be written");
+    }
+
+    /// <summary>Reloads the temp file through the real load path onto a fresh canvas.</summary>
+    private async Task<DesignCanvasViewModel> LoadFromDisk()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(canvas);
+        (await loadVm.LoadDesignFromPathAsync(_designFilePath)).ShouldBeTrue(
+            "the saved design must load through the real load path");
+        return canvas;
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns the canvas.</summary>
+    private static async Task<DesignCanvasViewModel> LoadGateOnCanvas()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = CreateFileOperations(canvas);
+        var examplePath = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+        (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+            $"the shipped example '{ExampleFileName}' must load through the real load path");
+        return canvas;
+    }
+
+    private static ComponentGroup SingleGateGroup(DesignCanvasViewModel canvas) =>
+        canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+
+    private static FileOperationsViewModel CreateFileOperations(DesignCanvasViewModel canvas)
+    {
+        var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
+        return new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!);
+    }
+}


### PR DESCRIPTION
Automated implementation for #981

- New `TruthTablePinAssignment` (Components.Core) carries input/output/bias names + threshold.
- `ComponentGroup` runtime property + `DesignGroupData` DTO field mirror the #938 ProcessBinding pattern.
- Save writes the block only after a successful extraction; legacy files stay untouched (serializer already drops nulls).
- Panel captures the assignment post-extraction; prefill restores checkboxes + threshold on group select, skipping stale pin names.
- Rebased onto `origin/dev-ki` — rung-4 Truth Table + ProcessBinding infrastructure lives there, not on main; PR must target dev-ki.
- Rejected alternative: state on the panel VM (wouldn't survive panel rebuilds; group-scoped state matches ProcessBinding precedent).
- Verified: 3 new integration tests (round-trip identity, prefill + NAND re-extract without manual roles, legacy load unchanged) — local suite 5784 passed, 0 failed.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 8,484,561
- **Estimated cost:** $4.7514 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>