### PR TITLE
Agent: duplicate group identifiers merge groups on load + duplicated-gate wire-delay persistence (#1049)

### DIFF
--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -1566,54 +1566,54 @@ public partial class FileOperationsViewModel : ObservableObject
     /// </summary>
     private List<DesignGroupData> TopologicalSortGroups(List<DesignGroupData> groupDataList)
     {
-        // Build dependency map: group ID -> list of group IDs that depend on it (parents)
-        var dependents = new Dictionary<string, List<string>>();
-        var inDegree = new Dictionary<string, int>();
+        // Dependency bookkeeping keys are the data objects themselves, not the group
+        // identifier: identifiers are not unique — two groups sharing one must never
+        // merge into two copies of the first on load.
+        var dependents = new Dictionary<DesignGroupData, List<DesignGroupData>>();
+        var inDegree = new Dictionary<DesignGroupData, int>();
 
         foreach (var groupData in groupDataList)
         {
-            var groupId = groupData.GroupDto.Identifier;
-            if (!inDegree.ContainsKey(groupId))
-                inDegree[groupId] = 0;
+            if (!inDegree.ContainsKey(groupData))
+                inDegree[groupData] = 0;
 
             // Count how many child groups this group has (determines loading order)
             foreach (var childId in groupData.GroupDto.ChildComponentIds)
             {
                 // Check if this child is a group (appears as a group in the list)
                 var childGroup = groupDataList.FirstOrDefault(g => g.GroupDto.Identifier == childId);
-                if (childGroup != null)
+                if (childGroup != null && childGroup != groupData)
                 {
                     // This group depends on its child group being loaded first
-                    if (!dependents.ContainsKey(childId))
-                        dependents[childId] = new List<string>();
-                    dependents[childId].Add(groupId);
-                    inDegree[groupId]++;
+                    if (!dependents.ContainsKey(childGroup))
+                        dependents[childGroup] = new List<DesignGroupData>();
+                    dependents[childGroup].Add(groupData);
+                    inDegree[groupData]++;
                 }
             }
         }
 
         // Kahn's algorithm for topological sort
-        var queue = new Queue<string>();
+        var queue = new Queue<DesignGroupData>();
         foreach (var groupData in groupDataList)
         {
-            if (inDegree[groupData.GroupDto.Identifier] == 0)
-                queue.Enqueue(groupData.GroupDto.Identifier);
+            if (inDegree[groupData] == 0)
+                queue.Enqueue(groupData);
         }
 
         var sorted = new List<DesignGroupData>();
         while (queue.Count > 0)
         {
-            var currentId = queue.Dequeue();
-            var groupData = groupDataList.First(g => g.GroupDto.Identifier == currentId);
-            sorted.Add(groupData);
+            var current = queue.Dequeue();
+            sorted.Add(current);
 
-            if (dependents.ContainsKey(currentId))
+            if (dependents.TryGetValue(current, out var dependentList))
             {
-                foreach (var dependentId in dependents[currentId])
+                foreach (var dependent in dependentList)
                 {
-                    inDegree[dependentId]--;
-                    if (inDegree[dependentId] == 0)
-                        queue.Enqueue(dependentId);
+                    inDegree[dependent]--;
+                    if (inDegree[dependent] == 0)
+                        queue.Enqueue(dependent);
                 }
             }
         }

--- a/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
+++ b/Connect-A-Pic-Core/Components/Core/ComponentGroup.cs
@@ -596,6 +596,9 @@ public class ComponentGroup : Component, INotifyPropertyChanged
             WidthMicrometers = WidthMicrometers,
             HeightMicrometers = HeightMicrometers,
             Rotation90CounterClock = Rotation90CounterClock,
+            // A copy of a gate is a gate: the pin roles travel with the copy (copied,
+            // not shared — the assignment and its lists are mutable).
+            TruthTablePinAssignment = TruthTablePinAssignment?.Copy(),
             // Immutable record — sharing the reference is safe.
             ProcessBinding = ProcessBinding,
             // Immutable records — sharing the list is safe (same rule as Component.DeepCopy).

--- a/Connect-A-Pic-Core/Components/Core/TruthTablePinAssignment.cs
+++ b/Connect-A-Pic-Core/Components/Core/TruthTablePinAssignment.cs
@@ -37,4 +37,20 @@ public sealed class TruthTablePinAssignment
     /// pin carries a signal name; legacy files without the block load unchanged.
     /// </summary>
     public Dictionary<string, string>? InputSignalNames { get; set; }
+
+    /// <summary>
+    /// Creates an independent copy of the assignment: the lists and the signal-name
+    /// dictionary are mutable, so copies of one gate must not share them.
+    /// </summary>
+    /// <returns>A new assignment with the same roles, threshold, and signal names.</returns>
+    public TruthTablePinAssignment Copy() => new()
+    {
+        InputPinNames = new List<string>(InputPinNames),
+        OutputPinNames = new List<string>(OutputPinNames),
+        BiasPinNames = new List<string>(BiasPinNames),
+        Threshold = Threshold,
+        InputSignalNames = InputSignalNames == null
+            ? null
+            : new Dictionary<string, string>(InputSignalNames)
+    };
 }

--- a/UnitTests/Components/ComponentGroupCloningTests.cs
+++ b/UnitTests/Components/ComponentGroupCloningTests.cs
@@ -320,4 +320,39 @@ public class ComponentGroupCloningTests
         clone2.PhysicalX.ShouldBe(original.PhysicalX,
             "Modifying one clone should not affect another");
     }
+
+    /// <summary>
+    /// Verifies that DeepCopy carries the persisted Truth Table pin roles as an
+    /// independent copy: a duplicated gate must stay a gate, and the assignment's
+    /// mutable lists must not be shared with the original.
+    /// </summary>
+    [Fact]
+    public void DeepCopy_GroupWithPersistedPinRoles_CarriesAnIndependentCopy()
+    {
+        var original = TestComponentFactory.CreateComponentGroup("GateGroup", addChildren: false);
+        original.TruthTablePinAssignment = new TruthTablePinAssignment
+        {
+            InputPinNames = new List<string> { "A", "B" },
+            OutputPinNames = new List<string> { "Y" },
+            BiasPinNames = new List<string> { "BIAS" },
+            Threshold = 0.125,
+            InputSignalNames = new Dictionary<string, string> { ["A"] = "A" }
+        };
+
+        var copy = original.DeepCopy();
+
+        var copiedRoles = copy.TruthTablePinAssignment.ShouldNotBeNull(
+            "a duplicated gate must keep its pin roles");
+        copiedRoles.ShouldNotBeSameAs(original.TruthTablePinAssignment,
+            "the assignment and its lists are mutable — copies must not share them");
+        copiedRoles.InputPinNames.ShouldBe(original.TruthTablePinAssignment!.InputPinNames);
+        copiedRoles.OutputPinNames.ShouldBe(original.TruthTablePinAssignment.OutputPinNames);
+        copiedRoles.BiasPinNames.ShouldBe(original.TruthTablePinAssignment.BiasPinNames);
+        copiedRoles.Threshold.ShouldBe(original.TruthTablePinAssignment.Threshold);
+        copiedRoles.InputSignalNames.ShouldBe(original.TruthTablePinAssignment.InputSignalNames);
+
+        copiedRoles.InputPinNames.Add("Mutated");
+        original.TruthTablePinAssignment.InputPinNames.Count.ShouldBe(2,
+            "mutating the copy's role list must not leak into the original");
+    }
 }

--- a/UnitTests/Integration/DuplicateIdentifierGroupLoadTests.cs
+++ b/UnitTests/Integration/DuplicateIdentifierGroupLoadTests.cs
@@ -1,0 +1,69 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Regression for the load path defect found while building the wire-delay honesty
+/// tests (#1037): two groups sharing one identifier saved on one canvas came back from
+/// <c>LoadDesignFromPathAsync</c> as two copies of the first — the topological sort in
+/// the loader keyed its bookkeeping by the identifier string. Group identifiers are not
+/// unique (library instances keep them until a copy/paste regenerates), so a file with
+/// a duplicate merges silently.
+/// </summary>
+public class DuplicateIdentifierGroupLoadTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (var path in _tempFiles.Where(File.Exists))
+            File.Delete(path);
+    }
+
+    [Fact]
+    public async Task SaveLoadReload_TwoGroupsSharingOneIdentifier_KeepTheirDistinctNames()
+    {
+        var first = SingleGroup(await LogicGateHalfAdderExampleTests.LoadCanvas(NotNandPath()));
+        first.GroupName = "DUP1";
+        var second = SingleGroup(await LogicGateHalfAdderExampleTests.LoadCanvas(NotNandPath()));
+        second.GroupName = "DUP2";
+        second.Identifier.ShouldBe(first.Identifier,
+            "this fixture needs two genuinely identifier-sharing groups");
+
+        var canvas = new DesignCanvasViewModel();
+        canvas.AddComponent(first);
+        canvas.AddComponent(second);
+        var savedPath = await Save(canvas);
+        var reloaded = await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath);
+
+        LogicGateHalfAdderExampleTests.GroupsOf(reloaded)
+            .Select(g => g.GroupName).ShouldBe(new[] { "DUP1", "DUP2" }, ignoreOrder: true,
+                "duplicate identifiers must not merge two groups into copies of the first on load");
+    }
+
+    private static string NotNandPath() =>
+        Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), "Logic Gate NOT-NAND.lun");
+
+    private static ComponentGroup SingleGroup(DesignCanvasViewModel canvas) =>
+        (ComponentGroup)canvas.Components.Single(c => c.Component is ComponentGroup).Component;
+
+    private async Task<string> Save(DesignCanvasViewModel canvas)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"duplicate-identifier-{Guid.NewGuid():N}.lun");
+        _tempFiles.Add(path);
+        var saveVm = LogicGateHalfAdderExampleTests.CreateFileOperations(canvas);
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(path);
+        saveVm.FileDialogService = dialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(path).ShouldBeTrue("the real save path must write the temp .lun");
+        return path;
+    }
+}

--- a/UnitTests/Integration/DuplicatedGateWireDelayHonestyTests.cs
+++ b/UnitTests/Integration/DuplicatedGateWireDelayHonestyTests.cs
@@ -1,0 +1,139 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Honesty test for building circuits by duplicating gates (issue #1049, rung 3/4,
+/// feature #1020/#1027): a gate group with persisted pin roles is duplicated via
+/// <see cref="ComponentGroup.DeepCopy"/> — the way copy/paste and library instantiation
+/// build adders — the copy keeps its persisted roles (a copy of a gate is a gate), moves
+/// 3 mm away through the real canvas move API, and a wire from the driver's output pin to
+/// the copy's input pin is routed through the real router, bound to the groups' synced
+/// external pins exactly as the interactive wiring flow binds them. The assembled network
+/// must report the non-zero wire delay of that wire (L·n_g/c, recomputed independently
+/// from the connection), and the routed path — and with it the delay — must survive the
+/// real save → load path unchanged.
+/// </summary>
+public class DuplicatedGateWireDelayHonestyTests : IDisposable
+{
+    private const double DelayTolerancePicoseconds = 1e-9;
+    private const double MinRoutedLengthMicrometers = 1000;
+    private const double MoveDeltaMicrometers = 3000;
+    private const int WavelengthNm = 1550;
+    private const string NotNandFileName = "Logic Gate NOT-NAND.lun";
+
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (var path in _tempFiles.Where(File.Exists))
+            File.Delete(path);
+    }
+
+    [Fact]
+    public async Task DuplicatedGate_SaveLoadReload_KeepsTheNonZeroWireDelay()
+    {
+        var driver = await LoadGateWithPersistedRoles("G1");
+        var load = driver.DeepCopy();
+        load.GroupName = "G2";
+        load.TruthTablePinAssignment.ShouldNotBeNull(
+            "a duplicated gate must keep its pin roles — otherwise it silently drops " +
+            "out of the logic network");
+        load.EnsureSMatrixComputed();
+
+        var canvas = new DesignCanvasViewModel();
+        canvas.AddComponent(driver);
+        var loadVm = canvas.AddComponent(load);
+        var oldY = load.PhysicalY;
+        canvas.MoveComponent(loadVm, 0, MoveDeltaMicrometers);
+        load.PhysicalY.ShouldBe(oldY + MoveDeltaMicrometers,
+            "the real move API must accept the distant placement");
+
+        var connection = (await canvas.ConnectPinsAsync(
+            driver.PhysicalPins.Single(p => p.Name == "Y"),
+            load.PhysicalPins.Single(p => p.Name == "A")))!.Connection;
+        connection.PathLengthMicrometers.ShouldBeGreaterThan(MinRoutedLengthMicrometers,
+            "the real router must route the distant pair with a substantial path");
+
+        var before = await new LogicNetworkAssembler().AssembleAsync(
+            new Component[] { driver, load }, new[] { connection }, WavelengthNm);
+        var edge = before.WireDelaysPicoseconds.Keys.Single();
+        before.WireDelaysPicoseconds[edge].ShouldBeGreaterThan(0);
+        before.WireDelaysPicoseconds[edge].ShouldBe(
+            ExpectedDelayPicoseconds(connection), DelayTolerancePicoseconds);
+
+        var reloadedCanvas = await LogicGateHalfAdderExampleTests.LoadCanvas(await Save(canvas));
+        var reloadedConnection = reloadedCanvas.Connections.Select(c => c.Connection).Single();
+        reloadedConnection.PathLengthMicrometers.ShouldBeGreaterThan(MinRoutedLengthMicrometers,
+            "the routed path must survive the save → reload round-trip");
+
+        var reloaded = await LogicGateFullAdderExampleTests.AssembleNetwork(reloadedCanvas);
+        var reloadedDelay = reloaded.WireDelaysPicoseconds.Values.Single();
+        reloadedDelay.ShouldBeGreaterThan(0,
+            "the reloaded network must keep its non-zero wire delay");
+        reloadedDelay.ShouldBe(before.WireDelaysPicoseconds[edge], DelayTolerancePicoseconds,
+            "the wire delay is identical after load → save → reload");
+        reloadedDelay.ShouldBe(ExpectedDelayPicoseconds(reloadedConnection), DelayTolerancePicoseconds,
+            "the reloaded delay still matches the reloaded connection's geometry");
+    }
+
+    /// <summary>delay = routed path length × n_g / c, recomputed from the connection itself.</summary>
+    private static double ExpectedDelayPicoseconds(WaveguideConnection connection) =>
+        connection.PathLengthMicrometers
+        * (connection.DispersionModel?.GroupIndexAt(WavelengthNm) ?? GateDelayCalculator.DefaultGroupIndex)
+        / GateDelayCalculator.SpeedOfLightMicrometersPerPicosecond;
+
+    /// <summary>
+    /// Delivers one gate group the way the interactive flow produces it: the shipped
+    /// NOT/NAND example is loaded, its truth table extracted through the real panel
+    /// flow (which seeds the persisted assignment), saved, and reloaded.
+    /// </summary>
+    private async Task<ComponentGroup> LoadGateWithPersistedRoles(string gateId)
+    {
+        var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), NotNandFileName);
+        var canvas = await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+        var groupVm = canvas.Components.Single(c => c.Component is ComponentGroup);
+        canvas.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, canvas);
+        vm.IsGroupSelected.ShouldBeTrue("the loaded gate group must activate the panel");
+        foreach (var name in new[] { "A", "B" })
+            vm.InputPins.Single(p => p.PinName == name).IsChecked = true;
+        vm.OutputPins.Single(p => p.PinName == "Y").IsChecked = true;
+        vm.BiasPins.Single(p => p.PinName == "BIAS").IsChecked = true;
+        vm.Threshold = 0.125;
+        await vm.ExtractCommand.ExecuteAsync(null);
+        vm.HasResult.ShouldBeTrue("the extraction that seeds persistence must succeed");
+
+        ((ComponentGroup)groupVm.Component).GroupName = gateId;
+        var group = LogicGateHalfAdderExampleTests.GroupsOf(
+            await LogicGateHalfAdderExampleTests.LoadCanvas(await Save(canvas))).Single();
+        group.TruthTablePinAssignment.ShouldNotBeNull("the reloaded group must carry the persisted roles");
+        group.EnsureSMatrixComputed();
+        return group;
+    }
+
+    /// <summary>Saves the canvas's design through the real save path to a temp file.</summary>
+    private async Task<string> Save(DesignCanvasViewModel canvas)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"wire-delay-honesty-{Guid.NewGuid():N}.lun");
+        _tempFiles.Add(path);
+        var saveVm = LogicGateHalfAdderExampleTests.CreateFileOperations(canvas);
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(path);
+        saveVm.FileDialogService = dialog.Object;
+        await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(path).ShouldBeTrue("the real save path must write the temp .lun");
+        return path;
+    }
+}


### PR DESCRIPTION
## What & why

**Load-path defect (#1049):** group identifiers are not unique (library instances keep them; loading the same .lun twice reuses them), and `FileOperationsViewModel.TopologicalSortGroups` keyed its dependency bookkeeping by the identifier *string*. A file containing two groups that share one identifier came back from `LoadDesignFromPathAsync` as two copies of the first group — the second group's name/content was silently lost. Anyone duplicating gates to build a circuit (the normal adder workflow, i.e. every education persona) could hit this.

**Fixes landed here:**
1. **Topological sort keys objects, not strings** (recovered orphaned patch, applied as-is): the dependency graph in the loader now keys on the `DesignGroupData` object and skips self-references, so identifier-sharing groups load independently.
2. **`ComponentGroup.DeepCopy` carries the pin roles**: the orphan run's noted finding — `DeepCopy` dropped `TruthTablePinAssignment`, so a duplicated gate silently stopped being a gate in the logic network (`LogicNetworkAssembler` ignores role-less groups). The assignment and its lists are mutable, so `DeepCopy` now stores an independent `Copy()`. Regenerated identifiers need no change: `DeepCopy` already mints a fresh group id (`group_{Guid}`) and per-child suffixed ids — covered by existing cloning/library tests; explicit note per the issue's request.

## Root cause of the still-failing orphaned scenario

Investigated by reproducing the orphan's verbatim `LogicWireDelayHonestyTests.cs` (recovered from the stash's untracked commit): `DuplicatedGate_SaveLoadReload_KeepsTheNonZeroWireDelay` never reached its wire-delay assertions — it called the loader with a **bare relative filename** (`Logic Gate NOT-NAND.lun` instead of the `examples/`-rooted path), so the initial load returned false and the scenario died at setup. With the path fixed, the duplicated-gate save → reload scenario passes end-to-end: the reloaded connection keeps its routed path and the assembled network reports the identical non-zero delay (1e-9 tolerance vs L·n_g/c). The landed test pins that full chain (panel extraction → persisted roles → DeepCopy → 3 mm move → routed wire → real save/load path). The orphan's other scenario (moved critical-path gate) is covered by the merged #1044 and is deliberately not duplicated.

## How it was tested

- `DuplicateIdentifierGroupLoadTests`: save two identifier-sharing groups, reload — both names survive (fails without the production fix, passes with it).
- `DuplicatedGateWireDelayHonestyTests`: the orphan's scenario, corrected, plus an explicit assertion that `DeepCopy` now carries the roles.
- `ComponentGroupCloningTests.DeepCopy_GroupWithPersistedPinRoles_CarriesAnIndependentCopy`: roles carried as an independent copy.
- Local suite: 6084 passed, 0 failed (15 skipped, env-dependent) — `dotnet test UnitTests/UnitTests.csproj --filter "Category!=Slow"`.