### PR TITLE
Agent: GDS-imported components block all light: empty S-matrix instead of lossless pass-through

### DIFF
--- a/CAP.Avalonia/Services/GdsImport/GdsCellDraftMapper.cs
+++ b/CAP.Avalonia/Services/GdsImport/GdsCellDraftMapper.cs
@@ -9,9 +9,11 @@ namespace CAP.Avalonia.Services.GdsImport;
 /// Maps a <see cref="GdsCellDraft"/> (pure-data output of the GDS hierarchy
 /// importer) to a persistable <see cref="PdkComponentDraft"/>, mirroring the
 /// shape <c>CustomComponentDraftFactory</c> establishes for black-box custom
-/// components: <see cref="PdkComponentDraft.SMatrix"/> stays null (no simulation
-/// model — the component simulates as a lossless pass-through), and geometry is
-/// carried by <see cref="PdkComponentDraft.RawCode"/> plus the outline polygons.
+/// components: <see cref="PdkComponentDraft.SMatrix"/> stays null (no measured or
+/// computed model — the template converter applies its black-box default: a cell
+/// with exactly two optical pins simulates as a lossless pass-through, any other
+/// pin count absorbs), and geometry is carried by
+/// <see cref="PdkComponentDraft.RawCode"/> plus the outline polygons.
 /// </summary>
 public static class GdsCellDraftMapper
 {

--- a/CAP.Avalonia/Services/PdkTemplateConverter.cs
+++ b/CAP.Avalonia/Services/PdkTemplateConverter.cs
@@ -192,12 +192,25 @@ public static class PdkTemplateConverter
         return sMatrix;
     }
 
+    /// <summary>
+    /// Builds the runtime <see cref="SMatrix"/> from a fixed (non-parametric)
+    /// <see cref="PdkSMatrixDraft"/>. A null draft means the component has no
+    /// simulation model at all (GDS import, black-box custom component) and gets
+    /// the black-box default of <see cref="ApplyBlackBoxDefault"/>; a draft with
+    /// no connections stays fully absorbing.
+    /// </summary>
     public static SMatrix CreateSMatrixFromPdk(List<Pin> pins, PdkSMatrixDraft? sMatrixDraft)
     {
         var pinIds = pins.SelectMany(p => new[] { p.IDInFlow, p.IDOutFlow }).ToList();
         var sMatrix = new SMatrix(pinIds, new List<(Guid, double)>());
 
-        if (sMatrixDraft?.Connections == null || sMatrixDraft.Connections.Count == 0)
+        if (sMatrixDraft == null)
+        {
+            ApplyBlackBoxDefault(pins, sMatrix);
+            return sMatrix;
+        }
+
+        if (sMatrixDraft.Connections == null || sMatrixDraft.Connections.Count == 0)
             return sMatrix;
 
         var pinByName = new Dictionary<string, Pin>(StringComparer.OrdinalIgnoreCase);
@@ -221,5 +234,28 @@ public static class PdkTemplateConverter
 
         sMatrix.SetValues(transfers);
         return sMatrix;
+    }
+
+    /// <summary>
+    /// Simulation default for a component without any S-matrix model. Exactly two
+    /// optical pins have one unambiguous ideal — the lossless pass-through
+    /// (magnitude 1, phase 0, both directions), mirroring
+    /// <c>FdtdSMatrixToDraftConverter.LosslessTwoPort</c> — so an imported waveguide
+    /// passes light instead of swallowing it. Every other pin count has no canonical
+    /// model and stays absorbing: an all-pairs unit-magnitude default would be
+    /// non-passive and could diverge the field iteration, and any invented split
+    /// ratio would be fabricated physics.
+    /// </summary>
+    private static void ApplyBlackBoxDefault(List<Pin> pins, SMatrix sMatrix)
+    {
+        var opticalPins = pins.Where(p => p.MatterType == MatterType.Light).ToList();
+        if (opticalPins.Count != 2)
+            return;
+
+        sMatrix.SetValues(new Dictionary<(Guid, Guid), Complex>
+        {
+            [(opticalPins[0].IDInFlow, opticalPins[1].IDOutFlow)] = Complex.One,
+            [(opticalPins[1].IDInFlow, opticalPins[0].IDOutFlow)] = Complex.One,
+        });
     }
 }

--- a/UnitTests/Services/GdsImport/GdsCellDraftMapperTests.cs
+++ b/UnitTests/Services/GdsImport/GdsCellDraftMapperTests.cs
@@ -225,6 +225,25 @@ public class GdsCellDraftMapperTests
     }
 
     [Fact]
+    public void Map_TwoOpticalPins_PlacedComponentPassesLightThrough()
+    {
+        // A GDS-imported 2-pin cell must not absorb all light — the placed
+        // component's S-matrix carries the lossless in↔out pass-through.
+        var componentDraft = GdsCellDraftMapper.Map(Draft(), "/tmp/lib/circuit.gds");
+        var template = PdkTemplateConverter.ConvertToTemplate(componentDraft, "user-pdk", null);
+        var component = ComponentTemplates.CreateFromTemplate(template, 0, 0);
+
+        var matrix = component.WaveLengthToSMatrixMap[1550];
+        var inPin = component.PhysicalPins.Select(p => p.LogicalPin!).Single(p => p.Name == "in");
+        var outPin = component.PhysicalPins.Select(p => p.LogicalPin!).Single(p => p.Name == "out");
+
+        var transfers = matrix.GetNonNullValues();
+        transfers.Count.ShouldBe(2);
+        transfers[(inPin.IDInFlow, outPin.IDOutFlow)].Magnitude.ShouldBe(1.0, Tolerance);
+        transfers[(outPin.IDInFlow, inPin.IDOutFlow)].Magnitude.ShouldBe(1.0, Tolerance);
+    }
+
+    [Fact]
     public void Map_ProvenElectricalPin_PlacedComponentPinIsElectrical()
     {
         // The whole survival chain: DetectedPin.IsElectrical → pinKind JSON field

--- a/UnitTests/Services/PdkTemplateConverterTests.cs
+++ b/UnitTests/Services/PdkTemplateConverterTests.cs
@@ -1,0 +1,149 @@
+using System.Numerics;
+using CAP.Avalonia.Services;
+using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation;
+using CAP_Core.Tiles;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Services;
+
+/// <summary>
+/// Tests for <see cref="PdkTemplateConverter.CreateSMatrixFromPdk"/>, focused on the
+/// black-box default: a component draft without any S-matrix model (GDS import,
+/// black-box custom component) must not swallow light. Exactly two optical pins get
+/// the lossless bidirectional pass-through; every other topology stays absorbing
+/// because no canonical model exists.
+/// </summary>
+public class PdkTemplateConverterTests
+{
+    private const double Tolerance = 1e-12;
+
+    private static List<Pin> OpticalPins(params string[] names) =>
+        names.Select((name, i) => new Pin(name, i, MatterType.Light, RectSide.Left)).ToList();
+
+    [Fact]
+    public void CreateSMatrixFromPdk_NullDraft_TwoOpticalPins_LosslessPassThroughBothDirections()
+    {
+        var pins = OpticalPins("in", "out");
+
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        var transfers = matrix.GetNonNullValues();
+        transfers.Count.ShouldBe(2);
+        transfers[(pins[0].IDInFlow, pins[1].IDOutFlow)].ShouldBe(Complex.One);
+        transfers[(pins[1].IDInFlow, pins[0].IDOutFlow)].ShouldBe(Complex.One);
+    }
+
+    [Fact]
+    public async Task CreateSMatrixFromPdk_NullDraft_TwoOpticalPins_InputLightArrivesAtOutputPin()
+    {
+        // The field iteration must carry unit amplitude through the component —
+        // with an empty matrix the output pin sees zero field.
+        var pins = OpticalPins("in", "out");
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        var input = MathNet.Numerics.LinearAlgebra.Vector<Complex>.Build.Dense(matrix.SMat.RowCount);
+        input[matrix.PinReference[pins[0].IDInFlow]] = Complex.One;
+
+        var field = await matrix.CalcFieldAtPinsAfterStepsAsync(
+            input, maxIterations: 10, new CancellationTokenSource());
+
+        field[pins[1].IDOutFlow].Magnitude.ShouldBe(1.0, Tolerance);
+        field[pins[0].IDOutFlow].Magnitude.ShouldBe(0.0, Tolerance,
+            "an ideal pass-through has no reflection");
+    }
+
+    [Fact]
+    public void CreateSMatrixFromPdk_NullDraft_ThreeOpticalPins_StaysAbsorbing()
+    {
+        // No canonical model exists for a multi-port black box; an all-pairs
+        // unit-magnitude default would be non-passive, so absorption is honest.
+        var pins = OpticalPins("a", "b", "c");
+
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        matrix.GetNonNullValues().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreateSMatrixFromPdk_NullDraft_SingleOpticalPin_StaysAbsorbing()
+    {
+        var pins = OpticalPins("only");
+
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        matrix.GetNonNullValues().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreateSMatrixFromPdk_NullDraft_OneOpticalOneElectricalPin_StaysAbsorbing()
+    {
+        // An electrical pin carries no light; wiring it into the default would
+        // invent an opto-electronic converter.
+        var pins = new List<Pin>
+        {
+            new("o1", 0, MatterType.Light, RectSide.Left),
+            new("e1", 1, MatterType.Electricity, RectSide.Right),
+        };
+
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        matrix.GetNonNullValues().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreateSMatrixFromPdk_NullDraft_TwoOpticalPinsPlusElectrical_PassesBetweenOpticalPins()
+    {
+        // e.g. an imported heated waveguide with a detected metal pad: the optical
+        // path is still an unambiguous waveguide, the electrical pin is inert.
+        var pins = new List<Pin>
+        {
+            new("in", 0, MatterType.Light, RectSide.Left),
+            new("out", 1, MatterType.Light, RectSide.Right),
+            new("heater", 2, MatterType.Electricity, RectSide.Up),
+        };
+
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, null);
+
+        var transfers = matrix.GetNonNullValues();
+        transfers.Count.ShouldBe(2);
+        transfers[(pins[0].IDInFlow, pins[1].IDOutFlow)].ShouldBe(Complex.One);
+        transfers[(pins[1].IDInFlow, pins[0].IDOutFlow)].ShouldBe(Complex.One);
+    }
+
+    [Fact]
+    public void CreateSMatrixFromPdk_ExplicitDraftWithoutConnections_StaysAbsorbing()
+    {
+        // Only a null draft means "no model"; a draft the author explicitly left
+        // connection-less keeps the previous absorbing behavior.
+        var pins = OpticalPins("in", "out");
+        var draft = new PdkSMatrixDraft { WavelengthNm = 1550 };
+
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, draft);
+
+        matrix.GetNonNullValues().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void CreateSMatrixFromPdk_DraftWithConnections_KeepsAuthoredTransfers()
+    {
+        var pins = OpticalPins("in", "out");
+        var draft = new PdkSMatrixDraft
+        {
+            WavelengthNm = 1550,
+            Connections = new List<SMatrixConnection>
+            {
+                new() { FromPin = "in", ToPin = "out", Magnitude = 0.5, PhaseDegrees = 90 },
+            },
+        };
+
+        var matrix = PdkTemplateConverter.CreateSMatrixFromPdk(pins, draft);
+
+        var transfers = matrix.GetNonNullValues();
+        transfers[(pins[0].IDInFlow, pins[1].IDOutFlow)].Magnitude.ShouldBe(0.5, Tolerance);
+        transfers[(pins[1].IDInFlow, pins[0].IDOutFlow)].Magnitude.ShouldBe(0.5, Tolerance,
+            "connections stay symmetrized as before");
+    }
+}


### PR DESCRIPTION
Automated implementation for #1005

Already processed — that's the 1415-test batch (Components, Analysis, ComponentSettings, Persistence, GDS dialog render) I incorporated earlier: **1415/1415 passed**. All work on issue #1005 is complete; no outstanding tasks.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 114,723
- **Estimated cost:** $0.0642 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>