### PR TITLE
Agent: Logic timing: event timeline slice 1 — per-gate switch events with arrival times (rung 4→5 groundwork)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicEventTimeline.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicEventTimeline.cs
@@ -1,0 +1,138 @@
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// One gate output pin switching to a new logic level at one point in time. The
+/// timeline any future execution visualizer consumes: when the network inputs
+/// toggle, this is what propagates through the gate DAG.
+/// </summary>
+/// <param name="TimePicoseconds">Absolute time of the switch, counted from the input toggle at t = 0.</param>
+/// <param name="GateId">The network-local id of the gate whose output switches.</param>
+/// <param name="OutputPin">The output pin of that gate producing the new level.</param>
+/// <param name="NewValue">The logic level the pin switches to.</param>
+public sealed record LogicSwitchEvent(
+    double TimePicoseconds,
+    string GateId,
+    string OutputPin,
+    bool NewValue);
+
+/// <summary>
+/// Event-driven view of one <see cref="LogicNetworkEvaluator"/> transition: given
+/// the input assignment before and after a toggle, produces the ordered list of
+/// per-gate switch events. A network input changes at t = 0; a gate output
+/// switches at <c>max(arrival over its inputs) + gateDelay</c>, where an arrival
+/// is the driver's switch time plus that wire's delay (a driver that never
+/// switches contributes a stable arrival of 0). Gates whose output value does
+/// not change emit no event. This slice models exactly one switch per pin — no
+/// glitch/hazard modeling — and reuses the evaluator's
+/// <see cref="LogicNetworkEvaluator.GateDelaysPicoseconds"/> and
+/// <see cref="LogicNetworkEvaluator.WireDelaysPicoseconds"/> without recomputing
+/// any physics.
+/// </summary>
+public static class LogicEventTimeline
+{
+    /// <summary>
+    /// Computes the ordered switch events between two input assignments.
+    /// </summary>
+    /// <param name="network">The network to walk; supplies gates, wiring, and delays.</param>
+    /// <param name="previousInputs">The input assignment before the toggle.</param>
+    /// <param name="nextInputs">The input assignment after the toggle.</param>
+    /// <returns>
+    /// The switch events sorted by time, ties broken by gate id, then by pin name.
+    /// An empty list when no gate output changes.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Any argument is null.</exception>
+    /// <exception cref="ArgumentException">An input bit is missing or unknown.</exception>
+    public static IReadOnlyList<LogicSwitchEvent> Compute(
+        LogicNetworkEvaluator network,
+        IReadOnlyDictionary<string, bool> previousInputs,
+        IReadOnlyDictionary<string, bool> nextInputs)
+    {
+        if (network == null) throw new ArgumentNullException(nameof(network));
+        if (previousInputs == null) throw new ArgumentNullException(nameof(previousInputs));
+        if (nextInputs == null) throw new ArgumentNullException(nameof(nextInputs));
+        network.ValidateInputBits(previousInputs);
+        network.ValidateInputBits(nextInputs);
+
+        var before = EvaluateAllGateOutputs(network, previousInputs);
+        var after = EvaluateAllGateOutputs(network, nextInputs);
+
+        var switchTimes = new Dictionary<LogicPinRef, double>();
+        var events = new List<LogicSwitchEvent>();
+        foreach (var gateId in network.EvaluationOrder)
+        {
+            var gate = network.Gates[gateId];
+            var arrival = LatestInputArrival(network, gateId, switchTimes);
+            var switchTime = arrival + network.GateDelaysPicoseconds[gateId];
+            foreach (var pinName in gate.OutputPinNames)
+            {
+                var pin = new LogicPinRef(gateId, pinName);
+                if (before[pin] == after[pin])
+                    continue;
+                switchTimes[pin] = switchTime;
+                events.Add(new LogicSwitchEvent(switchTime, gateId, pinName, after[pin]));
+            }
+        }
+
+        return events
+            .OrderBy(e => e.TimePicoseconds)
+            .ThenBy(e => e.GateId, StringComparer.Ordinal)
+            .ThenBy(e => e.OutputPin, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// The latest arrival over one gate's inputs: a network input is stable at
+    /// its final level from t = 0; a gate-output driver contributes its switch
+    /// time plus the wire delay when it switched, and 0 (stable) otherwise.
+    /// </summary>
+    private static double LatestInputArrival(
+        LogicNetworkEvaluator network,
+        string gateId,
+        IReadOnlyDictionary<LogicPinRef, double> switchTimes)
+    {
+        var latest = 0.0;
+        foreach (var pinName in network.Gates[gateId].InputPinNames)
+        {
+            var load = new LogicPinRef(gateId, pinName);
+            if (network.InputWiring[load] is not LogicNetDriver.GateOutput source)
+                continue;
+            if (!switchTimes.TryGetValue(source.Pin, out var driverSwitch))
+                continue;
+            var edge = new LogicWireEdge(source.Pin, load);
+            var arrival = driverSwitch + network.WireDelaysPicoseconds[edge];
+            if (arrival > latest)
+                latest = arrival;
+        }
+        return latest;
+    }
+
+    /// <summary>
+    /// Evaluates every gate output pin (not just the network taps) for one input
+    /// assignment, walking the same topological order <see cref="LogicNetworkEvaluator.Evaluate"/>
+    /// uses.
+    /// </summary>
+    private static IReadOnlyDictionary<LogicPinRef, bool> EvaluateAllGateOutputs(
+        LogicNetworkEvaluator network,
+        IReadOnlyDictionary<string, bool> inputBits)
+    {
+        var outputs = new Dictionary<LogicPinRef, bool>();
+        foreach (var gateId in network.EvaluationOrder)
+        {
+            var gate = network.Gates[gateId];
+            var gateInputs = new Dictionary<string, bool>(gate.InputPinNames.Count);
+            foreach (var pinName in gate.InputPinNames)
+            {
+                var load = new LogicPinRef(gateId, pinName);
+                gateInputs[pinName] = network.InputWiring[load] switch
+                {
+                    LogicNetDriver.NetworkInput input => inputBits[input.PinName],
+                    LogicNetDriver.GateOutput source => outputs[source.Pin],
+                    _ => throw new InvalidOperationException("Unsupported driver type."),
+                };
+            }
+            foreach (var (pinName, bit) in gate.Evaluate(gateInputs))
+                outputs[new LogicPinRef(gateId, pinName)] = bit;
+        }
+        return outputs;
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Validation.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Validation.cs
@@ -110,7 +110,7 @@ public sealed partial class LogicNetworkEvaluator
     }
 
     /// <summary>Rejects missing or unknown network input bits before any gate fires.</summary>
-    private void ValidateInputBits(IReadOnlyDictionary<string, bool> inputBits)
+    internal void ValidateInputBits(IReadOnlyDictionary<string, bool> inputBits)
     {
         var missing = InputPinNames.FirstOrDefault(name => !inputBits.ContainsKey(name));
         if (missing != null)

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
@@ -74,6 +74,12 @@ public sealed partial class LogicNetworkEvaluator
     /// <summary>Network-level output taps: the tapped gate output pin per output name.</summary>
     public IReadOnlyDictionary<string, LogicPinRef> OutputTaps => _outputTaps;
 
+    /// <summary>The driver of every gate input pin — exposed for the event-timeline walker.</summary>
+    internal IReadOnlyDictionary<LogicPinRef, LogicNetDriver> InputWiring => _inputWiring;
+
+    /// <summary>The topological gate order — exposed for the event-timeline walker.</summary>
+    internal IReadOnlyList<string> EvaluationOrder => _evaluationOrder;
+
     /// <summary>
     /// Evaluates the network for one input combination: every gate fires exactly
     /// once in topological order, reading clean bits and producing clean bits.

--- a/UnitTests/Analysis/LogicAnalysis/LogicEventTimelineTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicEventTimelineTests.cs
@@ -1,0 +1,208 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Per-gate switch events with arrival times (issue #1035, rung 4→5 groundwork):
+/// a chain accumulates gate and wire delays along the events; a join gate waits
+/// for the slower of its two arrivals; an input assignment that changes nothing
+/// produces an empty timeline; a stable mid-chain driver is treated as arrival 0
+/// so a downstream gate still switches off the changed branch alone; ties on
+/// time are broken deterministically by gate id. When the switching path IS the
+/// critical path, the last event lands exactly on the critical-path delay.
+/// </summary>
+public class LogicEventTimelineTests
+{
+    private static readonly LogicWireEdge NandToInv = new(new("nand", "Y"), new("inv", "A"));
+
+    [Fact]
+    public void Compute_Chain_AccumulatesGateAndWireDelaysAlongTheEvents()
+    {
+        var network = Chain(
+            new Dictionary<string, double> { ["nand"] = 10, ["inv"] = 20 },
+            new Dictionary<LogicWireEdge, double> { [NandToInv] = 5 });
+
+        var events = LogicEventTimeline.Compute(
+            network,
+            Bits(("a", true), ("b", true)),
+            Bits(("a", false), ("b", true)));
+
+        events.ShouldBe(new[]
+        {
+            new LogicSwitchEvent(10, "nand", "Y", true),
+            new LogicSwitchEvent(35, "inv", "Y", false),
+        });
+        events[^1].TimePicoseconds.ShouldBe(network.CriticalPathDelayPicoseconds,
+            "the switching path IS the critical path: the last event lands exactly on it");
+    }
+
+    [Fact]
+    public void Compute_ForkJoin_JoinGateWaitsForTheSlowerArrival()
+    {
+        var network = ForkJoin(
+            new Dictionary<string, double> { ["fast"] = 10, ["slow"] = 50, ["nand"] = 5 },
+            new Dictionary<LogicWireEdge, double> { [new(new("fast", "Y"), new("nand", "A"))] = 7 });
+
+        var events = LogicEventTimeline.Compute(
+            network,
+            Bits(("a", false), ("b", false)),
+            Bits(("a", true), ("b", true)));
+
+        events.ShouldBe(new[]
+        {
+            new LogicSwitchEvent(10, "fast", "Y", false),
+            new LogicSwitchEvent(50, "slow", "Y", false),
+            new LogicSwitchEvent(55, "nand", "Y", true),
+        }, "the fast branch arrives at 17 ps but the join waits for the slow branch's 50 ps");
+        events[^1].TimePicoseconds.ShouldBe(network.CriticalPathDelayPicoseconds);
+    }
+
+    [Fact]
+    public void Compute_NoChangeInput_EmptyTimeline()
+    {
+        var network = Chain(
+            new Dictionary<string, double> { ["nand"] = 10, ["inv"] = 20 },
+            new Dictionary<LogicWireEdge, double> { [NandToInv] = 5 });
+
+        LogicEventTimeline.Compute(
+            network,
+            Bits(("a", true), ("b", true)),
+            Bits(("a", true), ("b", true))).ShouldBeEmpty();
+
+        LogicEventTimeline.Compute(
+            network,
+            Bits(("a", true), ("b", false)),
+            Bits(("a", true), ("b", false))).ShouldBeEmpty(
+            "toggling no input leaves every gate output at its previous level");
+    }
+
+    [Fact]
+    public void Compute_JoinAbsorbsTheToggle_OnlyTheFirstGateFires()
+    {
+        var network = ForkJoin(
+            new Dictionary<string, double> { ["fast"] = 10, ["slow"] = 50, ["nand"] = 5 },
+            null);
+
+        var events = LogicEventTimeline.Compute(
+            network,
+            Bits(("a", false), ("b", true)),
+            Bits(("a", true), ("b", true)));
+
+        events.ShouldBe(new[]
+        {
+            new LogicSwitchEvent(10, "fast", "Y", false),
+        }, "slow is false either way, so NAND(·, false) = true absorbs fast's flip — the timeline stops");
+    }
+
+    [Fact]
+    public void Compute_JoinWithOneStableInput_SwitchesOffTheChangedBranchAlone()
+    {
+        var network = ForkJoin(
+            new Dictionary<string, double> { ["fast"] = 10, ["slow"] = 50, ["nand"] = 5 },
+            null);
+
+        var events = LogicEventTimeline.Compute(
+            network,
+            Bits(("a", false), ("b", false)),
+            Bits(("a", true), ("b", false)));
+
+        events.ShouldBe(new[]
+        {
+            new LogicSwitchEvent(10, "fast", "Y", false),
+            new LogicSwitchEvent(15, "nand", "Y", true),
+        }, "slow never switches — its stable arrival of 0 lets the join fire off the fast branch");
+    }
+
+    [Fact]
+    public void Compute_SimultaneousEvents_TiesBrokenByGateId()
+    {
+        var network = ForkJoin(
+            new Dictionary<string, double> { ["fast"] = 10, ["slow"] = 10, ["nand"] = 5 },
+            null);
+
+        var events = LogicEventTimeline.Compute(
+            network,
+            Bits(("a", false), ("b", false)),
+            Bits(("a", true), ("b", true)));
+
+        events.Take(2).ShouldBe(new[]
+        {
+            new LogicSwitchEvent(10, "fast", "Y", false),
+            new LogicSwitchEvent(10, "slow", "Y", false),
+        }, "same switch time → deterministic order by gate id");
+        events[^1].ShouldBe(new LogicSwitchEvent(15, "nand", "Y", true));
+    }
+
+    [Fact]
+    public void Compute_MissingInputBit_ThrowsNamingThePin()
+    {
+        var network = Chain(null, null);
+
+        var exception = Should.Throw<ArgumentException>(() =>
+            LogicEventTimeline.Compute(network, Bits(("a", true)), Bits(("a", true), ("b", true))));
+        exception.Message.ShouldContain("b");
+    }
+
+    [Fact]
+    public void Compute_NullArguments_Throw()
+    {
+        var network = Chain(null, null);
+
+        Should.Throw<ArgumentNullException>(() =>
+            LogicEventTimeline.Compute(null!, Bits(("a", true), ("b", true)), Bits(("a", true), ("b", true))));
+        Should.Throw<ArgumentNullException>(() =>
+            LogicEventTimeline.Compute(network, null!, Bits(("a", true), ("b", true))));
+        Should.Throw<ArgumentNullException>(() =>
+            LogicEventTimeline.Compute(network, Bits(("a", true), ("b", true)), null!));
+    }
+
+    /// <summary>The AND-from-NAND chain: a, b → nand → inv → y.</summary>
+    private static LogicNetworkEvaluator Chain(
+        IReadOnlyDictionary<string, double>? gateDelays,
+        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays) =>
+        new(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["nand"] = PinnedGateTables.NandGate(),
+                ["inv"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("nand", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("inv", "Y") },
+            gateDelays,
+            wireDelays);
+
+    /// <summary>Two NOTs fanning in to one NAND: a → fast, b → slow, (fast, slow) → nand → y.</summary>
+    private static LogicNetworkEvaluator ForkJoin(
+        IReadOnlyDictionary<string, double>? gateDelays,
+        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays) =>
+        new(
+            new[] { "a", "b" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["fast"] = PinnedGateTables.NotGate(),
+                ["slow"] = PinnedGateTables.NotGate(),
+                ["nand"] = PinnedGateTables.NandGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("fast", "A")] = new LogicNetDriver.NetworkInput("a"),
+                [new LogicPinRef("slow", "A")] = new LogicNetDriver.NetworkInput("b"),
+                [new LogicPinRef("nand", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("fast", "Y")),
+                [new LogicPinRef("nand", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("slow", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["y"] = new("nand", "Y") },
+            gateDelays,
+            wireDelays);
+
+    /// <summary>One dictionary of network input bits.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}

--- a/UnitTests/Integration/LogicEventTimelineFullAdderTests.cs
+++ b/UnitTests/Integration/LogicEventTimelineFullAdderTests.cs
@@ -1,0 +1,80 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Event timeline over the shipped <c>examples/Logic Gate Full Adder.lun</c>
+/// (issue #1035, rung 4→5 groundwork): toggling Cin with A = B = 0 produces a
+/// non-empty, strictly time-ordered list of per-gate switch events whose every
+/// event references a real gate of the assembled network and whose last event
+/// lands at or below the critical-path delay. Together with the hand-built
+/// networks of <c>LogicEventTimelineTests</c> this pins the data structure any
+/// future execution visualizer consumes.
+/// </summary>
+public class LogicEventTimelineFullAdderTests
+    : IClassFixture<LogicGateFullAdderExampleTests.FullAdderFixture>
+{
+    private readonly LogicGateFullAdderExampleTests.FullAdderFixture _fixture;
+
+    /// <summary>Attaches the shared loaded full-adder network.</summary>
+    public LogicEventTimelineFullAdderTests(LogicGateFullAdderExampleTests.FullAdderFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public void Compute_TogglingCinWithAAndBLow_ProducesOrderedEventsOnRealGates()
+    {
+        var network = _fixture.Network;
+
+        var events = LogicEventTimeline.Compute(
+            network,
+            _fixture.InputBits(a: false, b: false, cin: false),
+            _fixture.InputBits(a: false, b: false, cin: true));
+
+        events.ShouldNotBeEmpty("Cin feeds the second half adder — Sum must switch");
+        events.ShouldAllBe(
+            e => network.Gates.ContainsKey(e.GateId),
+            "every event references a real gate of the assembled network");
+        events.ShouldAllBe(
+            e => network.Gates[e.GateId].OutputPinNames.Contains(e.OutputPin),
+            "every event references a real output pin of its gate");
+        events.Select(e => e.TimePicoseconds).ShouldBe(
+            events.Select(e => e.TimePicoseconds).OrderBy(t => t),
+            "the timeline is time-ordered");
+        events.ShouldAllBe(
+            e => e.TimePicoseconds >= 0 && double.IsFinite(e.TimePicoseconds),
+            "every switch time is a finite, non-negative number of picoseconds");
+        events[^1].TimePicoseconds.ShouldBeLessThanOrEqualTo(
+            network.CriticalPathDelayPicoseconds,
+            "no signal can arrive later than the critical path");
+    }
+
+    [Fact]
+    public void Compute_IdenticalInputAssignment_ProducesEmptyTimeline()
+    {
+        var events = LogicEventTimeline.Compute(
+            _fixture.Network,
+            _fixture.InputBits(a: true, b: false, cin: true),
+            _fixture.InputBits(a: true, b: false, cin: true));
+
+        events.ShouldBeEmpty("no input changed → no gate output changes → no events");
+    }
+
+    [Fact]
+    public void Compute_EveryEventMatchesTheEvaluatedAfterState()
+    {
+        var network = _fixture.Network;
+        var before = _fixture.InputBits(a: false, b: false, cin: false);
+        var after = _fixture.InputBits(a: false, b: false, cin: true);
+
+        var events = LogicEventTimeline.Compute(network, before, after);
+        var afterTaps = network.Evaluate(after);
+
+        foreach (var e in events)
+        {
+            afterTaps[$"{e.GateId}.{e.OutputPin}"].ShouldBe(e.NewValue,
+                $"the event's new value must equal the network's evaluated after-state at {e.GateId}.{e.OutputPin}");
+        }
+    }
+}


### PR DESCRIPTION
Automated implementation for #1035

- Added `LogicEventTimeline` static class + `LogicSwitchEvent` record under `Analysis/LogicAnalysis`.
- Arrival semantics: network input at t=0; gate output at `max(arrival) + gateDelay`; arrival = driver switch + wire delay.
- Reuses `GateDelaysPicoseconds`/`WireDelaysPicoseconds` — no physics recomputed.
- No-change gates emit no event; events sorted by time, ties by gate id then pin (ordinal).
- Exposed `InputWiring`/`EvaluationOrder`/`ValidateInputBits` as internal on the evaluator — public API unchanged.
- 8 unit tests (chain, fork/join, absorb, no-change, tie-break, validation) + 3 integration tests over `Logic Gate Full Adder.lun`.
- Verified: build clean; new 11/11 pass; `Logic` filter 290/290 pass; architecture tests green.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 2,715,729
- **Estimated cost:** $1.5208 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>