### PR TITLE
Agent: Reject cross-role signal-name collisions in LogicNetworkBuilder (#1061)

### DIFF
--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.Validation.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.Validation.cs
@@ -31,6 +31,25 @@ public sealed partial class LogicNetworkBuilder
                 nameof(contexts));
     }
 
+    /// <summary>
+    /// Rejects a network input name that equals an output tap name: input names merge
+    /// pins, output names rename taps, and a name shared across the two roles reads as
+    /// the same wire in the Logic panel. Checking against every tap name (not only
+    /// signal-named ones) also catches an input signal named like a raw
+    /// <c>&lt;gate&gt;.&lt;pin&gt;</c> tap.
+    /// </summary>
+    private static void ThrowOnInputOutputNameCollision(
+        IReadOnlyDictionary<string, List<string>> inputMembers,
+        IReadOnlyDictionary<string, LogicPinRef> outputTaps)
+    {
+        var collision = inputMembers.Keys.FirstOrDefault(outputTaps.ContainsKey);
+        if (collision == null)
+            return;
+        throw new ArgumentException(
+            $"Signal name '{collision}' is used by input pins ({string.Join(", ", inputMembers[collision])}) " +
+            $"and by output pin {collision} — rename one of them.");
+    }
+
     /// <summary>One gate group with its prevalidated logic interface.</summary>
     private sealed class GateContext
     {

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
@@ -18,7 +18,8 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 /// Bias pins take no part in wiring (they are constantly on — the extraction
 /// contract); a connection into a bias pin, a connection between two input pins,
 /// and a gate input driven by two different outputs are rejected with messages
-/// naming the pins.
+/// naming the pins. A network input name shared with an output tap name is likewise
+/// rejected — a name spanning both roles reads as the same wire in the Logic panel.
 /// </summary>
 public sealed partial class LogicNetworkBuilder
 {
@@ -162,6 +163,7 @@ public sealed partial class LogicNetworkBuilder
         double wavelengthNm)
     {
         var networkInputs = new List<string>();
+        var inputMembers = new Dictionary<string, List<string>>();
         var wiring = new Dictionary<LogicPinRef, LogicNetDriver>();
         var outputTaps = new Dictionary<string, LogicPinRef>();
         var models = new Dictionary<string, LogicGateModel>();
@@ -183,13 +185,15 @@ public sealed partial class LogicNetworkBuilder
                 var load = new LogicPinRef(context.GateId, pinName);
                 wiring[load] = drivers.TryGetValue(load, out var source)
                     ? new LogicNetDriver.GateOutput(source)
-                    : new LogicNetDriver.NetworkInput(NetworkInputName(networkInputs, context, load));
+                    : new LogicNetDriver.NetworkInput(NetworkInputName(networkInputs, inputMembers, context, load));
             }
             foreach (var pinName in context.Model.OutputPinNames)
             {
                 outputTaps[$"{context.GateId}.{pinName}"] = new LogicPinRef(context.GateId, pinName);
             }
         }
+
+        ThrowOnInputOutputNameCollision(inputMembers, outputTaps);
 
         return new LogicNetworkEvaluator(networkInputs, models, wiring, outputTaps, delays, wireDelays);
     }
@@ -199,13 +203,21 @@ public sealed partial class LogicNetworkBuilder
     /// input: the pin's persisted signal name when it carries one — every member pin
     /// of the signal maps to the same network input, registered once — else the
     /// pin's own <c>&lt;group&gt;.&lt;pin&gt;</c> name (no merging by bare pin name).
+    /// The pin is recorded as a member of its network input so a later name
+    /// collision can name the pins behind the colliding name.
     /// </summary>
     private static string NetworkInputName(
-        ICollection<string> networkInputs, GateContext context, LogicPinRef load)
+        ICollection<string> networkInputs,
+        IDictionary<string, List<string>> inputMembers,
+        GateContext context,
+        LogicPinRef load)
     {
         var name = context.SignalNameOf(load.PinName) ?? Format(load);
         if (!networkInputs.Contains(name))
             networkInputs.Add(name);
+        if (!inputMembers.TryGetValue(name, out var members))
+            inputMembers[name] = members = new List<string>();
+        members.Add(Format(load));
         return name;
     }
 }

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkBuilderSignalNameTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkBuilderSignalNameTests.cs
@@ -14,7 +14,8 @@ namespace UnitTests.Analysis.LogicAnalysis;
 /// without a signal name keeps its own <c>&lt;gate&gt;.&lt;pin&gt;</c> name and
 /// never merges by bare pin name, so two unrelated inputs that happen to share a
 /// pin name stay two inputs. Signal names on non-input pins and empty names are
-/// rejected at build time.
+/// rejected at build time — and so is a network input name that collides with an
+/// output tap name, because a name spanning both roles reads as the same wire.
 /// </summary>
 public class LogicNetworkBuilderSignalNameTests
 {
@@ -143,6 +144,34 @@ public class LogicNetworkBuilderSignalNameTests
 
         error.Message.ShouldContain("'A'");
         error.Message.ShouldContain("empty signal name");
+    }
+
+    [Fact]
+    public void Build_InputSignalNamedLikeAnOutputTap_ThrowsNamingBothSides()
+    {
+        var first = NotInstance("G1", signalOfA: "G3.Y");
+        var second = NotInstance("G2", signalOfA: "G3.Y");
+        var tap = NotInstance("G3");
+
+        var error = Should.Throw<ArgumentException>(
+            () => new LogicNetworkBuilder().Build(new[] { first, second, tap }, Array.Empty<WaveguideConnection>()));
+
+        error.Message.ShouldContain("'G3.Y'");
+        error.Message.ShouldContain("G1.A");
+        error.Message.ShouldContain("G2.A");
+        error.Message.ShouldContain("output pin G3.Y");
+    }
+
+    [Fact]
+    public void Build_SignalNameSharingOnlyAPrefixWithATap_Builds()
+    {
+        var named = NotInstance("G1", signalOfA: "G3");
+        var tap = NotInstance("G3");
+
+        var network = new LogicNetworkBuilder().Build(new[] { named, tap }, Array.Empty<WaveguideConnection>());
+
+        network.InputPinNames.ShouldBe(new[] { "G3", "G3.A" }, ignoreOrder: true);
+        network.OutputPinNames.ShouldBe(new[] { "G1.Y", "G3.Y" }, ignoreOrder: true);
     }
 
     /// <summary>A NAND gate instance on a synthetic group exposing the example's pin interface.</summary>


### PR DESCRIPTION
## What & why

Rung-4 polish (issue #1061, follow-up to #1046/PR #1052 review): input signal names and output tap names lived in separate namespaces, so a design could name an input signal `S` and an output tap `S` — the Logic panel would show a toggle "S" and an output "S" side by side, reading like the same wire. Input names merge pins; output names rename taps; a shared name across the two roles is never intentional, so the builder now rejects it.

- `LogicNetworkBuilder` (validation partial): after collecting network inputs and output taps, `ThrowOnInputOutputNameCollision` rejects a build where a network input name equals an output tap name, in the same `ArgumentException` style as the existing rejections. The message names both sides, e.g. `Signal name 'G3.Y' is used by input pins (G1.A, G2.A) and by output pin G3.Y — rename one of them.`
- The check runs against **all** tap names, not just signal-named ones, so the raw-tap collision (an input signal literally named `G3.Y`) is covered for free.
- To word the message, assembly now records the member pins behind each network input name (one small dictionary alongside `networkInputs`).
- The error is thrown from Core; the Logic panel already surfaces builder errors via its status text — no UI change, no new i18n keys.

### Note on PR #1052 (still open)

This branch is based on `origin/dev-ki`, which does not yet contain #1052's output signal names (taps are still raw `<gate>.<pin>` here), so the input-`S`-vs-output-`S` case cannot be exercised on this base. The check compares against the **final** tap-name keys after tap collection, so once #1052 merges and named outputs rename their taps, the same check rejects an input signal `S` colliding with an output named `S` with no further change. The raw-tap case is tested here directly.

## How it was tested (headless)

- New tests in `LogicNetworkBuilderSignalNameTests`:
  - `Build_InputSignalNamedLikeAnOutputTap_ThrowsNamingBothSides` — input signal `G3.Y` on `G1.A`/`G2.A` vs raw output tap `G3.Y` throws, naming the signal, both member pins, and the output pin.
  - `Build_SignalNameSharingOnlyAPrefixWithATap_Builds` — disjoint names (signal `G3` vs tap `G3.Y`) still build; no prefix false-positives.
- Existing coverage keeps proving disjoint names build (signal merging, full-adder-shaped signals) and the shipped examples assemble (`LogicNetworkBuilderExampleTests`, full-adder/4-bit-adder integration tests) — all green.
- Full non-Slow suite run locally before opening this PR.

Local suite: 6091 passed, 0 failed