### PR TITLE
Agent: Install KLayout CLI on the xUnit runner so foundry-deck DRC tests stop skipping (#1017)

### DIFF
--- a/.github/workflows/Build_Exe.yaml
+++ b/.github/workflows/Build_Exe.yaml
@@ -48,6 +48,15 @@ jobs:
           pip install "https://github.com/aignermax/Lunima/releases/download/vendor-cache-nazca-0.6.1/nazca-0.6.1.tar.gz"
           python3 -c "import nazca, nazca.demofab, gdstk, klayout.db, siepic_ebeam_pdk; print('PDK preview deps ok')"
 
+      # Mirrors the step in xUnitTests.yaml: the klayout pip wheel ships only the
+      # Python module, but the foundry-deck DRC tests probe a `klayout` executable.
+      - name: Install KLayout CLI (for foundry-deck DRC tests)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y klayout
+          klayout -v
+
       - name: Test
         working-directory: UnitTests
         env:

--- a/.github/workflows/xUnitTests.yaml
+++ b/.github/workflows/xUnitTests.yaml
@@ -97,6 +97,18 @@ jobs:
           pip install "https://github.com/aignermax/Lunima/releases/download/vendor-cache-nazca-0.6.1/nazca-0.6.1.tar.gz"
           python3 -c "import nazca, nazca.demofab, gdstk, klayout.db, siepic_ebeam_pdk; print('PDK preview deps ok')"
 
+      - name: 🔬 Install KLayout CLI (for foundry-deck DRC tests)
+        run: |
+          set -euo pipefail
+          # The klayout pip wheel above ships only the Python module (klayout.db) —
+          # no executable on PATH. The foundry-deck DRC tests probe a `klayout`/
+          # `klayout_app` executable ($KLAYOUT or PATH), so the runner needs the
+          # app itself. Ubuntu universe ships 0.28.x, which runs the vendored
+          # CORNERSTONE pre-DRC deck headless (-b) just fine.
+          sudo apt-get update
+          sudo apt-get install -y klayout
+          klayout -v
+
       - name: 🏃 Run xUnit Tests
         working-directory: UnitTests
         env:


### PR DESCRIPTION
## What & why

Fixes #1017. The xUnit workflow installed the `klayout` **pip wheel**, which ships only the Python module (`klayout.db`) — no `klayout`/`klayout_app` executable on PATH. `ExternalToolProbes.FindKlayoutAsync()` probes exactly those (plus `$KLAYOUT`), so every KLayout-gated foundry-deck test skipped fleet-wide:

- `FullAdderManufacturingJourneyTests.Step4_GdsExportAndFoundryDeck_EmptyViolationBaselineHolds` (#995)
- `CornerstoneDrcIntegrationTests.BrokenDesign_..._IsFlaggedByTheFoundryDeck` / `CleanExportedCornerstoneSinDesign_PassesTheFoundryDeck` (#932)
- `MultiProcessManufacturingJourneyTests.Step7_CornerstonePreDrc_ExportedGdsPinnedCleanForTheSinChiplet` (#1010)

## Fix

New `🔬 Install KLayout CLI` step in `.github/workflows/xUnitTests.yaml`: `sudo apt-get install -y klayout` (Ubuntu universe ships 0.28.15 on noble), verified with `klayout -v` so a broken install fails loudly, mirroring the OpenVAF/NGSpice steps. The existing `QT_QPA_PLATFORM: offscreen` env on the test step already covers headless Qt. With a real CLI on PATH, the deck runner (`klayout -b -r deck.lydrc -rd input=... -rd report=...`) and all four gated tests un-skip.

## How it was tested

- Workflow YAML validated (parse check).
- Local suite: 5977 passed, 0 failed (15 skipped — tool-gated tests incl. the KLayout ones, expected on a machine without the CLI).
- The real proof is this PR's own `🔍 xUnit Tests` run: the four tests above should now execute (not skip) on the runner.

## Notes for review

- No code/test changes: the existing KLayout-gated tests *are* the coverage — this PR makes them run.
- `docs/ROADMAP.md` rung-7 still names #1017 as the known gap; the next status-sync commit can flip it once this lands.