### PR TITLE
Agent: Full-adder manufacturing journey — GDS export + Cornerstone pre-DRC pinned clean (#995)

### DIFF
--- a/UnitTests/Integration/FullAdderManufacturingJourneyTests.cs
+++ b/UnitTests/Integration/FullAdderManufacturingJourneyTests.cs
@@ -1,0 +1,207 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using CAP_DataAccess.Import.Gds;
+using Shouldly;
+using UnitTests.Export;
+using UnitTests.Export.CornerstoneDrc;
+using UnitTests.Services.GdsImport;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Hard end-to-end scenario of the rung 4→7 chain (issue #995): the shipped
+/// <c>examples/Logic Gate Full Adder.lun</c> — 32 gate groups wired to the textbook
+/// full adder — must survive the whole manufacturing path, not just simulate. The
+/// journey loads the design through the real load path, assembles the logic network
+/// (<see cref="LogicNetworkAssembler"/>) and pins the corner combinations as the proof
+/// it is *the* full adder, exports the design to GDS through the real nazca path,
+/// and runs the vendored CORNERSTONE SiN pre-DRC deck headless over the export
+/// (nazca/KLayout gated, same skip behavior as the GDS round-trips). The foundry-deck
+/// verdict is pinned to an empty violation set: today the export writes only layers
+/// none of the deck's rules inspect — any new violation class fails this journey.
+/// </summary>
+public class FullAdderManufacturingJourneyTests
+    : IClassFixture<FullAdderManufacturingJourneyTests.ManufacturingJourneyFixture>
+{
+    private const string SumTap = "H2SUM.Y";
+    private const string CarryOutTap = "OROUT.Y";
+
+    private readonly ManufacturingJourneyFixture _journey;
+
+    /// <summary>Attaches the shared journey fixture.</summary>
+    public FullAdderManufacturingJourneyTests(ManufacturingJourneyFixture journey) => _journey = journey;
+
+    [Fact]
+    public void Step1_Load_ExampleArrivesAsWiredGateGroupsWithPersistedRoles()
+    {
+        _journey.Groups.Select(g => g.GroupName)
+            .ShouldBe(ExpectedGateNames, ignoreOrder: true);
+        _journey.Groups.ShouldAllBe(g => g.TruthTablePinAssignment != null,
+            "every gate group must carry its persisted pin roles for the manufacturing path to matter");
+        _journey.Canvas.Connections.Count.ShouldBe(30, "thirty wires join the thirty-two gates");
+    }
+
+    [Theory]
+    [InlineData(false, false, false, false, false)]
+    [InlineData(true, true, true, true, true)]
+    [InlineData(true, false, true, false, true)]
+    public void Step2_AssembledNetwork_CornerCombinations_YieldFullAdderSumAndCarryOut(
+        bool a, bool b, bool cin, bool expectedSum, bool expectedCarryOut)
+    {
+        var result = _journey.Network.Evaluate(_journey.InputBits(a, b, cin));
+
+        result[SumTap].ShouldBe(expectedSum, "Sum = A XOR B XOR Cin");
+        result[CarryOutTap].ShouldBe(expectedCarryOut, "Cout = majority(A, B, Cin)");
+    }
+
+    [Fact]
+    public void Step3_NazcaExport_WritesTheDesignAsGdsTopCell()
+    {
+        _journey.NazcaScript.ShouldNotBeNullOrEmpty(
+            "the real export path must produce a nazca script for the loaded full adder");
+        _journey.NazcaScript.ShouldContain("nd.export_gds(topcells=[design]",
+            Case.Sensitive, "the exported GDS carries the design as its top cell");
+    }
+
+    [Trait("Category", "Slow")]
+    [SkippableFact]
+    public async Task Step4_GdsExportAndFoundryDeck_EmptyViolationBaselineHolds()
+    {
+        var python = await GdsUserDesignFixture.FindNazcaPythonAsync();
+        Skip.If(python == null, "No Python with nazca available — the GDS export needs the real engine.");
+        var klayout = await ExternalToolProbes.FindKlayoutAsync();
+        Skip.If(klayout == null, "No KLayout on PATH/$KLAYOUT — the foundry-deck proof needs the real engine.");
+
+        var exportDir = Path.Combine(_journey.WorkDirectory, "export");
+        Directory.CreateDirectory(exportDir);
+        var scriptPath = Path.Combine(exportDir, "full_adder_manufacturing.py");
+        await File.WriteAllTextAsync(scriptPath, _journey.NazcaScript);
+        var export = await SiepicRealGeometryExportTests.RunPythonAsync(python, exportDir, scriptPath);
+        export.ExitCode.ShouldBe(0, $"the nazca export of the full adder must succeed:\n{export.StdOut}\n{export.StdErr}");
+
+        var gdsPath = Path.ChangeExtension(scriptPath, ".gds");
+        File.Exists(gdsPath).ShouldBeTrue($"the export script must write {gdsPath}:\n{export.StdOut}");
+
+        GdsLibrary library;
+        await using (var stream = File.OpenRead(gdsPath))
+            library = await new GdsReader().ReadAsync(stream);
+        library.TopCellCandidates.ShouldContain("ConnectAPIC_Design");
+        var designCell = library.Cells["ConnectAPIC_Design"];
+        designCell.Elements.OfType<GdsReference>().ShouldNotBeEmpty(
+            "the gate group children are placed as cell references");
+        designCell.Elements.OfType<GdsPolygon>().ShouldNotBeEmpty(
+            "the gate wiring flattens into real top-cell geometry");
+
+        var reportPath = Path.Combine(exportDir, "full_adder.lyrdb");
+        var (exitCode, output, error) = await ExternalToolProbes.RunToolAsync(
+            python, CornerstoneDrcPaths.RunnerScript, gdsPath,
+            "--klayout", klayout, "--report", reportPath);
+
+        exitCode.ShouldBe(0,
+            $"the vendored foundry deck must complete.\nstdout:\n{output}\nstderr:\n{error}");
+        output.ShouldContain("PASSED: 0 DRC violations.",
+            Case.Sensitive,
+            "the empty violation set is the pinned baseline today (the export targets none " +
+            "of the deck's layers); a new violation class must fail this journey here");
+    }
+
+    private static readonly string[] ExpectedGateNames =
+    {
+        "H1N1A1", "H1N1B1", "H1N21", "H1N31", "H1SUM1",
+        "H1N1A2", "H1N1B2", "H1N22", "H1N32", "H1SUM2",
+        "H1N1A3", "H1N1B3", "H1N23", "H1N33", "H1SUM3",
+        "H1N1A4", "H1N1B4", "H1N24", "H1N34", "H1SUM4",
+        "H1N5", "H1CARRY",
+        "H2N1A", "H2N1B", "H2N2", "H2N3", "H2SUM", "H2N5", "H2CARRY",
+        "ORNOT1", "ORNOT2", "OROUT",
+    };
+
+    /// <summary>
+    /// Shared journey fixture: performs the journey's stateful steps once (load →
+    /// assemble → export-script) so each fact asserts one step of the same continuous
+    /// journey and the DRC step drives exactly what the export produced.
+    /// </summary>
+    public class ManufacturingJourneyFixture : IAsyncLifetime
+    {
+        private const string ExampleFileName = "Logic Gate Full Adder.lun";
+
+        /// <summary>Laser wavelength the persisted roles were extracted at.</summary>
+        public const int WavelengthNm = 1550;
+
+        /// <summary>Network inputs driven by addend A (fan-out at the logic layer).</summary>
+        private static readonly string[] InputsA =
+        {
+            "H1N1A1.A", "H1N1B1.A", "H1N21.A",
+            "H1N1A2.A", "H1N1B2.A", "H1N22.A",
+            "H1N1A3.A", "H1N1B3.A", "H1N23.A",
+            "H1N1A4.A", "H1N1B4.A", "H1N24.A",
+            "H1N5.A",
+        };
+
+        /// <summary>Network inputs driven by addend B (fan-out at the logic layer).</summary>
+        private static readonly string[] InputsB =
+        {
+            "H1N1A1.B", "H1N1B1.B", "H1N31.B",
+            "H1N1A2.B", "H1N1B2.B", "H1N32.B",
+            "H1N1A3.B", "H1N1B3.B", "H1N33.B",
+            "H1N1A4.B", "H1N1B4.B", "H1N34.B",
+            "H1N5.B",
+        };
+
+        /// <summary>Network inputs driven by the carry-in (fan-out at the logic layer).</summary>
+        private static readonly string[] InputsCin = { "H2N1A.A", "H2N1B.A", "H2N2.A", "H2N5.A" };
+
+        /// <summary>Temp working directory for the GDS export and the DRC report.</summary>
+        public string WorkDirectory { get; } =
+            Path.Combine(Path.GetTempPath(), "full-adder-manufacturing-" + Guid.NewGuid().ToString("N"));
+
+        /// <summary>The canvas the shipped example loaded onto.</summary>
+        public DesignCanvasViewModel Canvas { get; private set; } = null!;
+
+        /// <summary>The loaded top-level gate groups, in file order.</summary>
+        public List<ComponentGroup> Groups { get; private set; } = null!;
+
+        /// <summary>The logic network assembled from the loaded design.</summary>
+        public LogicNetworkEvaluator Network { get; private set; } = null!;
+
+        /// <summary>The nazca export script of the loaded design.</summary>
+        public string NazcaScript { get; private set; } = null!;
+
+        /// <summary>Loads the shipped example, assembles its logic network, generates its export script.</summary>
+        public async Task InitializeAsync()
+        {
+            var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+            Canvas = await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+            Groups = LogicGateHalfAdderExampleTests.GroupsOf(Canvas);
+            Network = await LogicGateFullAdderExampleTests.AssembleNetwork(Canvas);
+            NazcaScript = new SimpleNazcaExporter().Export(Canvas);
+        }
+
+        /// <summary>Removes the temp working directory.</summary>
+        public Task DisposeAsync()
+        {
+            try
+            {
+                if (Directory.Exists(WorkDirectory)) Directory.Delete(WorkDirectory, recursive: true);
+            }
+            catch
+            {
+                // temp cleanup is best effort
+            }
+            return Task.CompletedTask;
+        }
+
+        /// <summary>The network input bits for one operand triple (A, B and Cin fan out at the logic layer).</summary>
+        public Dictionary<string, bool> InputBits(bool a, bool b, bool cin)
+        {
+            var bits = new Dictionary<string, bool>();
+            foreach (var name in InputsA) bits[name] = a;
+            foreach (var name in InputsB) bits[name] = b;
+            foreach (var name in InputsCin) bits[name] = cin;
+            return bits;
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Closes #995 — the kill-review's "hard end-to-end scenario" for the rung 4→7 chain: the promise is not "simulate a full adder" but "tape out the computer you built". #978 proved the single-gate journey; this proves a *multi-gate logic design* survives the whole manufacturing path.

One new integration test file, `UnitTests/Integration/FullAdderManufacturingJourneyTests.cs`, walking the real code paths end to end (no mocks):

1. **Load** — `examples/Logic Gate Full Adder.lun` through the real load path; asserts all 32 gate groups arrive with their persisted pin roles and 30 wires.
2. **Logic** — `LogicNetworkAssembler` builds the evaluable network from the loaded design; the corner combinations 000, 111, 101 assert Sum (`H2SUM.Y`) and Cout (`OROUT.Y`) — proof the design is *the* full adder, not just loadable.
3. **Export** — the loaded design goes through the real nazca export path; the generated script carries the design top cell.
4. **GDS + foundry deck** — nazca/KLayout-gated with `[Trait("Category", "Slow")]`, skipping cleanly without the engines (same pattern as #978's GDS step and #932's deck tests; CI runs the suite unfiltered). The export runs through real nazca 0.6.1, the produced `ConnectAPIC_Design` top cell is checked for cell references and real wiring geometry, then the vendored CORNERSTONE SiN pre-DRC deck (#932's headless runner) runs over the GDS through real KLayout.

## Pinned DRC baseline (with reasoning)

The deck's verdict on the full-adder export is pinned to an **empty violation set** (`PASSED: 0 DRC violations.`, runner exit code 0). Reasoning: the demo-PDK stub export writes only nazca's default layers (core layer 1, port labels on (1,10), documentation frames on (1003,0)) — none of the layers the vendored SiN deck inspects (203/204/39/41/100/22/99) are touched, and the export grid stays on the deck's 1 nm grid. **Verified locally against the real engines** (vendored nazca 0.6.1 + KLayout 0.30.9): the export succeeds, the runner completes, and zero violations are reported. Because the empty set is asserted verbatim, any *new* violation class fails this journey — exactly the regression bar the issue sets. No violation classes exist today, so no follow-up issues were filed.

## How it was tested

- The gated journey step ran headlessly on this machine against the real engines: nazca export of the full adder succeeded, the GDS top cell held both component references and wiring polygons, and the foundry deck reported `PASSED: 0 DRC violations.` — all 6 journey tests green.
- Full filtered suite run before opening this PR.

Local suite: 5860 passed, 0 failed