### PR TITLE
Agent: named output chips on canvas gate badges (#1067)

### DIFF
--- a/CAP.Avalonia/Controls/Rendering/LogicGateStateBadgeRenderer.cs
+++ b/CAP.Avalonia/Controls/Rendering/LogicGateStateBadgeRenderer.cs
@@ -11,9 +11,11 @@ namespace CAP.Avalonia.Controls.Rendering;
 /// panel's network is built: a small dark chip at the group's top-right corner carrying
 /// the evaluated bit of one gate output pin — LightGreen for 1, gray for 0, the same
 /// colors the Logic panel's output list uses. A multi-output gate gets one chip per
-/// output pin, stacked downward. Gate input pins carrying a persisted signal name get
-/// an additional wider chip below, showing the signal name next to its live bit
-/// (<c>A0 = 1</c>, issue #1051); unnamed pins keep the plain square 0/1 chip exactly.
+/// output pin, stacked downward. Pins carrying a persisted signal name get a wider
+/// chip instead of the square one, showing the signal name next to its live bit —
+/// the gate input chips (<c>A0 = 1</c>, issue #1051) and, symmetric to them, the
+/// named output taps (<c>S0 = 1</c>, issue #1067); unnamed pins keep the plain
+/// square 0/1 chip exactly.
 /// The chips only ever sit on top of the group — the
 /// group itself is never repainted — and they vanish with the network (rebuild, cancel,
 /// design edit, load), driven entirely by <see cref="LogicGateStateOverlay"/>.

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.Replay.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.Replay.cs
@@ -137,9 +137,12 @@ public partial class LogicPanelViewModel
     }
 
     /// <summary>
-    /// The badge states of one evaluation result: the anonymous chip per gate output
-    /// pin (walked through the tap names the result keys by) plus the named input
-    /// chips of the given input assignment (issue #1051).
+    /// The badge states of one evaluation result: one chip per gate output pin (walked
+    /// through the tap names the result keys by), each named when its output tap carries
+    /// a persisted signal name — the tap key then differs from the raw
+    /// <c>&lt;gate&gt;.&lt;pin&gt;</c> id, so the chip reads <c>S0 = 1</c> (issue #1067),
+    /// symmetric to the named input chips of the given input assignment (issue #1051).
+    /// Unnamed outputs keep their exact anonymous chip.
     /// </summary>
     private IEnumerable<LogicGateBadgeState> BadgeStatesOf(
         IReadOnlyDictionary<string, bool> result, IReadOnlyDictionary<string, bool> inputBits)
@@ -147,7 +150,12 @@ public partial class LogicPanelViewModel
         if (_network == null)
             yield break;
         foreach (var tap in _network.OutputTaps)
-            yield return new LogicGateBadgeState(tap.Value.GateId, tap.Value.PinName, result[tap.Key]);
+        {
+            var rawTapName = $"{tap.Value.GateId}.{tap.Value.PinName}";
+            var outputSignalName = tap.Key == rawTapName ? null : tap.Key;
+            yield return new LogicGateBadgeState(
+                tap.Value.GateId, tap.Value.PinName, result[tap.Key], outputSignalName);
+        }
         var signalNamesByGate = PersistedInputSignalNamesByGate();
         foreach (var gateId in _network.Gates.Keys)
         {

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.cs
@@ -171,9 +171,10 @@ public partial class LogicPanelViewModel : ObservableObject
     /// Pushes the freshly evaluated bit of every gate output pin onto the canvas overlay,
     /// so each gate group carries its live 0/1 badge (issue #994) — the same table-lookup
     /// data the panel's output list shows, no new simulation. Result bits are keyed by
-    /// tap name, so the walk goes through the taps: a signal-named output reads under
-    /// its signal name, not its raw <c>&lt;gate&gt;.&lt;pin&gt;</c> id. Gate input pins
-    /// carrying a persisted signal name additionally get a named badge (<c>A0 = 1</c>,
+    /// tap name, so the walk goes through the taps: a signal-named output additionally
+    /// shows its signal name in the badge (<c>S0 = 1</c>, issue #1067), reading under
+    /// that name instead of the raw <c>&lt;gate&gt;.&lt;pin&gt;</c> id. Gate input pins
+    /// carrying a persisted signal name get a named badge too (<c>A0 = 1</c>,
     /// issue #1051): an unconnected named pin merged into the network input of its
     /// signal's name, so its live bit is the toggle bit itself — display only, nothing
     /// re-evaluated.

--- a/CAP.Avalonia/ViewModels/Canvas/LogicGateStateOverlay.cs
+++ b/CAP.Avalonia/ViewModels/Canvas/LogicGateStateOverlay.cs
@@ -9,9 +9,11 @@ namespace CAP.Avalonia.ViewModels.Canvas;
 /// owns the single instance as the canvas-side source of truth; the Logic panel writes
 /// the freshly evaluated gate output bits into it after every evaluation and clears it
 /// when the network is discarded (rebuild, cancel, failure, design edit, load), so the
-/// badges always mirror exactly the data the panel's output list shows. Gate input pins
-/// carrying a persisted signal name additionally get a named badge
-/// (<c>A0 = 1</c>, issue #1051), so a student can tell which badge reads which signal.
+/// badges always mirror exactly the data the panel's output list shows. Pins carrying a
+/// persisted signal name get a named badge instead of the anonymous one — the gate
+/// input chips (<c>A0 = 1</c>, issue #1051) and, symmetric to them, the named output
+/// taps (<c>S0 = 1</c>, issue #1067) — so a student can tell which badge reads which
+/// signal.
 /// </summary>
 public sealed class LogicGateStateOverlay
 {
@@ -21,8 +23,8 @@ public sealed class LogicGateStateOverlay
     /// <summary>Raised after every badge mutation (rebuild or clear) so the canvas repaints.</summary>
     public event EventHandler? StatesChanged;
 
-    /// <summary>Replaces all badges with one freshly evaluated state per gate output pin.</summary>
-    /// <param name="states">One entry per gate output pin of the evaluated network.</param>
+    /// <summary>Replaces all badges with one freshly evaluated state per chip.</summary>
+    /// <param name="states">One entry per gate output pin, plus one per named input pin of the evaluated network.</param>
     public void ShowStates(IEnumerable<LogicGateBadgeState> states)
     {
         Badges.Clear();
@@ -43,23 +45,24 @@ public sealed class LogicGateStateOverlay
     }
 }
 
-/// <summary>One evaluated gate output bit destined for a canvas badge.</summary>
+/// <summary>One evaluated gate pin bit destined for a canvas badge.</summary>
 /// <param name="GroupName">Name of the gate group on the canvas.</param>
 /// <param name="PinName">The gate pin the bit belongs to.</param>
 /// <param name="IsOne">The evaluated bit.</param>
 /// <param name="SignalName">
-/// The persisted signal name of a gate input pin (issue #1051), or null for the
-/// anonymous per-output-pin badges.
+/// The pin's persisted signal name — a gate input pin's network signal (issue #1051)
+/// or a gate output tap's signal name (issue #1067) — or null for anonymous badges.
 /// </param>
 public readonly record struct LogicGateBadgeState(string GroupName, string PinName, bool IsOne, string? SignalName = null);
 
 /// <summary>
-/// One logic-state badge on a gate group: the evaluated bit of one of the gate's output
+/// One logic-state badge on a gate group: the evaluated bit of one of the gate's
 /// pins. Single-output gates — every gate of the shipped logic examples — get exactly one
-/// badge; a multi-output gate gets one badge per output pin, stacked on the group.
-/// Gate input pins carrying a persisted signal name get an additional named badge
-/// showing the signal's live bit (<c>A0 = 1</c>, issue #1051); unnamed pins keep the
-/// plain 0/1 chip exactly.
+/// badge per output pin; a multi-output gate gets one per output pin, stacked on the
+/// group. Gate input pins carrying a persisted signal name get an additional named badge
+/// showing the signal's live bit (<c>A0 = 1</c>, issue #1051), and a gate output tap
+/// carrying a persisted signal name shows its name the same way (<c>S0 = 1</c>,
+/// issue #1067); unnamed pins keep the plain 0/1 chip exactly.
 /// </summary>
 public sealed class LogicGateBadgeViewModel
 {
@@ -81,7 +84,7 @@ public sealed class LogicGateBadgeViewModel
     /// <summary>The currently evaluated bit at this pin.</summary>
     public bool IsOne { get; }
 
-    /// <summary>The persisted signal name of a named input pin, or null for anonymous badges.</summary>
+    /// <summary>The persisted signal name of a named pin, or null for anonymous badges.</summary>
     public string? SignalName { get; }
 
     /// <summary>True when the badge carries a persisted signal name.</summary>
@@ -91,8 +94,8 @@ public sealed class LogicGateBadgeViewModel
     public string BitText => IsOne ? "1" : "0";
 
     /// <summary>
-    /// The badge's full display text: <c>A0 = 1</c> for a named signal, the plain
-    /// bit ("1" or "0") for an anonymous badge.
+    /// The badge's full display text: <c>A0 = 1</c> or <c>S0 = 1</c> for a named
+    /// signal, the plain bit ("1" or "0") for an anonymous badge.
     /// </summary>
     public string LabelText => HasSignalName ? $"{SignalName} = {BitText}" : BitText;
 }

--- a/UnitTests/Canvas/LogicGateStateOverlayTests.cs
+++ b/UnitTests/Canvas/LogicGateStateOverlayTests.cs
@@ -5,12 +5,14 @@ using Xunit;
 namespace UnitTests.Canvas;
 
 /// <summary>
-/// View-model tests for the canvas logic-state overlay's named badges (issue #1051,
-/// rung 4→5 of the NAND game): a gate input pin carrying a persisted signal name gets a
-/// badge that shows the name next to the live bit (<c>A0 = 1</c>), so a student watching
-/// the adder compute can tell which badge is which signal. Unnamed pins keep the plain
-/// 0/1 chip exactly, and a name that disappears from the design disappears from the
-/// badge on the next rebuild — the overlay mirrors exactly the states it is handed.
+/// View-model tests for the canvas logic-state overlay's named badges (issues
+/// #1051/#1067, rung 4→5 of the NAND game): a pin carrying a persisted signal name
+/// gets a badge that shows the name next to the live bit — the input chip
+/// (<c>A0 = 1</c>) and, symmetric to it, the named output tap (<c>S0 = 1</c>) — so a
+/// student watching the adder compute can tell which badge is which signal. Unnamed
+/// pins keep the plain 0/1 chip exactly, and a name that disappears from the design
+/// disappears from the badge on the next rebuild — the overlay mirrors exactly the
+/// states it is handed.
 /// </summary>
 public class LogicGateStateOverlayTests
 {
@@ -29,6 +31,21 @@ public class LogicGateStateOverlayTests
         named.HasSignalName.ShouldBeTrue();
         named.SignalName.ShouldBe("A0");
         named.LabelText.ShouldBe("A0 = 1");
+    }
+
+    [Fact]
+    public void ShowStates_NamedOutputTap_BadgeShowsSignalNameAndBit()
+    {
+        // Issue #1067: the named output chip is the input chip's symmetric sibling —
+        // the state hands the output tap's signal name through to the badge label.
+        var overlay = new LogicGateStateOverlay();
+
+        overlay.ShowStates(new[] { new LogicGateBadgeState("T0H2SUM", "Y", true, "S0") });
+
+        var named = overlay.Badges.Single();
+        named.HasSignalName.ShouldBeTrue();
+        named.SignalName.ShouldBe("S0");
+        named.LabelText.ShouldBe("S0 = 1");
     }
 
     [Fact]

--- a/UnitTests/Integration/FourBitAdderStudentJourneyTests.cs
+++ b/UnitTests/Integration/FourBitAdderStudentJourneyTests.cs
@@ -14,11 +14,12 @@ namespace UnitTests.Integration;
 /// (#1046), event timeline (#1045) and named canvas badges (#1051). The journey loads
 /// the example through the real load path, builds the logic network with the real
 /// <see cref="LogicNetworkAssembler"/>, and pins what the student sees: nine named input
-/// toggles, output taps reading S0–S3/Cout, an anonymous output badge per gate plus a
-/// named chip per operand pin, and — the new cross-feature assertion — a toggle whose
-/// timeline event set matches exactly the anonymous badges whose bit flipped, with the
-/// last event no later than the critical path. Toggling back to zero shows the falling
-/// events. Fixture-per-test isolation keeps each step deterministic.
+/// toggles, output taps reading S0–S3/Cout, an output badge per gate — named for the
+/// five pinned sum/carry taps (issue #1067), anonymous elsewhere — plus a named chip
+/// per operand pin, and — the new cross-feature assertion — a toggle whose timeline
+/// event set matches exactly the output badges whose bit flipped, with the last event
+/// no later than the critical path. Toggling back to zero shows the falling events.
+/// Fixture-per-test isolation keeps each step deterministic.
 /// </summary>
 public class FourBitAdderStudentJourneyTests
     : IClassFixture<LogicGateFourBitAdderExampleTests.FourBitAdderFixture>
@@ -60,7 +61,7 @@ public class FourBitAdderStudentJourneyTests
     }
 
     [Fact]
-    public async Task Step2_CanvasBadges_AnonymousOutputChipPerGate_PlusNamedOperandChips()
+    public async Task Step2_CanvasBadges_OneOutputChipPerGate_PlusNamedOperandChips()
     {
         var vm = await BuildPanel();
 
@@ -72,19 +73,21 @@ public class FourBitAdderStudentJourneyTests
             var expectedNamed = group.TruthTablePinAssignment?.InputSignalNames;
             var expectedCount = 1 + (expectedNamed?.Count ?? 0);
             owner.Count.ShouldBe(expectedCount,
-                $"gate '{group.GroupName}': one anonymous output chip plus a named chip per named pin");
-            owner.Where(b => !b.HasSignalName).Single().PinName.ShouldBe("Y",
-                $"the anonymous chip of '{group.GroupName}' reads its output pin");
+                $"gate '{group.GroupName}': one output chip plus a named chip per named pin");
+            var outputChip = owner.Single(b => b.PinName == "Y");
+            var expectedOutputName = group.TruthTablePinAssignment?.OutputSignalNames?.GetValueOrDefault("Y");
+            outputChip.SignalName.ShouldBe(expectedOutputName,
+                $"the output chip of '{group.GroupName}' names its pinned tap (#1067) or stays anonymous");
             if (expectedNamed != null)
             {
-                owner.Where(b => b.HasSignalName).Select(b => b.SignalName)
+                owner.Where(b => b.PinName != "Y").Select(b => b.SignalName)
                     .ShouldBe(expectedNamed.Values, ignoreOrder: true,
-                        customMessage: $"the named chips of '{group.GroupName}' mirror the persisted roles");
+                        customMessage: $"the named operand chips of '{group.GroupName}' mirror the persisted roles");
             }
         }
         badges.Where(b => b.HasSignalName).ShouldAllBe(b =>
             !b.IsOne && b.LabelText == $"{b.SignalName} = 0",
-                "with all inputs off every named chip reads its zero");
+                "with all inputs off every named chip — operand or named output — reads its zero");
         AssertBadgesMirrorPanelOutputs(vm);
     }
 
@@ -127,17 +130,18 @@ public class FourBitAdderStudentJourneyTests
         try
         {
             vm.Inputs.Single(i => i.PinName == "A0").IsOn = true;
-            var before = AnonymousBadges().ToDictionary(b => (b.GroupName, b.PinName), b => b.IsOne);
+            var before = OutputBadges().ToDictionary(b => (b.GroupName, b.PinName), b => b.IsOne);
             vm.Inputs.Single(i => i.PinName == "B0").IsOn = true;
 
+            // The S0/S1 chips carry signal names since #1067; the timeline still matches
+            // the flipped output chips — named or anonymous — exactly.
             var changed = _fixture.Canvas.LogicGateStates.Badges
-                .Where(b => !b.HasSignalName)
                 .Where(b => before.TryGetValue((b.GroupName, b.PinName), out var was) && was != b.IsOne)
                 .Select(b => (b.GroupName, b.PinName))
                 .ToHashSet();
             var timelinePairs = vm.TimelineEvents.Select(e => (e.Event.GateId, e.Event.OutputPin));
             changed.ShouldBe(timelinePairs.ToHashSet(), ignoreOrder: true,
-                "the timeline's switched gates match exactly the anonymous badges whose bit flipped — " +
+                "the timeline's switched gates match exactly the output badges whose bit flipped — " +
                 "badge chips and event rows must never contradict each other on screen");
 
             var times = vm.TimelineEvents.Select(e => e.Event.TimePicoseconds).ToList();
@@ -181,18 +185,27 @@ public class FourBitAdderStudentJourneyTests
             "the last toggle leaves its 1→0 events on the timeline");
     }
 
-    /// <summary>The anonymous (output-pin) badges currently on the canvas, materialized.</summary>
-    private List<LogicGateBadgeViewModel> AnonymousBadges() =>
-        _fixture.Canvas.LogicGateStates.Badges.Where(b => !b.HasSignalName).ToList();
+    /// <summary>
+    /// The output-pin badges currently on the canvas, materialized: every chip sitting
+    /// on a gate's output tap — anonymous or named (the S0–S3/Cout chips of #1067).
+    /// Named input chips (issue #1051) carry their signal's live bit, not a gate
+    /// output bit, so tap mirroring steps around them.
+    /// </summary>
+    private List<LogicGateBadgeViewModel> OutputBadges() =>
+        _fixture.Canvas.LogicGateStates.Badges
+            .Where(b => _fixture.Network.OutputTaps.Values.Any(
+                p => p.GateId == b.GroupName && p.PinName == b.PinName))
+            .ToList();
 
     /// <summary>
-    /// Every anonymous badge must carry the same bit the panel's output list shows for
-    /// its tapped pin — anonymous chips and output rows must never disagree on screen.
+    /// Every output badge must carry the same bit the panel's output list shows for
+    /// its tapped pin — chips and output rows must never disagree on screen, whether
+    /// the chip reads a signal name or stays anonymous.
     /// </summary>
     private void AssertBadgesMirrorPanelOutputs(LogicPanelViewModel vm)
     {
         var outputsByRawPin = vm.Outputs.ToDictionary(o => o.RawPinName, o => o);
-        foreach (var badge in AnonymousBadges())
+        foreach (var badge in OutputBadges())
         {
             var raw = $"{badge.GroupName}.{badge.PinName}";
             outputsByRawPin.TryGetValue(raw, out var output).ShouldBeTrue(
@@ -202,7 +215,8 @@ public class FourBitAdderStudentJourneyTests
         }
 
         var namedBySignal = vm.Inputs.ToDictionary(i => i.PinName, i => i.IsOn);
-        foreach (var badge in _fixture.Canvas.LogicGateStates.Badges.Where(b => b.HasSignalName))
+        foreach (var badge in _fixture.Canvas.LogicGateStates.Badges
+                     .Where(b => b.HasSignalName && NetworkInputs.Contains(b.SignalName)))
         {
             badge.IsOne.ShouldBe(namedBySignal[badge.SignalName!],
                 $"named chip '{badge.SignalName}' on '{badge.GroupName}' mirrors its toggle bit");

--- a/UnitTests/Integration/LogicGateOutputSignalBadgeTests.cs
+++ b/UnitTests/Integration/LogicGateOutputSignalBadgeTests.cs
@@ -1,0 +1,158 @@
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Unit part of the named output-chip tests (issue #1067, rung 4→5 of the NAND game,
+/// symmetric to the named input chips of issue #1051): over the shared loaded half-adder
+/// canvas one gate's persisted roles gain an output signal name, and
+/// <c>LogicPanelViewModel.BadgeStatesOf</c> must attach that name to the tap's badge
+/// state (<c>S = 1</c> instead of the bare bit) while every raw
+/// <c>&lt;gate&gt;.&lt;pin&gt;</c> tap stays anonymous. The data is already on the wire:
+/// the evaluation result keys by tap name, so the badge walk attaches the name whenever
+/// the tap key differs from the raw pin id.
+/// </summary>
+public class LogicGateOutputSignalBadgeUnitTests : IClassFixture<LogicPanelViewModelTests.LoadedHalfAdder>
+{
+    private readonly LogicPanelViewModelTests.LoadedHalfAdder _fixture;
+
+    /// <summary>Attaches the shared loaded half-adder canvas.</summary>
+    public LogicGateOutputSignalBadgeUnitTests(LogicPanelViewModelTests.LoadedHalfAdder fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task BuildNetwork_NamedOutputTapChipsItsName_RawTapsStayAnonymous()
+    {
+        var group = _fixture.Canvas.Components
+            .Select(c => c.Component).OfType<ComponentGroup>()
+            .Single(g => g.GroupName == "NAND4");
+        var persisted = group.TruthTablePinAssignment!.OutputSignalNames;
+        group.TruthTablePinAssignment!.OutputSignalNames =
+            new Dictionary<string, string> { ["Y"] = "S" };
+        try
+        {
+            var vm = new LogicPanelViewModel();
+            vm.Configure(_fixture.Canvas);
+            await vm.BuildNetworkCommand.ExecuteAsync(null);
+            vm.HasNetwork.ShouldBeTrue(vm.StatusText);
+
+            var chip = _fixture.Canvas.LogicGateStates.Badges
+                .Single(b => b.GroupName == "NAND4" && b.PinName == "Y");
+            chip.HasSignalName.ShouldBeTrue("the named tap chips its signal name, not the bare bit");
+            chip.SignalName.ShouldBe("S");
+            chip.LabelText.ShouldBe("S = 0", "the half adder starts with its sum off");
+            chip.IsOne.ShouldBe(vm.Outputs.Single(o => o.PinName == "S").IsOne,
+                "the chip mirrors the panel's named output row");
+
+            var anonymous = _fixture.Canvas.LogicGateStates.Badges.Where(b => !b.HasSignalName).ToList();
+            anonymous.ShouldAllBe(b => b.PinName == "Y" && b.LabelText == b.BitText,
+                "raw <gate>.<pin> taps keep the exact anonymous chip");
+            anonymous.ShouldNotContain(b => b.GroupName == "NAND4" && b.PinName == "Y",
+                "only the named tap lost its anonymity");
+
+            vm.Inputs.Single(i => i.PinName == "A").IsOn = true;
+            _fixture.Canvas.LogicGateStates.Badges.Single(b => b.SignalName == "S")
+                .IsOne.ShouldBeTrue("S = A XOR B");
+            _fixture.Canvas.LogicGateStates.Badges.Single(b => b.SignalName == "S")
+                .LabelText.ShouldBe("S = 1");
+            vm.Inputs.Single(i => i.PinName == "A").IsOn = false;
+        }
+        finally
+        {
+            group.TruthTablePinAssignment!.OutputSignalNames = persisted;
+        }
+    }
+}
+
+/// <summary>
+/// Integration part of the named output-chip tests (issue #1067): over the shipped
+/// <c>examples/Logic Gate 4-Bit Adder.lun</c> — real load path, real build — the gates
+/// behind the network's named taps <c>S0</c>–<c>S3</c>/<c>Cout</c> carry named chips
+/// mirroring the panel's output rows, toggling <c>A0</c>/<c>B0</c> flips the
+/// <c>S0</c> chip, and the unnamed intermediate gates stay exactly anonymous.
+/// </summary>
+public class LogicGateOutputSignalBadgeTests
+    : IClassFixture<LogicGateFourBitAdderExampleTests.FourBitAdderFixture>
+{
+    /// <summary>The named output taps of the 4-bit adder (#1046), per tapped gate.</summary>
+    private static readonly Dictionary<string, string> NamedOutputsByGate = new()
+    {
+        ["T0H2SUM"] = "S0", ["T1H2SUM"] = "S1", ["T2H2SUM"] = "S2",
+        ["T3H2SUM"] = "S3", ["T3OROUT"] = "Cout",
+    };
+
+    private readonly LogicGateFourBitAdderExampleTests.FourBitAdderFixture _fixture;
+
+    /// <summary>Attaches the shared 4-bit-adder fixture.</summary>
+    public LogicGateOutputSignalBadgeTests(LogicGateFourBitAdderExampleTests.FourBitAdderFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task BuildNetwork_FourBitAdder_SumAndCarryGatesCarryNamedChips()
+    {
+        var vm = await BuildPanel();
+
+        foreach (var (gate, signal) in NamedOutputsByGate)
+        {
+            var chip = ChipOf(gate);
+            chip.SignalName.ShouldBe(signal,
+                $"the gate '{gate}' behind the named tap chips its persisted output signal name");
+            chip.LabelText.ShouldBe($"{signal} = 0", "0 + 0 + Cin 0 sums to zero");
+            chip.IsOne.ShouldBe(vm.Outputs.Single(o => o.PinName == signal).IsOne,
+                $"the chip of '{gate}' mirrors the panel's named output row");
+        }
+
+        var anonymous = _fixture.Canvas.LogicGateStates.Badges.Where(b => !b.HasSignalName).ToList();
+        anonymous.Select(b => b.GroupName).Distinct().ShouldAllBe(
+            gate => !NamedOutputsByGate.ContainsKey(gate),
+            "only the five named output taps lose their anonymity");
+        anonymous.ShouldAllBe(b => b.PinName == "Y" && b.LabelText == b.BitText,
+            "raw <gate>.<pin> taps keep the exact anonymous chip — no visual change");
+        var intermediate = anonymous.Single(b => b.GroupName == "T1H1SUM1");
+        intermediate.HasSignalName.ShouldBeFalse(
+            "an unnamed intermediate gate of the sum ladder stays anonymous");
+    }
+
+    [Fact]
+    public async Task ToggleA0AndB0_FourBitAdder_FlipsTheS0Chip()
+    {
+        var vm = await BuildPanel();
+        try
+        {
+            ChipOf("T0H2SUM").LabelText.ShouldBe("S0 = 0");
+
+            vm.Inputs.Single(i => i.PinName == "A0").IsOn = true;
+            ChipOf("T0H2SUM").IsOne.ShouldBeTrue("A0 = 1 sums to 1 at the low bit");
+            ChipOf("T0H2SUM").LabelText.ShouldBe("S0 = 1");
+
+            vm.Inputs.Single(i => i.PinName == "B0").IsOn = true;
+            ChipOf("T0H2SUM").IsOne.ShouldBeFalse("1 + 1 carries — the low bit drops to 0");
+            ChipOf("T0H2SUM").LabelText.ShouldBe("S0 = 0");
+            vm.Outputs.Single(o => o.PinName == "S0").IsOne.ShouldBeFalse(
+                "the chip and the panel's named output row agree");
+        }
+        finally
+        {
+            vm.Inputs.Single(i => i.PinName == "A0").IsOn = false;
+            vm.Inputs.Single(i => i.PinName == "B0").IsOn = false;
+        }
+    }
+
+    /// <summary>The output chip of one gate group on the badge overlay.</summary>
+    private LogicGateBadgeViewModel ChipOf(string gateName) =>
+        _fixture.Canvas.LogicGateStates.Badges.Single(b => b.GroupName == gateName && b.PinName == "Y");
+
+    /// <summary>Builds a fresh panel on the shared loaded canvas; fails fast on assembly errors.</summary>
+    private async Task<LogicPanelViewModel> BuildPanel()
+    {
+        var vm = new LogicPanelViewModel();
+        vm.Configure(_fixture.Canvas);
+        await vm.BuildNetworkCommand.ExecuteAsync(null);
+        vm.HasNetwork.ShouldBeTrue(vm.StatusText);
+        return vm;
+    }
+}

--- a/UnitTests/Integration/LogicPanelReplayTests.cs
+++ b/UnitTests/Integration/LogicPanelReplayTests.cs
@@ -14,9 +14,12 @@ namespace UnitTests.Integration;
 /// canvas badges — every pin whose switch event has time ≤ t_k shows its new value,
 /// every other pin still shows the before value (mirror derivation in test code over
 /// <see cref="LogicNetworkEvaluator.Evaluate"/>, like
-/// <c>LogicTimelineCriticalPathConsistencyTests</c>). Prev/Next walk the event bounds,
-/// deselecting returns the badges to the live end state, a new toggle exits replay,
-/// and a design edit clears replay together with the network.
+/// <c>LogicTimelineCriticalPathConsistencyTests</c>). The named output chips
+/// (<c>S</c>, <c>Cout</c>, issue #1067) keep their names frozen at t_k as well —
+/// replay flows through the same <c>BadgeStatesOf</c> as the live evaluation.
+/// Prev/Next walk the event bounds, deselecting returns the badges to the live end
+/// state, a new toggle exits replay, and a design edit clears replay together with
+/// the network.
 /// </summary>
 public class LogicPanelReplayTests
     : IClassFixture<LogicGateFullAdderExampleTests.FullAdderFixture>
@@ -61,13 +64,46 @@ public class LogicPanelReplayTests
             .Where(e => e.Event.TimePicoseconds <= firstTime)
             .Select(e => $"{e.Event.GateId}.{e.Event.OutputPin}")
             .ToHashSet();
-        foreach (var badge in _fixture.Canvas.LogicGateStates.Badges.Where(b => !b.HasSignalName))
+        foreach (var badge in _fixture.Canvas.LogicGateStates.Badges.Where(IsOutputChip))
         {
             var tap = $"{badge.GroupName}.{badge.PinName}";
             if (!switched.Contains(tap))
                 badge.IsOne.ShouldBe(before[tap],
                     $"{tap} has not switched yet at t = {firstTime:0.0} ps — it stays on its old bit");
         }
+    }
+
+    [Fact]
+    public async Task SelectEvent_FullAdder_NamedOutputChipsKeepTheirNameFrozenAtTk()
+    {
+        // Issue #1067: replay flows through the same BadgeStatesOf as the live
+        // evaluation, so the named output chips keep their signals (S, Cout) at every
+        // replayed instant and freeze at the derived state of t_k.
+        var vm = await BuildAndToggleCin();
+
+        for (var k = 0; k < vm.TimelineEvents.Count; k++)
+        {
+            vm.SelectTimelineEventCommand.Execute(vm.TimelineEvents[k]);
+            var atK = StateAt(vm.TimelineEvents[k].Event.TimePicoseconds);
+
+            var sum = _fixture.Canvas.LogicGateStates.Badges
+                .Single(b => b.GroupName == "H2SUM" && b.PinName == "Y");
+            sum.SignalName.ShouldBe("S", "the sum chip keeps its signal name in replay");
+            sum.LabelText.ShouldBe($"S = {(sum.IsOne ? "1" : "0")}");
+            sum.IsOne.ShouldBe(atK["H2SUM.Y"], $"the S chip freezes at the derived state of event {k}");
+
+            var cout = _fixture.Canvas.LogicGateStates.Badges
+                .Single(b => b.GroupName == "OROUT" && b.PinName == "Y");
+            cout.SignalName.ShouldBe("Cout", "the carry chip keeps its signal name in replay");
+            cout.IsOne.ShouldBe(atK["OROUT.Y"], $"the Cout chip freezes at the derived state of event {k}");
+        }
+
+        vm.ExitReplayCommand.Execute(null);
+
+        var live = LiveEndState();
+        _fixture.Canvas.LogicGateStates.Badges
+            .Single(b => b.GroupName == "H2SUM" && b.PinName == "Y")
+            .IsOne.ShouldBe(live["H2SUM.Y"], "leaving replay returns the S chip to the live end state");
     }
 
     [Fact]
@@ -187,14 +223,21 @@ public class LogicPanelReplayTests
     }
 
     /// <summary>
-    /// The anonymous output badges currently on the canvas, keyed <c>gate.pin</c>.
-    /// Named input chips (issue #1051) ride along on the overlay but carry the live
-    /// input bits, not gate output states — replay derivations exclude them.
+    /// The output-pin badges currently on the canvas, keyed <c>gate.pin</c> — the
+    /// named output chips (issue #1067) ride along with their tap's signal name, so
+    /// they match by raw pin ref, not by anonymity. Named input chips (issue #1051)
+    /// carry the live input bits, not gate output states — replay derivations exclude
+    /// them.
     /// </summary>
     private Dictionary<string, bool> BadgeStates() =>
         _fixture.Canvas.LogicGateStates.Badges
-            .Where(b => !b.HasSignalName)
+            .Where(IsOutputChip)
             .ToDictionary(b => $"{b.GroupName}.{b.PinName}", b => b.IsOne);
+
+    /// <summary>True for a chip on a gate's output tap — anonymous or named (issue #1067).</summary>
+    private bool IsOutputChip(LogicGateBadgeViewModel badge) =>
+        _fixture.Network.OutputTaps.Values.Any(
+            p => p.GateId == badge.GroupName && p.PinName == badge.PinName);
 
     /// <summary>Asserts the canvas badges show exactly the expected pin states.</summary>
     private void BadgesShouldShow(IReadOnlyDictionary<string, bool> expected, string because)

--- a/UnitTests/Rendering/LogicGateSignalNameBadgeRenderTests.cs
+++ b/UnitTests/Rendering/LogicGateSignalNameBadgeRenderTests.cs
@@ -14,13 +14,14 @@ using Xunit;
 namespace UnitTests.Rendering;
 
 /// <summary>
-/// Render smoke tests for the named canvas logic-state badges (issue #1051, rung 4→5 of
-/// the NAND game): over the shipped <c>examples/Logic Gate 4-Bit Adder.lun</c> — whose
-/// operand pins carry the persisted signal names A0–A3, B0–B3 and Cin since #1032/#1034 —
-/// the Logic panel's build puts a named badge (<c>A0 = 1</c>) next to the live bit on
-/// every gate group reading a named signal, and the badge renderer actually paints those
-/// chips headlessly. A synthetic geometry test pins the chip layout: the named chip
-/// widens to fit its label while the anonymous output badge keeps its exact square.
+/// Render smoke tests for the named canvas logic-state badges (issues #1051/#1067,
+/// rung 4→5 of the NAND game): over the shipped <c>examples/Logic Gate 4-Bit Adder.lun</c>
+/// — whose operand pins carry the persisted signal names A0–A3, B0–B3 and Cin since
+/// #1032/#1034 and whose output taps carry S0–S3/Cout since #1046 — the Logic panel's
+/// build puts a named badge (<c>A0 = 1</c>, <c>S0 = 1</c>) next to the live bit on
+/// every gate group reading a named signal, and the badge renderer actually paints
+/// those chips headlessly. A synthetic geometry test pins the chip layout: the named
+/// chip widens to fit its label while the anonymous output badge keeps its exact square.
 /// Renders the production renderer into a <see cref="RenderTargetBitmap"/> and samples
 /// real pixels — same pattern as <see cref="ComponentGroupOutlineRenderingTests"/>.
 /// </summary>
@@ -37,9 +38,12 @@ public class LogicGateSignalNameBadgeRenderTests
     private const int RowTop = 14;   // BadgeMargin + 10 origin offset
     private const int SquareLeftEdge = 50;
 
-    /// <summary>The nine network signals of the 4-bit adder (issues #1025/#1034).</summary>
-    private static readonly string[] NetworkSignals =
+    /// <summary>The nine named operands of the 4-bit adder (issues #1025/#1034).</summary>
+    private static readonly string[] OperandSignals =
         { "A0", "A1", "A2", "A3", "B0", "B1", "B2", "B3", "Cin" };
+
+    /// <summary>The five named output taps of the 4-bit adder (issue #1046).</summary>
+    private static readonly string[] OutputSignals = { "S0", "S1", "S2", "S3", "Cout" };
 
     private readonly LogicGateFourBitAdderExampleTests.FourBitAdderFixture _fixture;
 
@@ -48,7 +52,7 @@ public class LogicGateSignalNameBadgeRenderTests
         _fixture = fixture;
 
     [AvaloniaFact]
-    public async Task FourBitAdder_NamedSignalBadges_ShowOnInputGatesAndRender()
+    public async Task FourBitAdder_NamedSignalBadges_ShowOnInputAndOutputGatesAndRender()
     {
         var vm = new LogicPanelViewModel();
         vm.Configure(_fixture.Canvas);
@@ -57,9 +61,19 @@ public class LogicGateSignalNameBadgeRenderTests
 
         var badges = _fixture.Canvas.LogicGateStates.Badges;
         var named = badges.Where(b => b.HasSignalName).ToList();
-        named.Select(b => b.SignalName).Distinct().ShouldBe(NetworkSignals, ignoreOrder: true,
-            customMessage: "every named operand signal shows on the canvas badges of its input gates");
+        named.Select(b => b.SignalName).Distinct().ShouldBe(
+            OperandSignals.Concat(OutputSignals).ToArray(), ignoreOrder: true,
+            customMessage: "every named operand shows on its input gates, and the named output taps of #1046 chip their names (#1067)");
         named.ShouldAllBe(b => b.LabelText == $"{b.SignalName} = {(b.IsOne ? "1" : "0")}");
+        foreach (var (gate, signal) in new Dictionary<string, string>
+                 {
+                     ["T0H2SUM"] = "S0", ["T1H2SUM"] = "S1", ["T2H2SUM"] = "S2",
+                     ["T3H2SUM"] = "S3", ["T3OROUT"] = "Cout",
+                 })
+        {
+            badges.Single(b => b.GroupName == gate && b.PinName == "Y").SignalName.ShouldBe(signal,
+                $"the gate '{gate}' behind the named tap carries the named output chip");
+        }
         badges.Where(b => !b.HasSignalName).ShouldAllBe(
             b => b.PinName == "Y" && b.LabelText == b.BitText,
             "the anonymous per-output badges stay exactly as before");
@@ -82,6 +96,38 @@ public class LogicGateSignalNameBadgeRenderTests
             .ShouldBeGreaterThan(10, "the A0 chip paints its label text (inputs are off — gray)");
         CountInRow(pixels, row: 2, IsGrayTextPixel)
             .ShouldBeGreaterThan(10, "the B0 chip paints its label text (inputs are off — gray)");
+    }
+
+    [AvaloniaFact]
+    public void NamedOutputChip_WidensLikeTheInputChips_AndPaintsItsLabel()
+    {
+        // Issue #1067: the named output chip (S0 = 1) is the symmetric sibling of the
+        // named input chip — the renderer widens the square the same way and paints
+        // the signal-naming label headlessly.
+        var canvas = new DesignCanvasViewModel();
+        var group = TestComponentFactory.CreateComponentGroup("T0H2SUM");
+        var child = TestComponentFactory.CreateStraightWaveGuide();
+        child.PhysicalX = 0;
+        child.PhysicalY = 0;
+        child.WidthMicrometers = 100;
+        child.HeightMicrometers = 60;
+        group.AddChild(child);
+        canvas.AddComponent(group);
+        canvas.LogicGateStates.ShowStates(new[]
+        {
+            new LogicGateBadgeState("T0H2SUM", "Y", true, "S0"),
+        });
+        var bounds = ComponentGroupRenderer.CalculateGroupBounds(group);
+
+        using var bitmap = RenderBadgeCorner(canvas, bounds);
+        var pixels = ReadPixels(bitmap);
+
+        var left = LeftmostPainted(pixels, row: 0);
+        left.ShouldNotBeNull("the named output chip renders");
+        left.Value.ShouldBeLessThan(SquareLeftEdge - 6,
+            "the named output chip widens left past the square to fit its 'S0 = 1' label");
+        CountInRow(pixels, row: 0, (r, g, b) => g > 150 && g > r + 30)
+            .ShouldBeGreaterThan(10, "the named output chip paints its green 'S0 = 1' label");
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## What & why

Issue #1067 (rung 4→5, education pillar, ROADMAP #537): #1051 gave input pins named chips (`A0 = 1`) on the canvas; output pins still showed anonymous 0/1 badges, so a student watching the 4-bit adder compute had to open the Logic panel to know which badge was `S2` or `Cout`. Now a gate output pin whose network tap carries a persisted signal name (#1046) shows that name in its badge (`S0 = 1`), symmetric to the input chips. Unnamed outputs keep the exact anonymous chip — no visual change.

## How

`LogicPanelViewModel.BadgeStatesOf` walks `_network.OutputTaps`; the tap **key** is the persisted signal name whenever one exists (it differs from the raw `<gate>.<pin>` id by construction in `LogicNetworkBuilder`). The fix attaches that name to the badge state when the key differs from the raw id — display only, no re-evaluation. The renderer's named-chip path (widen-to-label) from #1051 was already generic. Replay (#1058) flows through the same `BadgeStatesOf`, so the named chips freeze at t_k with no extra code. No new user-visible strings (`{name} = {bit}` is persisted data, like #1051).

## How it was tested

- Unit: `LogicGateOutputSignalBadgeUnitTests` — loaded half adder with a named tap injected: the named tap chips its name, raw taps stay anonymous. Overlay-level: `ShowStates_NamedOutputTap_BadgeShowsSignalNameAndBit`.
- Integration (shipped 4-bit adder, real load + build): `LogicGateOutputSignalBadgeTests` — S0–S3/Cout chips mirror the panel's outputs, toggling A0/B0 flips the S0 chip, unnamed intermediate gates stay anonymous.
- Replay: `LogicPanelReplayTests.SelectEvent_FullAdder_NamedOutputChipsKeepTheirNameFrozenAtTk` — the S/Cout chips keep their names frozen at the derived state per selected event; exiting replay restores the live end state.
- Render smoke: `NamedOutputChip_WidensLikeTheInputChips_AndPaintsItsLabel` — headless pixel sampling, same pattern as the #1051 render tests.
- Expectations that pinned the old anonymous-output behavior were updated to the named chips in `FourBitAdderStudentJourneyTests`, `LogicPanelReplayTests`, `LogicGateSignalNameBadgeRenderTests`.

Local suite: 6167 passed, 0 failed

## Manual verification after vacation

Open `examples/Logic Gate 4-Bit Adder.lun`, click Logic panel → Build Network, toggle A0/B0 on — the sum gates' chips read `S0 = 1` etc. right on the canvas, next to the `A0 = 1` operand chips.