### PR TITLE
Agent: Load path — nested groups sharing an identifier bind their actual child (#1060)

### DIFF
--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -1578,10 +1578,26 @@ public partial class FileOperationsViewModel : ObservableObject
                 inDegree[groupData] = 0;
 
             // Count how many child groups this group has (determines loading order)
-            foreach (var childId in groupData.GroupDto.ChildComponentIds)
+            var childIds = groupData.GroupDto.ChildComponentIds;
+            var childGuids = groupData.GroupDto.ChildComponentGuids;
+            for (var i = 0; i < childIds.Count; i++)
             {
-                // Check if this child is a group (appears as a group in the list)
-                var childGroup = groupDataList.FirstOrDefault(g => g.GroupDto.Identifier == childId);
+                // Check if this child is a group (appears as a group in the list).
+                // Match by saved Guid: identifiers are not unique, so a string match
+                // can pick a same-named group that merely appears earlier in the file
+                // and misorder the reconstruction (the parent then binds the wrong
+                // child through the name fallback). The identifier match remains as
+                // the fallback for files that predate the Guid fields.
+                DesignGroupData? childGroup = null;
+                if (i < childGuids.Count && Guid.TryParse(childGuids[i], out var childGuid))
+                {
+                    childGroup = groupDataList.FirstOrDefault(g =>
+                        g.GroupDto.IdGuid != null
+                        && Guid.TryParse(g.GroupDto.IdGuid, out var groupGuid)
+                        && groupGuid == childGuid);
+                }
+
+                childGroup ??= groupDataList.FirstOrDefault(g => g.GroupDto.Identifier == childIds[i]);
                 if (childGroup != null && childGroup != groupData)
                 {
                     // This group depends on its child group being loaded first

--- a/UnitTests/Integration/DuplicateIdentifierGroupLoadTests.cs
+++ b/UnitTests/Integration/DuplicateIdentifierGroupLoadTests.cs
@@ -46,6 +46,39 @@ public class DuplicateIdentifierGroupLoadTests : IDisposable
                 "duplicate identifiers must not merge two groups into copies of the first on load");
     }
 
+    [Fact]
+    public async Task SaveLoadReload_NestedGroupSharingIdentifierWithEarlierTopLevelGroup_BindsItsActualChild()
+    {
+        var decoy = SingleGroup(await LogicGateHalfAdderExampleTests.LoadCanvas(NotNandPath()));
+        decoy.GroupName = "DECOY";
+        var parent = SingleGroup(await LogicGateHalfAdderExampleTests.LoadCanvas(NotNandPath()));
+        parent.GroupName = "PARENT";
+        parent.Identifier = "PARENT-ID";
+        var inner = SingleGroup(await LogicGateHalfAdderExampleTests.LoadCanvas(NotNandPath()));
+        inner.GroupName = "INNER";
+        var leaf = SingleGroup(await LogicGateHalfAdderExampleTests.LoadCanvas(NotNandPath()));
+        leaf.GroupName = "LEAF";
+        leaf.Identifier = "LEAF-ID";
+
+        inner.Identifier.ShouldBe(decoy.Identifier,
+            "this fixture needs the nested group and the top-level decoy to share one identifier");
+
+        inner.AddChild(leaf);
+        parent.AddChild(inner);
+
+        // Decoy first so it precedes the nested child in the file's group list.
+        var canvas = new DesignCanvasViewModel();
+        canvas.AddComponent(decoy);
+        canvas.AddComponent(parent);
+        var savedPath = await Save(canvas);
+        var reloaded = await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath);
+
+        var reloadedParent = LogicGateHalfAdderExampleTests.GroupsOf(reloaded)
+            .Single(g => g.GroupName == "PARENT");
+        reloadedParent.ChildComponents.OfType<ComponentGroup>().Single().GroupName.ShouldBe("INNER",
+            "the parent must bind its actual nested child, not the earlier top-level group sharing its identifier");
+    }
+
     private static string NotNandPath() =>
         Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), "Logic Gate NOT-NAND.lun");
 


### PR DESCRIPTION
## What & why

PR #1055 fixed the flat case of duplicate group identifiers (topological sort keys objects, not identifier strings), but the loader's **child-group lookup was still by identifier string**: `FileOperationsViewModel.TopologicalSortGroups` matched `groupDataList.FirstOrDefault(g => g.GroupDto.Identifier == childId)`.

With nested groups this misattributes the dependency edge: for parent P → child C1 → leaf G plus an independent top-level decoy C2 where `C2.Identifier == C1.Identifier` and C2 precedes C1 in the file, P's edge landed on C2 instead of C1. Kahn's algorithm then reconstructs P **before** C1, the Guid lookup in `ComponentGroupSerializer.FromDto` misses (C1 not yet reconstructed), and the name fallback silently binds C2's content into P — wrong content loaded, no error.

Group identifiers are legitimately non-unique (library instances keep them; the adder workflow duplicates gates), so this is reachable by normal educational use (rung 3, hierarchy).

## Fix

Minimal and local, same object-identity philosophy as #1055: `TopologicalSortGroups` now resolves the child group by the saved Guid pair (`ChildComponentGuids[i]` ↔ the group's `IdGuid`) and only falls back to the identifier-string match for files that predate the Guid fields. With correct edge attribution the reconstruction order puts C1 before P, and the existing Guid-based binding in `FromDto` resolves the actual child. No loader refactoring beyond that.

Alternative considered: regenerating colliding identifiers on load before reconstruction — rejected as larger and riskier (identifiers are referenced from connections, frozen paths, pin roles).

## How it was tested

- Repro first: new integration test `SaveLoadReload_NestedGroupSharingIdentifierWithEarlierTopLevelGroup_BindsItsActualChild` in `UnitTests/Integration/DuplicateIdentifierGroupLoadTests.cs` builds P → C1 → G plus decoy C2 (shared identifier, earlier in the file) through the **real save/load path** (`SaveDesignAsCommand` → `LoadDesignFromPathAsync`). It failed before the fix (parent bound "DECOY" instead of "INNER") and passes after.
- Full non-Slow suite run locally: `dotnet test UnitTests/UnitTests.csproj --filter "Category!=Slow"`.

Local suite: 6090 passed, 0 failed (15 skipped)

No UI changes — no manual verification needed after vacation.