### PR TITLE
Agent: GDS-imported 2-pin components default to lossless pass-through (#1005)

### DIFF
--- a/CAP.Avalonia/Services/GdsImport/GdsCellDraftMapper.cs
+++ b/CAP.Avalonia/Services/GdsImport/GdsCellDraftMapper.cs
@@ -10,7 +10,8 @@ namespace CAP.Avalonia.Services.GdsImport;
 /// importer) to a persistable <see cref="PdkComponentDraft"/>, mirroring the
 /// shape <c>CustomComponentDraftFactory</c> establishes for black-box custom
 /// components: <see cref="PdkComponentDraft.SMatrix"/> stays null (no simulation
-/// model — the component simulates as a lossless pass-through), and geometry is
+/// model — <c>PdkTemplateConverter.CreateSMatrixFromPdk</c> turns a null model
+/// on a 2-optical-pin component into a lossless pass-through), and geometry is
 /// carried by <see cref="PdkComponentDraft.RawCode"/> plus the outline polygons.
 /// </summary>
 public static class GdsCellDraftMapper

--- a/CAP.Avalonia/Services/PdkTemplateConverter.cs
+++ b/CAP.Avalonia/Services/PdkTemplateConverter.cs
@@ -143,7 +143,10 @@ public static class PdkTemplateConverter
         var sMatrix = new SMatrix(pinIds, new List<(Guid, double)>());
 
         if (sMatrixDraft?.Connections == null || sMatrixDraft.Connections.Count == 0)
+        {
+            AddDefaultPassThrough(pins, sMatrixDraft, sMatrix);
             return sMatrix;
+        }
 
         var pinByName = new Dictionary<string, Pin>(StringComparer.OrdinalIgnoreCase);
         foreach (var pin in pins)
@@ -166,5 +169,32 @@ public static class PdkTemplateConverter
 
         sMatrix.SetValues(transfers);
         return sMatrix;
+    }
+
+    /// <summary>
+    /// A draft without a simulation model (<c>null</c> S-matrix — GDS-imported
+    /// cells and black-box custom components) defaults to a lossless
+    /// pass-through: with exactly two optical pins, light crosses in both
+    /// directions at magnitude 1.0 (issue #1005 — previously the empty matrix
+    /// absorbed all light). Any other optical pin count keeps the empty,
+    /// fully absorbing matrix: a multi-port default would have to guess the
+    /// internal routing and would violate passivity. An explicitly declared
+    /// but empty connection list is honored as-is (intentional absorber).
+    /// </summary>
+    private static void AddDefaultPassThrough(List<Pin> pins, PdkSMatrixDraft? sMatrixDraft, SMatrix sMatrix)
+    {
+        if (sMatrixDraft != null)
+            return;
+
+        var opticalPins = pins.Where(p => p.MatterType == MatterType.Light).ToList();
+        if (opticalPins.Count != 2)
+            return;
+
+        var transfers = new Dictionary<(Guid, Guid), Complex>
+        {
+            [(opticalPins[0].IDInFlow, opticalPins[1].IDOutFlow)] = Complex.One,
+            [(opticalPins[1].IDInFlow, opticalPins[0].IDOutFlow)] = Complex.One,
+        };
+        sMatrix.SetValues(transfers);
     }
 }

--- a/UnitTests/Integration/GdsImportJourneyTests.cs
+++ b/UnitTests/Integration/GdsImportJourneyTests.cs
@@ -77,8 +77,8 @@ public class GdsImportJourneyTests : IClassFixture<GdsImportJourneyFixture>
     /// <summary>
     /// Step 3 — Simulate: S-matrix light propagation runs over the design;
     /// power arrives at the imported component's input pin through the real
-    /// connection from the Grating Coupler. The imported component's own
-    /// pass-through is blocked by its empty S-matrix (defect #1005).
+    /// connection from the Grating Coupler, and the imported component passes
+    /// it through to its output pin (lossless pass-through default, #1005).
     /// </summary>
     [Fact]
     public async Task Step3_Simulate_PowerArrivesAtImportedInput()
@@ -99,6 +99,14 @@ public class GdsImportJourneyTests : IClassFixture<GdsImportJourneyFixture>
             "the simulation must produce a field value at the imported input pin");
         result.FieldResults[inPin.LogicalPin.IDInFlow].Magnitude
             .ShouldBeGreaterThan(0, "no light arrives at the imported component's input");
+
+        // #1005: the imported waveguide's default lossless pass-through must
+        // carry the light on to its "out" pin instead of absorbing it.
+        var outPin = importedComponent.PhysicalPins.Single(p => p.Name == "out");
+        result.FieldResults.ContainsKey(outPin.LogicalPin!.IDOutFlow).ShouldBeTrue(
+            "the simulation must produce a field value at the imported output pin");
+        result.FieldResults[outPin.LogicalPin.IDOutFlow].Magnitude
+            .ShouldBeGreaterThan(0, "the imported component absorbed the light instead of passing it through");
     }
 
     /// <summary>

--- a/UnitTests/Services/PdkTemplateConverterTests.cs
+++ b/UnitTests/Services/PdkTemplateConverterTests.cs
@@ -1,0 +1,119 @@
+using CAP.Avalonia.Services;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Services;
+
+/// <summary>
+/// Tests for <see cref="PdkTemplateConverter.CreateSMatrixFromPdk"/> (issue
+/// #1005): a draft without a simulation model (<c>null</c> S-matrix — GDS
+/// imports, black-box custom components) must default to a lossless
+/// pass-through on 2-optical-pin components instead of absorbing all light.
+/// </summary>
+public class PdkTemplateConverterTests
+{
+    private static List<Pin> OpticalPins(params string[] names) =>
+        names.Select((name, i) => new Pin(name, i, MatterType.Light, RectSide.Left)).ToList();
+
+    [Fact]
+    public void NullSMatrixDraft_TwoOpticalPins_CreatesBidirectionalLosslessPassThrough()
+    {
+        var pins = OpticalPins("in", "out");
+
+        var sMatrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        var transfers = sMatrix.GetNonNullValues();
+        transfers.Count.ShouldBe(2);
+        transfers[(pins[0].IDInFlow, pins[1].IDOutFlow)].Magnitude.ShouldBe(1.0, 1e-12);
+        transfers[(pins[1].IDInFlow, pins[0].IDOutFlow)].Magnitude.ShouldBe(1.0, 1e-12);
+    }
+
+    [Fact]
+    public void NullSMatrixDraft_TwoOpticalPins_LightActuallyPropagatesThroughTheMatrix()
+    {
+        var pins = OpticalPins("in", "out");
+        var sMatrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        var systemMatrix = SMatrix.CreateSystemSMatrix(new List<SMatrix> { sMatrix });
+        var input = MathNet.Numerics.LinearAlgebra.Vector<System.Numerics.Complex>.Build
+            .Sparse(systemMatrix.SMat.RowCount);
+        input[systemMatrix.PinReference[pins[0].IDInFlow]] = System.Numerics.Complex.One;
+
+        var field = systemMatrix.CalcFieldAtPinsAfterStepsAsync(
+            input, maxIterations: 10, new CancellationTokenSource()).Result;
+
+        field[pins[1].IDOutFlow].Magnitude.ShouldBeGreaterThan(0,
+            "light entering pin 'in' must exit at pin 'out' (lossless pass-through)");
+        field[pins[1].IDOutFlow].Magnitude.ShouldBe(1.0, 1e-9);
+    }
+
+    [Fact]
+    public void NullSMatrixDraft_SingleOpticalPin_StaysAbsorbing()
+    {
+        var pins = OpticalPins("in");
+
+        var sMatrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        sMatrix.GetNonNullValues().ShouldBeEmpty(
+            "a 1-pin component (probe/bond pad) has no pass-through partner");
+    }
+
+    [Fact]
+    public void NullSMatrixDraft_ThreeOpticalPins_StaysAbsorbing()
+    {
+        var pins = OpticalPins("in", "out1", "out2");
+
+        var sMatrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        sMatrix.GetNonNullValues().ShouldBeEmpty(
+            "a multi-port default would have to guess the routing and violate passivity");
+    }
+
+    [Fact]
+    public void NullSMatrixDraft_OneOpticalPlusOneElectricalPin_StaysAbsorbing()
+    {
+        var pins = OpticalPins("in");
+        pins.Add(new Pin("vcc", 1, MatterType.Electricity, RectSide.Right));
+
+        var sMatrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        sMatrix.GetNonNullValues().ShouldBeEmpty(
+            "an electrical pin is never a light pass-through partner");
+    }
+
+    [Fact]
+    public void ExplicitEmptyConnections_TwoOpticalPins_StaysAbsorbing()
+    {
+        var pins = OpticalPins("in", "out");
+        var draft = new PdkSMatrixDraft { WavelengthNm = 1550, Connections = new List<SMatrixConnection>() };
+
+        var sMatrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, draft);
+
+        sMatrix.GetNonNullValues().ShouldBeEmpty(
+            "an explicitly declared empty connection list is honored as an intentional absorber");
+    }
+
+    [Fact]
+    public void DeclaredConnections_TwoOpticalPins_AreUnaffectedByTheDefault()
+    {
+        var pins = OpticalPins("in", "out");
+        var draft = new PdkSMatrixDraft
+        {
+            WavelengthNm = 1550,
+            Connections = new List<SMatrixConnection>
+            {
+                new() { FromPin = "in", ToPin = "out", Magnitude = 0.5, PhaseDegrees = 0 },
+            },
+        };
+
+        var sMatrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, draft);
+
+        var transfers = sMatrix.GetNonNullValues();
+        transfers.Count.ShouldBe(2);
+        transfers[(pins[0].IDInFlow, pins[1].IDOutFlow)].Magnitude.ShouldBe(0.5, 1e-12);
+    }
+}


### PR DESCRIPTION
## What & why

Fixes #1005. `GdsCellDraftMapper.Map` sets `SMatrix = null` with the comment "the component simulates as a lossless pass-through" — but `PdkTemplateConverter.ConvertToTemplate` mapped that to `CreateSMatrixFromPdk(pins, null)`, which returned an **empty SMatrix**: no transfers between any pins, so the imported component absorbed all light (a black hole in simulation). Any circuit containing a GDS-imported component could not be simulated correctly.

## Fix

In `PdkTemplateConverter.CreateSMatrixFromPdk` (`CAP.Avalonia/Services/PdkTemplateConverter.cs`): when the S-matrix draft is **null** (no simulation model — GDS imports, black-box custom components) and the component has **exactly two optical pins**, the matrix now gets default bidirectional pass-through transfers (in↔out, magnitude 1.0, phase 0°), matching the documented intent.

Deliberate boundary decisions (documented in the code):

- **Other optical pin counts (1, 3+) stay absorbing.** A multi-port default would have to guess the internal routing and would violate passivity; 1-pin pads (Probe Pad, Bond Pad) keep their current behavior. No bundled PDK component is affected — only Probe Pad (1 pin, no sMatrix) and Bond Pad (1 pin, empty sMatrix) ship without connections.
- **An explicitly declared but empty connection list is honored as-is** (intentional absorber) — only a `null` model triggers the default.
- Electrical pins are never pass-through partners.

Also updated: the `GdsCellDraftMapper` doc comment now points to where the pass-through actually comes from, and journey test `GdsImportJourneyTests.Step3_Simulate_PowerArrivesAtImportedInput` (the issue's reproduction) now additionally asserts that power reaches the imported component's **output** pin.

## How it was tested

- New `UnitTests/Services/PdkTemplateConverterTests.cs` (7 tests): bidirectional magnitude-1.0 transfers for a null 2-optical-pin draft; real Neumann-series field propagation through the matrix (input at `in` exits at `out` with magnitude 1.0); 1-pin / 3-pin / optical+electrical stay absorbing; explicit empty connections honored; declared connections unaffected.
- Integration: `GdsImportJourneyTests` steps 1–4 green headless (step 5 is nazca-gated / Slow).
- No UI changes → no i18n strings, no manual UI verification needed.

Local suite: 5932 passed, 0 failed