### PR TITLE
Agent: Inter-gate wire delays in the logic critical path (#1020)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/GateDelayCalculator.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/GateDelayCalculator.cs
@@ -13,8 +13,8 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 /// <see cref="DefaultGroupIndex"/>; component widths use the first group index the
 /// recursive paths carry, else the default (a silicon strip waveguide). The result is
 /// a physically plausible estimate — µm of path times n_g/c lands in the fs–ps range —
-/// not an exact timing model: per-edge wire delays between gates and event-driven
-/// simulation are a later rung.
+/// not an exact timing model: event-driven simulation is a later rung. The waveguides
+/// between gates contribute their own per-edge delays, see <see cref="WireDelayCalculator"/>.
 /// </summary>
 public sealed class GateDelayCalculator
 {

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNet.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNet.cs
@@ -5,6 +5,13 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 /// <param name="PinName">The pin name on that gate.</param>
 public sealed record LogicPinRef(string GateId, string PinName);
 
+/// <summary>
+/// One inter-gate wire of the logic network: a gate output pin driving a gate input pin.
+/// </summary>
+/// <param name="Source">The driving gate output pin.</param>
+/// <param name="Load">The driven gate input pin.</param>
+public sealed record LogicWireEdge(LogicPinRef Source, LogicPinRef Load);
+
 /// <summary>The driver of a gate input pin: a network-level input or another gate's output.</summary>
 public abstract record LogicNetDriver
 {

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
@@ -19,6 +19,7 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 public sealed partial class LogicNetworkBuilder
 {
     private readonly GateDelayCalculator _delayCalculator = new();
+    private readonly WireDelayCalculator _wireDelayCalculator = new();
 
     /// <summary>
     /// Derives and validates the logic network behind the given gate groups and the
@@ -58,19 +59,21 @@ public sealed partial class LogicNetworkBuilder
         ThrowOnDuplicateGateIds(contexts);
 
         var drivers = new Dictionary<LogicPinRef, LogicPinRef>();
+        var edgeConnections = new Dictionary<LogicPinRef, WaveguideConnection>();
         foreach (var connection in connections)
         {
-            AddConnectionDrivers(contexts, connection, drivers);
+            AddConnectionDrivers(contexts, connection, drivers, edgeConnections);
         }
 
-        return AssembleNetwork(contexts, drivers, wavelengthNm ?? StandardWaveLengths.RedNM);
+        return AssembleNetwork(contexts, drivers, edgeConnections, wavelengthNm ?? StandardWaveLengths.RedNM);
     }
 
-    /// <summary>Classifies one design connection and records the logic driver it implies, if any.</summary>
+    /// <summary>Classifies one design connection and records the logic driver and wire it implies, if any.</summary>
     private static void AddConnectionDrivers(
         IReadOnlyList<GateContext> contexts,
         WaveguideConnection connection,
-        IDictionary<LogicPinRef, LogicPinRef> drivers)
+        IDictionary<LogicPinRef, LogicPinRef> drivers,
+        IDictionary<LogicPinRef, WaveguideConnection> edgeConnections)
     {
         var start = ResolveEndpoint(contexts, connection.StartPin);
         var end = ResolveEndpoint(contexts, connection.EndPin);
@@ -83,6 +86,7 @@ public sealed partial class LogicNetworkBuilder
                 $"Gate input '{Format(load)}' is driven by two different gate outputs: " +
                 $"'{Format(existing)}' and '{Format(source)}'. One logic wire needs exactly one driver.");
         drivers[load] = source;
+        edgeConnections.TryAdd(load, connection);
     }
 
     /// <summary>Determines which endpoint drives which, rejecting logically invalid pairings.</summary>
@@ -143,11 +147,13 @@ public sealed partial class LogicNetworkBuilder
     /// Assembles the evaluator: unconnected gate inputs become network-level inputs
     /// named <c>&lt;group&gt;.&lt;pin&gt;</c>, and every gate output pin becomes a
     /// network-level output tap under the same naming. Each gate's propagation delay
-    /// is derived from its group's internal optical path length.
+    /// is derived from its group's internal optical path length, and each inter-gate
+    /// wire's delay from the connecting waveguide's routed path.
     /// </summary>
     private LogicNetworkEvaluator AssembleNetwork(
         IReadOnlyList<GateContext> contexts,
         IReadOnlyDictionary<LogicPinRef, LogicPinRef> drivers,
+        IReadOnlyDictionary<LogicPinRef, WaveguideConnection> edgeConnections,
         double wavelengthNm)
     {
         var networkInputs = new List<string>();
@@ -155,6 +161,13 @@ public sealed partial class LogicNetworkBuilder
         var outputTaps = new Dictionary<string, LogicPinRef>();
         var models = new Dictionary<string, LogicGateModel>();
         var delays = new Dictionary<string, double>();
+        var wireDelays = new Dictionary<LogicWireEdge, double>();
+
+        foreach (var (load, connection) in edgeConnections)
+        {
+            wireDelays[new LogicWireEdge(drivers[load], load)] =
+                _wireDelayCalculator.CalculatePicoseconds(connection, wavelengthNm);
+        }
 
         foreach (var context in contexts)
         {
@@ -173,7 +186,7 @@ public sealed partial class LogicNetworkBuilder
             }
         }
 
-        return new LogicNetworkEvaluator(networkInputs, models, wiring, outputTaps, delays);
+        return new LogicNetworkEvaluator(networkInputs, models, wiring, outputTaps, delays, wireDelays);
     }
 
     /// <summary>Registers and returns the network-level input name of an unconnected gate input.</summary>

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Timing.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Timing.cs
@@ -2,14 +2,16 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 
 /// <summary>
 /// Timing half of <see cref="LogicNetworkEvaluator"/>: per-gate propagation delays in
-/// picoseconds and the critical path — the longest cumulative delay from any network
-/// input to any output over the gate DAG. The delays arrive with the network (derived
-/// from each gate group's internal optical path length, see
-/// <see cref="GateDelayCalculator"/>); the critical path walks the same topological
-/// order <see cref="Evaluate"/> uses, so a gate's cumulative delay is its own delay
-/// plus the slowest driving gate's cumulative delay. Networks built without delay
-/// data report zero delays. Wire delays between gates are not modeled yet — every
-/// logic wire is still ideal.
+/// picoseconds, per-wire delays for the waveguides between gates, and the critical
+/// path — the longest cumulative delay from any network input to any output over the
+/// gate DAG, summing gate delays and inter-gate wire delays along the path. The gate
+/// delays arrive with the network (derived from each gate group's internal optical
+/// path length, see <see cref="GateDelayCalculator"/>), the wire delays from the
+/// connecting waveguide geometry (see <see cref="WireDelayCalculator"/>); the critical
+/// path walks the same topological order <see cref="Evaluate"/> uses, so a gate's
+/// cumulative delay is its own delay plus the slowest arrival (driver cumulative delay
+/// plus that wire's delay) over its driven inputs. Networks built without delay data
+/// report zero delays.
 /// </summary>
 public sealed partial class LogicNetworkEvaluator
 {
@@ -18,8 +20,15 @@ public sealed partial class LogicNetworkEvaluator
         = new Dictionary<string, double>();
 
     /// <summary>
+    /// Propagation delay of every inter-gate wire in picoseconds, keyed by the
+    /// (driver output → load input) edge. Exposed for future wire-delay visualization.
+    /// </summary>
+    public IReadOnlyDictionary<LogicWireEdge, double> WireDelaysPicoseconds { get; private set; }
+        = new Dictionary<LogicWireEdge, double>();
+
+    /// <summary>
     /// Total delay of the critical path in picoseconds: the longest cumulative delay
-    /// from any network input to any network output.
+    /// from any network input to any network output, summing gate and wire delays.
     /// </summary>
     public double CriticalPathDelayPicoseconds { get; private set; }
 
@@ -29,10 +38,13 @@ public sealed partial class LogicNetworkEvaluator
     /// </summary>
     public IReadOnlyList<string> CriticalPathGateIds { get; private set; } = Array.Empty<string>();
 
-    /// <summary>Stores the per-gate delays and derives the critical path over the gate DAG.</summary>
-    private void InitializeTiming(IReadOnlyDictionary<string, double>? gateDelays)
+    /// <summary>Stores the per-gate and per-wire delays and derives the critical path over the gate DAG.</summary>
+    private void InitializeTiming(
+        IReadOnlyDictionary<string, double>? gateDelays,
+        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays)
     {
         GateDelaysPicoseconds = BuildDelayMap(gateDelays);
+        WireDelaysPicoseconds = BuildWireDelayMap(wireDelays);
         (CriticalPathDelayPicoseconds, CriticalPathGateIds) = ComputeCriticalPath();
     }
 
@@ -61,8 +73,42 @@ public sealed partial class LogicNetworkEvaluator
     }
 
     /// <summary>
-    /// Accumulates delays in topological order, then backtracks from the slowest output
-    /// tap through the slowest-driver chain to the network input.
+    /// Fills one delay per inter-gate wire, rejecting edges the wiring does not
+    /// contain and implausible values.
+    /// </summary>
+    private IReadOnlyDictionary<LogicWireEdge, double> BuildWireDelayMap(
+        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays)
+    {
+        var delays = _inputWiring
+            .Where(pair => pair.Value is LogicNetDriver.GateOutput)
+            .ToDictionary(
+                pair => new LogicWireEdge(((LogicNetDriver.GateOutput)pair.Value).Pin, pair.Key),
+                _ => 0.0);
+        if (wireDelays == null)
+            return delays;
+
+        foreach (var (edge, delay) in wireDelays)
+        {
+            if (!delays.ContainsKey(edge))
+                throw new ArgumentException(
+                    $"A wire delay was passed for edge '{FormatPin(edge.Source)}' → '{FormatPin(edge.Load)}', " +
+                    "which the network wiring does not contain.",
+                    nameof(wireDelays));
+            if (double.IsNaN(delay) || double.IsInfinity(delay) || delay < 0)
+                throw new ArgumentException(
+                    $"Wire '{FormatPin(edge.Source)}' → '{FormatPin(edge.Load)}' has an invalid propagation delay " +
+                    $"of {delay} ps — a delay must be a finite, non-negative number.",
+                    nameof(wireDelays));
+            delays[edge] = delay;
+        }
+        return delays;
+    }
+
+    /// <summary>
+    /// Accumulates delays in topological order — a gate's cumulative delay is its own
+    /// delay plus the slowest arrival over its driven inputs (driver cumulative delay
+    /// plus that wire's delay) — then backtracks from the slowest output tap through
+    /// the slowest-driver chain to the network input.
     /// </summary>
     private (double Delay, IReadOnlyList<string> Path) ComputeCriticalPath()
     {
@@ -81,7 +127,7 @@ public sealed partial class LogicNetworkEvaluator
         return (cumulative[criticalGate], Backtrack(criticalGate, predecessor));
     }
 
-    /// <summary>The cumulative delay of the slowest gate driving one of this gate's inputs.</summary>
+    /// <summary>The slowest arrival at one of this gate's inputs: driver cumulative delay plus wire delay.</summary>
     private (double Delay, string? GateId) SlowestDriver(
         string gateId, IReadOnlyDictionary<string, double> cumulative)
     {
@@ -89,11 +135,14 @@ public sealed partial class LogicNetworkEvaluator
         string? driverId = null;
         foreach (var pinName in Gates[gateId].InputPinNames)
         {
-            if (_inputWiring[new LogicPinRef(gateId, pinName)] is not LogicNetDriver.GateOutput source)
+            var load = new LogicPinRef(gateId, pinName);
+            if (_inputWiring[load] is not LogicNetDriver.GateOutput source)
                 continue;
-            if (cumulative[source.Pin.GateId] > delay)
+            var arrival = cumulative[source.Pin.GateId]
+                + WireDelaysPicoseconds[new LogicWireEdge(source.Pin, load)];
+            if (arrival > delay)
             {
-                delay = cumulative[source.Pin.GateId];
+                delay = arrival;
                 driverId = source.Pin.GateId;
             }
         }

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
@@ -30,6 +30,11 @@ public sealed partial class LogicNetworkEvaluator
     /// Optional propagation delay per gate in picoseconds (see
     /// <see cref="GateDelayCalculator"/>); gates without an entry report zero delay.
     /// </param>
+    /// <param name="wireDelays">
+    /// Optional propagation delay per inter-gate wire in picoseconds (see
+    /// <see cref="WireDelayCalculator"/>), keyed by the (driver output → load input)
+    /// edge; edges without an entry report zero delay.
+    /// </param>
     /// <exception cref="ArgumentException">
     /// A gate, pin, or network input is unknown; a gate input is left undriven; or the
     /// wiring is otherwise inconsistent. The message names the offending element.
@@ -40,7 +45,8 @@ public sealed partial class LogicNetworkEvaluator
         IReadOnlyDictionary<string, LogicGateModel> gates,
         IReadOnlyDictionary<LogicPinRef, LogicNetDriver> inputWiring,
         IReadOnlyDictionary<string, LogicPinRef> outputTaps,
-        IReadOnlyDictionary<string, double>? gateDelays = null)
+        IReadOnlyDictionary<string, double>? gateDelays = null,
+        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays = null)
     {
         InputPinNames = inputPinNames ?? throw new ArgumentNullException(nameof(inputPinNames));
         Gates = gates ?? throw new ArgumentNullException(nameof(gates));
@@ -53,7 +59,7 @@ public sealed partial class LogicNetworkEvaluator
         ValidateOutputTaps();
         _evaluationOrder = TopologicalOrder();
         DetectFanOut();
-        InitializeTiming(gateDelays);
+        InitializeTiming(gateDelays, wireDelays);
     }
 
     /// <summary>Network-level input pin names.</summary>

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/WireDelayCalculator.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/WireDelayCalculator.cs
@@ -1,0 +1,34 @@
+using CAP_Core.Components.Connections;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Derives the propagation delay of one inter-gate waveguide from its routed path:
+/// geometric length · n_g / c — the same convention and dispersion-model fallback as
+/// <see cref="GateDelayCalculator"/>: the connection's dispersion model supplies the
+/// group index when it carries one, else <see cref="GateDelayCalculator.DefaultGroupIndex"/>
+/// (a silicon strip waveguide). A connection without a routed path (direct-adjacent
+/// pins) contributes zero delay; the result never goes negative.
+/// </summary>
+public sealed class WireDelayCalculator
+{
+    /// <summary>
+    /// Computes the wire's propagation delay in picoseconds from its routed path length.
+    /// </summary>
+    /// <param name="connection">The waveguide connection joining two gate pins.</param>
+    /// <param name="wavelengthNm">
+    /// Wavelength in nm the group index is evaluated at (only relevant when the
+    /// connection carries a wavelength-dependent dispersion model).
+    /// </param>
+    /// <returns>The delay light needs to cross the wire, in picoseconds.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="connection"/> is null.</exception>
+    public double CalculatePicoseconds(WaveguideConnection connection, double wavelengthNm)
+    {
+        if (connection == null) throw new ArgumentNullException(nameof(connection));
+        var groupIndex = connection.DispersionModel?.GroupIndexAt(wavelengthNm)
+            ?? GateDelayCalculator.DefaultGroupIndex;
+        var delay = connection.PathLengthMicrometers * groupIndex
+            / GateDelayCalculator.SpeedOfLightMicrometersPerPicosecond;
+        return Math.Max(0, delay);
+    }
+}

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkBuilderTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkBuilderTests.cs
@@ -1,6 +1,8 @@
 using CAP_Core.Analysis.LogicAnalysis;
 using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
+using CAP_Core.LightCalculation.MaterialDispersion;
+using CAP_Core.Routing;
 using Shouldly;
 using Xunit;
 
@@ -327,9 +329,70 @@ public class LogicNetworkBuilderTests
         return group;
     }
 
+    [Fact]
+    public void Build_GatesJoinedByLongWaveguide_AddsTheWireDelayToTheCriticalPath()
+    {
+        var nand = NandInstance("NAND");
+        var inv = NotInstance("INV");
+        var connections = new[] { ConnectWithPath(nand, "Y", inv, "A", 1000) };
+
+        var network = new LogicNetworkBuilder().Build(new[] { nand, inv }, connections);
+
+        var wireDelay = 1000 * GateDelayCalculator.DefaultGroupIndex
+            / GateDelayCalculator.SpeedOfLightMicrometersPerPicosecond;
+        wireDelay.ShouldBeInRange(14, 15, "~14.01 ps for 1 mm of silicon waveguide");
+        var gateSum = network.CriticalPathGateIds.Sum(id => network.GateDelaysPicoseconds[id]);
+        network.CriticalPathDelayPicoseconds.ShouldBe(gateSum + wireDelay, 1e-9,
+            "critical path = gate delays + wire delay along the chain");
+        network.WireDelaysPicoseconds.ShouldBe(new Dictionary<LogicWireEdge, double>
+        {
+            [new LogicWireEdge(new LogicPinRef("NAND", "Y"), new LogicPinRef("INV", "A"))] = wireDelay,
+        });
+    }
+
+    [Fact]
+    public void Build_ConnectionCarryingDispersionModel_UsesItsGroupIndexForTheWireDelay()
+    {
+        var nand = NandInstance("NAND");
+        var inv = NotInstance("INV");
+        var connection = ConnectWithPath(nand, "Y", inv, "A", 1000);
+        connection.DispersionModel = new ConstantDispersion(groupIndex: 2.0);
+
+        var network = new LogicNetworkBuilder().Build(new[] { nand, inv }, new[] { connection });
+
+        var wireDelay = 1000 * 2.0 / GateDelayCalculator.SpeedOfLightMicrometersPerPicosecond;
+        network.WireDelaysPicoseconds.Values.Single().ShouldBe(wireDelay, 1e-9);
+    }
+
+    [Fact]
+    public void Build_ConnectionWithoutRoutedPath_ContributesZeroWireDelay()
+    {
+        var nand = NandInstance("NAND");
+        var inv = NotInstance("INV");
+        var connections = new[] { Connect(nand, "Y", inv, "A") };
+
+        var network = new LogicNetworkBuilder().Build(new[] { nand, inv }, connections);
+
+        network.WireDelaysPicoseconds.Values.Single().ShouldBe(0,
+            "direct-adjacent pins have no waveguide length to cross");
+        network.WireDelaysPicoseconds.Values.ShouldAllBe(delay => delay >= 0,
+            "wire delays never go negative");
+    }
+
     /// <summary>A design connection between two gate groups' external pins.</summary>
     private static WaveguideConnection Connect(LogicGateInstance from, string fromPin, LogicGateInstance to, string toPin) =>
         new() { StartPin = Pin(from.Group, fromPin), EndPin = Pin(to.Group, toPin) };
+
+    /// <summary>A design connection whose routed path is one straight segment of known length.</summary>
+    private static WaveguideConnection ConnectWithPath(
+        LogicGateInstance from, string fromPin, LogicGateInstance to, string toPin, double lengthMicrometers)
+    {
+        var connection = Connect(from, fromPin, to, toPin);
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, lengthMicrometers, 0, 0));
+        connection.ReplaceRoutedPath(path);
+        return connection;
+    }
 
     /// <summary>Looks up a group's connectable external pin.</summary>
     private static PhysicalPin Pin(ComponentGroup group, string name) =>

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkWireDelayTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkWireDelayTests.cs
@@ -1,0 +1,111 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Inter-gate wire delays in the network timing (issue #1020): the critical path
+/// sums gate delays AND wire delays along the path — a long wire on the otherwise
+/// fast branch makes that branch the critical one. Edges the wiring does not
+/// contain and implausible wire delays are rejected with messages naming the pins;
+/// networks built without wire-delay data report zero wire delays.
+/// </summary>
+public class LogicNetworkWireDelayTests
+{
+    private static readonly LogicWireEdge NandToInv = new(new("nand", "Y"), new("inv", "A"));
+
+    [Fact]
+    public void CriticalPath_TwoGateChainWithWireDelay_SumsGateDelaysPlusWireDelay()
+    {
+        var network = Chain(
+            new Dictionary<string, double> { ["nand"] = 10, ["inv"] = 20 },
+            new Dictionary<LogicWireEdge, double> { [NandToInv] = 5 });
+
+        network.WireDelaysPicoseconds[NandToInv].ShouldBe(5);
+        network.CriticalPathDelayPicoseconds.ShouldBe(35);
+        network.CriticalPathGateIds.ShouldBe(new[] { "nand", "inv" },
+            "the wire slows the path down but does not change its gate sequence");
+    }
+
+    [Fact]
+    public void CriticalPath_LongWireOnTheFastBranch_MakesThatBranchCritical()
+    {
+        var network = new LogicNetworkEvaluator(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["fast"] = PinnedGateTables.NotGate(),
+                ["slow"] = PinnedGateTables.NotGate(),
+                ["nand"] = PinnedGateTables.NandGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("fast", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("slow", "A")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("fast", "Y")),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("slow", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") },
+            new Dictionary<string, double> { ["fast"] = 10, ["slow"] = 50, ["nand"] = 5 },
+            new Dictionary<LogicWireEdge, double> { [new(new("fast", "Y"), new("nand", "A"))] = 100 });
+
+        network.CriticalPathDelayPicoseconds.ShouldBe(115,
+            "10 ps gate + 100 ps wire + 5 ps gate beats the wire-free 50 ps branch");
+        network.CriticalPathGateIds.ShouldBe(new[] { "fast", "nand" });
+    }
+
+    [Fact]
+    public void Constructor_NoWireDelayData_ReportsZeroWireDelaysForEveryEdge()
+    {
+        var network = Chain(new Dictionary<string, double> { ["nand"] = 10, ["inv"] = 20 }, null);
+
+        network.WireDelaysPicoseconds.ShouldBe(
+            new Dictionary<LogicWireEdge, double> { [NandToInv] = 0 });
+        network.CriticalPathDelayPicoseconds.ShouldBe(30);
+    }
+
+    [Fact]
+    public void Constructor_WireDelayForUnknownEdge_ThrowsNamingThePins()
+    {
+        var wireDelays = new Dictionary<LogicWireEdge, double> { [new(new("nand", "Y"), new("nand", "A"))] = 1 };
+
+        var exception = Should.Throw<ArgumentException>(() => Chain(null, wireDelays));
+        exception.Message.ShouldContain("nand.Y");
+        exception.Message.ShouldContain("nand.A");
+    }
+
+    [Theory]
+    [InlineData(-1.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void Constructor_ImplausibleWireDelay_ThrowsNamingThePins(double delay)
+    {
+        var wireDelays = new Dictionary<LogicWireEdge, double> { [NandToInv] = delay };
+
+        var exception = Should.Throw<ArgumentException>(() => Chain(null, wireDelays));
+        exception.Message.ShouldContain("nand.Y");
+        exception.Message.ShouldContain("inv.A");
+    }
+
+    /// <summary>The AND-from-NAND chain: a, b → nand → inv → y, with optional per-edge wire delays.</summary>
+    private static LogicNetworkEvaluator Chain(
+        IReadOnlyDictionary<string, double>? gateDelays,
+        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays) =>
+        new(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["nand"] = PinnedGateTables.NandGate(),
+                ["inv"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("nand", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "Y") },
+            gateDelays,
+            wireDelays);
+}

--- a/UnitTests/Analysis/LogicAnalysis/WireDelayCalculatorTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/WireDelayCalculatorTests.cs
@@ -1,0 +1,66 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.LightCalculation.MaterialDispersion;
+using CAP_Core.Routing;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Per-wire propagation delay from the connecting waveguide's routed path
+/// (issue #1020): delay = L · n_g / c, with n_g from the connection's dispersion
+/// model when it carries one, else the default silicon group index — the same
+/// convention as <see cref="GateDelayCalculator"/>. Zero-length or unrouted
+/// connections contribute zero and never go negative.
+/// </summary>
+public class WireDelayCalculatorTests
+{
+    private const double WavelengthNm = 1550;
+
+    [Fact]
+    public void CalculatePicoseconds_ThousandMicrometerWaveguide_ConvertsLengthWithDefaultGroupIndex()
+    {
+        var delay = new WireDelayCalculator().CalculatePicoseconds(StraightConnection(1000), WavelengthNm);
+
+        delay.ShouldBe(
+            1000 * GateDelayCalculator.DefaultGroupIndex
+            / GateDelayCalculator.SpeedOfLightMicrometersPerPicosecond, 1e-9);
+        delay.ShouldBeInRange(14, 15, "~14.01 ps: physically plausible for 1 mm of silicon waveguide");
+    }
+
+    [Fact]
+    public void CalculatePicoseconds_ConnectionWithDispersionModel_UsesItsOwnGroupIndex()
+    {
+        var connection = StraightConnection(1000);
+        connection.DispersionModel = new ConstantDispersion(groupIndex: 2.0);
+
+        var delay = new WireDelayCalculator().CalculatePicoseconds(connection, WavelengthNm);
+
+        delay.ShouldBe(1000 * 2.0 / GateDelayCalculator.SpeedOfLightMicrometersPerPicosecond, 1e-9);
+    }
+
+    [Fact]
+    public void CalculatePicoseconds_ConnectionWithoutRoutedPath_ContributesZeroDelay()
+    {
+        var delay = new WireDelayCalculator().CalculatePicoseconds(new WaveguideConnection(), WavelengthNm);
+
+        delay.ShouldBe(0, "direct-adjacent pins have no waveguide length to cross");
+        delay.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public void CalculatePicoseconds_NullConnection_Throws() =>
+        Should.Throw<ArgumentNullException>(
+            () => new WireDelayCalculator().CalculatePicoseconds(null!, WavelengthNm));
+
+    /// <summary>A connection whose routed path is one straight segment of known length.</summary>
+    private static WaveguideConnection StraightConnection(double lengthMicrometers)
+    {
+        var path = new RoutedPath();
+        path.Segments.Add(new StraightSegment(0, 0, lengthMicrometers, 0, 0));
+        var connection = new WaveguideConnection();
+        connection.ReplaceRoutedPath(path);
+        return connection;
+    }
+}

--- a/UnitTests/Integration/LogicNetworkTimingExampleTests.cs
+++ b/UnitTests/Integration/LogicNetworkTimingExampleTests.cs
@@ -8,10 +8,11 @@ namespace UnitTests.Integration;
 
 /// <summary>
 /// Propagation delays and the critical path on the shipped half-adder example
-/// (issue #1002): the assembled network carries a non-zero, finite delay per gate
-/// derived from the group's internal optical path length with the documented
-/// formula (delay = L · n_g / c, default silicon group index), and the critical
-/// path equals the sum of the delays along its ordered gate chain.
+/// (issue #1002, wire delays #1020): the assembled network carries a non-zero,
+/// finite delay per gate derived from the group's internal optical path length with
+/// the documented formula (delay = L · n_g / c, default silicon group index), and the
+/// critical path equals the sum of gate delays plus inter-gate wire delays along its
+/// ordered gate chain.
 /// </summary>
 public class LogicNetworkTimingExampleTests : IClassFixture<LogicPanelViewModelTests.LoadedHalfAdder>
 {
@@ -34,8 +35,32 @@ public class LogicNetworkTimingExampleTests : IClassFixture<LogicPanelViewModelT
         network.CriticalPathGateIds.Count.ShouldBeGreaterThan(1,
             "the half adder's critical path is a chain of gates, not a single gate");
         network.CriticalPathDelayPicoseconds.ShouldBe(
-            network.CriticalPathGateIds.Sum(id => network.GateDelaysPicoseconds[id]), 1e-9,
-            "the critical path is the sum of the delays along its gate chain");
+            GateDelaySum(network) + WireDelaySumAlongPath(network), 1e-9,
+            "the critical path sums gate delays and inter-gate wire delays along its gate chain");
+    }
+
+    /// <summary>The sum of the gate delays along the critical path's gate chain.</summary>
+    private static double GateDelaySum(LogicNetworkEvaluator network) =>
+        network.CriticalPathGateIds.Sum(id => network.GateDelaysPicoseconds[id]);
+
+    /// <summary>
+    /// The wire delays the critical path picks up between consecutive gates of its
+    /// chain: for each hop, the slowest wire from the previous gate into the next
+    /// (a gate driven twice by the same predecessor pays only the slower wire).
+    /// </summary>
+    private static double WireDelaySumAlongPath(LogicNetworkEvaluator network)
+    {
+        var path = network.CriticalPathGateIds;
+        var sum = 0.0;
+        for (var i = 1; i < path.Count; i++)
+        {
+            sum += network.WireDelaysPicoseconds
+                .Where(pair => pair.Key.Source.GateId == path[i - 1] && pair.Key.Load.GateId == path[i])
+                .Select(pair => pair.Value)
+                .DefaultIfEmpty(0)
+                .Max();
+        }
+        return sum;
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

The critical path of a logic network summed **gate delays only** — the waveguides *between* gates were treated as ideal (zero-delay). On real layouts (e.g. the full adder's long inter-stage wires) that wiring can dominate the timing, so the reported critical path underestimated. The wire is not free: light takes time.

This slice (rung 4, #1020, Core-only / Recipe B):

- **New `WireDelayCalculator`** (`Connect-A-Pic-Core/Analysis/LogicAnalysis/`): derives one inter-gate wire's delay from the connecting waveguide's routed path — geometric length × n_g / c, the same convention and dispersion-model fallback as `GateDelayCalculator` (`DefaultGroupIndex` = 4.2 when the connection carries no dispersion model). Zero-length / unrouted (direct-adjacent) connections contribute 0 and never go negative.
- **`LogicNetworkEvaluator`** accepts optional per-edge wire delays (new `LogicWireEdge` record: driver output pin → load input pin), validates them (unknown edges and NaN/negative/infinite values rejected naming the pins), exposes them as `WireDelaysPicoseconds` for future visualization, and folds them into the timing: `CriticalPathDelayPicoseconds` = max over paths of (Σ gate delays + Σ wire delays along the path). `CriticalPathGateIds` stays the gate sequence.
- **`LogicNetworkBuilder`** keeps track of the waveguide connection behind each logic edge and derives its delay at the build wavelength, so canvas-built and loaded designs price their wiring automatically.
- **No UI changes**: the existing Logic-panel critical-path text simply shows the larger, honest number (no new user-visible strings).

## How it was tested

- New `WireDelayCalculatorTests`: 1000 µm waveguide → exactly 1000·4.2/c ≈ 14.01 ps; a connection carrying a dispersion model uses its own group index; unrouted connection → 0, never negative.
- New `LogicNetworkWireDelayTests`: two-gate chain sums gate + wire delays; a 100 ps wire on the otherwise fast branch makes that branch critical; edge/implausibility validation; networks without wire data report zero wire delays.
- `LogicNetworkBuilderTests`: two gates joined by a 1000 µm waveguide → critical path = gateA + gateB + 1000·n_g/c (pinned, ~14.01 ps), per-edge delay exposed keyed by edge; dispersion-model connection uses its own index; unrouted connection contributes 0.
- `LogicNetworkTimingExampleTests` (half-adder): critical-path assertion updated to the documented formula Σ gate delays + Σ wire delays along the chain — no assertions deleted.

Local suite: 5991 passed, 0 failed