### PR TITLE
test: fan-out verdict VM failing-path + i18n placeholder-parity guards (#1011 follow-up)

### DIFF
--- a/UnitTests/Analysis/LogicAnalysis/LogicFanOutWarningViewModelTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicFanOutWarningViewModelTests.cs
@@ -1,0 +1,83 @@
+using CAP.Avalonia.Services.Localization;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Display-wrapper tests for the fan-out level report strings (issue #1011): the
+/// ViewModel formats the split line from the report (split count, driver power,
+/// per-branch power, split loss in dB) and picks the pass/fail verdict key per
+/// receiving input. The panel test only exercises the all-pass half adder — these
+/// cover the would-fail path, culture-proofed by building the expected strings
+/// through the same translation keys.
+/// </summary>
+public class LogicFanOutWarningViewModelTests
+{
+    [Fact]
+    public void GateOutputWarning_FormatsWarningAndSplitLine_FromTheReport()
+    {
+        var warning = TwoLoadWarning(
+            driverDisplayName: "SRC.Y", isNetworkInputSignal: false,
+            new FanOutBranchLevel("NAND.A", 0.125, true),
+            new FanOutBranchLevel("NAND.B", 0.125, true));
+
+        var vm = new LogicFanOutWarningViewModel(warning);
+
+        vm.WarningText.ShouldBe(string.Format(Translate("LogicPanel.FanOutWarning.GateLine"), "SRC.Y", 2));
+        vm.SplitLine.ShouldBe(string.Format(
+            Translate("LogicPanel.FanOutWarning.SplitLine"),
+            2, 0.5, 0.25, FanOutLevelCalculator.SplitLossDb(2)));
+        vm.VerdictLines.ShouldBe(new[]
+        {
+            string.Format(Translate("LogicPanel.FanOutWarning.BranchStillOne"), "NAND.A", 0.125),
+            string.Format(Translate("LogicPanel.FanOutWarning.BranchStillOne"), "NAND.B", 0.125),
+        });
+    }
+
+    [Fact]
+    public void FailingBranch_GetsTheWouldFailLine_PassingBranchKeepsTheStillOneLine()
+    {
+        var warning = TwoLoadWarning(
+            driverDisplayName: "SRC.Y", isNetworkInputSignal: false,
+            new FanOutBranchLevel("NAND.A", 0.125, true),
+            new FanOutBranchLevel("INV.A", 0.375, false));
+
+        var vm = new LogicFanOutWarningViewModel(warning);
+
+        vm.VerdictLines.ShouldBe(new[]
+        {
+            string.Format(Translate("LogicPanel.FanOutWarning.BranchStillOne"), "NAND.A", 0.125),
+            string.Format(Translate("LogicPanel.FanOutWarning.BranchWouldFail"), "INV.A", 0.375),
+        });
+        vm.VerdictLines[1].ShouldContain("INV.A");
+        vm.VerdictLines[0].Contains("INV.A").ShouldBeFalse("only the failing branch's line names it");
+    }
+
+    [Fact]
+    public void NetworkInputWarning_UsesTheInputSignalLine()
+    {
+        var warning = TwoLoadWarning(
+            driverDisplayName: "A", isNetworkInputSignal: true,
+            new FanOutBranchLevel("NAND1.A", 0.125, true),
+            new FanOutBranchLevel("NAND2.A", 0.125, true));
+
+        var vm = new LogicFanOutWarningViewModel(warning);
+
+        vm.WarningText.ShouldBe(string.Format(Translate("LogicPanel.FanOutWarning.InputLine"), "A", 2));
+    }
+
+    /// <summary>A two-load warning over an ideal 1×2 split of a 0.5-power driver (3.01 dB).</summary>
+    private static LogicFanOutWarning TwoLoadWarning(
+        string driverDisplayName, bool isNetworkInputSignal, params FanOutBranchLevel[] branches) =>
+        new(
+            driverDisplayName,
+            isNetworkInputSignal,
+            branches.Length,
+            branches.Select(branch => branch.LoadName).ToArray(),
+            new FanOutLevelReport(0.5, 0.25, FanOutLevelCalculator.SplitLossDb(branches.Length), branches));
+
+    private static string Translate(string key) => LocalizationService.Instance.Translate(key);
+}

--- a/UnitTests/Services/Localization/FanOutSplitLineLocalizationTests.cs
+++ b/UnitTests/Services/Localization/FanOutSplitLineLocalizationTests.cs
@@ -1,0 +1,74 @@
+using System.Text.RegularExpressions;
+using CAP.Avalonia.Services.Localization;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Services.Localization;
+
+/// <summary>
+/// Placeholder-parity guard for the fan-out level report strings (issue #1011):
+/// the completeness tests pin the key set per language, but a translator can still
+/// drop a <c>{1}</c> inside a value — silently losing the per-branch power from the
+/// panel — or add one, which throws <see cref="FormatException"/> at runtime. Every
+/// shipped language must carry exactly English's placeholder indices, and every
+/// string must format cleanly with the values the ViewModel passes.
+/// </summary>
+public partial class FanOutSplitLineLocalizationTests
+{
+    private const string SplitLineKey = "LogicPanel.FanOutWarning.SplitLine";
+    private const string StillOneKey = "LogicPanel.FanOutWarning.BranchStillOne";
+    private const string WouldFailKey = "LogicPanel.FanOutWarning.BranchWouldFail";
+
+    [GeneratedRegex(@"\{(\d+)(:[^}]*)?\}")]
+    private static partial Regex PlaceholderRegex();
+
+    [Theory]
+    [InlineData(SplitLineKey)]
+    [InlineData(StillOneKey)]
+    [InlineData(WouldFailKey)]
+    public void EveryLanguage_CarriesExactlyEnglishsPlaceholderIndices(string key)
+    {
+        var english = LocalizationResourceLoader.Load(SupportedLanguage.English.Code);
+        var expected = PlaceholderIndices(english[key]);
+
+        foreach (var language in SupportedLanguage.All)
+        {
+            var table = LocalizationResourceLoader.Load(language.Code);
+            PlaceholderIndices(table[key]).ShouldBe(expected,
+                $"{language.Code}:{key} must keep placeholders {string.Join(", ", expected)} — " +
+                "a dropped index silently loses a number from the panel, an added one throws at runtime");
+        }
+    }
+
+    [Fact]
+    public void EveryLanguage_FormatsCleanly_WithTheValuesTheViewModelPasses()
+    {
+        // Mirrors LogicFanOutWarningViewModel: the split line gets (load count,
+        // driver power, per-branch power, split loss in dB); the branch lines get
+        // (load name, threshold).
+        var argsPerKey = new Dictionary<string, object[]>
+        {
+            [SplitLineKey] = new object[] { 4, 1.0, 0.25, 6.0206 },
+            [StillOneKey] = new object[] { "NAND1.A", 0.125 },
+            [WouldFailKey] = new object[] { "NAND1.A", 0.125 },
+        };
+
+        foreach (var language in SupportedLanguage.All)
+        {
+            var table = LocalizationResourceLoader.Load(language.Code);
+            foreach (var (key, args) in argsPerKey)
+            {
+                var formatted = string.Format(table[key], args);
+                formatted.ShouldNotBeNullOrWhiteSpace();
+                formatted.Contains('{').ShouldBeFalse($"{language.Code}:{key} left an unformatted placeholder");
+            }
+        }
+    }
+
+    /// <summary>The sorted placeholder indices (<c>{0}</c>, <c>{2:0.###}</c>) of a format string.</summary>
+    private static int[] PlaceholderIndices(string format) =>
+        PlaceholderRegex().Matches(format)
+            .Select(match => int.Parse(match.Groups[1].Value))
+            .OrderBy(index => index)
+            .ToArray();
+}


### PR DESCRIPTION
## What & why

Follow-up to #1018 (which closed #1011). A parallel session had independently implemented #1011 when #1018 merged first; per the divergence playbook the orphaned local version is preserved at tag `orphaned/issue-1011-local-impl`, and this PR salvages only its **unique value as test-only additions** — two coverage gaps the merged tests do not close. No production code changes.

## What is added

**`UnitTests/Analysis/LogicAnalysis/LogicFanOutWarningViewModelTests.cs`** — the ViewModel's **would-fail formatting path**. The merged panel test only exercises the all-pass half adder (every branch reads ✓). These cover:
- `GateLine` vs. `InputLine` selection for gate-output vs. network-input warnings
- `SplitLine` formatting from the report (split count, driver power, per-branch power, dB loss)
- Per-branch key selection: a failing branch gets `BranchWouldFail`, a passing one keeps `BranchStillOne`

Expected strings are built through `LocalizationService.Instance.Translate` + `string.Format` with the same values, so the tests pass under any OS UI culture.

**`UnitTests/Services/Localization/FanOutSplitLineLocalizationTests.cs`** — **placeholder parity** for the three verdict strings (`SplitLine`, `BranchStillOne`, `BranchWouldFail`) across all five shipped languages. The existing completeness tests pin the key *set*, but a translator can still drop a `{1}` inside a value — silently losing the per-branch power from the panel — or add one, which throws `FormatException` at runtime. Also formats every language with the exact values the ViewModel passes (catches format-specifier/type mismatches like `{1:0.###}` applied to a string).

## How it was tested

- 7 new tests, all green.
- Local suite: 5984 passed, 0 failed (15 skipped; `Category!=Slow`, 5 m 24 s)

## Notes

- The alternative UI approach from the orphaned version (single summarized verdict line with pass/fail coloring instead of per-branch lines) is deliberately **not** salvaged — the per-branch presentation was reviewed and merged in #1018; re-litigating it would be churn.
- Base: `dev-ki` (rung-4 chain).