### PR TITLE
Agent: LogicNetworkAssembler — loaded .lun design to evaluable logic network (#985)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkAssembler.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkAssembler.cs
@@ -1,0 +1,108 @@
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Assembles an evaluable <see cref="LogicNetworkEvaluator"/> straight from a loaded
+/// design — no hand-built <see cref="LogicGateInstance"/>s: every top-level group
+/// carrying a persisted <see cref="TruthTablePinAssignment"/> is a logic gate, its
+/// <see cref="LogicGateModel"/> is re-extracted with exactly the persisted pin roles
+/// and threshold, and the design's own connections wire the gates (the canvas stays
+/// the source of truth, see <see cref="LogicNetworkBuilder"/>). Groups without a
+/// persisted assignment are not gates and are simply ignored; a design with no gate
+/// group at all is reported as a readable error instead of yielding an empty network.
+/// Identical groups are extracted per instance — the extraction is the source of the
+/// model, and caching would only ever save simulation runs, never change the result.
+/// </summary>
+public sealed class LogicNetworkAssembler
+{
+    private readonly TruthTableExtractor _extractor;
+    private readonly LogicNetworkBuilder _builder;
+
+    /// <summary>
+    /// Creates an assembler over the pipeline stages; the parameterless defaults cover
+    /// the production path, tests inject their own stages.
+    /// </summary>
+    /// <param name="extractor">Re-extracts each gate's truth table from its group.</param>
+    /// <param name="builder">Derives and validates the network from gates and connections.</param>
+    public LogicNetworkAssembler(TruthTableExtractor? extractor = null, LogicNetworkBuilder? builder = null)
+    {
+        _extractor = extractor ?? new TruthTableExtractor();
+        _builder = builder ?? new LogicNetworkBuilder();
+    }
+
+    /// <summary>
+    /// Builds the logic network of a loaded design: collects the top-level gate groups
+    /// (those with a persisted <see cref="TruthTablePinAssignment"/>), re-extracts each
+    /// gate's model with the persisted roles and threshold, and lets the
+    /// <see cref="LogicNetworkBuilder"/> derive the wiring from
+    /// <paramref name="connections"/>. Extraction and builder errors pass through
+    /// unchanged — their messages name the offending pins.
+    /// </summary>
+    /// <param name="components">
+    /// The design's top-level components. Non-group components and groups without a
+    /// persisted assignment take no part in the network.
+    /// </param>
+    /// <param name="connections">
+    /// The design's waveguide connections. Only connections joining external pins of
+    /// two gate groups take part in wiring; everything else is ignored.
+    /// </param>
+    /// <param name="wavelengthNm">Laser wavelength in nm the gate tables are re-extracted at.</param>
+    /// <param name="cancellationToken">Cancels the assembly between combinations.</param>
+    /// <returns>The validated, evaluation-ready network behind the design's gate groups.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="components"/> or <paramref name="connections"/> is null.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">The design contains no gate group.</exception>
+    public async Task<LogicNetworkEvaluator> AssembleAsync(
+        IReadOnlyList<Component> components,
+        IReadOnlyList<WaveguideConnection> connections,
+        int wavelengthNm,
+        CancellationToken cancellationToken = default)
+    {
+        if (components == null) throw new ArgumentNullException(nameof(components));
+        if (connections == null) throw new ArgumentNullException(nameof(connections));
+
+        var gateGroups = components
+            .OfType<ComponentGroup>()
+            .Where(group => group.TruthTablePinAssignment != null)
+            .ToList();
+        if (gateGroups.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "The design contains no logic gate: no top-level group carries a persisted " +
+                "truth-table pin assignment. Extract a group's truth table in the Truth Table " +
+                "panel to turn the group into a gate.");
+        }
+
+        var gates = new List<LogicGateInstance>(gateGroups.Count);
+        foreach (var group in gateGroups)
+        {
+            gates.Add(await ExtractGateAsync(group, wavelengthNm, cancellationToken));
+        }
+
+        return _builder.Build(gates, connections);
+    }
+
+    /// <summary>Re-extracts one gate group's model with exactly its persisted roles and threshold.</summary>
+    private async Task<LogicGateInstance> ExtractGateAsync(
+        ComponentGroup group, int wavelengthNm, CancellationToken cancellationToken)
+    {
+        var persisted = group.TruthTablePinAssignment!;
+        var roles = new GateRoleAssignment(
+            persisted.InputPinNames,
+            persisted.OutputPinNames,
+            persisted.BiasPinNames,
+            persisted.Threshold);
+        var table = await _extractor.ExtractAsync(
+            group,
+            roles.InputPinNames,
+            roles.OutputPinNames,
+            roles.BiasPinNames,
+            roles.PowerThreshold,
+            wavelengthNm,
+            cancellationToken);
+        return new LogicGateInstance(group, LogicGateModel.FromTruthTable(table), roles);
+    }
+}

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkAssemblerTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkAssemblerTests.cs
@@ -1,0 +1,171 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The design-to-network assembler over the numeric fixtures: a top-level group
+/// carrying a persisted <see cref="TruthTablePinAssignment"/> becomes a gate whose
+/// model is re-extracted with the persisted roles — the 50/50 combiner group plays
+/// an OR gate at threshold 0.25, so a wired cascade must evaluate as a three-input
+/// OR by pure table lookup. Groups without an assignment (and non-group components)
+/// are ignored, a design without any gate fails readably, and builder errors pass
+/// through with their pin names intact.
+/// </summary>
+public class LogicNetworkAssemblerTests
+{
+    private const double OrThreshold = 0.25;
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    [InlineData(true, true, true)]
+    public async Task AssembleAsync_OutputWiredToInput_EvaluatesTheCascadedNetworkFromTheCanvasConnection(
+        bool a, bool b, bool c)
+    {
+        var first = OrGate("OR1");
+        var second = OrGate("OR2");
+        var connections = new[] { Connect(first, "y", second, "a") };
+
+        var network = await Assemble(new Component[] { first, second }, connections);
+
+        network.InputPinNames.ShouldBe(new[] { "OR1.a", "OR1.b", "OR2.b" },
+            "the unconnected gate inputs become the network-level inputs");
+        network.OutputPinNames.ShouldBe(new[] { "OR1.y", "OR2.y" });
+        var outputs = network.Evaluate(Bits(("OR1.a", a), ("OR1.b", b), ("OR2.b", c)));
+        outputs["OR2.y"].ShouldBe(a || b || c, $"OR2.y = OR(OR(a, b), c) for a={a}, b={b}, c={c}");
+        outputs["OR1.y"].ShouldBe(a || b, $"OR1.y stays readable as a tap for a={a}, b={b}");
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task AssembleAsync_GroupWithoutAssignmentAndNonGroupComponent_AreIgnored(bool a, bool b)
+    {
+        var gate = OrGate("OR1");
+        var unassigned = LogicGateFixtureFactory.CreateCombinerGroup();
+        unassigned.GroupName = "PLAIN";
+        var nonGroup = unassigned.ChildComponents.Single();
+
+        var network = await Assemble(
+            new Component[] { gate, unassigned, nonGroup }, Array.Empty<WaveguideConnection>());
+
+        network.Gates.Keys.ShouldBe(new[] { "OR1" },
+            "only the group with a persisted assignment is a gate");
+        network.Evaluate(Bits(("OR1.a", a), ("OR1.b", b)))["OR1.y"]
+            .ShouldBe(a || b, $"the remaining gate still evaluates for a={a}, b={b}");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_NoGateGroup_ThrowsAReadableError()
+    {
+        var plain = new ComponentGroup("PLAIN");
+
+        var error = await Should.ThrowAsync<InvalidOperationException>(
+            () => Assemble(new Component[] { plain }, Array.Empty<WaveguideConnection>()));
+
+        error.Message.ShouldContain("no logic gate");
+        error.Message.ShouldContain("truth-table pin assignment");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_EmptyDesign_ThrowsAReadableError()
+    {
+        var error = await Should.ThrowAsync<InvalidOperationException>(
+            () => Assemble(Array.Empty<Component>(), Array.Empty<WaveguideConnection>()));
+
+        error.Message.ShouldContain("no logic gate");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_DuplicateGateNames_PassesTheBuilderErrorThrough()
+    {
+        var first = OrGate("OR1");
+        var second = OrGate("OR1");
+
+        var error = await Should.ThrowAsync<ArgumentException>(
+            () => Assemble(new Component[] { first, second }, Array.Empty<WaveguideConnection>()));
+
+        error.Message.ShouldContain("'OR1'");
+        error.Message.ShouldContain("must be unique");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_OutputToOutputWiring_PassesTheBuilderErrorThroughNamingThePins()
+    {
+        var first = OrGate("OR1");
+        var second = OrGate("OR2");
+        var connections = new[] { Connect(first, "y", second, "y") };
+
+        var error = await Should.ThrowAsync<ArgumentException>(
+            () => Assemble(new Component[] { first, second }, connections));
+
+        error.Message.ShouldContain("two gate output pins");
+        error.Message.ShouldContain("OR1.y");
+        error.Message.ShouldContain("OR2.y");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_NullComponents_Throws()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => new LogicNetworkAssembler().AssembleAsync(
+                null!, Array.Empty<WaveguideConnection>(), LogicGateFixtureFactory.WavelengthNm));
+    }
+
+    [Fact]
+    public async Task AssembleAsync_NullConnections_Throws()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => new LogicNetworkAssembler().AssembleAsync(
+                Array.Empty<Component>(), null!, LogicGateFixtureFactory.WavelengthNm));
+    }
+
+    /// <summary>Runs the assembler at the fixture wavelength.</summary>
+    private static Task<LogicNetworkEvaluator> Assemble(
+        IReadOnlyList<Component> components, IReadOnlyList<WaveguideConnection> connections) =>
+        new LogicNetworkAssembler().AssembleAsync(
+            components, connections, LogicGateFixtureFactory.WavelengthNm);
+
+    /// <summary>
+    /// A combiner group with the OR-reading assignment persisted, as a save → load
+    /// round trip would deliver it; the S-matrix sync surfaces the connectable pins.
+    /// </summary>
+    private static ComponentGroup OrGate(string groupName)
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        group.GroupName = groupName;
+        group.TruthTablePinAssignment = new TruthTablePinAssignment
+        {
+            InputPinNames = new List<string> { "a", "b" },
+            OutputPinNames = new List<string> { "y" },
+            BiasPinNames = new List<string>(),
+            Threshold = OrThreshold,
+        };
+        group.EnsureSMatrixComputed();
+        return group;
+    }
+
+    /// <summary>A design connection between two gate groups' external pins.</summary>
+    private static WaveguideConnection Connect(
+        ComponentGroup from, string fromPin, ComponentGroup to, string toPin) =>
+        new() { StartPin = Pin(from, fromPin), EndPin = Pin(to, toPin) };
+
+    /// <summary>Looks up a group's connectable external pin.</summary>
+    private static PhysicalPin Pin(ComponentGroup group, string name) =>
+        group.PhysicalPins.Single(p => p.Name == name);
+
+    /// <summary>Builds an input-bit dictionary from (name, bit) pairs.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}

--- a/UnitTests/Integration/LogicNetworkAssemblerExampleTests.cs
+++ b/UnitTests/Integration/LogicNetworkAssemblerExampleTests.cs
@@ -1,0 +1,226 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using UnitTests.Helpers;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Rung-4 assembly from a loaded design: two instances of the shipped
+/// <c>examples/Logic Gate NOT-NAND.lun</c> gate — one read as NAND, one as NOT —
+/// carry their pin roles and thresholds as persisted <see cref="TruthTablePinAssignment"/>s
+/// delivered by the real extract → save → load path (the test never hands roles to the
+/// assembler). Wired NAND.Y→NOT.A through a design connection, the
+/// <see cref="LogicNetworkAssembler"/> turns the pair into an evaluator that reads the
+/// AND truth table by pure table lookup. A group without a persisted assignment on the
+/// same canvas is ignored, and a design without any gate group fails with a readable
+/// error instead of an empty network.
+/// </summary>
+public class LogicNetworkAssemblerExampleTests : IDisposable
+{
+    private const string ExampleFileName = "Logic Gate NOT-NAND.lun";
+    private const string NandGateId = "NAND";
+    private const string NotGateId = "NOT";
+    private const double NandThreshold = 0.125;
+    private const double NotThreshold = 0.375;
+    private const int WavelengthNm = 1550;
+
+    private static readonly string[] NandInputs = { "A", "B" };
+    private static readonly string[] NotInputs = { "A" };
+    private static readonly string[] Outputs = { "Y" };
+    private static readonly string[] Biases = { "BIAS" };
+
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (var path in _tempFiles.Where(File.Exists))
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task AssembleAsync_PersistedNandAndNotWiredOnCanvas_EvaluatesTheAndTruthTable()
+    {
+        var nand = await LoadGateWithPersistedRoles(NandGateId, NandInputs, NandThreshold);
+        var inv = await LoadGateWithPersistedRoles(NotGateId, NotInputs, NotThreshold);
+        var connections = new[] { Connect(nand, "Y", inv, "A") };
+
+        var network = await new LogicNetworkAssembler().AssembleAsync(
+            new Component[] { nand, inv }, connections, WavelengthNm);
+
+        network.InputPinNames.ShouldBe(new[] { "NAND.A", "NAND.B" },
+            "the unconnected NAND inputs become the network-level inputs");
+        network.OutputPinNames.ShouldBe(new[] { "NAND.Y", "NOT.Y" },
+            "every gate output pin becomes a network-level output tap");
+        foreach (var a in new[] { false, true })
+        foreach (var b in new[] { false, true })
+        {
+            var outputs = network.Evaluate(Bits(("NAND.A", a), ("NAND.B", b)));
+            outputs["NOT.Y"].ShouldBe(a && b, $"AND = NOT(NAND(A, B)) for A={a}, B={b}");
+            outputs["NAND.Y"].ShouldBe(!(a && b),
+                $"the driving gate output stays readable as a tap for A={a}, B={b}");
+        }
+    }
+
+    [Fact]
+    public async Task AssembleAsync_GroupWithoutAssignmentOnTheCanvas_IsIgnored()
+    {
+        var nand = await LoadGateWithPersistedRoles(NandGateId, NandInputs, NandThreshold);
+        var plain = SingleGateGroup(await LoadGateOnCanvas());
+        plain.GroupName = "PLAIN";
+
+        var network = await new LogicNetworkAssembler().AssembleAsync(
+            new Component[] { nand, plain }, Array.Empty<WaveguideConnection>(), WavelengthNm);
+
+        network.Gates.Keys.ShouldBe(new[] { NandGateId },
+            "the group without a persisted assignment is not a gate");
+        foreach (var a in new[] { false, true })
+        foreach (var b in new[] { false, true })
+        {
+            network.Evaluate(Bits(("NAND.A", a), ("NAND.B", b)))["NAND.Y"]
+                .ShouldBe(!(a && b), $"the remaining gate still evaluates for A={a}, B={b}");
+        }
+    }
+
+    [Fact]
+    public async Task AssembleAsync_DesignWithoutGateGroups_ThrowsAReadableError()
+    {
+        var plain = SingleGateGroup(await LoadGateOnCanvas());
+
+        var error = await Should.ThrowAsync<InvalidOperationException>(
+            () => new LogicNetworkAssembler().AssembleAsync(
+                new Component[] { plain }, Array.Empty<WaveguideConnection>(), WavelengthNm));
+
+        error.Message.ShouldContain("no logic gate");
+    }
+
+    /// <summary>
+    /// Delivers one gate group the way Jonas gets it: the shipped example is loaded,
+    /// its truth table extracted through the real panel flow (which seeds the persisted
+    /// assignment), saved, and reloaded — the reloaded group carries roles and threshold
+    /// from the file, not from this test.
+    /// </summary>
+    private async Task<ComponentGroup> LoadGateWithPersistedRoles(
+        string gateId, string[] inputPinNames, double threshold)
+    {
+        var canvas = await LoadGateOnCanvas();
+        await ExtractThroughPanel(canvas, inputPinNames, threshold);
+        SingleGateGroup(canvas).GroupName = gateId;
+        var path = NewTempFile();
+        await Save(canvas, path);
+
+        var group = SingleGateGroup(await LoadFromDisk(path));
+        group.TruthTablePinAssignment.ShouldNotBeNull(
+            "the reloaded group must carry the persisted roles — the assembler reads them from here");
+        group.EnsureSMatrixComputed();
+        return group;
+    }
+
+    /// <summary>
+    /// Drives the loaded example through the Truth Table panel's ViewModel exactly as
+    /// the interactive flow does — this is what populates the persisted assignment.
+    /// </summary>
+    private static async Task ExtractThroughPanel(
+        DesignCanvasViewModel canvas, string[] inputPinNames, double threshold)
+    {
+        var groupVm = canvas.Components.Single(c => c.Component is ComponentGroup);
+        canvas.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, canvas);
+        vm.IsGroupSelected.ShouldBeTrue("the loaded gate group must activate the panel");
+        foreach (var name in inputPinNames)
+        {
+            vm.InputPins.Single(p => p.PinName == name).IsChecked = true;
+        }
+        vm.OutputPins.Single(p => p.PinName == Outputs[0]).IsChecked = true;
+        vm.BiasPins.Single(p => p.PinName == Biases[0]).IsChecked = true;
+        vm.Threshold = threshold;
+        await vm.ExtractCommand.ExecuteAsync(null);
+        vm.HasResult.ShouldBeTrue("the extraction that seeds persistence must succeed");
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns the canvas.</summary>
+    private static async Task<DesignCanvasViewModel> LoadGateOnCanvas()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = CreateFileOperations(canvas);
+        var examplePath = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+        (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+            $"the shipped example '{ExampleFileName}' must load through the real load path");
+        return canvas;
+    }
+
+    /// <summary>Saves the canvas's design through the real save path to a temp file.</summary>
+    private static async Task Save(DesignCanvasViewModel canvas, string path)
+    {
+        var saveVm = CreateFileOperations(canvas);
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(path);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(path).ShouldBeTrue("the design file must be written");
+    }
+
+    /// <summary>Reloads a saved design through the real load path onto a fresh canvas.</summary>
+    private static async Task<DesignCanvasViewModel> LoadFromDisk(string path)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var fileOps = CreateFileOperations(canvas);
+        (await fileOps.LoadDesignFromPathAsync(path)).ShouldBeTrue(
+            "the saved design must load through the real load path");
+        return canvas;
+    }
+
+    /// <summary>The canvas wiring between two gate groups' external pins: NAND.Y → NOT.A.</summary>
+    private static WaveguideConnection Connect(
+        ComponentGroup from, string fromPin, ComponentGroup to, string toPin) =>
+        new() { StartPin = Pin(from, fromPin), EndPin = Pin(to, toPin) };
+
+    /// <summary>The group's connectable external pin, surfaced by the S-matrix sync.</summary>
+    private static PhysicalPin Pin(ComponentGroup group, string name) =>
+        group.PhysicalPins.Single(p => p.Name == name);
+
+    private static ComponentGroup SingleGateGroup(DesignCanvasViewModel canvas) =>
+        canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+
+    private static FileOperationsViewModel CreateFileOperations(DesignCanvasViewModel canvas)
+    {
+        var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
+        return new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!);
+    }
+
+    private string NewTempFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"logic-assembler-{Guid.NewGuid():N}.lun");
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    /// <summary>Builds an input-bit dictionary from (name, bit) pairs.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}


### PR DESCRIPTION
Closes #985 (rung 4 of #537).

=== PR SUMMARY ===
- New `LogicNetworkAssembler` (Core/Analysis/LogicAnalysis): loaded design → `LogicNetworkEvaluator`.
- Top-level groups with persisted `TruthTablePinAssignment` become gates; models re-extracted with persisted roles/threshold.
- Groups without assignment and non-group components ignored; design without gates → readable `InvalidOperationException`.
- Canvas connections go straight to `LogicNetworkBuilder.Build`; builder errors pass through naming the pins.
- No caching — identical groups extracted per instance (issue allows optional caching; skipped for simplicity).
- Integration test seeds roles via real extract → save → load path; wired NAND→NOT evaluates the AND table by lookup.
- Verified: build clean (0 errors/warnings); local suite: 5815 passed, 0 failed, 16 skipped (Category!=Slow).
=== END ===

Core-only (Recipe B) — no UI; panel/visualization is a separate later step. Manual verification after the holidays: none.