### PR TITLE
Agent: Core meander path generator — stretch a route to a target length (#1003)

### DIFF
--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderBounds.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderBounds.cs
@@ -1,0 +1,19 @@
+namespace CAP_Core.Routing.MeanderGeneration;
+
+/// <summary>
+/// Axis-aligned bounding rectangle (µm) that a generated meander path must stay inside.
+/// </summary>
+public sealed record MeanderBounds(double MinX, double MinY, double MaxX, double MaxY)
+{
+    /// <summary>
+    /// True when the given tight segment bounds lie inside this rectangle,
+    /// allowing <paramref name="slackMicrometers"/> for floating-point noise.
+    /// </summary>
+    public bool Contains(
+        (double MinX, double MinY, double MaxX, double MaxY) segmentBounds,
+        double slackMicrometers)
+        => segmentBounds.MinX >= MinX - slackMicrometers
+        && segmentBounds.MinY >= MinY - slackMicrometers
+        && segmentBounds.MaxX <= MaxX + slackMicrometers
+        && segmentBounds.MaxY <= MaxY + slackMicrometers;
+}

--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderPathGenerator.Validation.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderPathGenerator.Validation.cs
@@ -1,0 +1,106 @@
+namespace CAP_Core.Routing.MeanderGeneration;
+
+/// <summary>
+/// Validation half of <see cref="MeanderPathGenerator"/>: argument checks and the
+/// geometric post-checks every emitted path must pass (length, bend-radius floor,
+/// bounds, continuity, endpoint poses) before it may leave the generator.
+/// </summary>
+public sealed partial class MeanderPathGenerator
+{
+    private bool IsValidCandidate(RoutedPath path, MeanderRequest request, double tolerance)
+    {
+        if (!path.IsValid || !PoseMatches(path, request))
+            return false;
+        if (Math.Abs(path.TotalLengthMicrometers - request.TargetLengthMicrometers) > tolerance)
+            return false;
+
+        foreach (var segment in path.Segments)
+        {
+            if (segment is BendSegment bend
+                && bend.RadiusMicrometers < request.MinBendRadiusMicrometers - RadiusSlackMicrometers)
+                return false;
+            if (!request.Bounds.Contains(PathSegmentBounds.Of(segment), BoundsSlackMicrometers))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsWithinBounds(RoutedPath path, MeanderBounds bounds)
+        => path.Segments.All(s => bounds.Contains(PathSegmentBounds.Of(s), BoundsSlackMicrometers));
+
+    private static bool PoseMatches(RoutedPath path, MeanderRequest request)
+    {
+        if (path.Segments.Count == 0)
+        {
+            double dx = request.EndX - request.StartX;
+            double dy = request.EndY - request.StartY;
+            return Math.Sqrt(dx * dx + dy * dy) <= PosePositionToleranceMicrometers;
+        }
+
+        var first = path.Segments[0];
+        var last = path.Segments[^1];
+        return Distance(first.StartPoint, (request.StartX, request.StartY)) <= PosePositionToleranceMicrometers
+            && Distance(last.EndPoint, (request.EndX, request.EndY)) <= PosePositionToleranceMicrometers
+            && AngleDistanceDegrees(first.StartAngleDegrees, request.StartDirectionDegrees) <= PoseAngleToleranceDegrees
+            && AngleDistanceDegrees(last.EndAngleDegrees, request.EndDirectionDegrees) <= PoseAngleToleranceDegrees;
+    }
+
+    private static int IndexOfLongestStraight(RoutedPath path)
+    {
+        int index = -1;
+        double longest = 0.0;
+        for (int i = 0; i < path.Segments.Count; i++)
+        {
+            if (path.Segments[i] is StraightSegment straight
+                && straight.LengthMicrometers > longest + GeometrySlackMicrometers)
+            {
+                index = i;
+                longest = straight.LengthMicrometers;
+            }
+        }
+
+        return index;
+    }
+
+    private static void ValidateArguments(MeanderRequest request)
+    {
+        if (!double.IsFinite(request.StartX) || !double.IsFinite(request.StartY)
+            || !double.IsFinite(request.EndX) || !double.IsFinite(request.EndY)
+            || !double.IsFinite(request.StartDirectionDegrees) || !double.IsFinite(request.EndDirectionDegrees)
+            || !double.IsFinite(request.TargetLengthMicrometers) || !double.IsFinite(request.ToleranceMicrometers)
+            || !double.IsFinite(request.MinBendRadiusMicrometers))
+            throw new ArgumentException("All request values must be finite.", nameof(request));
+        if (request.MinBendRadiusMicrometers <= 0)
+            throw new ArgumentException("Minimum bend radius must be positive.", nameof(request));
+        if (request.TargetLengthMicrometers < 0)
+            throw new ArgumentException("Target length must not be negative.", nameof(request));
+        if (request.ToleranceMicrometers < 0)
+            throw new ArgumentException("Tolerance must not be negative.", nameof(request));
+        if (request.Bounds.MaxX <= request.Bounds.MinX || request.Bounds.MaxY <= request.Bounds.MinY)
+            throw new ArgumentException("Bounds must have positive width and height.", nameof(request));
+    }
+
+    private static double Distance((double X, double Y) a, (double X, double Y) b)
+    {
+        double dx = a.X - b.X;
+        double dy = a.Y - b.Y;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+
+    private static double Normalize360(double angleDeg)
+    {
+        angleDeg %= 360.0;
+        if (angleDeg < 0.0)
+            angleDeg += 360.0;
+        return angleDeg;
+    }
+
+    private static double AngleDistanceDegrees(double aDeg, double bDeg)
+    {
+        double delta = Normalize360(aDeg) - Normalize360(bDeg);
+        if (delta < 0.0)
+            delta += 360.0;
+        return Math.Min(delta, 360.0 - delta);
+    }
+}

--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderPathGenerator.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderPathGenerator.cs
@@ -1,0 +1,212 @@
+namespace CAP_Core.Routing.MeanderGeneration;
+
+/// <summary>
+/// Stretches the route between two poses (point + tangent direction) to a prescribed
+/// geometric length: the nominal smooth route is computed first, then the extra length
+/// is folded into its longest straight section — as hairpin loops for large extras, or
+/// as a double S-bend trim for extras smaller than one loop. The result uses the same
+/// <see cref="StraightSegment"/>/<see cref="BendSegment"/> primitives the waveguide
+/// router produces, so it can be handed to the exporters unchanged.
+/// Pure and deterministic: identical inputs yield an identical path.
+/// </summary>
+public sealed partial class MeanderPathGenerator
+{
+    private const double GeometrySlackMicrometers = 1e-6;
+    private const double BoundsSlackMicrometers = 1e-4;
+    private const double PosePositionToleranceMicrometers = 1e-4;
+    private const double PoseAngleToleranceDegrees = 1e-4;
+    private const double RadiusSlackMicrometers = 1e-9;
+    private const int MaxLoopCount = 4096;
+    private const int BisectionIterations = 60;
+
+    /// <summary>
+    /// Generates a path from the start pose to the end pose whose geometric length is
+    /// within tolerance of the target, all bends at or above the minimum radius, fully
+    /// inside the bounds — or a typed failure explaining why that is impossible.
+    /// </summary>
+    public MeanderResult Generate(MeanderRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateArguments(request);
+
+        double tolerance = Math.Max(request.ToleranceMicrometers, GeometrySlackMicrometers);
+        RoutedPath? nominal = BuildNominalPath(request);
+        if (nominal == null || !PoseMatches(nominal, request))
+        {
+            return MeanderResult.Failure(
+                MeanderFailureReason.EndpointsNotRoutableAtMinRadius,
+                "No tangent-continuous route between the two poses exists at the given minimum bend radius.");
+        }
+
+        double nominalLength = nominal.TotalLengthMicrometers;
+        if (request.TargetLengthMicrometers < nominalLength - tolerance)
+        {
+            return MeanderResult.Failure(
+                MeanderFailureReason.TargetShorterThanDirectPath,
+                "The target length is shorter than the direct route between the poses.");
+        }
+
+        if (!IsWithinBounds(nominal, request.Bounds))
+        {
+            return MeanderResult.Failure(
+                MeanderFailureReason.BoundsTooSmallForMeander,
+                "The bounding rectangle does not contain the direct route between the poses.");
+        }
+
+        if (Math.Abs(request.TargetLengthMicrometers - nominalLength) <= tolerance)
+            return MeanderResult.Success(nominal);
+
+        double extra = request.TargetLengthMicrometers - nominalLength;
+        int hostIndex = IndexOfLongestStraight(nominal);
+        if (hostIndex < 0)
+        {
+            return MeanderResult.Failure(
+                MeanderFailureReason.BoundsTooSmallForMeander,
+                "The direct route has no straight section that could host a meander.");
+        }
+
+        foreach (double side in new[] { 1.0, -1.0 })
+        {
+            RoutedPath? candidate = TryBuildMeander(nominal, hostIndex, extra,
+                request.MinBendRadiusMicrometers, side);
+            if (candidate != null && IsValidCandidate(candidate, request, tolerance))
+                return MeanderResult.Success(candidate);
+        }
+
+        return MeanderResult.Failure(
+            MeanderFailureReason.BoundsTooSmallForMeander,
+            "No meander with the required extra length fits inside the bounding rectangle at the given minimum bend radius.");
+    }
+
+    private static RoutedPath BuildNominalPath(MeanderRequest request)
+    {
+        var path = new RoutedPath();
+        double dx = request.EndX - request.StartX;
+        double dy = request.EndY - request.StartY;
+        double distance = Math.Sqrt(dx * dx + dy * dy);
+
+        if (distance <= GeometrySlackMicrometers)
+        {
+            bool sameDirection = AngleDistanceDegrees(
+                request.StartDirectionDegrees, request.EndDirectionDegrees) <= PoseAngleToleranceDegrees;
+            if (sameDirection)
+                return path;
+        }
+        else
+        {
+            double lineAngle = Normalize360(Math.Atan2(dy, dx) * 180.0 / Math.PI);
+            if (AngleDistanceDegrees(lineAngle, request.StartDirectionDegrees) <= PoseAngleToleranceDegrees
+                && AngleDistanceDegrees(lineAngle, request.EndDirectionDegrees) <= PoseAngleToleranceDegrees)
+            {
+                path.Segments.Add(new StraightSegment(
+                    request.StartX, request.StartY, request.EndX, request.EndY, lineAngle));
+                return path;
+            }
+        }
+
+        new ManhattanRouter(request.MinBendRadiusMicrometers).Route(
+            request.StartX, request.StartY, request.StartDirectionDegrees,
+            request.EndX, request.EndY, request.EndDirectionDegrees, path);
+        return path;
+    }
+
+    private static RoutedPath? TryBuildMeander(
+        RoutedPath nominal, int hostIndex, double extraMicrometers, double radius, double side)
+    {
+        double hostLength = nominal.Segments[hostIndex].LengthMicrometers;
+        double loopMinExtra = (2.0 * Math.PI - 4.0) * radius;
+
+        if (extraMicrometers >= loopMinExtra)
+        {
+            int byLength = (int)Math.Floor(extraMicrometers / loopMinExtra);
+            int byRoom = (int)Math.Floor((hostLength + GeometrySlackMicrometers) / (4.0 * radius));
+            int loops = Math.Min(Math.Min(byLength, byRoom), MaxLoopCount);
+            if (loops >= 1)
+            {
+                double height = (extraMicrometers / loops - loopMinExtra) / 2.0;
+                return Assemble(nominal, hostIndex, loops * 4.0 * radius,
+                    builder => EmitLoops(builder, loops, height, radius, side));
+            }
+        }
+
+        // Extra smaller than one hairpin loop (or no room for one): a double S-bend
+        // leaves the host axis and returns to it, absorbing exactly 4r·(sweep − sin sweep)
+        // — which reaches loopMinExtra at sweep = 90°, so the two shapes meet seamlessly.
+        if (extraMicrometers > loopMinExtra)
+            return null;
+
+        double sweepDeg = SolveDoubleSBendSweepDegrees(extraMicrometers, radius);
+        double footprint = 4.0 * radius * Math.Sin(sweepDeg * Math.PI / 180.0);
+        if (footprint > hostLength + GeometrySlackMicrometers)
+            return null;
+
+        return Assemble(nominal, hostIndex, footprint, builder =>
+        {
+            builder.AppendArc(sweepDeg * side, radius);
+            builder.AppendArc(-sweepDeg * side, radius);
+            builder.AppendArc(-sweepDeg * side, radius);
+            builder.AppendArc(sweepDeg * side, radius);
+        });
+    }
+
+    private static RoutedPath Assemble(
+        RoutedPath nominal, int hostIndex, double meanderFootprint, Action<PosePathBuilder> emitMeander)
+    {
+        var host = nominal.Segments[hostIndex];
+        double dirX = host.EndPoint.X - host.StartPoint.X;
+        double dirY = host.EndPoint.Y - host.StartPoint.Y;
+        double hostLength = Math.Sqrt(dirX * dirX + dirY * dirY);
+        dirX /= hostLength;
+        dirY /= hostLength;
+        double headingDeg = Normalize360(Math.Atan2(dirY, dirX) * 180.0 / Math.PI);
+
+        double prefix = Math.Max(0.0, (hostLength - meanderFootprint) / 2.0);
+        var result = new RoutedPath();
+        for (int i = 0; i < hostIndex; i++)
+            result.Segments.Add(nominal.Segments[i]);
+
+        var builder = new PosePathBuilder(result, host.StartPoint.X, host.StartPoint.Y, headingDeg);
+        builder.AppendStraight(prefix);
+        emitMeander(builder);
+        builder.AppendStraight(hostLength - prefix - meanderFootprint);
+
+        for (int i = hostIndex + 1; i < nominal.Segments.Count; i++)
+            result.Segments.Add(nominal.Segments[i]);
+        return result;
+    }
+
+    private static void EmitLoops(
+        PosePathBuilder builder, int loops, double heightMicrometers, double radius, double side)
+    {
+        for (int i = 0; i < loops; i++)
+        {
+            builder.AppendArc(90.0 * side, radius);
+            builder.AppendStraight(heightMicrometers);
+            builder.AppendArc(-180.0 * side, radius);
+            builder.AppendStraight(heightMicrometers);
+            builder.AppendArc(90.0 * side, radius);
+        }
+    }
+
+    /// <summary>
+    /// Sweep for the four arcs of a double S-bend (out and back to the host axis) so
+    /// that its length exceeds the straight chord it replaces by exactly
+    /// <paramref name="extraMicrometers"/>: extra = 4r·(sweep − sin sweep) is strictly
+    /// monotone, so bisection converges.
+    /// </summary>
+    private static double SolveDoubleSBendSweepDegrees(double extraMicrometers, double radius)
+    {
+        double lo = 0.0;
+        double hi = Math.PI / 2.0;
+        for (int i = 0; i < BisectionIterations; i++)
+        {
+            double mid = (lo + hi) / 2.0;
+            if (4.0 * radius * (mid - Math.Sin(mid)) < extraMicrometers)
+                lo = mid;
+            else
+                hi = mid;
+        }
+
+        return (lo + hi) / 2.0 * 180.0 / Math.PI;
+    }
+}

--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderRequest.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderRequest.cs
@@ -5,7 +5,7 @@ namespace CAP_Core.Routing.MeanderGeneration;
 /// to a prescribed geometric length, inside a bounding rectangle.
 /// Directions follow the <see cref="PathSegment"/> tangent convention (degrees,
 /// 0 = +X, counter-clockwise positive); the end direction is the direction of travel
-/// at arrival, not the pin's outward normal. <paramref name="MinBendRadiusMicrometers"/>
+/// at arrival, not the pin's outward normal. The minimum bend radius
 /// carries the process floor semantics of ProcessXsection.MinRadiusUm: no arc in the
 /// result may have a smaller radius.
 /// </summary>

--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderRequest.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderRequest.cs
@@ -1,0 +1,22 @@
+namespace CAP_Core.Routing.MeanderGeneration;
+
+/// <summary>
+/// Input for <see cref="MeanderPathGenerator"/>: stretch the route between two poses
+/// to a prescribed geometric length, inside a bounding rectangle.
+/// Directions follow the <see cref="PathSegment"/> tangent convention (degrees,
+/// 0 = +X, counter-clockwise positive); the end direction is the direction of travel
+/// at arrival, not the pin's outward normal. <paramref name="MinBendRadiusMicrometers"/>
+/// carries the process floor semantics of ProcessXsection.MinRadiusUm: no arc in the
+/// result may have a smaller radius.
+/// </summary>
+public sealed record MeanderRequest(
+    double StartX,
+    double StartY,
+    double StartDirectionDegrees,
+    double EndX,
+    double EndY,
+    double EndDirectionDegrees,
+    double TargetLengthMicrometers,
+    double ToleranceMicrometers,
+    double MinBendRadiusMicrometers,
+    MeanderBounds Bounds);

--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderResult.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/MeanderResult.cs
@@ -1,0 +1,50 @@
+namespace CAP_Core.Routing.MeanderGeneration;
+
+/// <summary>
+/// Why meander generation is physically impossible for the given inputs.
+/// </summary>
+public enum MeanderFailureReason
+{
+    /// <summary>The target length is shorter than the direct smooth route between the poses.</summary>
+    TargetShorterThanDirectPath,
+
+    /// <summary>The bounding rectangle is too small for the required meander at the minimum bend radius.</summary>
+    BoundsTooSmallForMeander,
+
+    /// <summary>No tangent-continuous route between the two poses exists at the minimum bend radius.</summary>
+    EndpointsNotRoutableAtMinRadius,
+}
+
+/// <summary>
+/// Result of <see cref="MeanderPathGenerator.Generate"/>: either a valid path whose
+/// geometric length is within tolerance of the target, or a typed failure saying why
+/// that is impossible. A failure never carries an invalid path.
+/// </summary>
+public sealed class MeanderResult
+{
+    private MeanderResult(RoutedPath? path, MeanderFailureReason? failureReason, string? failureMessage)
+    {
+        Path = path;
+        FailureReason = failureReason;
+        FailureMessage = failureMessage;
+    }
+
+    /// <summary>The generated path; null when generation failed.</summary>
+    public RoutedPath? Path { get; }
+
+    /// <summary>Why generation failed; null on success.</summary>
+    public MeanderFailureReason? FailureReason { get; }
+
+    /// <summary>Diagnostic detail for the failure; null on success.</summary>
+    public string? FailureMessage { get; }
+
+    /// <summary>True when a valid path was generated.</summary>
+    public bool IsSuccess => Path != null;
+
+    /// <summary>Creates a successful result.</summary>
+    public static MeanderResult Success(RoutedPath path) => new(path, null, null);
+
+    /// <summary>Creates a typed failure result.</summary>
+    public static MeanderResult Failure(MeanderFailureReason reason, string message)
+        => new(null, reason, message);
+}

--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/PosePathBuilder.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/PosePathBuilder.cs
@@ -1,0 +1,79 @@
+namespace CAP_Core.Routing.MeanderGeneration;
+
+/// <summary>
+/// Incrementally appends tangent-continuous straights and arcs to a <see cref="RoutedPath"/>,
+/// tracking the current pose. Arcs follow the <see cref="BendSegment"/> convention
+/// (positive sweep = counter-clockwise) and are split into pieces of at most 90°,
+/// matching the router's output granularity.
+/// </summary>
+internal sealed class PosePathBuilder
+{
+    private const double Eps = 1e-9;
+    private const double MaxArcPieceDegrees = 90.0;
+
+    private readonly RoutedPath _path;
+    private double _x;
+    private double _y;
+    private double _headingDeg;
+
+    public PosePathBuilder(RoutedPath path, double startX, double startY, double headingDegrees)
+    {
+        _path = path;
+        _x = startX;
+        _y = startY;
+        _headingDeg = Normalize360(headingDegrees);
+    }
+
+    /// <summary>Current pen position.</summary>
+    public (double X, double Y) Position => (_x, _y);
+
+    /// <summary>Appends a straight of the given length along the current heading.</summary>
+    public void AppendStraight(double lengthMicrometers)
+    {
+        if (lengthMicrometers <= Eps)
+            return;
+
+        double rad = _headingDeg * Math.PI / 180.0;
+        double endX = _x + lengthMicrometers * Math.Cos(rad);
+        double endY = _y + lengthMicrometers * Math.Sin(rad);
+        _path.Segments.Add(new StraightSegment(_x, _y, endX, endY, _headingDeg));
+        _x = endX;
+        _y = endY;
+    }
+
+    /// <summary>Appends an arc starting tangent to the current heading.</summary>
+    public void AppendArc(double sweepDegrees, double radiusMicrometers)
+    {
+        double remaining = sweepDegrees;
+        while (Math.Abs(remaining) > Eps)
+        {
+            double piece = Math.Clamp(remaining, -MaxArcPieceDegrees, MaxArcPieceDegrees);
+            AppendArcPiece(piece, radiusMicrometers);
+            remaining -= piece;
+        }
+    }
+
+    private void AppendArcPiece(double sweepDegrees, double radiusMicrometers)
+    {
+        double sign = Math.Sign(sweepDegrees);
+        double centerAngleRad = (_headingDeg + 90.0 * sign) * Math.PI / 180.0;
+        var bend = new BendSegment(
+            _x + radiusMicrometers * Math.Cos(centerAngleRad),
+            _y + radiusMicrometers * Math.Sin(centerAngleRad),
+            radiusMicrometers,
+            _headingDeg,
+            sweepDegrees);
+        _path.Segments.Add(bend);
+        _x = bend.EndPoint.X;
+        _y = bend.EndPoint.Y;
+        _headingDeg = Normalize360(_headingDeg + sweepDegrees);
+    }
+
+    private static double Normalize360(double angleDeg)
+    {
+        angleDeg %= 360.0;
+        if (angleDeg < 0.0)
+            angleDeg += 360.0;
+        return angleDeg;
+    }
+}

--- a/UnitTests/Routing/MeanderGeneration/MeanderPathGeneratorPropertyTests.cs
+++ b/UnitTests/Routing/MeanderGeneration/MeanderPathGeneratorPropertyTests.cs
@@ -1,0 +1,69 @@
+using CAP_Core.Routing;
+using CAP_Core.Routing.MeanderGeneration;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing.MeanderGeneration;
+
+/// <summary>
+/// Property-style sweep: for a grid of targets between the direct length and 5× the
+/// direct length, generation must succeed with the length error inside the tolerance,
+/// every bend at or above the radius floor, and the whole path inside the bounds.
+/// </summary>
+public class MeanderPathGeneratorPropertyTests
+{
+    private const double DirectLength = 200.0;
+    private const double Radius = 5.0;
+    private const double Tolerance = 1.0;
+    private const double AssertSlack = 1e-6;
+
+    private static readonly MeanderBounds Bounds = new(-5, -60, 205, 60);
+
+    [Theory]
+    [InlineData(1.00)] // degenerate: target ≈ direct length
+    [InlineData(1.01)] // double S-bend branch (extra below one loop)
+    [InlineData(1.04)] // double S-bend near its 90° ceiling
+    [InlineData(1.10)]
+    [InlineData(1.25)]
+    [InlineData(1.50)]
+    [InlineData(1.75)]
+    [InlineData(2.00)]
+    [InlineData(2.50)]
+    [InlineData(3.00)]
+    [InlineData(3.50)]
+    [InlineData(4.00)]
+    [InlineData(4.50)]
+    [InlineData(5.00)]
+    public void Generate_TargetGridBetweenDirectAndFiveTimesDirect_LengthErrorStaysWithinTolerance(
+        double factor)
+    {
+        double target = DirectLength * factor;
+        var request = new MeanderRequest(0, 0, 0, DirectLength, 0, 0,
+            target, Tolerance, Radius, Bounds);
+
+        var result = new MeanderPathGenerator().Generate(request);
+
+        result.IsSuccess.ShouldBeTrue($"factor {factor}: {result.FailureMessage}");
+        var path = result.Path!;
+        Math.Abs(path.TotalLengthMicrometers - target).ShouldBeLessThanOrEqualTo(
+            Tolerance, $"factor {factor}");
+        path.IsValid.ShouldBeTrue($"factor {factor}");
+
+        foreach (var segment in path.Segments)
+        {
+            if (segment is BendSegment bend)
+                bend.RadiusMicrometers.ShouldBeGreaterThanOrEqualTo(Radius, $"factor {factor}");
+
+            var b = PathSegmentBounds.Of(segment);
+            b.MinX.ShouldBeGreaterThanOrEqualTo(Bounds.MinX - AssertSlack, $"factor {factor}");
+            b.MinY.ShouldBeGreaterThanOrEqualTo(Bounds.MinY - AssertSlack, $"factor {factor}");
+            b.MaxX.ShouldBeLessThanOrEqualTo(Bounds.MaxX + AssertSlack, $"factor {factor}");
+            b.MaxY.ShouldBeLessThanOrEqualTo(Bounds.MaxY + AssertSlack, $"factor {factor}");
+        }
+
+        path.Segments[0].StartPoint.X.ShouldBe(0.0, AssertSlack);
+        path.Segments[0].StartPoint.Y.ShouldBe(0.0, AssertSlack);
+        path.Segments[^1].EndPoint.X.ShouldBe(DirectLength, AssertSlack);
+        path.Segments[^1].EndPoint.Y.ShouldBe(0.0, AssertSlack);
+    }
+}

--- a/UnitTests/Routing/MeanderGeneration/MeanderPathGeneratorTests.cs
+++ b/UnitTests/Routing/MeanderGeneration/MeanderPathGeneratorTests.cs
@@ -1,0 +1,251 @@
+using CAP_Core.Routing;
+using CAP_Core.Routing.MeanderGeneration;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing.MeanderGeneration;
+
+public class MeanderPathGeneratorTests
+{
+    private const double AssertSlack = 1e-6;
+
+    private static MeanderRequest AlignedRequest(
+        double target, MeanderBounds? bounds = null, double tolerance = 0.5, double radius = 5.0)
+        => new(0, 0, 0, 100, 0, 0, target, tolerance, radius,
+            bounds ?? new MeanderBounds(0, -20, 100, 20));
+
+    [Fact]
+    public void Generate_TargetEqualsDirectLength_ReturnsDirectStraight()
+    {
+        var result = new MeanderPathGenerator().Generate(AlignedRequest(target: 100));
+
+        result.IsSuccess.ShouldBeTrue();
+        result.FailureReason.ShouldBeNull();
+        var path = result.Path!;
+        path.Segments.Count.ShouldBe(1);
+        path.Segments[0].ShouldBeOfType<StraightSegment>();
+        path.TotalLengthMicrometers.ShouldBe(100.0, AssertSlack);
+    }
+
+    [Fact]
+    public void Generate_TargetWithinToleranceOfDirect_ReturnsNearDirectPath()
+    {
+        var result = new MeanderPathGenerator().Generate(AlignedRequest(target: 100.3));
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Path!.Segments.Count.ShouldBe(1);
+        result.Path.TotalLengthMicrometers.ShouldBe(100.0, AssertSlack);
+    }
+
+    [Fact]
+    public void Generate_TargetShorterThanDirect_ReturnsTypedFailureWithoutPath()
+    {
+        var result = new MeanderPathGenerator().Generate(AlignedRequest(target: 50));
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Path.ShouldBeNull();
+        result.FailureReason.ShouldBe(MeanderFailureReason.TargetShorterThanDirectPath);
+    }
+
+    [Fact]
+    public void Generate_MeanderRequired_HitsTargetLengthWithinTolerance()
+    {
+        var request = AlignedRequest(target: 250);
+        var result = new MeanderPathGenerator().Generate(request);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        var path = result.Path!;
+        Math.Abs(path.TotalLengthMicrometers - 250).ShouldBeLessThanOrEqualTo(request.ToleranceMicrometers);
+        path.Segments.OfType<BendSegment>().ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void Generate_MeanderRequired_EveryBendRespectsMinRadius()
+    {
+        var request = AlignedRequest(target: 250);
+        var path = new MeanderPathGenerator().Generate(request).Path!;
+
+        foreach (var bend in path.Segments.OfType<BendSegment>())
+        {
+            bend.RadiusMicrometers.ShouldBeGreaterThanOrEqualTo(request.MinBendRadiusMicrometers);
+            Math.Abs(bend.SweepAngleDegrees).ShouldBeLessThanOrEqualTo(90.0 + AssertSlack);
+        }
+    }
+
+    [Fact]
+    public void Generate_MeanderRequired_StaysFullyInsideBounds()
+    {
+        var request = AlignedRequest(target: 250);
+        var path = new MeanderPathGenerator().Generate(request).Path!;
+
+        foreach (var segment in path.Segments)
+        {
+            var b = PathSegmentBounds.Of(segment);
+            b.MinX.ShouldBeGreaterThanOrEqualTo(request.Bounds.MinX - AssertSlack);
+            b.MinY.ShouldBeGreaterThanOrEqualTo(request.Bounds.MinY - AssertSlack);
+            b.MaxX.ShouldBeLessThanOrEqualTo(request.Bounds.MaxX + AssertSlack);
+            b.MaxY.ShouldBeLessThanOrEqualTo(request.Bounds.MaxY + AssertSlack);
+        }
+    }
+
+    [Fact]
+    public void Generate_MeanderRequired_PreservesEndpointPosesAndContinuity()
+    {
+        var path = new MeanderPathGenerator().Generate(AlignedRequest(target: 250)).Path!;
+
+        path.IsValid.ShouldBeTrue();
+        path.Segments[0].StartPoint.X.ShouldBe(0.0, AssertSlack);
+        path.Segments[0].StartPoint.Y.ShouldBe(0.0, AssertSlack);
+        AngleDistance(path.Segments[0].StartAngleDegrees, 0.0).ShouldBeLessThanOrEqualTo(AssertSlack);
+        path.Segments[^1].EndPoint.X.ShouldBe(100.0, AssertSlack);
+        path.Segments[^1].EndPoint.Y.ShouldBe(0.0, AssertSlack);
+        AngleDistance(path.Segments[^1].EndAngleDegrees, 0.0).ShouldBeLessThanOrEqualTo(AssertSlack);
+    }
+
+    private static double AngleDistance(double aDeg, double bDeg)
+    {
+        double delta = (aDeg - bDeg) % 360.0;
+        if (delta < 0.0)
+            delta += 360.0;
+        return Math.Min(delta, 360.0 - delta);
+    }
+
+    [Fact]
+    public void Generate_SmallExtraLength_UsesDoubleSBendAndHitsTarget()
+    {
+        // Extra 3 µm < (2π-4)·r = 11.4 µm: too small for even one hairpin loop.
+        var request = AlignedRequest(target: 103);
+        var result = new MeanderPathGenerator().Generate(request);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        Math.Abs(result.Path!.TotalLengthMicrometers - 103)
+            .ShouldBeLessThanOrEqualTo(request.ToleranceMicrometers);
+    }
+
+    [Fact]
+    public void Generate_MediumExtraLength_UsesDoubleSBendNear90DegreesAndHitsTarget()
+    {
+        // Extra 10 µm is just below the first hairpin loop at (2π-4)·r = 11.4 µm,
+        // so the double S-bend sweep is close to its 90° ceiling.
+        var request = AlignedRequest(target: 110);
+        var result = new MeanderPathGenerator().Generate(request);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        Math.Abs(result.Path!.TotalLengthMicrometers - 110)
+            .ShouldBeLessThanOrEqualTo(request.ToleranceMicrometers);
+    }
+
+    [Fact]
+    public void Generate_BoundsTooNarrowForMeander_ReturnsTypedFailureWithoutPath()
+    {
+        var bounds = new MeanderBounds(0, -0.5, 100, 0.5);
+        var result = new MeanderPathGenerator().Generate(AlignedRequest(target: 250, bounds: bounds));
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Path.ShouldBeNull();
+        result.FailureReason.ShouldBe(MeanderFailureReason.BoundsTooSmallForMeander);
+    }
+
+    [Fact]
+    public void Generate_BoundsExcludeDirectRoute_ReturnsTypedFailureWithoutPath()
+    {
+        var bounds = new MeanderBounds(10, -20, 100, 20);
+        var result = new MeanderPathGenerator().Generate(AlignedRequest(target: 100, bounds: bounds));
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Path.ShouldBeNull();
+        result.FailureReason.ShouldBe(MeanderFailureReason.BoundsTooSmallForMeander);
+    }
+
+    [Fact]
+    public void Generate_OffsetParallelPins_MeandersOnSmoothNominalRoute()
+    {
+        double nominalLength = NominalRouteLength(0, 0, 0, 100, 20, 0, radius: 5.0);
+        var request = new MeanderRequest(0, 0, 0, 100, 20, 0,
+            nominalLength + 40, 0.5, 5.0, new MeanderBounds(-50, -50, 150, 70));
+
+        var result = new MeanderPathGenerator().Generate(request);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        var path = result.Path!;
+        path.IsValid.ShouldBeTrue();
+        Math.Abs(path.TotalLengthMicrometers - request.TargetLengthMicrometers)
+            .ShouldBeLessThanOrEqualTo(request.ToleranceMicrometers);
+        path.Segments[^1].EndPoint.X.ShouldBe(100.0, AssertSlack);
+        path.Segments[^1].EndPoint.Y.ShouldBe(20.0, AssertSlack);
+    }
+
+    [Fact]
+    public void Generate_PerpendicularPins_MeandersOnSmoothNominalRoute()
+    {
+        double nominalLength = NominalRouteLength(0, 0, 0, 200, -100, 270, radius: 5.0);
+        var request = new MeanderRequest(0, 0, 0, 200, -100, 270,
+            nominalLength + 30, 0.5, 5.0, new MeanderBounds(-50, -150, 250, 50));
+
+        var result = new MeanderPathGenerator().Generate(request);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        var path = result.Path!;
+        path.IsValid.ShouldBeTrue();
+        Math.Abs(path.TotalLengthMicrometers - request.TargetLengthMicrometers)
+            .ShouldBeLessThanOrEqualTo(request.ToleranceMicrometers);
+        path.Segments[^1].EndAngleDegrees.ShouldBe(270.0, AssertSlack);
+    }
+
+    [Fact]
+    public void Generate_CoincidentPosesZeroTarget_ReturnsEmptyPath()
+    {
+        var request = new MeanderRequest(10, 10, 90, 10, 10, 90,
+            0, 0.5, 5.0, new MeanderBounds(0, 0, 20, 20));
+
+        var result = new MeanderPathGenerator().Generate(request);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        result.Path!.TotalLengthMicrometers.ShouldBe(0.0, AssertSlack);
+    }
+
+    [Fact]
+    public void Generate_SameInputsTwice_ProducesIdenticalPath()
+    {
+        var request = AlignedRequest(target: 250);
+        var generator = new MeanderPathGenerator();
+
+        var first = generator.Generate(request).Path!;
+        var second = generator.Generate(request).Path!;
+
+        second.Segments.Count.ShouldBe(first.Segments.Count);
+        for (int i = 0; i < first.Segments.Count; i++)
+        {
+            var a = first.Segments[i];
+            var b = second.Segments[i];
+            b.GetType().ShouldBe(a.GetType());
+            b.StartPoint.ShouldBe(a.StartPoint);
+            b.EndPoint.ShouldBe(a.EndPoint);
+            b.StartAngleDegrees.ShouldBe(a.StartAngleDegrees);
+            b.EndAngleDegrees.ShouldBe(a.EndAngleDegrees);
+            if (a is BendSegment bendA)
+            {
+                var bendB = (BendSegment)b;
+                bendB.Center.ShouldBe(bendA.Center);
+                bendB.RadiusMicrometers.ShouldBe(bendA.RadiusMicrometers);
+                bendB.SweepAngleDegrees.ShouldBe(bendA.SweepAngleDegrees);
+            }
+        }
+    }
+
+    [Fact]
+    public void Generate_NonPositiveRadius_Throws()
+    {
+        Should.Throw<ArgumentException>(
+            () => new MeanderPathGenerator().Generate(AlignedRequest(target: 100, radius: 0)));
+    }
+
+    private static double NominalRouteLength(
+        double startX, double startY, double startAngle,
+        double endX, double endY, double endAngle, double radius)
+    {
+        var path = new RoutedPath();
+        new ManhattanRouter(radius).Route(startX, startY, startAngle, endX, endY, endAngle, path);
+        return path.TotalLengthMicrometers;
+    }
+}


### PR DESCRIPTION
## What & why

Kernel for #753 (waveguide length matching / phase matching — MZI arms, delay lines): a deterministic generator that stretches the route between two poses (point + tangent direction) to a prescribed geometric length inside an axis-aligned bounding rectangle. Core only — no UI, no router integration, no A* obstacle avoidance (the bounding box is the contract); those stay in the #753 umbrella.

New vertical slice `Connect-A-Pic-Core/Routing/MeanderGeneration/`:

- `MeanderPathGenerator.Generate(MeanderRequest)` — input: start/end point + direction, target length, tolerance, minimum bend radius (ProcessXsection.MinRadiusUm semantics), bounding rectangle.
- Output reuses the router's own route-geometry primitives (`RoutedPath` of `StraightSegment`/`BendSegment`, arcs split into ≤90° pieces like `ManhattanRouter` emits), so the result can later be handed to the exporter unchanged.
- How it works: the nominal smooth route is built first (straight special case, else `ManhattanRouter` CSC at the given radius). The extra length is then folded into the route's longest straight section — as hairpin loops (extra = 2h + (2π−4)r per loop, solved exactly for loop count and height) for large extras, or as a double S-bend trim (extra = 4r·(sweep − sin sweep), solved by bisection) for extras below one loop; the two shapes meet seamlessly at (2π−4)r. Both meander sides are tried; every candidate is re-validated (length within tolerance, every bend ≥ radius floor, tight per-segment bounds inside the rectangle, continuity, endpoint poses) before it is returned.
- Typed failures instead of invalid paths: `TargetShorterThanDirectPath`, `BoundsTooSmallForMeander`, `EndpointsNotRoutableAtMinRadius`.
- Deterministic: pure math, fixed bisection iteration count, fixed side order — same inputs → identical path (asserted bit-for-bit in a test).

## How it was tested

- `UnitTests/Routing/MeanderGeneration/MeanderPathGeneratorTests.cs` (16 tests): exact-length hit for straight-line-possible and meander-required cases; bend-radius floor asserted geometrically on every arc; bounds containment via `PathSegmentBounds`; endpoint-pose preservation and continuity; impossible cases return the typed failure with no path; degenerate target ≈ direct length returns the near-direct path; meander on S-bend and perpendicular nominal routes; determinism (two runs → identical segments); argument validation.
- `MeanderPathGeneratorPropertyTests.cs`: property-style grid of targets from 1× to 5× the direct length (14 factors, covering the degenerate, double-S-bend, and hairpin-loop branches) — length error stays within tolerance, radius floor and bounds hold on every row.
- Full non-Slow suite: `dotnet test UnitTests/UnitTests.csproj --filter "Category!=Slow"`.

Local suite: 5897 passed, 0 failed

No UI changes, so no manual verification needed after vacation.