### PR TITLE
Agent: 2-to-1 multiplexer example from NAND gate groups with signal names (#1059)

### DIFF
--- a/UnitTests/Integration/LogicEventTimelineMuxTests.cs
+++ b/UnitTests/Integration/LogicEventTimelineMuxTests.cs
@@ -1,0 +1,80 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Event timeline over the shipped <c>examples/Logic Gate MUX.lun</c> (issue #1059):
+/// toggling Sel with A = 0, B = 1 switches the output from A to B and produces a
+/// non-empty, strictly time-ordered list of per-gate switch events whose every event
+/// references a real gate of the assembled network and whose last event lands at or
+/// below the critical-path delay. Mirrors <c>LogicEventTimelineFullAdderTests</c>
+/// (#1035) so the future execution visualizer's data structure stays pinned on the
+/// datapath steering element too.
+/// </summary>
+public class LogicEventTimelineMuxTests
+    : IClassFixture<LogicGateMuxExampleTests.MuxFixture>
+{
+    private readonly LogicGateMuxExampleTests.MuxFixture _fixture;
+
+    /// <summary>Attaches the shared loaded MUX network.</summary>
+    public LogicEventTimelineMuxTests(LogicGateMuxExampleTests.MuxFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public void Compute_TogglingSel_ProducesOrderedEventsOnRealGates()
+    {
+        var network = _fixture.Network;
+
+        var events = LogicEventTimeline.Compute(
+            network,
+            _fixture.InputBits(a: false, b: true, sel: false),
+            _fixture.InputBits(a: false, b: true, sel: true));
+
+        events.ShouldNotBeEmpty("Sel steers the output — Out must switch from A to B");
+        events.ShouldAllBe(
+            e => network.Gates.ContainsKey(e.GateId),
+            "every event references a real gate of the assembled network");
+        events.ShouldAllBe(
+            e => network.Gates[e.GateId].OutputPinNames.Contains(e.OutputPin),
+            "every event references a real output pin of its gate");
+        events.Select(e => e.TimePicoseconds).ShouldBe(
+            events.Select(e => e.TimePicoseconds).OrderBy(t => t),
+            "the timeline is time-ordered");
+        events.ShouldAllBe(
+            e => e.TimePicoseconds >= 0 && double.IsFinite(e.TimePicoseconds),
+            "every switch time is a finite, non-negative number of picoseconds");
+        events[^1].TimePicoseconds.ShouldBeLessThanOrEqualTo(
+            network.CriticalPathDelayPicoseconds,
+            "no signal can arrive later than the critical path");
+    }
+
+    [Fact]
+    public void Compute_IdenticalInputAssignment_ProducesEmptyTimeline()
+    {
+        var events = LogicEventTimeline.Compute(
+            _fixture.Network,
+            _fixture.InputBits(a: true, b: false, sel: true),
+            _fixture.InputBits(a: true, b: false, sel: true));
+
+        events.ShouldBeEmpty("no input changed → no gate output changes → no events");
+    }
+
+    [Fact]
+    public void Compute_EveryEventMatchesTheEvaluatedAfterState()
+    {
+        var network = _fixture.Network;
+        var before = _fixture.InputBits(a: false, b: true, sel: false);
+        var after = _fixture.InputBits(a: false, b: true, sel: true);
+
+        var events = LogicEventTimeline.Compute(network, before, after);
+        var afterTaps = network.Evaluate(after);
+
+        foreach (var e in events)
+        {
+            afterTaps[$"{e.GateId}.{e.OutputPin}"].ShouldBe(e.NewValue,
+                $"the event's new value must equal the network's evaluated after-state at {e.GateId}.{e.OutputPin}");
+        }
+    }
+}

--- a/UnitTests/Integration/LogicGateMuxExampleTests.cs
+++ b/UnitTests/Integration/LogicGateMuxExampleTests.cs
@@ -1,0 +1,208 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Pinned tests for the shipped <c>examples/Logic Gate MUX.lun</c> (issue #1059,
+/// rung 5 datapath stone of the NAND game): four top-level instances of the NOT/NAND
+/// gate — three read as NAND, one as NOT — wired to the textbook 2-to-1 multiplexer
+/// Out = NAND(NAND(A, NOT(Sel)), NAND(B, Sel)). The file loads through the real load
+/// path, every group carries its persisted <see cref="TruthTablePinAssignment"/>, and
+/// the merged <see cref="LogicNetworkAssembler"/> (#988) turns the loaded design into
+/// the evaluable network: Sel = 0 ⇒ Out = A, Sel = 1 ⇒ Out = B at <c>Out.Y</c>,
+/// evaluated by pure table lookup. The fan-out of Sel onto NOT1 and NANDB happens at
+/// the logic layer, where the persisted signal names (issue #1025) merge the select
+/// pins into the single network input <c>Sel</c> — exactly the three toggles A, B and
+/// Sel, one named output <c>Out</c>. Unlike the adders, no shared stage needs
+/// duplication here: the MUX's only fan-out (Sel) is between unconnected pins, which
+/// the signal names merge without a waveguide.
+/// </summary>
+public class LogicGateMuxExampleTests : IClassFixture<LogicGateMuxExampleTests.MuxFixture>
+{
+    private const double NandThreshold = 0.125;
+    private const double NotThreshold = 0.375;
+
+    private static readonly string[] GateNames = { "NOT1", "NANDA", "NANDB", "Out" };
+
+    /// <summary>The persisted signal names per gate group (issue #1025); null = no named pins.</summary>
+    private static readonly Dictionary<string, Dictionary<string, string>?> ExpectedSignalNames = new()
+    {
+        ["NOT1"] = new() { ["A"] = "Sel" },
+        ["NANDA"] = new() { ["A"] = "A" },
+        ["NANDB"] = new() { ["A"] = "Sel", ["B"] = "B" },
+        ["Out"] = null,
+    };
+
+    private readonly MuxFixture _fixture;
+
+    /// <summary>Attaches the shared MUX fixture.</summary>
+    public LogicGateMuxExampleTests(MuxFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Example_LoadsOnlyTopLevelGateGroups_EachWithPersistedRoles()
+    {
+        _fixture.Canvas.Components.ShouldAllBe(
+            c => c.Component is ComponentGroup,
+            "the multiplexer contains only top-level gate groups");
+        _fixture.Canvas.Connections.Count.ShouldBe(3, "three wires join the four gates");
+
+        var groups = _fixture.Groups;
+        groups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+        foreach (var group in groups)
+        {
+            var roles = group.TruthTablePinAssignment.ShouldNotBeNull(
+                $"group '{group.GroupName}' must ship its persisted pin roles");
+            var isNot = group.GroupName == "NOT1";
+            roles.InputPinNames.ShouldBe(isNot ? new[] { "A" } : new[] { "A", "B" });
+            roles.OutputPinNames.ShouldBe(new[] { "Y" });
+            roles.BiasPinNames.ShouldBe(new[] { "BIAS" });
+            roles.Threshold.ShouldBe(isNot ? NotThreshold : NandThreshold);
+            roles.InputSignalNames.ShouldBe(ExpectedSignalNames[group.GroupName],
+                $"group '{group.GroupName}' ships its network-signal identity (issue #1025)");
+            group.Description.ShouldContain("logic layer", Case.Sensitive,
+                "every gate carries the education note about logic-layer composition");
+            group.Description.ShouldContain(isNot ? "0.375" : "0.125");
+        }
+    }
+
+    [Fact]
+    public void AssembledNetwork_ExposesThreeTogglesAndEveryGateOutputAsTap()
+    {
+        _fixture.Network.InputPinNames.ShouldBe(new[] { "A", "B", "Sel" }, ignoreOrder: true,
+            customMessage: "the signal names merge the five operand pins into exactly three network " +
+                "inputs (issue #1025) — the select toggle Sel drives NOT1.A and NANDB.A without a wire");
+        _fixture.Network.OutputPinNames.ShouldBe(
+            GateNames.Select(name => $"{name}.Y").ToArray(), ignoreOrder: true);
+    }
+
+    [Theory]
+    [InlineData(false, false, false, false)]
+    [InlineData(true, false, false, true)]
+    [InlineData(false, true, false, false)]
+    [InlineData(true, true, false, true)]
+    [InlineData(false, false, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(false, true, true, true)]
+    [InlineData(true, true, true, true)]
+    public void LogicLayer_AllInputCombinations_YieldTheMuxFunction(
+        bool a, bool b, bool sel, bool expectedOut)
+    {
+        var result = _fixture.Network.Evaluate(_fixture.InputBits(a, b, sel));
+
+        result["Out.Y"].ShouldBe(expectedOut, "Out = A when Sel = 0, B when Sel = 1");
+        result["NOT1.Y"].ShouldBe(!sel, "the select inverter stays readable as a tap");
+        result["NANDA.Y"].ShouldBe(!(a && !sel), "the A-side select term stays readable as a tap");
+        result["NANDB.Y"].ShouldBe(!(b && sel), "the B-side select term stays readable as a tap");
+    }
+
+    [Fact]
+    public async Task SaveLoadRoundTrip_ReAssembledNetwork_YieldsTheSameMux()
+    {
+        var savedPath = await _fixture.SaveToTempFile();
+        try
+        {
+            var reloadedCanvas = await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath);
+
+            var reloadedGroups = LogicGateHalfAdderExampleTests.GroupsOf(reloadedCanvas);
+            reloadedGroups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+            reloadedGroups.ShouldAllBe(g => g.TruthTablePinAssignment != null,
+                "the persisted pin roles must survive the save → load round trip");
+            foreach (var group in reloadedGroups)
+            {
+                group.TruthTablePinAssignment!.InputSignalNames.ShouldBe(
+                    ExpectedSignalNames[group.GroupName],
+                    $"the signal names of '{group.GroupName}' must survive the save → load round trip (#1025)");
+            }
+            reloadedCanvas.Connections.Count.ShouldBe(3,
+                "every gate wire must survive the save → load round trip");
+
+            var reloaded = await AssembleNetwork(reloadedCanvas);
+            reloaded.InputPinNames.ShouldBe(_fixture.Network.InputPinNames);
+            reloaded.OutputPinNames.ShouldBe(_fixture.Network.OutputPinNames);
+            foreach (var a in new[] { false, true })
+            foreach (var b in new[] { false, true })
+            foreach (var sel in new[] { false, true })
+            {
+                var expected = _fixture.Network.Evaluate(_fixture.InputBits(a, b, sel));
+                reloaded.Evaluate(_fixture.InputBits(a, b, sel)).ShouldBe(expected,
+                    $"the re-assembled network must evaluate identically for A={a}, B={b}, Sel={sel}");
+            }
+        }
+        finally
+        {
+            if (File.Exists(savedPath)) File.Delete(savedPath);
+        }
+    }
+
+    /// <summary>
+    /// Assembles the logic network exactly as the canvas states it: the merged
+    /// <see cref="LogicNetworkAssembler"/> re-extracts every gate's truth table at the
+    /// roles persisted in the file and derives the wiring from the design's connections.
+    /// </summary>
+    internal static async Task<LogicNetworkEvaluator> AssembleNetwork(DesignCanvasViewModel canvas)
+    {
+        var components = canvas.Components.Select(c => c.Component).ToList();
+        var connections = canvas.Connections.Select(c => c.Connection).ToList();
+        return await new LogicNetworkAssembler().AssembleAsync(
+            components, connections, MuxFixture.WavelengthNm);
+    }
+
+    /// <summary>
+    /// Shared fixture: loads the shipped example once and assembles its logic network
+    /// (each extraction is a real simulation run), so every fact asserts against the
+    /// same loaded design and assembled network.
+    /// </summary>
+    public class MuxFixture : IAsyncLifetime
+    {
+        private const string ExampleFileName = "Logic Gate MUX.lun";
+
+        /// <summary>Laser wavelength the persisted roles were extracted at.</summary>
+        public const int WavelengthNm = 1550;
+
+        /// <summary>The canvas the shipped example loaded onto.</summary>
+        public DesignCanvasViewModel Canvas { get; private set; } = null!;
+
+        /// <summary>The loaded top-level gate groups, in file order.</summary>
+        public List<ComponentGroup> Groups { get; private set; } = null!;
+
+        /// <summary>The logic network assembled from the loaded design.</summary>
+        public LogicNetworkEvaluator Network { get; private set; } = null!;
+
+        /// <summary>Loads the shipped example and assembles its logic network.</summary>
+        public async Task InitializeAsync()
+        {
+            var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+            Canvas = await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+            Groups = LogicGateHalfAdderExampleTests.GroupsOf(Canvas);
+            Network = await AssembleNetwork(Canvas);
+        }
+
+        /// <summary>No shared state to release.</summary>
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        /// <summary>The network input bits for one operand triple — one bit per signal (issue #1025).</summary>
+        public Dictionary<string, bool> InputBits(bool a, bool b, bool sel) =>
+            new() { ["A"] = a, ["B"] = b, ["Sel"] = sel };
+
+        /// <summary>Saves the loaded design through the real save path and returns the file path.</summary>
+        public async Task<string> SaveToTempFile()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"mux-{Guid.NewGuid():N}.lun");
+            var saveVm = LogicGateHalfAdderExampleTests.CreateFileOperations(Canvas);
+            var dialog = new Mock<IFileDialogService>();
+            dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(path);
+            saveVm.FileDialogService = dialog.Object;
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+            File.Exists(path).ShouldBeTrue("the real save path must write the temp .lun");
+            return path;
+        }
+    }
+}

--- a/examples/Logic Gate MUX.lun
+++ b/examples/Logic Gate MUX.lun
@@ -1,0 +1,1360 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 1,
+      "EndPinName": "B",
+      "StartComponentId": "group_9069822b1f6e4fc681cc21abfadf2014",
+      "EndComponentId": "group_05f01bd275184eb7b8df0af493985470",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 2,
+      "StartPinName": "Y",
+      "EndComponentIndex": 3,
+      "EndPinName": "B",
+      "StartComponentId": "group_1f69cd41bac2442e820dd8423c412b8d",
+      "EndComponentId": "group_1545a734014d4f5284547207c3d2e473",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 1,
+      "StartPinName": "Y",
+      "EndComponentIndex": 3,
+      "EndPinName": "A",
+      "StartComponentId": "group_05f01bd275184eb7b8df0af493985470",
+      "EndComponentId": "group_1545a734014d4f5284547207c3d2e473",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    }
+  ],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "NOT1",
+        "Description": "NOT reading (input A, BIAS constantly on, threshold 0.375) of the shipped 'Logic Gate NOT-NAND' gate. Role in the multiplexer: select inversion, Y = NOT(Sel), feeding NANDA.B. The whole multiplexer composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here. The fan-out of A, B and Sel onto several gates happens at the logic layer (each gate input is driven by the same network bit through its persisted signal name); the canvas wires one waveguide per pin (like NAND1A/NAND1B in 'Logic Gate Half Adder').",
+        "Identifier": "group_9069822b1f6e4fc681cc21abfadf2014",
+        "IdGuid": "9a7cdd35-686d-454c-8f39-cae3dd386d4e",
+        "ChildComponentGuids": [
+          "7f29949d-5822-4e4d-8fa4-242ff82a1796",
+          "8a9f262e-3b04-45c9-8baf-78bc9f1a9f54",
+          "fdea704c-f65e-4f48-8628-7e27c8110d7b",
+          "7054ac45-961a-47f4-aaf6-c60dec71ae0c",
+          "af5d0b88-5a36-48ec-bc2c-e3cda665b7bb",
+          "d7683bce-32e2-4cbc-9941-6000f126e0ec"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_8b4f2acb93394e178a936944b138fc4c",
+          "input_92dbc4821da74fea92c005f5f8b98c60",
+          "combine_2591aa9ff37f4803a17e87d7dc54128d",
+          "phase_8d7ddf5adc8d403da203310225748847",
+          "recombine_eae896f9f1e94c53b7338211cb19dc59",
+          "output_0be775cefbb04ab8bd6df134f6ed42a8"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "f40ad666-e082-44ba-a90d-ce5778eebca3",
+            "StartComponentId": "input_8b4f2acb93394e178a936944b138fc4c",
+            "StartComponentGuid": "7f29949d-5822-4e4d-8fa4-242ff82a1796",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_2591aa9ff37f4803a17e87d7dc54128d",
+            "EndComponentGuid": "fdea704c-f65e-4f48-8628-7e27c8110d7b",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "70e98cae-6b25-455a-893f-be6f2c2ffb73",
+            "StartComponentId": "input_92dbc4821da74fea92c005f5f8b98c60",
+            "StartComponentGuid": "8a9f262e-3b04-45c9-8baf-78bc9f1a9f54",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_2591aa9ff37f4803a17e87d7dc54128d",
+            "EndComponentGuid": "fdea704c-f65e-4f48-8628-7e27c8110d7b",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "ef5d399c-0f83-48c5-bc68-56a464b8c5ce",
+            "StartComponentId": "combine_2591aa9ff37f4803a17e87d7dc54128d",
+            "StartComponentGuid": "fdea704c-f65e-4f48-8628-7e27c8110d7b",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_eae896f9f1e94c53b7338211cb19dc59",
+            "EndComponentGuid": "af5d0b88-5a36-48ec-bc2c-e3cda665b7bb",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "0f1ee263-a643-43f0-a96f-e9b0ff263660",
+            "StartComponentId": "phase_8d7ddf5adc8d403da203310225748847",
+            "StartComponentGuid": "7054ac45-961a-47f4-aaf6-c60dec71ae0c",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_eae896f9f1e94c53b7338211cb19dc59",
+            "EndComponentGuid": "af5d0b88-5a36-48ec-bc2c-e3cda665b7bb",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f5b004a2-d310-4b1e-bbb6-6e00abf5ef5d",
+            "StartComponentId": "recombine_eae896f9f1e94c53b7338211cb19dc59",
+            "StartComponentGuid": "af5d0b88-5a36-48ec-bc2c-e3cda665b7bb",
+            "StartPinName": "out1",
+            "EndComponentId": "output_0be775cefbb04ab8bd6df134f6ed42a8",
+            "EndComponentGuid": "d7683bce-32e2-4cbc-9941-6000f126e0ec",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "22e8be4b-f8dc-407c-bf54-acf068cab407",
+            "Name": "A",
+            "InternalComponentId": "input_8b4f2acb93394e178a936944b138fc4c",
+            "InternalComponentGuid": "7f29949d-5822-4e4d-8fa4-242ff82a1796",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "55b9b8ca-d6be-4f34-807e-b55cabcc6fb3",
+            "Name": "B",
+            "InternalComponentId": "input_92dbc4821da74fea92c005f5f8b98c60",
+            "InternalComponentGuid": "8a9f262e-3b04-45c9-8baf-78bc9f1a9f54",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "1f302bda-c456-425b-a194-8a38521b39eb",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_8d7ddf5adc8d403da203310225748847",
+            "InternalComponentGuid": "7054ac45-961a-47f4-aaf6-c60dec71ae0c",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "bf63a57a-1fac-473f-a5b4-a55a664090aa",
+            "Name": "Y",
+            "InternalComponentId": "output_0be775cefbb04ab8bd6df134f6ed42a8",
+            "InternalComponentGuid": "d7683bce-32e2-4cbc-9941-6000f126e0ec",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_8b4f2acb93394e178a936944b138fc4c",
+          "ComponentGuid": "7f29949d-5822-4e4d-8fa4-242ff82a1796",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_92dbc4821da74fea92c005f5f8b98c60",
+          "ComponentGuid": "8a9f262e-3b04-45c9-8baf-78bc9f1a9f54",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_2591aa9ff37f4803a17e87d7dc54128d",
+          "ComponentGuid": "fdea704c-f65e-4f48-8628-7e27c8110d7b",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_8d7ddf5adc8d403da203310225748847",
+          "ComponentGuid": "7054ac45-961a-47f4-aaf6-c60dec71ae0c",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_eae896f9f1e94c53b7338211cb19dc59",
+          "ComponentGuid": "af5d0b88-5a36-48ec-bc2c-e3cda665b7bb",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_0be775cefbb04ab8bd6df134f6ed42a8",
+          "ComponentGuid": "d7683bce-32e2-4cbc-9941-6000f126e0ec",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.375,
+        "InputSignalNames": {
+          "A": "Sel"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "NANDA",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the multiplexer: A-side select term, Y = NAND(A, NOT(Sel)) = NOT(A) when Sel = 0 and 1 when Sel = 1, feeding Out.A. Its A pin reads the operand toggle through the signal name A at the logic layer. The whole multiplexer composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here. The fan-out of A, B and Sel onto several gates happens at the logic layer (each gate input is driven by the same network bit through its persisted signal name); the canvas wires one waveguide per pin (like NAND1A/NAND1B in 'Logic Gate Half Adder').",
+        "Identifier": "group_05f01bd275184eb7b8df0af493985470",
+        "IdGuid": "cd910827-89aa-4861-8f60-86dbacfb091f",
+        "ChildComponentGuids": [
+          "17fe1e5a-f696-458c-be64-4c26b51b68d3",
+          "0ca06abc-2d03-4b00-9d5d-a44d79dbff98",
+          "1b8f9c29-8d9f-451f-afc9-a4b66ca4bc8a",
+          "501e94c7-fe08-4e24-ab48-a47f19cc5b8b",
+          "d251ca5e-5db7-4e89-97df-5ec6d26a4363",
+          "3e2d786c-70ae-47b5-b568-bececc9c41bb"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_fe7cba0075e3432eacbc63e7c90ab527",
+          "input_5c27ffe315914375bac7c587e2d9fcd2",
+          "combine_3429a3fb84074cdbbfe9e0b3471a6b11",
+          "phase_40d45ba8c07543a8a60fa790a69565d1",
+          "recombine_09cfd967dd4e4c4f81de3f239d700b67",
+          "output_cd2dc7d2635148db94d70189fc4df8da"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "394fd1c8-0400-4a43-baba-a69c5d993a4f",
+            "StartComponentId": "input_fe7cba0075e3432eacbc63e7c90ab527",
+            "StartComponentGuid": "17fe1e5a-f696-458c-be64-4c26b51b68d3",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_3429a3fb84074cdbbfe9e0b3471a6b11",
+            "EndComponentGuid": "1b8f9c29-8d9f-451f-afc9-a4b66ca4bc8a",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "94e5a8c4-e465-485b-b23b-3460ddcd280b",
+            "StartComponentId": "input_5c27ffe315914375bac7c587e2d9fcd2",
+            "StartComponentGuid": "0ca06abc-2d03-4b00-9d5d-a44d79dbff98",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_3429a3fb84074cdbbfe9e0b3471a6b11",
+            "EndComponentGuid": "1b8f9c29-8d9f-451f-afc9-a4b66ca4bc8a",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "ab5463d7-0096-4a95-bd68-62075754f3ca",
+            "StartComponentId": "combine_3429a3fb84074cdbbfe9e0b3471a6b11",
+            "StartComponentGuid": "1b8f9c29-8d9f-451f-afc9-a4b66ca4bc8a",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_09cfd967dd4e4c4f81de3f239d700b67",
+            "EndComponentGuid": "d251ca5e-5db7-4e89-97df-5ec6d26a4363",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f2c3a966-a2be-4e36-bf3d-b7a01ef0e2d7",
+            "StartComponentId": "phase_40d45ba8c07543a8a60fa790a69565d1",
+            "StartComponentGuid": "501e94c7-fe08-4e24-ab48-a47f19cc5b8b",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_09cfd967dd4e4c4f81de3f239d700b67",
+            "EndComponentGuid": "d251ca5e-5db7-4e89-97df-5ec6d26a4363",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "b38d5d47-eca7-4d11-b531-d33e5560e47d",
+            "StartComponentId": "recombine_09cfd967dd4e4c4f81de3f239d700b67",
+            "StartComponentGuid": "d251ca5e-5db7-4e89-97df-5ec6d26a4363",
+            "StartPinName": "out1",
+            "EndComponentId": "output_cd2dc7d2635148db94d70189fc4df8da",
+            "EndComponentGuid": "3e2d786c-70ae-47b5-b568-bececc9c41bb",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "a11e7685-3542-4ed6-9672-1de071a5870d",
+            "Name": "A",
+            "InternalComponentId": "input_fe7cba0075e3432eacbc63e7c90ab527",
+            "InternalComponentGuid": "17fe1e5a-f696-458c-be64-4c26b51b68d3",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "b33be434-1361-471d-9ce6-9a72b10e1c81",
+            "Name": "B",
+            "InternalComponentId": "input_5c27ffe315914375bac7c587e2d9fcd2",
+            "InternalComponentGuid": "0ca06abc-2d03-4b00-9d5d-a44d79dbff98",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "3fd12d11-fe13-4bee-a408-841a0e3f11e0",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_40d45ba8c07543a8a60fa790a69565d1",
+            "InternalComponentGuid": "501e94c7-fe08-4e24-ab48-a47f19cc5b8b",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "12eefce5-9ae9-4873-96d1-36d7e4ab1c32",
+            "Name": "Y",
+            "InternalComponentId": "output_cd2dc7d2635148db94d70189fc4df8da",
+            "InternalComponentGuid": "3e2d786c-70ae-47b5-b568-bececc9c41bb",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_fe7cba0075e3432eacbc63e7c90ab527",
+          "ComponentGuid": "17fe1e5a-f696-458c-be64-4c26b51b68d3",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_5c27ffe315914375bac7c587e2d9fcd2",
+          "ComponentGuid": "0ca06abc-2d03-4b00-9d5d-a44d79dbff98",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_3429a3fb84074cdbbfe9e0b3471a6b11",
+          "ComponentGuid": "1b8f9c29-8d9f-451f-afc9-a4b66ca4bc8a",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_40d45ba8c07543a8a60fa790a69565d1",
+          "ComponentGuid": "501e94c7-fe08-4e24-ab48-a47f19cc5b8b",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_09cfd967dd4e4c4f81de3f239d700b67",
+          "ComponentGuid": "d251ca5e-5db7-4e89-97df-5ec6d26a4363",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_cd2dc7d2635148db94d70189fc4df8da",
+          "ComponentGuid": "3e2d786c-70ae-47b5-b568-bececc9c41bb",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 500,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "InputSignalNames": {
+          "A": "A"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "NANDB",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the multiplexer: B-side select term, Y = NAND(B, Sel) = 1 when Sel = 0 and NOT(B) when Sel = 1, feeding Out.B. Its pins read the operand and select toggles through the signal names B and Sel at the logic layer \u2014 no waveguide needed, so Sel fans out onto NOT1.A and NANDB.A without a duplicated gate. The whole multiplexer composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here. The fan-out of A, B and Sel onto several gates happens at the logic layer (each gate input is driven by the same network bit through its persisted signal name); the canvas wires one waveguide per pin (like NAND1A/NAND1B in 'Logic Gate Half Adder').",
+        "Identifier": "group_1f69cd41bac2442e820dd8423c412b8d",
+        "IdGuid": "cfbdc31e-72ff-4ccd-a560-bbca8e885a36",
+        "ChildComponentGuids": [
+          "6730a911-f3e3-4d96-b47a-cb05c16d2970",
+          "ee33bee1-4e7d-4d99-b97d-784fab99d8e4",
+          "d2da6765-2f90-4a87-ab6d-94dc0f198bc4",
+          "6708df51-3181-48fb-acb2-09a443967e8c",
+          "c61d49a4-4c18-40c3-892e-0766fcc6abfd",
+          "af160e81-1dc0-4dff-b767-234a0c522d43"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 400,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_a3b9ead09adb4d9b9842dcbc2de0fc09",
+          "input_21f110d5ef274eb4be858e81805dcc25",
+          "combine_c8f3937377804d1ea2ef99a79820e898",
+          "phase_0db0bf4ee95f4557bee8bb1e19b37592",
+          "recombine_d6c0b06a2425442ea257690930ed15f3",
+          "output_9c39b5a6c2fc40b5a22c46eefc4c9fae"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "23e94203-0020-4b51-8505-d17c17940028",
+            "StartComponentId": "input_a3b9ead09adb4d9b9842dcbc2de0fc09",
+            "StartComponentGuid": "6730a911-f3e3-4d96-b47a-cb05c16d2970",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_c8f3937377804d1ea2ef99a79820e898",
+            "EndComponentGuid": "d2da6765-2f90-4a87-ab6d-94dc0f198bc4",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "4478cefd-363b-42d6-b239-ef2106446c2b",
+            "StartComponentId": "input_21f110d5ef274eb4be858e81805dcc25",
+            "StartComponentGuid": "ee33bee1-4e7d-4d99-b97d-784fab99d8e4",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_c8f3937377804d1ea2ef99a79820e898",
+            "EndComponentGuid": "d2da6765-2f90-4a87-ab6d-94dc0f198bc4",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "397ab433-4e67-4f9d-b6f5-892f63a1be57",
+            "StartComponentId": "combine_c8f3937377804d1ea2ef99a79820e898",
+            "StartComponentGuid": "d2da6765-2f90-4a87-ab6d-94dc0f198bc4",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_d6c0b06a2425442ea257690930ed15f3",
+            "EndComponentGuid": "c61d49a4-4c18-40c3-892e-0766fcc6abfd",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1c117fde-35a1-4df5-9d7f-ba46822e2df4",
+            "StartComponentId": "phase_0db0bf4ee95f4557bee8bb1e19b37592",
+            "StartComponentGuid": "6708df51-3181-48fb-acb2-09a443967e8c",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_d6c0b06a2425442ea257690930ed15f3",
+            "EndComponentGuid": "c61d49a4-4c18-40c3-892e-0766fcc6abfd",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "850faa11-7457-43ae-b1a9-90c3b57ec6d1",
+            "StartComponentId": "recombine_d6c0b06a2425442ea257690930ed15f3",
+            "StartComponentGuid": "c61d49a4-4c18-40c3-892e-0766fcc6abfd",
+            "StartPinName": "out1",
+            "EndComponentId": "output_9c39b5a6c2fc40b5a22c46eefc4c9fae",
+            "EndComponentGuid": "af160e81-1dc0-4dff-b767-234a0c522d43",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "11285582-2374-4ee8-837e-83dd1216d473",
+            "Name": "A",
+            "InternalComponentId": "input_a3b9ead09adb4d9b9842dcbc2de0fc09",
+            "InternalComponentGuid": "6730a911-f3e3-4d96-b47a-cb05c16d2970",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "49e6a5de-5310-489f-9e17-8e7b29a64a68",
+            "Name": "B",
+            "InternalComponentId": "input_21f110d5ef274eb4be858e81805dcc25",
+            "InternalComponentGuid": "ee33bee1-4e7d-4d99-b97d-784fab99d8e4",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "468d142d-f1dc-4601-a2ba-f41088058233",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_0db0bf4ee95f4557bee8bb1e19b37592",
+            "InternalComponentGuid": "6708df51-3181-48fb-acb2-09a443967e8c",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a2ce75e8-db08-42f1-9b23-d567559bcab9",
+            "Name": "Y",
+            "InternalComponentId": "output_9c39b5a6c2fc40b5a22c46eefc4c9fae",
+            "InternalComponentGuid": "af160e81-1dc0-4dff-b767-234a0c522d43",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_a3b9ead09adb4d9b9842dcbc2de0fc09",
+          "ComponentGuid": "6730a911-f3e3-4d96-b47a-cb05c16d2970",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_21f110d5ef274eb4be858e81805dcc25",
+          "ComponentGuid": "ee33bee1-4e7d-4d99-b97d-784fab99d8e4",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_c8f3937377804d1ea2ef99a79820e898",
+          "ComponentGuid": "d2da6765-2f90-4a87-ab6d-94dc0f198bc4",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_0db0bf4ee95f4557bee8bb1e19b37592",
+          "ComponentGuid": "6708df51-3181-48fb-acb2-09a443967e8c",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_d6c0b06a2425442ea257690930ed15f3",
+          "ComponentGuid": "c61d49a4-4c18-40c3-892e-0766fcc6abfd",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_9c39b5a6c2fc40b5a22c46eefc4c9fae",
+          "ComponentGuid": "af160e81-1dc0-4dff-b767-234a0c522d43",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 400,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "InputSignalNames": {
+          "A": "Sel",
+          "B": "B"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "Out",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the multiplexer: output OR, Y = NAND(NANDA.Y, NANDB.Y) = A when Sel = 0 and B when Sel = 1 \u2014 the multiplexer output. The whole multiplexer composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here. The fan-out of A, B and Sel onto several gates happens at the logic layer (each gate input is driven by the same network bit through its persisted signal name); the canvas wires one waveguide per pin (like NAND1A/NAND1B in 'Logic Gate Half Adder').",
+        "Identifier": "group_1545a734014d4f5284547207c3d2e473",
+        "IdGuid": "e4638ff9-6ad5-4ee2-95be-d090341637af",
+        "ChildComponentGuids": [
+          "d423f409-242a-4de3-bdd6-8e8e46186abf",
+          "28ff92e8-cd4c-4020-82c1-87992f4a9274",
+          "8b6be3ef-66f6-48dd-825a-b43afdadf85b",
+          "1c071f3b-8c54-4d74-ad7b-b19e968a47e0",
+          "cda82e3b-b7ce-4752-86f1-369193eed183",
+          "3494fbf1-b82f-44b8-a9f7-8923efd986ca"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_c59054d7d365480e8eb9c34af66f7221",
+          "input_e85f7fc1692241e99ca9745a43db269a",
+          "combine_8c548655317a408ea53a1ee461b3debb",
+          "phase_2133a8fdbe5248f89a0355c929a08e0e",
+          "recombine_2a8c58782a5b4486a8d4c897dd0efc55",
+          "output_24c75656cdde4c319ad4b4044b0e292d"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "60d269be-9802-40e3-97cd-46db271dee7e",
+            "StartComponentId": "input_c59054d7d365480e8eb9c34af66f7221",
+            "StartComponentGuid": "d423f409-242a-4de3-bdd6-8e8e46186abf",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_8c548655317a408ea53a1ee461b3debb",
+            "EndComponentGuid": "8b6be3ef-66f6-48dd-825a-b43afdadf85b",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "77221a19-3e7f-4bac-87cb-955e865d9b2e",
+            "StartComponentId": "input_e85f7fc1692241e99ca9745a43db269a",
+            "StartComponentGuid": "28ff92e8-cd4c-4020-82c1-87992f4a9274",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_8c548655317a408ea53a1ee461b3debb",
+            "EndComponentGuid": "8b6be3ef-66f6-48dd-825a-b43afdadf85b",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6a8e684c-f5d0-41bb-a06a-d158dc384d61",
+            "StartComponentId": "combine_8c548655317a408ea53a1ee461b3debb",
+            "StartComponentGuid": "8b6be3ef-66f6-48dd-825a-b43afdadf85b",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_2a8c58782a5b4486a8d4c897dd0efc55",
+            "EndComponentGuid": "cda82e3b-b7ce-4752-86f1-369193eed183",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "0ca5e6ff-30d1-4c2a-9183-3b10e622f5dc",
+            "StartComponentId": "phase_2133a8fdbe5248f89a0355c929a08e0e",
+            "StartComponentGuid": "1c071f3b-8c54-4d74-ad7b-b19e968a47e0",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_2a8c58782a5b4486a8d4c897dd0efc55",
+            "EndComponentGuid": "cda82e3b-b7ce-4752-86f1-369193eed183",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f302baa3-86ed-487a-afc4-7b05a56f44d3",
+            "StartComponentId": "recombine_2a8c58782a5b4486a8d4c897dd0efc55",
+            "StartComponentGuid": "cda82e3b-b7ce-4752-86f1-369193eed183",
+            "StartPinName": "out1",
+            "EndComponentId": "output_24c75656cdde4c319ad4b4044b0e292d",
+            "EndComponentGuid": "3494fbf1-b82f-44b8-a9f7-8923efd986ca",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "6d3995dc-feda-4dbd-b880-7ad84b25a9fa",
+            "Name": "A",
+            "InternalComponentId": "input_c59054d7d365480e8eb9c34af66f7221",
+            "InternalComponentGuid": "d423f409-242a-4de3-bdd6-8e8e46186abf",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "40e349f1-91ec-4647-9d73-dd458fdaa643",
+            "Name": "B",
+            "InternalComponentId": "input_e85f7fc1692241e99ca9745a43db269a",
+            "InternalComponentGuid": "28ff92e8-cd4c-4020-82c1-87992f4a9274",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "25410a1f-43a6-4c14-b057-778ac58dde47",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_2133a8fdbe5248f89a0355c929a08e0e",
+            "InternalComponentGuid": "1c071f3b-8c54-4d74-ad7b-b19e968a47e0",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "73fb6a8e-6ea5-4127-8a5f-8de150d5c7b9",
+            "Name": "Y",
+            "InternalComponentId": "output_24c75656cdde4c319ad4b4044b0e292d",
+            "InternalComponentGuid": "3494fbf1-b82f-44b8-a9f7-8923efd986ca",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_c59054d7d365480e8eb9c34af66f7221",
+          "ComponentGuid": "d423f409-242a-4de3-bdd6-8e8e46186abf",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_e85f7fc1692241e99ca9745a43db269a",
+          "ComponentGuid": "28ff92e8-cd4c-4020-82c1-87992f4a9274",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_8c548655317a408ea53a1ee461b3debb",
+          "ComponentGuid": "8b6be3ef-66f6-48dd-825a-b43afdadf85b",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_2133a8fdbe5248f89a0355c929a08e0e",
+          "ComponentGuid": "1c071f3b-8c54-4d74-ad7b-b19e968a47e0",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_2a8c58782a5b4486a8d4c897dd0efc55",
+          "ComponentGuid": "cda82e3b-b7ce-4752-86f1-369193eed183",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_24c75656cdde4c319ad4b4044b0e292d",
+          "ComponentGuid": "3494fbf1-b82f-44b8-a9f7-8923efd986ca",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 900,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125
+      }
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-19",
+      "Modified": "2026-08-19T08:40:00.0000000Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}


### PR DESCRIPTION
## What & why

Ships `examples/Logic Gate MUX.lun` (issue #1059): a 2-to-1 multiplexer composed from the existing NOT/NAND gate groups, the same way the shipped half/full adder examples were built — the second datapath stone toward the tiny 4-bit ISA (rung 5), giving students the next NAND-game rung and rung 5 its steering element.

- Four top-level gate instances (three read as NAND at threshold 0.125, one as NOT at 0.375), each with its persisted `TruthTablePinAssignment`, wired to the textbook composition `Out = NAND(NAND(A, NOT(Sel)), NAND(B, Sel))`.
- Persisted signal names (#1025) on the operand pins merge the five unconnected operand pins into exactly **3 toggles: A, B, Sel** — Sel's fan-out onto NOT1.A and NANDB.A happens at the logic layer, so unlike the adders no gate needs duplication. The output gate is named **Out** (tap `Out.Y`).
- Same conventions as the adder examples: bias pins, thresholds, routed wires, per-gate education descriptions.

## How tested

New pinned integration tests, mirroring `LogicGateFullAdderExampleTests` / `LogicEventTimelineFullAdderTests`:

- `UnitTests/Integration/LogicGateMuxExampleTests.cs` — loads through the real load path, asserts exactly 3 toggles (A, B, Sel) + output `Out.Y`, truth table over **all 8 input combinations** equals the MUX function (Sel=0 ⇒ Out=A, Sel=1 ⇒ Out=B), intermediate taps stay readable, save → load round trip re-assembles the identical network with roles and signal names intact.
- `UnitTests/Integration/LogicEventTimelineMuxTests.cs` — toggling Sel produces a non-empty, time-ordered event list consistent with the evaluated after-state; identical assignment yields an empty timeline.
- `ExampleDesignFilesTests` still passes — the new example loads exactly what it declares.

Local suite: 6103 passed, 0 failed (`dotnet test UnitTests/UnitTests.csproj --filter "Category!=Slow"`, 15 skipped).

## Manual verification after vacation

Optional smoke check in the UI (headless verification already covers load + logic):

1. Start the app, open `examples/Logic Gate MUX.lun` from the Examples section.
2. Open the Logic panel: exactly three toggles **A**, **B**, **Sel** appear.
3. Toggle A and B with Sel off → `Out` follows A; flip Sel on → `Out` follows B.