### PR TITLE
Agent: E2E scenario: two chiplets, two processes → per-chiplet DRC → per-process GDS export → Cornerstone pre-DRC (rung 6→7) (#1010)

### DIFF
--- a/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
+++ b/UnitTests/Components/MultiProcessChipletJourneyDesign.cs
@@ -23,7 +23,7 @@ namespace UnitTests.Components;
 /// <see cref="MultiChipletCompositionJourneyTests"/>), now across two
 /// fabrication processes.
 /// </summary>
-internal sealed class MultiProcessChipletJourneyDesign
+public sealed class MultiProcessChipletJourneyDesign
 {
     public const string CornerstonePdkFile = "cornerstone-sin-pdk.json";
     public const string SiepicPdkFile = "siepic-ebeam-pdk.json";

--- a/UnitTests/Integration/MultiProcessManufacturingJourneyFixture.cs
+++ b/UnitTests/Integration/MultiProcessManufacturingJourneyFixture.cs
@@ -1,0 +1,211 @@
+using System.Collections.ObjectModel;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core.Components.Core;
+using CAP_Core.Components.Process;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using Moq;
+using Shouldly;
+using UnitTests.Components;
+using UnitTests.Export;
+using UnitTests.Services.GdsImport;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Shared fixture for <see cref="MultiProcessManufacturingJourneyTests"/> (issue #1010):
+/// performs the journey's stateful stations once so each fact asserts one step of the
+/// same continuous road — build + bind (steps 1–2), save → load (step 4), export script
+/// (step 5) and, when a nazca-capable Python exists, the executed GDS export the gated
+/// steps 6–7 drive.
+/// </summary>
+public class MultiProcessManufacturingJourneyFixture : IAsyncLifetime
+{
+    private readonly string _designFilePath;
+
+    /// <summary>Creates the fixture with a throwaway temp working directory.</summary>
+    public MultiProcessManufacturingJourneyFixture()
+    {
+        WorkDirectory = Path.Combine(Path.GetTempPath(), "multiprocess-manufacturing-" + Guid.NewGuid().ToString("N"));
+        _designFilePath = Path.Combine(WorkDirectory, "journey.lun");
+    }
+
+    /// <summary>Temp working directory for the .lun file, the export and the DRC report.</summary>
+    public string WorkDirectory { get; }
+
+    /// <summary>The composed two-chiplet design (Cornerstone SiN + SiEPIC EBeam).</summary>
+    public MultiProcessChipletJourneyDesign Design { get; private set; } = null!;
+
+    /// <summary>The production process catalog over the journey's two bundled PDKs.</summary>
+    public IReadOnlyList<ProcessGroup> Catalog { get; private set; } = null!;
+
+    /// <summary>Absolute positions of both chiplets' exposed pins, captured before the save.</summary>
+    public IReadOnlyDictionary<string, (double X, double Y)> PinPositionsBeforeSave { get; private set; } = null!;
+
+    /// <summary>Raw text of the saved .lun file.</summary>
+    public string SavedFileText { get; private set; } = null!;
+
+    /// <summary>Process-migration warning raised by the reload, when any.</summary>
+    public string? MigrationWarning { get; private set; }
+
+    /// <summary>The canvas the saved design reloaded onto.</summary>
+    public DesignCanvasViewModel LoadedCanvas { get; private set; } = null!;
+
+    /// <summary>Chiplet A after the round-trip.</summary>
+    public ComponentGroup LoadedChipletA { get; private set; } = null!;
+
+    /// <summary>Chiplet B after the round-trip.</summary>
+    public ComponentGroup LoadedChipletB { get; private set; } = null!;
+
+    /// <summary>The nazca export script of the journey design.</summary>
+    public string NazcaScript { get; private set; } = null!;
+
+    /// <summary>The nazca-capable Python the executed export ran with (null = gated steps skip).</summary>
+    public string? NazcaPython { get; private set; }
+
+    /// <summary>The executed export's GDS (null when no nazca Python is available or the export failed).</summary>
+    public string? ExportedGdsPath { get; private set; }
+
+    /// <summary>Export process stdout/stderr, kept for readable failure messages.</summary>
+    public string ExportLog { get; private set; } = string.Empty;
+
+    /// <summary>Builds the design, binds the chiplets, round-trips the file, exports the script.</summary>
+    public async Task InitializeAsync()
+    {
+        Design = MultiProcessChipletJourneyDesign.BuildComposed();
+        Catalog = ProcessCatalog.BuildGroups(new[]
+        {
+            new PdkProcessEntry(Design.Cornerstone.Name, ProcessFingerprintFactory.From(Design.Cornerstone)),
+            new PdkProcessEntry(Design.Siepic.Name, ProcessFingerprintFactory.From(Design.Siepic)),
+        });
+        BindChipletsViaPlacementPolicy();
+        PinPositionsBeforeSave = CapturePinPositions(Design.ChipletA, Design.ChipletB);
+        await SaveAndLoadAsync();
+        NazcaScript = new SimpleNazcaExporter().Export(Design.Canvas);
+        await TryExecuteExportAsync();
+    }
+
+    /// <summary>Removes the temp working directory.</summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(WorkDirectory)) Directory.Delete(WorkDirectory, recursive: true);
+        }
+        catch
+        {
+            // temp cleanup is best effort
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Binds both chiplets through the exact code path the UI uses when a chiplet is
+    /// placed: <see cref="PlacementPolicyContext.CheckGroupPlacementAt"/> derives the
+    /// binding from the children's PDK sources and the caller pins it onto the group
+    /// (CanvasInteractionViewModel assigns <c>GroupToPlace.ProcessBinding</c> the same way).
+    /// </summary>
+    private void BindChipletsViaPlacementPolicy()
+    {
+        var policy = new PlacementPolicyContext(
+            () => ActiveProcessSelection.Playground(),
+            () => Array.Empty<string>(),
+            component => ComponentPdkSourceResolver.Resolve(component, Design.Templates),
+            getProcessCatalog: () => Catalog);
+        foreach (var chiplet in new[] { Design.ChipletA, Design.ChipletB })
+        {
+            var (isAllowed, blockReason, derivedBinding) =
+                policy.CheckGroupPlacementAt(chiplet, targetGroup: null, chiplet.GroupName);
+            isAllowed.ShouldBeTrue($"the placement policy must admit chiplet '{chiplet.GroupName}': {blockReason}");
+            chiplet.ProcessBinding = derivedBinding;
+        }
+    }
+
+    private async Task SaveAndLoadAsync()
+    {
+        Directory.CreateDirectory(WorkDirectory);
+        var saveVm = CreateFileOperations(Design.Canvas, Design.Templates);
+        saveVm.ProcessCatalogProvider = () => Catalog;
+        var saveDialog = new Mock<IFileDialogService>();
+        saveDialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        saveVm.FileDialogService = saveDialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(_designFilePath).ShouldBeTrue("the journey design file must be written");
+        SavedFileText = await File.ReadAllTextAsync(_designFilePath);
+
+        LoadedCanvas = new DesignCanvasViewModel();
+        var loadVm = CreateFileOperations(LoadedCanvas, Design.Templates);
+        loadVm.ProcessCatalogProvider = () => Catalog;
+        loadVm.OnProcessMigrationWarning = w => MigrationWarning = w;
+        var loadDialog = new Mock<IFileDialogService>();
+        loadDialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_designFilePath);
+        loadVm.FileDialogService = loadDialog.Object;
+        await loadVm.LoadDesignCommand.ExecuteAsync(null);
+
+        var loadedGroups = LoadedCanvas.Components
+            .Where(c => c.Component is ComponentGroup)
+            .Select(c => (ComponentGroup)c.Component)
+            .ToList();
+        LoadedChipletA = loadedGroups.SingleOrDefault(g => g.Identifier == Design.ChipletA.Identifier)
+            .ShouldNotBeNull("chiplet A identity must survive the round-trip");
+        LoadedChipletB = loadedGroups.SingleOrDefault(g => g.Identifier == Design.ChipletB.Identifier)
+            .ShouldNotBeNull("chiplet B identity must survive the round-trip");
+    }
+
+    /// <summary>Executes the export script when a nazca-capable Python exists (CI does; local suites usually cannot).</summary>
+    private async Task TryExecuteExportAsync()
+    {
+        NazcaPython = await GdsUserDesignFixture.FindNazcaPythonAsync();
+        if (NazcaPython == null)
+            return;
+
+        var exportDir = Path.Combine(WorkDirectory, "export");
+        Directory.CreateDirectory(exportDir);
+        var scriptPath = Path.Combine(exportDir, "multiprocess_journey.py");
+        await File.WriteAllTextAsync(scriptPath, NazcaScript);
+        var export = await SiepicRealGeometryExportTests.RunPythonAsync(NazcaPython, exportDir, scriptPath);
+        ExportLog = $"exit {export.ExitCode}\nstdout:\n{export.StdOut}\nstderr:\n{export.StdErr}";
+        var gdsPath = Path.ChangeExtension(scriptPath, ".gds");
+        if (export.ExitCode == 0 && File.Exists(gdsPath))
+            ExportedGdsPath = gdsPath;
+    }
+
+    /// <summary>Snapshot of both chiplets' exposed-pin absolute positions, keyed by pin name.</summary>
+    private static IReadOnlyDictionary<string, (double X, double Y)> CapturePinPositions(
+        params ComponentGroup[] chiplets) =>
+        chiplets
+            .SelectMany(chiplet => chiplet.ExternalPins)
+            .ToDictionary(
+                pin => pin.Name,
+                pin =>
+                {
+                    var (x, y) = pin.InternalPin!.GetAbsolutePosition();
+                    return (x, y);
+                });
+
+    /// <summary>Creates the file-operations facade used for the .lun save/load round-trip.</summary>
+    private static FileOperationsViewModel CreateFileOperations(
+        DesignCanvasViewModel canvas, List<ComponentTemplate> templates)
+    {
+        var library = new ObservableCollection<ComponentTemplate>(templates);
+        return new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new CAP_Core.Export.SaxExporter(),
+            library,
+            new GdsExportViewModel(new CAP_Core.Export.GdsExportService()),
+            new CAP.Avalonia.ViewModels.Export.PhotonTorchExportViewModel(
+                new CAP_Core.Export.PhotonTorchExporter(), canvas),
+            null!,
+            errorConsole: new CAP_Core.ErrorConsoleService());
+    }
+}

--- a/UnitTests/Integration/MultiProcessManufacturingJourneyTests.Gated.cs
+++ b/UnitTests/Integration/MultiProcessManufacturingJourneyTests.Gated.cs
@@ -1,0 +1,138 @@
+using CAP_Core.Components.Core;
+using CAP_DataAccess.Import.Gds;
+using Shouldly;
+using UnitTests.Components;
+using UnitTests.Export.CornerstoneDrc;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Tool-gated stations of the multi-process manufacturing journey (issue #1010) — the
+/// executed GDS export (step 6) and the vendored CORNERSTONE pre-DRC deck over it
+/// (step 7). Both gate like the existing round-trip suites (#995): CI provides nazca +
+/// KLayout and runs them, local suites skip them cleanly. The fixture executes the
+/// export once when a nazca-capable Python exists; both steps skip from the same
+/// fixture state.
+/// </summary>
+public partial class MultiProcessManufacturingJourneyTests
+{
+    private const double GeometryToleranceUm = 0.05;
+    private const double PositionToleranceUm = 0.75;
+
+    [Trait("Category", "Slow")]
+    [SkippableFact]
+    public async Task Step6_ExecutedGdsExport_RoutesCarryTheirProcessGeometryAtCoordinates()
+    {
+        Skip.If(_journey.NazcaPython == null,
+            "Step 6: no Python with nazca available — the executed export needs the real engine (CI provides it).");
+        _journey.ExportedGdsPath.ShouldNotBeNull(
+            $"Step 6: the nazca export of the journey design must succeed.\n{_journey.ExportLog}");
+
+        GdsLibrary library;
+        await using (var stream = File.OpenRead(_journey.ExportedGdsPath!))
+            library = await new GdsReader().ReadAsync(stream);
+        library.TopCellCandidates.ShouldContain("ConnectAPIC_Design",
+            "Step 6: the exported GDS carries the design as its top cell");
+        var designCell = library.Cells["ConnectAPIC_Design"];
+        var wires = WireGeometryCandidates(designCell).ToList();
+
+        // Chiplet A's coupler→MMI wire: Cornerstone xs_nc — 1.2 µm wide on NITRIDE (203).
+        var (aFrom, aTo) = InternalWireEndpoints(_journey.Design.ChipletA, "cs_coupler", "o3", "cs_mmi", "o1");
+        AssertWireGeometry(wires, aFrom, aTo,
+            MultiProcessChipletJourneyDesign.CornerstoneGdsLayer, 1.2,
+            "Step 6: chiplet A's route must keep the Cornerstone width/layer in the real GDS (#960)");
+
+        // Chiplet B's Y-branch→taper wire: SiEPIC strip — 0.5 µm wide on WG (1).
+        var (bFrom, bTo) = InternalWireEndpoints(_journey.Design.ChipletB, "si_ybranch", "port 2", "si_taper", "port 1");
+        AssertWireGeometry(wires, bFrom, bTo,
+            MultiProcessChipletJourneyDesign.SiepicGdsLayer, 0.5,
+            "Step 6: chiplet B's route must keep the SiEPIC width/layer in the real GDS (#960)");
+    }
+
+    [Trait("Category", "Slow")]
+    [SkippableFact]
+    public async Task Step7_CornerstonePreDrc_ExportedGdsPinnedCleanForTheSinChiplet()
+    {
+        Skip.If(_journey.ExportedGdsPath == null,
+            "Step 7: no executed export (no nazca Python) — the foundry-deck proof needs the real engine (CI provides it).");
+        var klayout = await ExternalToolProbes.FindKlayoutAsync();
+        Skip.If(klayout == null,
+            "Step 7: no KLayout on PATH/$KLAYOUT — the foundry-deck proof needs the real engine (CI provides it).");
+
+        // The vendored deck inspects exactly the SiN chiplet's fabrication layers
+        // (GDS 203/204/…); the SiEPIC chiplet's layers are outside its scope, so this
+        // run IS the SiN chiplet's pre-DRC. Pinned clean (#932 infrastructure, #995 pattern).
+        var reportPath = Path.Combine(_journey.WorkDirectory, "multiprocess_journey.lyrdb");
+        var (exitCode, output, error) = await ExternalToolProbes.RunToolAsync(
+            _journey.NazcaPython!, CornerstoneDrcPaths.RunnerScript, _journey.ExportedGdsPath!,
+            "--klayout", klayout, "--report", reportPath);
+
+        exitCode.ShouldBe(0,
+            $"Step 7: the vendored foundry deck must complete.\nstdout:\n{output}\nstderr:\n{error}");
+        output.ShouldContain("PASSED: 0 DRC violations.", Case.Sensitive,
+            "Step 7: the SiN chiplet's exported geometry must be foundry-clean");
+    }
+
+    /// <summary>Absolute endpoint positions of one frozen intra-chiplet wire, by child identifiers.</summary>
+    private static ((double X, double Y) From, (double X, double Y) To) InternalWireEndpoints(
+        ComponentGroup chiplet, string fromComponent, string fromPin, string toComponent, string toPin)
+    {
+        PhysicalPin PinOf(string componentId, string pinName) =>
+            chiplet.ChildComponents.Single(c => c.Identifier == componentId)
+                .PhysicalPins.Single(p => p.Name == pinName);
+        return (PinOf(fromComponent, fromPin).GetAbsolutePosition(),
+                PinOf(toComponent, toPin).GetAbsolutePosition());
+    }
+
+    /// <summary>
+    /// All waveguide candidates of the top cell: paths contribute their centerline
+    /// (expanded by their width), polygons their outline — both as (layer, bbox).
+    /// </summary>
+    private static IEnumerable<(int Layer, double MinX, double MinY, double MaxX, double MaxY)> WireGeometryCandidates(
+        GdsCell designCell)
+    {
+        foreach (var polygon in designCell.Elements.OfType<GdsPolygon>())
+        {
+            yield return (polygon.Layer,
+                polygon.Points.Min(p => p.X), polygon.Points.Min(p => p.Y),
+                polygon.Points.Max(p => p.X), polygon.Points.Max(p => p.Y));
+        }
+        foreach (var path in designCell.Elements.OfType<GdsPath>())
+        {
+            var half = path.WidthMicrometers / 2;
+            yield return (path.Layer,
+                path.Points.Min(p => p.X) - half, path.Points.Min(p => p.Y) - half,
+                path.Points.Max(p => p.X) + half, path.Points.Max(p => p.Y) + half);
+        }
+    }
+
+    /// <summary>
+    /// Asserts a wire on the expected layer whose bounding box matches the editor
+    /// segment — Y-flipped into the export's coordinate system (nazcaY = -editorY) —
+    /// widened to the process cross-section's width.
+    /// </summary>
+    private static void AssertWireGeometry(
+        List<(int Layer, double MinX, double MinY, double MaxX, double MaxY)> wires,
+        (double X, double Y) from, (double X, double Y) to,
+        int expectedLayer, double expectedWidthUm, string because)
+    {
+        // A straight waveguide widens perpendicular to its direction only (flush ends).
+        var horizontal = Math.Abs(to.X - from.X) >= Math.Abs(to.Y - from.Y);
+        var half = expectedWidthUm / 2;
+        var expectedMinX = Math.Min(from.X, to.X) - (horizontal ? 0 : half);
+        var expectedMaxX = Math.Max(from.X, to.X) + (horizontal ? 0 : half);
+        var expectedMinY = -Math.Max(from.Y, to.Y) - (horizontal ? half : 0);
+        var expectedMaxY = -Math.Min(from.Y, to.Y) + (horizontal ? half : 0);
+
+        wires.ShouldContain(
+            wire => wire.Layer == expectedLayer
+                && Math.Abs((wire.MaxX - wire.MinX) - (expectedMaxX - expectedMinX)) < GeometryToleranceUm
+                && Math.Abs((wire.MaxY - wire.MinY) - (expectedMaxY - expectedMinY)) < GeometryToleranceUm
+                && Math.Abs((wire.MinX + wire.MaxX) / 2 - (expectedMinX + expectedMaxX) / 2) < PositionToleranceUm
+                && Math.Abs((wire.MinY + wire.MaxY) / 2 - (expectedMinY + expectedMaxY) / 2) < PositionToleranceUm,
+            $"{because}: no geometry on layer {expectedLayer} matches the wire " +
+            $"({from.X:F2},{from.Y:F2}) → ({to.X:F2},{to.Y:F2}) at {expectedWidthUm} µm width. " +
+            $"Found: {string.Join("; ", wires.Select(w => $"L{w.Layer} [{w.MinX:F2}..{w.MaxX:F2}]×[{w.MinY:F2}..{w.MaxY:F2}]"))}");
+    }
+}

--- a/UnitTests/Integration/MultiProcessManufacturingJourneyTests.cs
+++ b/UnitTests/Integration/MultiProcessManufacturingJourneyTests.cs
@@ -1,0 +1,227 @@
+using CAP.Avalonia.ViewModels.Diagnostics;
+using CAP.Avalonia.ViewModels.Library;
+using CAP_Core.Analysis;
+using CAP_Core.Components.Core;
+using CAP_DataAccess.Components.ComponentDraftMapper;
+using CAP_DataAccess.Components.ComponentDraftMapper.DTOs;
+using Shouldly;
+using UnitTests.Components;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Hard end-to-end scenario of the multi-process chain as ONE journey (issue #1010,
+/// rung 6→7): two chiplets bound to two different fabrication processes on one canvas,
+/// walked through per-chiplet DRC, the .lun round-trip, per-process GDS export and the
+/// vendored CORNERSTONE pre-DRC deck. Every station has unit tests elsewhere
+/// (#935/#936/#937/#938/#939); this class is the proof the whole road walks as one
+/// journey — built once in <see cref="MultiProcessManufacturingJourneyFixture"/>, each
+/// fact asserting one numbered step with step-named failure messages.
+///
+///   Step 1: both chiplets carry a process binding, derived through the same placement
+///           policy code path the UI uses (#935/#938).
+///   Step 2: each chiplet holds its small circuit; one cross-process link joins them.
+///   Step 3: Design Validation checks each chiplet against its OWN rule set (#936) —
+///           a width legal under SiEPIC is flagged under Cornerstone; the both-legal
+///           configuration is clean.
+///   Step 4: save → load keeps the process bindings and the geometry (#938).
+///   Step 5: the GDS export routes each chiplet on its own process cross-section (#939).
+///   Step 6 (gated): the executed export carries that geometry at the expected
+///           coordinates (nazca-gated like the existing round-trip suites — CI runs it,
+///           local suites skip it).
+///   Step 7 (gated): the vendored CORNERSTONE SiN pre-DRC deck (#932) over the exported
+///           GDS is pinned clean for the SiN chiplet's geometry.
+/// </summary>
+public partial class MultiProcessManufacturingJourneyTests
+    : IClassFixture<MultiProcessManufacturingJourneyFixture>
+{
+    private const double PositionTolerance = 1e-9;
+
+    private readonly MultiProcessManufacturingJourneyFixture _journey;
+
+    /// <summary>Attaches the shared journey fixture.</summary>
+    public MultiProcessManufacturingJourneyTests(MultiProcessManufacturingJourneyFixture journey) =>
+        _journey = journey;
+
+    [Fact]
+    public void Step1_BindChiplets_EachChipletCarriesItsOwnProcess()
+    {
+        var bindingA = _journey.Design.ChipletA.ProcessBinding;
+        bindingA.ShouldNotBeNull("Step 1: chiplet A must be bound to a fabrication process (#938)");
+        bindingA!.IsPlayground.ShouldBeFalse(
+            "Step 1: a bound chiplet is a first-class manufacturable state, not Playground");
+        bindingA.MemberPdkNames.ShouldContain(_journey.Design.Cornerstone.Name,
+            "Step 1: chiplet A fabricates in the Cornerstone SiN process");
+
+        var bindingB = _journey.Design.ChipletB.ProcessBinding;
+        bindingB.ShouldNotBeNull("Step 1: chiplet B must be bound to a fabrication process (#938)");
+        bindingB!.IsPlayground.ShouldBeFalse(
+            "Step 1: a bound chiplet is a first-class manufacturable state, not Playground");
+        bindingB.MemberPdkNames.ShouldContain(_journey.Design.Siepic.Name,
+            "Step 1: chiplet B fabricates in the SiEPIC EBeam process");
+    }
+
+    [Fact]
+    public void Step2_PlaceAndConnect_SmallCircuitPerChiplet_PlusInterChipletLink()
+    {
+        var design = _journey.Design;
+        design.ChipletA.ChildComponents.Count.ShouldBe(2, "Step 2: chiplet A owns coupler + MMI");
+        design.ChipletA.InternalPaths.Count.ShouldBe(1, "Step 2: the coupler→MMI wire freezes into chiplet A");
+        design.ChipletB.ChildComponents.Count.ShouldBe(2, "Step 2: chiplet B owns Y-branch + taper");
+        design.ChipletB.InternalPaths.Count.ShouldBe(1, "Step 2: the Y-branch→taper wire freezes into chiplet B");
+
+        design.Canvas.ConnectionManager.Connections.Count.ShouldBe(1,
+            "Step 2: exactly the one inter-chiplet link exists at canvas level");
+        var aOut = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletA, "cs_mmi_o2");
+        var bIn = MultiProcessChipletJourneyDesign.ExposedPin(design.ChipletB, "si_ybranch_port 1");
+        var (ax, ay) = aOut.GetAbsolutePosition();
+        var (bx, by) = bIn.GetAbsolutePosition();
+        bx.ShouldBe(ax, PositionTolerance, "Step 2: the edge-coupler path starts at a coincident pin pair (X)");
+        by.ShouldBe(ay, PositionTolerance, "Step 2: the edge-coupler path starts at a coincident pin pair (Y)");
+
+        aOut.WaveguideWidthMicrometers.ShouldBe(1.2, "Step 2: Cornerstone xs_nc width stamps chiplet A's pins");
+        aOut.Layer.ShouldBe(MultiProcessChipletJourneyDesign.CornerstoneGdsLayer,
+            "Step 2: Cornerstone NITRIDE layer stamps chiplet A's pins");
+        bIn.WaveguideWidthMicrometers.ShouldBe(0.5, "Step 2: SiEPIC strip width stamps chiplet B's pins");
+        bIn.Layer.ShouldBe(MultiProcessChipletJourneyDesign.SiepicGdsLayer,
+            "Step 2: SiEPIC WG layer stamps chiplet B's pins");
+    }
+
+    [Fact]
+    public void Step3_DesignValidation_EachChipletCheckedAgainstItsOwnRuleSet()
+    {
+        // (a) The journey design as built is the both-legal configuration: no
+        // per-process rule fires. The only findings are the two documented pin
+        // mismatches at the SiN↔SOI boundary — a real butt joint has a width/layer
+        // step a physical edge coupler absorbs; that is honest physics, not dirt.
+        var panel = RunValidation(_journey.Design.Canvas, _journey.Design.Templates, WithJourneyPdks(_journey.Design));
+        var abutment = _journey.Design.Canvas.ConnectionManager.Connections.Single();
+        panel.Issues.Count(i => i.Type is DesignIssueType.WaveguideBelowMinWidth
+                or DesignIssueType.WaveguideSpacingViolation
+                or DesignIssueType.BendRadiusBelowProcessMinimum)
+            .ShouldBe(0, "Step 3: in the both-legal configuration no per-chiplet rule set fires");
+        panel.Issues.ShouldAllBe(
+            i => i.Type == DesignIssueType.PinMismatch && ReferenceEquals(i.Connection, abutment),
+            "Step 3: the only remaining findings are the documented boundary pin mismatches");
+        panel.Issues.Count.ShouldBe(2,
+            "Step 3: one width + one layer mismatch at the inter-chiplet link, nothing else");
+
+        // (b) Violation probe on a fresh copy (mutating the shared journey design would
+        // contaminate the later steps): the SAME 0.2 µm route is flagged inside
+        // chiplet A (Cornerstone's declared 0.25 µm minimum, #924) and legal inside
+        // chiplet B (SiEPIC declares no minWidthUm — no invented values, #926).
+        var probe = MultiProcessChipletJourneyDesign.BuildComposed();
+        var narrowInA = AddStyledRoute(probe, probe.ChipletA, "cs_coupler_o4", "cs_mmi_o3");
+        var narrowInB = AddStyledRoute(probe, probe.ChipletB, "si_ybranch_port 3", "si_taper_port 2");
+        var probePanel = RunValidation(probe.Canvas, probe.Templates, WithJourneyPdks(probe));
+
+        probePanel.Issues.ShouldContain(
+            i => i.Type == DesignIssueType.WaveguideBelowMinWidth && ReferenceEquals(i.Connection, narrowInA),
+            "Step 3: the 0.2 µm route inside chiplet A must trip Cornerstone's 0.25 µm rule (#936)");
+        probePanel.Issues.ShouldNotContain(
+            i => i.Type == DesignIssueType.WaveguideBelowMinWidth && ReferenceEquals(i.Connection, narrowInB),
+            "Step 3: the identical route inside chiplet B stays legal under SiEPIC's rule set (#936)");
+        probePanel.Issues.Where(i => i.Type == DesignIssueType.WaveguideBelowMinWidth)
+            .ShouldAllBe(i => i.Description.Contains("0.25"),
+                "Step 3: the flagged minimum is Cornerstone's declared value, not a global one");
+    }
+
+    [Fact]
+    public void Step4_SaveLoad_ProcessBindingsAndGeometrySurvive()
+    {
+        _journey.SavedFileText.ShouldContain("\"ProcessBinding\"", Case.Sensitive,
+            "Step 4: each chiplet's process binding must be written into the .lun (#938)");
+        _journey.MigrationWarning.ShouldBeNull(
+            "Step 4: the persisted bindings describe the design completely — no Playground migration (#938)");
+
+        var loadedA = _journey.LoadedChipletA.ProcessBinding;
+        loadedA.ShouldNotBeNull("Step 4: chiplet A's process binding survives the round-trip (#938)");
+        loadedA!.MemberPdkNames.ShouldContain(_journey.Design.Cornerstone.Name,
+            "Step 4: chiplet A reloads bound to the Cornerstone SiN process");
+        var loadedB = _journey.LoadedChipletB.ProcessBinding;
+        loadedB.ShouldNotBeNull("Step 4: chiplet B's process binding survives the round-trip (#938)");
+        loadedB!.MemberPdkNames.ShouldContain(_journey.Design.Siepic.Name,
+            "Step 4: chiplet B reloads bound to the SiEPIC EBeam process");
+
+        _journey.LoadedCanvas.Connections.Count.ShouldBe(1,
+            "Step 4: the inter-chiplet link survives the round-trip");
+        foreach (var (pinName, (x, y)) in _journey.PinPositionsBeforeSave)
+        {
+            var loadedChiplet = _journey.LoadedChipletA.ExternalPins.Any(p => p.Name == pinName)
+                ? _journey.LoadedChipletA
+                : _journey.LoadedChipletB;
+            var (loadedX, loadedY) = MultiProcessChipletJourneyDesign.ExposedPin(loadedChiplet, pinName)
+                .GetAbsolutePosition();
+            loadedX.ShouldBe(x, PositionTolerance, $"Step 4: pin '{pinName}' keeps its X position");
+            loadedY.ShouldBe(y, PositionTolerance, $"Step 4: pin '{pinName}' keeps its Y position");
+        }
+    }
+
+    [Fact]
+    public void Step5_GdsExport_EachChipletRoutesOnItsOwnProcessCrossSection()
+    {
+        // Headless half of the export proof (#939/#960): one interconnect per process
+        // cross-section, resolved from the endpoint pins' PDK stamps — never one global
+        // user preference. Step 6 pins the same widths/layers in the executed GDS.
+        var script = _journey.NazcaScript;
+        script.ShouldContain("Interconnect(width=1.2, radius=10, layer=203)", Case.Sensitive,
+            "Step 5: chiplet A routes on the Cornerstone NITRIDE cross-section (xs_nc, 1.2 µm)");
+        script.ShouldContain("Interconnect(width=0.5, radius=10, layer=1)", Case.Sensitive,
+            "Step 5: chiplet B routes on the SiEPIC WG cross-section (strip, 0.5 µm)");
+        script.ShouldContain("nd.strt(length=5.00, width=1.2, layer=203)", Case.Sensitive,
+            "Step 5: chiplet A's coupler→MMI wire carries the Cornerstone width/layer");
+        script.ShouldContain("nd.strt(length=5.01, width=0.5, layer=1)", Case.Sensitive,
+            "Step 5: chiplet B's Y-branch→taper wire carries the SiEPIC width/layer");
+    }
+
+    /// <summary>Adds a deliberately narrow (0.2 µm) styled route between two exposed chiplet pins.</summary>
+    private static CAP_Core.Components.Connections.WaveguideConnection AddStyledRoute(
+        MultiProcessChipletJourneyDesign design, ComponentGroup chiplet, string fromPin, string toPin)
+    {
+        var from = MultiProcessChipletJourneyDesign.ExposedPin(chiplet, fromPin);
+        var to = MultiProcessChipletJourneyDesign.ExposedPin(chiplet, toPin);
+        var route = design.Canvas.ConnectPinsWithCachedRoute(
+            from, to, MultiProcessChipletJourneyDesign.StraightPath(from, to));
+        route.ShouldNotBeNull($"the probe route {fromPin} -> {toPin} must be created");
+        route!.Connection.WidthMicrometers = 0.2;
+        return route.Connection;
+    }
+
+    /// <summary>
+    /// Runs Design Validation wired exactly like <c>MainViewModel.RunDesignChecks</c>
+    /// (#936): the per-connection provider keys every connection's rules to its own
+    /// endpoint PDKs. Both chiplets' exposed pins are designated external ports — the
+    /// dangling-pin check (#908) targets forgotten pins, not the chiplet interfaces.
+    /// </summary>
+    private static DesignValidationViewModel RunValidation(
+        CAP.Avalonia.ViewModels.Canvas.DesignCanvasViewModel canvas,
+        List<ComponentTemplate> templates,
+        List<PdkDraft> drafts)
+    {
+        string? PdkSourceOf(PhysicalPin? pin) =>
+            pin?.ParentComponent is { } component
+                ? ComponentPdkSourceResolver.Resolve(component, templates)
+                : null;
+        var externalPortPins = canvas.Components
+            .SelectMany(vm => vm.Component is ComponentGroup group
+                ? group.ExternalPins
+                : Enumerable.Empty<GroupPin>())
+            .Select(pin => pin.InternalPin!)
+            .ToList();
+        var panel = new DesignValidationViewModel();
+        panel.RunValidation(
+            canvas.ConnectionManager.Connections,
+            allComponents: canvas.Components.Select(vm => vm.Component),
+            processLockActive: false,
+            externalPortPins: externalPortPins,
+            connectionDrcRuleProvider: connection =>
+                ConnectionDrcRuleResolver.ResolveForEndpointPdkNames(
+                    PdkSourceOf(connection.StartPin), PdkSourceOf(connection.EndPin), drafts));
+        return panel;
+    }
+
+    /// <summary>The journey design's two bundled PDK drafts, in catalog order.</summary>
+    private static List<PdkDraft> WithJourneyPdks(MultiProcessChipletJourneyDesign design) =>
+        new() { design.Cornerstone, design.Siepic };
+}


### PR DESCRIPTION
## What & why

Kill-review finding on the multi-process chain (#935/#936/#937/#938/#939, shipped through #960): every station has unit tests, but no test walked the whole road as one journey. This PR adds that hard end-to-end scenario for rung 6→7 (issue #1010): two chiplets bound to two different fabrication processes (bundled Cornerstone SiN 300nm + bundled SiEPIC EBeam), walked through per-chiplet DRC, the .lun round-trip, per-process GDS export and the vendored CORNERSTONE pre-DRC deck — one fixture, one continuous journey, each numbered step a fact with step-named failure messages.

New test class `UnitTests/Integration/MultiProcessManufacturingJourneyTests` (pattern mirrors #995's `FullAdderManufacturingJourneyTests`):

1. **Bind** — both chiplets carry a `ProcessBinding`, derived through the same placement-policy code path the UI uses (`PlacementPolicyContext.CheckGroupPlacementAt`, #935/#938).
2. **Place & connect** — small circuit per chiplet (Coupler→MMI / Y-Branch→Taper) plus one cross-process link on coincident pins; pins keep their own PDK's width/layer stamps.
3. **Design Validation** — each chiplet is checked against its OWN rule set (#936): the same 0.2 µm route is flagged inside the Cornerstone chiplet (declared 0.25 µm minimum) and legal inside the SiEPIC chiplet (no declared minWidthUm); the both-legal configuration is clean apart from the two documented boundary pin mismatches (honest SiN↔SOI butt-joint physics).
4. **Save → load** — process bindings and pin-exact geometry survive; no Playground migration (#938).
5. **GDS export** — each chiplet routes on its own process cross-section: `Interconnect(width=1.2, ..., layer=203)` vs `(width=0.5, ..., layer=1)` (#960).
6. **Executed export (nazca-gated, Slow)** — the real GDS carries a 1.2 µm-wide polygon on layer 203 at chiplet A's wire coordinates and a 0.5 µm-wide one on layer 1 at chiplet B's, via the in-process `GdsReader` (#995 pattern). Gated exactly like the existing round-trip suites.
7. **Cornerstone pre-DRC (nazca+KLayout-gated, Slow)** — the vendored SiN 300nm deck (#932) over the exported GDS is pinned clean; the deck inspects exactly the SiN chiplet's fabrication layers, so this run IS the SiN chiplet's pre-DRC.

No production code changes — every step pinned green against the shipped behavior. Only test-side edit: `MultiProcessChipletJourneyDesign` (the #933 journey builder) went `internal` → `public` so the Integration fixture can reuse it.

## How it was tested

- Full non-Slow suite locally: **Local suite: 5930 passed, 0 failed** (15 skipped — tool-gated tests without their engines).
- The nazca-gated step 6 also ran green locally (a nazca-capable Python exists on this machine), including the coordinate-level GDS assertions (layer 203: [60..65]×[-1.2..0] µm; layer 1: chiplet B's wire at 0.5 µm height).
- Green branch-CI run (nazca-gated steps execute there): https://github.com/aignermax/Lunima/actions/runs/32127966811 — step 6 ran and passed on the runner.

## Open point (not introduced here)

Step 7 skips on the current CI image: the workflow installs the `klayout` pip wheel, which ships no `klayout` CLI on PATH, so **every** KLayout-gated foundry-deck test skips fleet-wide — including #995's step 4 and both #932 tests (verified in the run above). Filed as #1017; the step is pinned and will run wherever a KLayout executable exists.

## Manual verification after vacation

None (headless journey).
