### PR TITLE
Agent: Meander integration — per-connection target length on the canvas (#1008)

### DIFF
--- a/CAP.Avalonia/ViewModels/MainViewModel.cs
+++ b/CAP.Avalonia/ViewModels/MainViewModel.cs
@@ -1578,6 +1578,15 @@ public class ConnectionData
 
     /// <summary>GDS datatype of the import source route polygons — see <see cref="SourceGdsLayer"/>.</summary>
     public int? SourceGdsDataType { get; set; }
+
+    /// <summary>
+    /// Target route length (µm) the connection was meandered to (issue #1008);
+    /// null = no length intent (also in files that predate the field).
+    /// </summary>
+    public double? TargetLengthMicrometers { get; set; }
+
+    /// <summary>Accepted deviation (µm) from <see cref="TargetLengthMicrometers"/>; null = no length intent.</summary>
+    public double? LengthToleranceMicrometers { get; set; }
 }
 
 /// <summary>

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -419,7 +419,9 @@ public partial class FileOperationsViewModel : ObservableObject
                             ? new Dictionary<int, double>(c.Connection.StraightShiftOffsets)
                             : null,
                         SourceGdsLayer = c.Connection.SourceGdsLayer,
-                        SourceGdsDataType = c.Connection.SourceGdsDataType
+                        SourceGdsDataType = c.Connection.SourceGdsDataType,
+                        TargetLengthMicrometers = c.Connection.TargetLengthMicrometers,
+                        LengthToleranceMicrometers = c.Connection.LengthToleranceMicrometers
                     };
                 }).ToList()
             };
@@ -1715,6 +1717,9 @@ public partial class FileOperationsViewModel : ObservableObject
         {
             connVm.Connection.SourceGdsLayer = connData.SourceGdsLayer;
             connVm.Connection.SourceGdsDataType = connData.SourceGdsDataType;
+            // Meander length intent (issue #1008); null in files that predate the field.
+            connVm.Connection.TargetLengthMicrometers = connData.TargetLengthMicrometers;
+            connVm.Connection.LengthToleranceMicrometers = connData.LengthToleranceMicrometers;
         }
 
         // Restore routing style / interconnect settings / freeze state (issue #574)

--- a/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
+++ b/Connect-A-Pic-Core/Components/Connections/WaveguideConnection.cs
@@ -115,6 +115,20 @@ namespace CAP_Core.Components.Connections
         public int? SourceGdsDataType { get; set; }
 
         /// <summary>
+        /// Optional target geometric length (µm) this connection's route was stretched to
+        /// with a meander (issue #1008). Null means no length intent — the route is whatever
+        /// the router produces. Set by the meander actuator together with a frozen route;
+        /// persisted in .lun files so the intent survives save/load.
+        /// </summary>
+        public double? TargetLengthMicrometers { get; set; }
+
+        /// <summary>
+        /// Accepted deviation (µm) from <see cref="TargetLengthMicrometers"/>.
+        /// Null when no target length is set.
+        /// </summary>
+        public double? LengthToleranceMicrometers { get; set; }
+
+        /// <summary>
         /// The actual routed path with all segments (straights and bends).
         /// Populated after calling RecalculateTransmission().
         /// </summary>

--- a/Connect-A-Pic-Core/Routing/MeanderGeneration/ConnectionLengthMatcher.cs
+++ b/Connect-A-Pic-Core/Routing/MeanderGeneration/ConnectionLengthMatcher.cs
@@ -1,0 +1,219 @@
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Routing.MeanderGeneration;
+
+/// <summary>
+/// Applies a per-connection target length on a real design (issue #1008): derives a
+/// <see cref="MeanderRequest"/> from a live <see cref="WaveguideConnection"/> — endpoint
+/// poses from the pin positions and directions, the minimum bend radius from the
+/// connection's process cross-section, the bounding rectangle from the free area around
+/// the current route — runs the <see cref="MeanderPathGenerator"/> and, on success,
+/// replaces the connection's route geometry. Typed failures pass through unchanged:
+/// the route is never silently left as-is without a reason.
+/// </summary>
+public sealed class ConnectionLengthMatcher
+{
+    /// <summary>
+    /// Clearance (µm) kept between the derived bounds and a component obstacle face,
+    /// so the meandered geometry never grazes a neighboring component.
+    /// </summary>
+    private const double ObstacleClearanceMicrometers = 1.0;
+
+    private readonly WaveguideRouter? _router;
+    private readonly MeanderPathGenerator _generator = new();
+
+    /// <summary>
+    /// Creates a matcher. The optional router supplies the per-connection process
+    /// bend-radius floor (<see cref="WaveguideRouter.ResolveProcessFloorFor"/>); without
+    /// one, the connection's own <see cref="WaveguideConnection.BendRadiusMicrometers"/>
+    /// alone governs the minimum radius.
+    /// </summary>
+    public ConnectionLengthMatcher(WaveguideRouter? router = null)
+    {
+        _router = router;
+    }
+
+    /// <summary>
+    /// Stretches the connection's route to <paramref name="targetLengthMicrometers"/>
+    /// ± <paramref name="toleranceMicrometers"/>. On success the route geometry is
+    /// replaced and frozen (later recalculations keep it while the endpoints stay put)
+    /// and the target/tolerance are recorded on the connection. On failure the
+    /// connection is left untouched and the returned <see cref="MeanderResult"/>
+    /// carries the typed reason.
+    /// </summary>
+    /// <param name="connection">The connection whose route is stretched.</param>
+    /// <param name="obstacleComponents">
+    /// The design's components, used to bound the free area around the current route.
+    /// </param>
+    public MeanderResult ApplyTargetLength(
+        WaveguideConnection connection,
+        IReadOnlyList<Component> obstacleComponents,
+        double targetLengthMicrometers,
+        double toleranceMicrometers)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(obstacleComponents);
+        if (connection.StartPin == null || connection.EndPin == null)
+        {
+            return MeanderResult.Failure(
+                MeanderFailureReason.EndpointsNotRoutableAtMinRadius,
+                "The connection has no endpoint pins to derive poses from.");
+        }
+
+        var request = BuildRequest(
+            connection, obstacleComponents, targetLengthMicrometers, toleranceMicrometers);
+        if (request.Bounds.MaxX <= request.Bounds.MinX || request.Bounds.MaxY <= request.Bounds.MinY)
+        {
+            return MeanderResult.Failure(
+                MeanderFailureReason.BoundsTooSmallForMeander,
+                "Component obstacles leave no free area around the current route.");
+        }
+
+        var result = _generator.Generate(request);
+        if (!result.IsSuccess)
+            return result;
+
+        connection.ReplaceRoutedPath(result.Path!);
+        connection.IsRouteFrozen = true;
+        connection.TargetLengthMicrometers = targetLengthMicrometers;
+        connection.LengthToleranceMicrometers = toleranceMicrometers;
+        return result;
+    }
+
+    /// <summary>
+    /// Derives the meander request for a connection: poses from the pin positions and
+    /// directions (the end direction is the direction of travel at arrival — the end
+    /// pin's outward normal reversed), the minimum bend radius from the connection's
+    /// process cross-section, and the bounding rectangle from the current route's
+    /// bounding box inflated toward the nearest component obstacle on each side.
+    /// </summary>
+    public MeanderRequest BuildRequest(
+        WaveguideConnection connection,
+        IReadOnlyList<Component> obstacleComponents,
+        double targetLengthMicrometers,
+        double toleranceMicrometers)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(obstacleComponents);
+        if (connection.StartPin == null || connection.EndPin == null)
+            throw new ArgumentException("The connection must have both endpoint pins.", nameof(connection));
+
+        var (startX, startY) = connection.StartPin.GetAbsolutePosition();
+        var (endX, endY) = connection.EndPin.GetAbsolutePosition();
+        double startDirection = connection.StartPin.GetAbsoluteAngle();
+        double endDirection = (connection.EndPin.GetAbsoluteAngle() + 180.0) % 360.0;
+
+        double minRadius = Math.Max(
+            connection.BendRadiusMicrometers,
+            _router?.ResolveProcessFloorFor(connection.StartPin, connection.EndPin) ?? 0.0);
+
+        var baseBounds = CurrentRouteBounds(connection, startX, startY, endX, endY);
+        var bounds = InflateTowardObstacles(
+            baseBounds, InflationMargin(targetLengthMicrometers, minRadius), obstacleComponents);
+
+        return new MeanderRequest(
+            startX, startY, startDirection,
+            endX, endY, endDirection,
+            targetLengthMicrometers, toleranceMicrometers,
+            minRadius, bounds);
+    }
+
+    /// <summary>
+    /// Per-side inflation of the route's bounding box. A meander's perpendicular reach is
+    /// largest when the whole extra length goes into a single hairpin loop
+    /// (extra/2 + 2r, and extra never exceeds the target), so this margin always leaves
+    /// room for the tightest fold; obstacle clamping keeps it inside the free area.
+    /// Keying the margin off the target (not the current route length) keeps the derived
+    /// bounds free of the route's present shape, so a saved-and-reloaded connection
+    /// re-derives the identical meander geometry.
+    /// </summary>
+    private static double InflationMargin(double targetLengthMicrometers, double minRadiusMicrometers)
+        => Math.Max(0.0, targetLengthMicrometers) / 2.0
+        + 2.0 * minRadiusMicrometers
+        + ObstacleClearanceMicrometers;
+
+    /// <summary>
+    /// Tight bounding box of the connection's current route geometry, always containing
+    /// both pin positions (a routeless connection degrades to the pin-to-pin box).
+    /// </summary>
+    private static (double MinX, double MinY, double MaxX, double MaxY) CurrentRouteBounds(
+        WaveguideConnection connection, double startX, double startY, double endX, double endY)
+    {
+        double minX = Math.Min(startX, endX);
+        double minY = Math.Min(startY, endY);
+        double maxX = Math.Max(startX, endX);
+        double maxY = Math.Max(startY, endY);
+
+        if (connection.RoutedPath != null)
+        {
+            foreach (var segment in connection.RoutedPath.Segments)
+            {
+                var b = PathSegmentBounds.Of(segment);
+                minX = Math.Min(minX, b.MinX);
+                minY = Math.Min(minY, b.MinY);
+                maxX = Math.Max(maxX, b.MaxX);
+                maxY = Math.Max(maxY, b.MaxY);
+            }
+        }
+
+        return (minX, minY, maxX, maxY);
+    }
+
+    /// <summary>
+    /// Inflates the base box by up to <paramref name="margin"/> per side, clamped so the
+    /// result never reaches closer than <see cref="ObstacleClearanceMicrometers"/> to a
+    /// component. Components the route already touches (its endpoint components) overlap
+    /// the base box and are anchors of the route, not obstacles to it. The perpendicular
+    /// overlap test uses the fully inflated range — conservative: a side may be clamped
+    /// by an obstacle that only the inflation on the OTHER axis would have reached.
+    /// </summary>
+    private static MeanderBounds InflateTowardObstacles(
+        (double MinX, double MinY, double MaxX, double MaxY) baseBounds,
+        double margin,
+        IReadOnlyList<Component> components)
+    {
+        double xMinus = margin;
+        double xPlus = margin;
+        double yMinus = margin;
+        double yPlus = margin;
+
+        foreach (var component in components)
+        {
+            if (!component.IsRoutingObstacle)
+                continue;
+
+            double rectMinX = component.PhysicalX;
+            double rectMinY = component.PhysicalY;
+            double rectMaxX = component.PhysicalX + component.WidthMicrometers;
+            double rectMaxY = component.PhysicalY + component.HeightMicrometers;
+
+            bool touchesRoute = rectMinX <= baseBounds.MaxX && rectMaxX >= baseBounds.MinX
+                && rectMinY <= baseBounds.MaxY && rectMaxY >= baseBounds.MinY;
+            if (touchesRoute)
+                continue;
+
+            bool overlapsY = rectMinY < baseBounds.MaxY + margin && rectMaxY > baseBounds.MinY - margin;
+            if (overlapsY)
+            {
+                if (rectMinX >= baseBounds.MaxX)
+                    xPlus = Math.Min(xPlus, Math.Max(0.0, rectMinX - baseBounds.MaxX - ObstacleClearanceMicrometers));
+                if (rectMaxX <= baseBounds.MinX)
+                    xMinus = Math.Min(xMinus, Math.Max(0.0, baseBounds.MinX - rectMaxX - ObstacleClearanceMicrometers));
+            }
+
+            bool overlapsX = rectMinX < baseBounds.MaxX + margin && rectMaxX > baseBounds.MinX - margin;
+            if (overlapsX)
+            {
+                if (rectMinY >= baseBounds.MaxY)
+                    yPlus = Math.Min(yPlus, Math.Max(0.0, rectMinY - baseBounds.MaxY - ObstacleClearanceMicrometers));
+                if (rectMaxY <= baseBounds.MinY)
+                    yMinus = Math.Min(yMinus, Math.Max(0.0, baseBounds.MinY - rectMaxY - ObstacleClearanceMicrometers));
+            }
+        }
+
+        return new MeanderBounds(
+            baseBounds.MinX - xMinus, baseBounds.MinY - yMinus,
+            baseBounds.MaxX + xPlus, baseBounds.MaxY + yPlus);
+    }
+}

--- a/UnitTests/Integration/MeanderedConnectionExportTests.cs
+++ b/UnitTests/Integration/MeanderedConnectionExportTests.cs
@@ -1,0 +1,171 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.CodeExporter;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Routing.MeanderGeneration;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Export equality for meandered connections (issue #1008): the Nazca/GDS export emits the
+/// connection's actual meandered geometry, so the route length encoded in the exported
+/// script equals the canvas length. Headless at the script level — the script IS the GDS
+/// geometry source (nazca turns these exact calls into the GDS polygons on CI).
+/// </summary>
+public class MeanderedConnectionExportTests
+{
+    private const double Tolerance = 1.0;
+
+    private static readonly Regex StraightCallRegex = new(
+        @"nd\.strt\(length=(\d+(?:\.\d+)?)[^)]*\)\.put\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex BendCallRegex = new(
+        @"nd\.bend\(radius=(\d+(?:\.\d+)?),\s*angle=(-?\d+(?:\.\d+)?)[^)]*\)\.put\(",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void Export_MeanderedConnection_ExportedLengthEqualsCanvasLength()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var (comp1, comp2) = PlaceFacingComponents(canvas);
+        ConnectStraight(canvas, comp1.PhysicalPins[0], comp2.PhysicalPins[0]);
+
+        var connection = canvas.Connections.ShouldHaveSingleItem().Connection;
+        var components = canvas.Components.Select(vm => vm.Component).ToList();
+        double target = 3.0 * connection.PathLengthMicrometers;
+        var applied = new ConnectionLengthMatcher().ApplyTargetLength(
+            connection, components, target, Tolerance);
+        applied.IsSuccess.ShouldBeTrue(applied.FailureMessage);
+
+        var script = new SimpleNazcaExporter().Export(canvas);
+
+        var connectionsSection = script.Substring(
+            script.IndexOf("# Waveguide Connections", StringComparison.Ordinal));
+        double exportedLength = SumExportedLength(connectionsSection, out double minBendRadius);
+
+        // The exporter rounds every number to two decimals, so each emitted segment
+        // contributes at most ~0.01 µm of rounding error to the sum.
+        double roundingSlack = 0.01 * connection.GetPathSegments().Count + 1e-6;
+        exportedLength.ShouldBe(connection.PathLengthMicrometers, roundingSlack);
+        minBendRadius.ShouldBeGreaterThanOrEqualTo(connection.BendRadiusMicrometers - 0.01);
+    }
+
+    [Fact]
+    public void Export_MeanderedConnection_ExportValidatorFindsNoErrors()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var (comp1, comp2) = PlaceFacingComponents(canvas);
+        ConnectStraight(canvas, comp1.PhysicalPins[0], comp2.PhysicalPins[0]);
+
+        var connection = canvas.Connections.ShouldHaveSingleItem().Connection;
+        var components = canvas.Components.Select(vm => vm.Component).ToList();
+        double target = 3.0 * connection.PathLengthMicrometers;
+        var applied = new ConnectionLengthMatcher().ApplyTargetLength(
+            connection, components, target, Tolerance);
+        applied.IsSuccess.ShouldBeTrue(applied.FailureMessage);
+
+        var script = new SimpleNazcaExporter().Export(canvas);
+        var validator = new ExportValidator();
+        var result = validator.Validate(
+            canvas.Components.Select(vm => vm.Component).ToList(),
+            canvas.Connections.Select(vm => vm.Connection).ToList(),
+            script);
+
+        result.IsValid.ShouldBeTrue(
+            $"Validation failed with {result.FailedChecks} errors:\n" +
+            string.Join("\n", result.Errors));
+    }
+
+    private static double SumExportedLength(string connectionsSection, out double minBendRadius)
+    {
+        var ci = CultureInfo.InvariantCulture;
+        double total = 0.0;
+        minBendRadius = double.MaxValue;
+
+        foreach (Match match in StraightCallRegex.Matches(connectionsSection))
+        {
+            total += double.Parse(match.Groups[1].Value, ci);
+        }
+
+        foreach (Match match in BendCallRegex.Matches(connectionsSection))
+        {
+            double radius = double.Parse(match.Groups[1].Value, ci);
+            double sweepDegrees = double.Parse(match.Groups[2].Value, ci);
+            total += radius * Math.Abs(sweepDegrees) * Math.PI / 180.0;
+            minBendRadius = Math.Min(minBendRadius, radius);
+        }
+
+        return total;
+    }
+
+    private static (Component Comp1, Component Comp2) PlaceFacingComponents(DesignCanvasViewModel canvas)
+    {
+        var comp1 = CreateTestComponent("MMI_1x2", 0, 0, 100, 50);
+        comp1.PhysicalPins.Add(new PhysicalPin
+        {
+            Name = "out1",
+            ParentComponent = comp1,
+            OffsetXMicrometers = 100,
+            OffsetYMicrometers = 25,
+            AngleDegrees = 0
+        });
+        canvas.AddComponent(comp1, "MMI_1x2");
+
+        var comp2 = CreateTestComponent("Detector", 250, 0, 50, 50);
+        comp2.PhysicalPins.Add(new PhysicalPin
+        {
+            Name = "in",
+            ParentComponent = comp2,
+            OffsetXMicrometers = 0,
+            OffsetYMicrometers = 25,
+            AngleDegrees = 180
+        });
+        canvas.AddComponent(comp2, "Detector");
+        return (comp1, comp2);
+    }
+
+    private static void ConnectStraight(
+        DesignCanvasViewModel canvas, PhysicalPin startPin, PhysicalPin endPin)
+    {
+        var (startX, startY) = startPin.GetAbsolutePosition();
+        var (endX, endY) = endPin.GetAbsolutePosition();
+
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(startX, startY, endX, endY, startPin.GetAbsoluteAngle()));
+        canvas.ConnectPinsWithCachedRoute(startPin, endPin, path);
+    }
+
+    private static Component CreateTestComponent(
+        string identifier, double x, double y, double width, double height)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+
+        var component = new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: $"test_{identifier.ToLower()}",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: identifier,
+            rotationCounterClock: DiscreteRotation.R0,
+            physicalPins: new List<PhysicalPin>());
+
+        component.PhysicalX = x;
+        component.PhysicalY = y;
+        component.WidthMicrometers = width;
+        component.HeightMicrometers = height;
+        component.NazcaOriginOffsetX = 0;
+        component.NazcaOriginOffsetY = height;
+        return component;
+    }
+}

--- a/UnitTests/Persistence/ConnectionLengthPersistenceTests.cs
+++ b/UnitTests/Persistence/ConnectionLengthPersistenceTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using CAP_Core.Routing;
+using CAP_Core.Routing.MeanderGeneration;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Persistence;
+
+/// <summary>
+/// The meander length intent of a connection (<see cref="CAP_Core.Components.Connections.WaveguideConnection.TargetLengthMicrometers"/>)
+/// must survive a Save/Load round trip together with the meandered geometry (issue #1008):
+/// a reloaded connection keeps its target+tolerance, and re-applying the matcher re-derives
+/// the identical geometry. Files that predate the field load without intent, unchanged.
+/// Mirrors the Save/Load helpers of <see cref="ConnectionSourceLayerPersistenceTests"/>.
+/// </summary>
+public class ConnectionLengthPersistenceTests
+{
+    private const double AssertSlack = 1e-6;
+    private const double Tolerance = 1.0;
+
+    private readonly ObservableCollection<ComponentTemplate> _library =
+        new(TestPdkLoader.LoadAllTemplates());
+
+    [Fact]
+    public async Task SaveLoad_MeanderedConnection_KeepsTargetToleranceAndGeometry()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"length_persist_{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas, _) = CreateSetup();
+            var (comp1, comp2) = PlaceFacingMmis(saveCanvas);
+            var startPin = comp1.PhysicalPins.First(p => p.Name == "out1");
+            var endPin = comp2.PhysicalPins.First(p => p.Name == "in");
+
+            var (sx, sy) = startPin.GetAbsolutePosition();
+            var (ex, ey) = endPin.GetAbsolutePosition();
+            var path = new RoutedPath();
+            path.Segments.Add(new StraightSegment(sx, sy, ex, ey, 0));
+            var connVm = saveCanvas.ConnectPinsWithCachedRoute(startPin, endPin, path);
+
+            var components = saveCanvas.Components.Select(vm => vm.Component).ToList();
+            var connection = connVm!.Connection;
+            double target = 3.0 * connection.PathLengthMicrometers;
+            var applied = new ConnectionLengthMatcher().ApplyTargetLength(
+                connection, components, target, Tolerance);
+            applied.IsSuccess.ShouldBeTrue(applied.FailureMessage);
+            double meanderedLength = connection.PathLengthMicrometers;
+            int meanderedSegmentCount = connection.RoutedPath!.Segments.Count;
+            await SaveToFile(saveVm, tempFile);
+
+            var (loadVm, loadCanvas, _) = CreateSetup();
+            await LoadFromFile(loadVm, tempFile);
+
+            var loaded = loadCanvas.Connections.ShouldHaveSingleItem().Connection;
+            loaded.TargetLengthMicrometers.ShouldBe(target,
+                "the meander target must survive the round trip");
+            loaded.LengthToleranceMicrometers.ShouldBe(Tolerance);
+            loaded.PathLengthMicrometers.ShouldBe(meanderedLength, AssertSlack);
+            loaded.RoutedPath!.Segments.Count.ShouldBe(meanderedSegmentCount);
+
+            var rederived = new ConnectionLengthMatcher().ApplyTargetLength(
+                loaded, loadCanvas.Components.Select(vm => vm.Component).ToList(),
+                loaded.TargetLengthMicrometers.Value, loaded.LengthToleranceMicrometers.Value);
+            rederived.IsSuccess.ShouldBeTrue(rederived.FailureMessage);
+            loaded.PathLengthMicrometers.ShouldBe(meanderedLength, AssertSlack);
+            loaded.RoutedPath!.Segments.Count.ShouldBe(meanderedSegmentCount);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Load_PreTargetLengthFile_LoadsWithoutLengthIntent()
+    {
+        // A file saved before the length intent existed carries no TargetLengthMicrometers/
+        // LengthToleranceMicrometers keys at all (simulated by stripping them after a
+        // normal save): the connection must load without intent, unchanged.
+        var tempFile = Path.Combine(Path.GetTempPath(), $"length_legacy_{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas, _) = CreateSetup();
+            var (comp1, comp2) = PlaceFacingMmis(saveCanvas);
+            var startPin = comp1.PhysicalPins.First(p => p.Name == "out1");
+            var endPin = comp2.PhysicalPins.First(p => p.Name == "in");
+
+            var (sx, sy) = startPin.GetAbsolutePosition();
+            var (ex, ey) = endPin.GetAbsolutePosition();
+            var path = new RoutedPath();
+            path.Segments.Add(new StraightSegment(sx, sy, ex, ey, 0));
+            saveCanvas.ConnectPinsWithCachedRoute(startPin, endPin, path);
+            await SaveToFile(saveVm, tempFile);
+
+            var json = await File.ReadAllTextAsync(tempFile);
+            var root = System.Text.Json.Nodes.JsonNode.Parse(json)!;
+            root["Connections"]![0]!.AsObject().Remove("TargetLengthMicrometers");
+            root["Connections"]![0]!.AsObject().Remove("LengthToleranceMicrometers");
+            await File.WriteAllTextAsync(tempFile, root.ToJsonString());
+
+            var (loadVm, loadCanvas, _) = CreateSetup();
+            await LoadFromFile(loadVm, tempFile);
+
+            var loaded = loadCanvas.Connections.ShouldHaveSingleItem().Connection;
+            loaded.TargetLengthMicrometers.ShouldBeNull();
+            loaded.LengthToleranceMicrometers.ShouldBeNull();
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    // ── Helpers (mirrors ConnectionSourceLayerPersistenceTests) ─────────────
+
+    private (Component Component1, Component Component2) PlaceFacingMmis(DesignCanvasViewModel canvas)
+    {
+        var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+        var comp1 = ComponentTemplates.CreateFromTemplate(mmiTemplate, 0, 27.5);
+        comp1.Identifier = "length_mmi_1";
+        canvas.AddComponent(comp1, mmiTemplate.Name);
+        var comp2 = ComponentTemplates.CreateFromTemplate(mmiTemplate, 200, 27.5);
+        comp2.Identifier = "length_mmi_2";
+        canvas.AddComponent(comp2, mmiTemplate.Name);
+        return (comp1, comp2);
+    }
+
+    private (FileOperationsViewModel vm, DesignCanvasViewModel canvas, ErrorConsoleService errorConsole)
+        CreateSetup()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var errorConsole = new ErrorConsoleService();
+        var vm = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            _library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!,
+            errorConsole: errorConsole);
+        return (vm, canvas, errorConsole);
+    }
+
+    private static async Task SaveToFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(filePath).ShouldBeTrue();
+    }
+
+    private static async Task LoadFromFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.LoadDesignCommand.ExecuteAsync(null);
+    }
+}

--- a/UnitTests/Routing/MeanderGeneration/ConnectionLengthMatcherTests.cs
+++ b/UnitTests/Routing/MeanderGeneration/ConnectionLengthMatcherTests.cs
@@ -1,0 +1,213 @@
+using CAP_Core.Components;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Routing;
+using CAP_Core.Routing.MeanderGeneration;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Routing.MeanderGeneration;
+
+/// <summary>
+/// <see cref="ConnectionLengthMatcher"/> actuator tests (issue #1008): a live connection
+/// gets a target length, the matcher derives the meander request from the design and
+/// replaces the route geometry — or passes a typed failure through without touching it.
+/// </summary>
+public class ConnectionLengthMatcherTests
+{
+    private const double AssertSlack = 1e-6;
+    private const double Tolerance = 1.0;
+
+    [Fact]
+    public void ApplyTargetLength_TargetThreeTimesDirect_MeandersWithinTolerance()
+    {
+        var (comp1, comp2, connection) = CreateStraightDesign();
+        var components = new List<Component> { comp1, comp2 };
+        double target = 3.0 * connection.PathLengthMicrometers;
+        var matcher = new ConnectionLengthMatcher();
+
+        var request = matcher.BuildRequest(connection, components, target, Tolerance);
+        var result = matcher.ApplyTargetLength(connection, components, target, Tolerance);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        result.FailureReason.ShouldBeNull();
+        connection.PathLengthMicrometers.ShouldBe(target, Tolerance);
+        connection.RoutedPath.ShouldBeSameAs(result.Path);
+        connection.TargetLengthMicrometers.ShouldBe(target);
+        connection.LengthToleranceMicrometers.ShouldBe(Tolerance);
+        connection.IsRouteFrozen.ShouldBeTrue(
+            "the meandered geometry must survive later recalculations while the endpoints stay put");
+
+        foreach (var bend in connection.RoutedPath!.Segments.OfType<BendSegment>())
+        {
+            bend.RadiusMicrometers.ShouldBeGreaterThanOrEqualTo(connection.BendRadiusMicrometers);
+        }
+
+        foreach (var segment in connection.RoutedPath!.Segments)
+        {
+            request.Bounds.Contains(PathSegmentBounds.Of(segment), AssertSlack).ShouldBeTrue(
+                "every segment must stay inside the derived free-area bounds");
+        }
+    }
+
+    [Fact]
+    public void ApplyTargetLength_MeanderedRoute_KeepsEndpointPoses()
+    {
+        var (comp1, comp2, connection) = CreateStraightDesign();
+        var components = new List<Component> { comp1, comp2 };
+        double target = 3.0 * connection.PathLengthMicrometers;
+        var (expectedStartX, expectedStartY) = connection.StartPin.GetAbsolutePosition();
+        var (expectedEndX, expectedEndY) = connection.EndPin.GetAbsolutePosition();
+
+        var result = new ConnectionLengthMatcher().ApplyTargetLength(
+            connection, components, target, Tolerance);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        var path = connection.RoutedPath!;
+        path.IsValid.ShouldBeTrue();
+        path.Segments[0].StartPoint.X.ShouldBe(expectedStartX, AssertSlack);
+        path.Segments[0].StartPoint.Y.ShouldBe(expectedStartY, AssertSlack);
+        path.Segments[^1].EndPoint.X.ShouldBe(expectedEndX, AssertSlack);
+        path.Segments[^1].EndPoint.Y.ShouldBe(expectedEndY, AssertSlack);
+    }
+
+    [Fact]
+    public void ApplyTargetLength_TargetShorterThanDirect_TypedFailureLeavesRouteUntouched()
+    {
+        var (comp1, comp2, connection) = CreateStraightDesign();
+        var components = new List<Component> { comp1, comp2 };
+        var routeBefore = connection.RoutedPath;
+        double target = connection.PathLengthMicrometers / 2.0;
+
+        var result = new ConnectionLengthMatcher().ApplyTargetLength(
+            connection, components, target, Tolerance);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.FailureReason.ShouldBe(MeanderFailureReason.TargetShorterThanDirectPath);
+        result.FailureMessage.ShouldNotBeNullOrEmpty();
+        connection.RoutedPath.ShouldBeSameAs(routeBefore);
+        connection.PathLengthMicrometers.ShouldBe(routeBefore!.TotalLengthMicrometers, AssertSlack);
+        connection.TargetLengthMicrometers.ShouldBeNull();
+        connection.LengthToleranceMicrometers.ShouldBeNull();
+        connection.IsRouteFrozen.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ApplyTargetLength_NoFreeAreaAroundRoute_TypedFailureLeavesRouteUntouched()
+    {
+        var (comp1, comp2, connection) = CreateStraightDesign();
+        // Wall components directly above and below the straight route clamp the
+        // perpendicular inflation to zero, so no meander can fit.
+        var wallAbove = CreateComponent("wall_above", 90, 0, 170, 24);
+        var wallBelow = CreateComponent("wall_below", 90, 26, 170, 24);
+        var components = new List<Component> { comp1, comp2, wallAbove, wallBelow };
+        var routeBefore = connection.RoutedPath;
+        double target = 3.0 * connection.PathLengthMicrometers;
+
+        var result = new ConnectionLengthMatcher().ApplyTargetLength(
+            connection, components, target, Tolerance);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.FailureReason.ShouldBe(MeanderFailureReason.BoundsTooSmallForMeander);
+        connection.RoutedPath.ShouldBeSameAs(routeBefore);
+        connection.TargetLengthMicrometers.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ApplyTargetLength_ProcessFloorAboveConnectionRadius_BendsRespectFloor()
+    {
+        var (comp1, comp2, connection) = CreateStraightDesign();
+        var components = new List<Component> { comp1, comp2 };
+        double target = 3.0 * connection.PathLengthMicrometers;
+        var router = new WaveguideRouter { ProcessMinBendRadiusMicrometers = 20.0 };
+
+        var result = new ConnectionLengthMatcher(router).ApplyTargetLength(
+            connection, components, target, Tolerance);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        connection.PathLengthMicrometers.ShouldBe(target, Tolerance);
+        foreach (var bend in connection.RoutedPath!.Segments.OfType<BendSegment>())
+        {
+            bend.RadiusMicrometers.ShouldBeGreaterThanOrEqualTo(20.0);
+        }
+    }
+
+    [Fact]
+    public void ApplyTargetLength_ReappliedToMeanderedConnection_ReDerivesIdenticalGeometry()
+    {
+        var (comp1, comp2, connection) = CreateStraightDesign();
+        var components = new List<Component> { comp1, comp2 };
+        double target = 3.0 * connection.PathLengthMicrometers;
+        var matcher = new ConnectionLengthMatcher();
+
+        matcher.ApplyTargetLength(connection, components, target, Tolerance);
+        double firstLength = connection.PathLengthMicrometers;
+        int firstSegmentCount = connection.RoutedPath!.Segments.Count;
+
+        var result = matcher.ApplyTargetLength(connection, components, target, Tolerance);
+
+        result.IsSuccess.ShouldBeTrue(result.FailureMessage);
+        connection.PathLengthMicrometers.ShouldBe(firstLength, AssertSlack);
+        connection.RoutedPath!.Segments.Count.ShouldBe(firstSegmentCount);
+    }
+
+    /// <summary>
+    /// Two facing components (out-pin at angle 0°, in-pin at 180°) joined by a 150 µm
+    /// straight route at y = 25.
+    /// </summary>
+    private static (Component Comp1, Component Comp2, WaveguideConnection Connection) CreateStraightDesign()
+    {
+        var comp1 = CreateComponent("src", 0, 0, 100, 50);
+        var startPin = new PhysicalPin
+        {
+            Name = "out",
+            ParentComponent = comp1,
+            OffsetXMicrometers = 100,
+            OffsetYMicrometers = 25,
+            AngleDegrees = 0
+        };
+        comp1.PhysicalPins.Add(startPin);
+
+        var comp2 = CreateComponent("dst", 250, 0, 100, 50);
+        var endPin = new PhysicalPin
+        {
+            Name = "in",
+            ParentComponent = comp2,
+            OffsetXMicrometers = 0,
+            OffsetYMicrometers = 25,
+            AngleDegrees = 180
+        };
+        comp2.PhysicalPins.Add(endPin);
+
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(100, 25, 250, 25, 0));
+        var connection = new WaveguideConnection { StartPin = startPin, EndPin = endPin };
+        connection.RestoreCachedPath(path);
+        return (comp1, comp2, connection);
+    }
+
+    private static Component CreateComponent(
+        string identifier, double x, double y, double width, double height)
+    {
+        var parts = new Part[1, 1];
+        parts[0, 0] = new Part(new List<Pin>());
+
+        var component = new Component(
+            laserWaveLengthToSMatrixMap: new Dictionary<int, SMatrix>(),
+            sliders: new List<Slider>(),
+            nazcaFunctionName: $"test_{identifier.ToLower()}",
+            nazcaFunctionParams: "",
+            parts: parts,
+            typeNumber: 0,
+            identifier: identifier,
+            rotationCounterClock: DiscreteRotation.R0,
+            physicalPins: new List<PhysicalPin>());
+
+        component.PhysicalX = x;
+        component.PhysicalY = y;
+        component.WidthMicrometers = width;
+        component.HeightMicrometers = height;
+        return component;
+    }
+}


### PR DESCRIPTION
## What & why

Issue #1008 (slice 2 of umbrella #753 — MZI arms / delay lines / phase matching): the meander kernel merged in #1007 (`MeanderPathGenerator`) had no actuator wiring — nothing on a real design could use it. This PR adds the Core actuator plus minimal persistence (no panel UI, per the slice definition).

- **`ConnectionLengthMatcher`** (`Connect-A-Pic-Core/Routing/MeanderGeneration/`, same vertical slice as the kernel): given a `WaveguideConnection`, the design's components, a target length (µm) and a tolerance, it derives the `MeanderRequest` from the connection's current route — endpoint poses from the pin positions/directions (end direction = direction of travel at arrival), min bend radius from the connection's process cross-section (`max(connection.BendRadiusMicrometers, router.ResolveProcessFloorFor(...))`), bounding rectangle from the current route's bounding box inflated toward the nearest component obstacle on each side (conservative: obstacle-clamped with 1 µm clearance; endpoint components that touch the route are anchors, not obstacles). On success it replaces the route geometry via `ReplaceRoutedPath`, freezes the route (so later recalculations keep the meander while the endpoints stay put), and records the intent on the connection. Typed failures (`TargetShorterThanDirectPath`, `BoundsTooSmallForMeander`, `EndpointsNotRoutableAtMinRadius`) pass through — the route is never silently left unchanged.
- **Persistence:** `TargetLengthMicrometers` / `LengthToleranceMicrometers` (nullable, additive — same pattern as the `SourceGdsLayer`/`ProcessBinding` additions; JSON omits nulls, so legacy .lun files are byte-identical and load without intent). The meandered geometry itself round-trips via the existing cached-segments mechanism, and re-applying the matcher after load re-derives identical geometry (the bounds margin is keyed off the target, not the current route shape, and the generator is deterministic).
- **Export equality:** the Nazca/GDS export already emits `conn.GetPathSegments()`, so replacing the route geometry automatically makes export equal canvas geometry — verified by test.
- **Not in this slice** (stays in #753): canvas live feedback, panel UI, pairwise arm matching. No new user-visible strings, so no i18n changes.

## How it was tested

- `UnitTests/Routing/MeanderGeneration/ConnectionLengthMatcherTests.cs` (6 tests): straight connection stretched to 3× direct length → `PathLengthMicrometers` within tolerance, all bends ≥ min radius, geometry inside the derived bounds, endpoint poses preserved; process floor above the connection radius is respected; impossible target (shorter than direct) and no-free-area (obstacle-walled route) → typed failures with the route untouched; re-applying to an already-meandered connection re-derives identical geometry.
- `UnitTests/Persistence/ConnectionLengthPersistenceTests.cs` (2 tests): save/load round trip keeps target+tolerance and the meandered geometry (and re-derives it identically); a pre-field legacy file (keys stripped) loads without intent, unchanged.
- `UnitTests/Integration/MeanderedConnectionExportTests.cs` (2 tests): the exported Nazca script's total waveguide length (Σ strt lengths + Σ bend arc lengths, F2-rounding slack accounted) equals the meandered canvas length, exported bend radii ≥ min radius, and `ExportValidator` finds no errors. Headless at the script level — the script is the exact GDS geometry source nazca turns into polygons on CI.

Local suite: 5935 passed, 0 failed

## Manual verification after vacation

None needed for this slice (no UI). The canvas UI slice follows in #753.