### PR TITLE
Agent: Truth Table panel: live signal-name collision hint before build (rung 4 polish, UX)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -1272,6 +1272,8 @@
   "TruthTable.NoGroupSelected": "Wähle genau eine Gruppe aus, um zu sehen, ob sie sich wie ein Logikgatter verhält.",
   "TruthTable.Outputs": "Ausgänge:",
   "TruthTable.Signal": "Signalname:",
+  "TruthTable.SignalWarnCrossRole": "„{0}“ benennt sowohl einen Eingang als auch einen Ausgang — der Netzwerk-Build lehnt Namen ab, die zwei Rollen überspannen.",
+  "TruthTable.SignalWarnDuplicateOutput": "Der Ausgang eines anderen Gatters verwendet „{0}“ bereits — Ausgangsnamen müssen eindeutig sein.",
   "TruthTable.SignalWatermark": "Signalname (optional)",
   "TruthTable.Threshold": "Schwellwert:",
   "TruthTable.Title": "Wahrheitstabelle:",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -1272,6 +1272,8 @@
   "TruthTable.NoGroupSelected": "Select exactly one group to see whether it behaves like a logic gate.",
   "TruthTable.Outputs": "Outputs:",
   "TruthTable.Signal": "Signal:",
+  "TruthTable.SignalWarnCrossRole": "'{0}' names both an input and an output — the network build rejects a name spanning two roles.",
+  "TruthTable.SignalWarnDuplicateOutput": "Another gate's output already uses '{0}' — output names must be unique.",
   "TruthTable.SignalWatermark": "signal name (optional)",
   "TruthTable.Threshold": "Threshold:",
   "TruthTable.Title": "Truth Table:",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -1272,6 +1272,8 @@
   "TruthTable.NoGroupSelected": "Selecciona exactamente un grupo para ver si se comporta como una puerta lógica.",
   "TruthTable.Outputs": "Salidas:",
   "TruthTable.Signal": "Señal:",
+  "TruthTable.SignalWarnCrossRole": "\"{0}\" nombra tanto una entrada como una salida — el ensamblado de la red rechaza un nombre que abarca dos roles.",
+  "TruthTable.SignalWarnDuplicateOutput": "La salida de otra puerta ya usa \"{0}\" — los nombres de salida deben ser únicos.",
   "TruthTable.SignalWatermark": "nombre de señal (opcional)",
   "TruthTable.Threshold": "Umbral:",
   "TruthTable.Title": "Tabla de verdad:",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -1272,6 +1272,8 @@
   "TruthTable.NoGroupSelected": "グループを 1 つだけ選択すると、論理ゲートとして振る舞うか確認できます。",
   "TruthTable.Outputs": "出力:",
   "TruthTable.Signal": "信号:",
+  "TruthTable.SignalWarnCrossRole": "「{0}」は入力と出力の両方を指しています — 二つの役割にまたがる名前はネットワークのビルドで拒否されます。",
+  "TruthTable.SignalWarnDuplicateOutput": "別のゲートの出力がすでに「{0}」を使用しています — 出力名は一意にする必要があります。",
   "TruthTable.SignalWatermark": "信号名（任意）",
   "TruthTable.Threshold": "しきい値:",
   "TruthTable.Title": "真理値表:",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -1272,6 +1272,8 @@
   "TruthTable.NoGroupSelected": "仅选中一个分组,即可查看它是否表现得像一个逻辑门。",
   "TruthTable.Outputs": "输出:",
   "TruthTable.Signal": "信号:",
+  "TruthTable.SignalWarnCrossRole": "“{0}”同时用作输入和输出的名称——网络构建会拒绝跨两种角色的名称。",
+  "TruthTable.SignalWarnDuplicateOutput": "另一个门的输出已使用“{0}”——输出名称必须唯一。",
   "TruthTable.SignalWatermark": "信号名称（可选）",
   "TruthTable.Threshold": "阈值:",
   "TruthTable.Title": "真值表:",

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/PinSelectionViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/PinSelectionViewModel.cs
@@ -39,4 +39,13 @@ public partial class PinSelectionViewModel : ObservableObject
     /// </summary>
     [ObservableProperty]
     private bool _signalEditingVisible;
+
+    /// <summary>
+    /// Live collision hint for the typed signal name (issue #1071): mirrors what the
+    /// <c>LogicNetworkBuilder</c> would reject — a duplicate output tap or a name
+    /// spanning both an input and an output. Empty while the name is clean; the view
+    /// hides the hint then. Warning only — the build keeps its authoritative rejection.
+    /// </summary>
+    [ObservableProperty]
+    private string _signalWarning = "";
 }

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Signals.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Signals.cs
@@ -1,3 +1,4 @@
+using CAP_Core.Analysis.LogicAnalysis;
 using CAP_Core.Components.Core;
 
 namespace CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
@@ -91,5 +92,51 @@ public partial class TruthTableViewModel
     {
         foreach (var pin in InputPins.Concat(OutputPins))
             pin.SignalEditingVisible = value;
+    }
+
+    /// <summary>
+    /// Recomputes the live collision hint on every input and output row (issue #1071):
+    /// the typed name is checked against the persisted assignments of every gate group
+    /// on the canvas — the same source <c>LogicNetworkBuilder</c> validates at build
+    /// time — so a duplicate output name or a name spanning both roles warns at typing
+    /// time instead of minutes later. Same-named inputs merge by design and stay silent.
+    /// </summary>
+    private void RefreshCollisionHints()
+    {
+        foreach (var pin in InputPins.Concat(OutputPins))
+            pin.SignalWarning = ComputeCollisionHint(pin);
+    }
+
+    /// <summary>The localized hint for one row's current signal name, empty while the name is clean.</summary>
+    private string ComputeCollisionHint(PinSelectionViewModel pin)
+    {
+        if (_group == null || !pin.IsChecked || pin.SignalName.Trim().Length == 0)
+            return "";
+        var kind = SignalNameCollisionProbe.Classify(
+            GateGroups(), _group, pin.PinName, InputPins.Contains(pin), pin.SignalName);
+        var key = kind switch
+        {
+            SignalCollisionKind.DuplicateOutput => "TruthTable.SignalWarnDuplicateOutput",
+            SignalCollisionKind.CrossRole => "TruthTable.SignalWarnCrossRole",
+            _ => null,
+        };
+        return key == null ? "" : string.Format(Translate(key), pin.SignalName.Trim());
+    }
+
+    /// <summary>
+    /// The gate groups feeding the collision walk: the canvas's assignment-carrying
+    /// groups, with the selected group appended — it is the live source of edits and
+    /// must be walked even when no canvas was given or the component never joined it.
+    /// </summary>
+    private IReadOnlyList<ComponentGroup> GateGroups()
+    {
+        var canvasGroups = _canvas?.Components
+            .Select(c => c.Component)
+            .OfType<ComponentGroup>()
+            .Where(g => g.TruthTablePinAssignment != null)
+            .ToList() ?? new List<ComponentGroup>();
+        if (_group?.TruthTablePinAssignment != null && !canvasGroups.Contains(_group))
+            canvasGroups.Add(_group);
+        return canvasGroups;
     }
 }

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
@@ -104,6 +104,7 @@ public partial class TruthTableViewModel : ObservableObject
         RebuildPinLists();
         PrefillFromPersistedAssignment();
         SignalNamesVisible = IsGroupSelected && _group?.TruthTablePinAssignment != null;
+        RefreshCollisionHints();
         WavelengthText = IsGroupSelected
             ? string.Format(Translate("TruthTable.Wavelength"), ResolveWavelengthNm())
             : "";
@@ -201,6 +202,7 @@ public partial class TruthTableViewModel : ObservableObject
         {
             if (!_revertingPinCheck && (InputPins.Contains(pin) || OutputPins.Contains(pin)))
                 ApplySignalNameEdit(pin);
+            RefreshCollisionHints();
             return;
         }
         if (_revertingPinCheck || e.PropertyName != nameof(PinSelectionViewModel.IsChecked))
@@ -209,6 +211,7 @@ public partial class TruthTableViewModel : ObservableObject
         {
             if (InputPins.Contains(pin) || OutputPins.Contains(pin))
                 RevokeSignalName(pin);
+            RefreshCollisionHints();
             return;
         }
 
@@ -222,6 +225,7 @@ public partial class TruthTableViewModel : ObservableObject
         {
             _revertingPinCheck = false;
         }
+        RefreshCollisionHints();
     }
 
     /// <summary>Unchecks the same pin name in the two lists the just-checked pin does not belong to.</summary>

--- a/CAP.Avalonia/Views/Panels/TruthTablePanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TruthTablePanel.axaml
@@ -56,23 +56,32 @@
             <ItemsControl ItemsSource="{Binding RightPanel.TruthTable.InputPins}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="logic:PinSelectionViewModel">
-                        <Grid ColumnDefinitions="*,110">
-                            <CheckBox Content="{Binding PinName}" IsChecked="{Binding IsChecked}"
-                                      Foreground="LightGray" FontSize="11" Margin="0,1" VerticalAlignment="Center"/>
-                            <!-- The signal field edits the group's persisted pin assignment,
-                                 so it appears only once the group carries one (after
-                                 extraction or load) and the pin is checked as input. -->
-                            <TextBox Grid.Column="1" Text="{Binding SignalName}"
-                                     Watermark="{loc:Localize TruthTable.SignalWatermark}"
-                                     FontSize="11" Padding="4,2" Margin="4,0,0,0" VerticalAlignment="Center">
-                                <TextBox.IsVisible>
-                                    <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                        <Binding Path="IsChecked"/>
-                                        <Binding Path="SignalEditingVisible"/>
-                                    </MultiBinding>
-                                </TextBox.IsVisible>
-                            </TextBox>
-                        </Grid>
+                        <StackPanel>
+                            <Grid ColumnDefinitions="*,110">
+                                <CheckBox Content="{Binding PinName}" IsChecked="{Binding IsChecked}"
+                                          Foreground="LightGray" FontSize="11" Margin="0,1" VerticalAlignment="Center"/>
+                                <!-- The signal field edits the group's persisted pin assignment,
+                                     so it appears only once the group carries one (after
+                                     extraction or load) and the pin is checked as input. -->
+                                <TextBox Grid.Column="1" Text="{Binding SignalName}"
+                                         Watermark="{loc:Localize TruthTable.SignalWatermark}"
+                                         FontSize="11" Padding="4,2" Margin="4,0,0,0" VerticalAlignment="Center">
+                                    <TextBox.IsVisible>
+                                        <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                            <Binding Path="IsChecked"/>
+                                            <Binding Path="SignalEditingVisible"/>
+                                        </MultiBinding>
+                                    </TextBox.IsVisible>
+                                </TextBox>
+                            </Grid>
+                            <!-- Live collision hint: warns at typing time about the duplicate
+                                 output name or the input/output cross-role name the build would
+                                 reject minutes later (issue #1071). Warning only — the build
+                                 keeps its authoritative rejection. -->
+                            <TextBlock Text="{Binding SignalWarning}" Foreground="#FFB86B" FontSize="9"
+                                       TextWrapping="Wrap" Margin="0,0,0,2"
+                                       IsVisible="{Binding SignalWarning, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                        </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
@@ -86,23 +95,29 @@
             <ItemsControl ItemsSource="{Binding RightPanel.TruthTable.OutputPins}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="logic:PinSelectionViewModel">
-                        <Grid ColumnDefinitions="*,110">
-                            <CheckBox Content="{Binding PinName}" IsChecked="{Binding IsChecked}"
-                                      Foreground="LightGray" FontSize="11" Margin="0,1" VerticalAlignment="Center"/>
-                            <!-- Same persisted-assignment semantics as the input rows:
-                                 a named output's tap reads the signal name in the Logic
-                                 panel (S0, Cout) instead of the raw gate.pin id. -->
-                            <TextBox Grid.Column="1" Text="{Binding SignalName}"
-                                     Watermark="{loc:Localize TruthTable.SignalWatermark}"
-                                     FontSize="11" Padding="4,2" Margin="4,0,0,0" VerticalAlignment="Center">
-                                <TextBox.IsVisible>
-                                    <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                        <Binding Path="IsChecked"/>
-                                        <Binding Path="SignalEditingVisible"/>
-                                    </MultiBinding>
-                                </TextBox.IsVisible>
-                            </TextBox>
-                        </Grid>
+                        <StackPanel>
+                            <Grid ColumnDefinitions="*,110">
+                                <CheckBox Content="{Binding PinName}" IsChecked="{Binding IsChecked}"
+                                          Foreground="LightGray" FontSize="11" Margin="0,1" VerticalAlignment="Center"/>
+                                <!-- Same persisted-assignment semantics as the input rows:
+                                     a named output's tap reads the signal name in the Logic
+                                     panel (S0, Cout) instead of the raw gate.pin id.
+                                     The inline warning under the field mirrors the input rows. -->
+                                <TextBox Grid.Column="1" Text="{Binding SignalName}"
+                                         Watermark="{loc:Localize TruthTable.SignalWatermark}"
+                                         FontSize="11" Padding="4,2" Margin="4,0,0,0" VerticalAlignment="Center">
+                                    <TextBox.IsVisible>
+                                        <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                            <Binding Path="IsChecked"/>
+                                            <Binding Path="SignalEditingVisible"/>
+                                        </MultiBinding>
+                                    </TextBox.IsVisible>
+                                </TextBox>
+                            </Grid>
+                            <TextBlock Text="{Binding SignalWarning}" Foreground="#FFB86B" FontSize="9"
+                                       TextWrapping="Wrap" Margin="0,0,0,2"
+                                       IsVisible="{Binding SignalWarning, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
+                        </StackPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/SignalNameCollisionProbe.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/SignalNameCollisionProbe.cs
@@ -1,0 +1,103 @@
+using CAP_Core.Components.Core;
+
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The collision a candidate signal name would cause in a logic network. Mirrors the
+/// rejections <see cref="LogicNetworkBuilder"/> enforces at build time: two outputs
+/// sharing one tap name (output names never merge) and a name spanning both an input
+/// and an output (cross-role — one name must not read as two wires). Same-named
+/// inputs merge by design and are never a collision.
+/// </summary>
+public enum SignalCollisionKind
+{
+    /// <summary>The candidate name is free — the build accepts it.</summary>
+    None,
+
+    /// <summary>Another gate output already resolves to the same tap name.</summary>
+    DuplicateOutput,
+
+    /// <summary>The name is used in the other role (an input's name on an output or vice versa).</summary>
+    CrossRole,
+}
+
+/// <summary>
+/// Read-only probe answering "would this signal name collide in the current design?"
+/// from the gate groups' persisted <see cref="TruthTablePinAssignment"/>s — the same
+/// source <see cref="LogicNetworkBuilder"/> validates, without triggering a build.
+/// Naming follows the builder's exact rules: a signal-named pin takes its signal,
+/// an unnamed pin keeps its raw <c>&lt;gate&gt;.&lt;pin&gt;</c> name. Groups without
+/// a persisted assignment are not gates and contribute no names.
+/// </summary>
+public static class SignalNameCollisionProbe
+{
+    /// <summary>
+    /// Classifies a candidate signal name for one pin against every gate group:
+    /// an input candidate colliding with any output tap name (signal-named or raw)
+    /// is a <see cref="SignalCollisionKind.CrossRole"/>, an output candidate colliding
+    /// with another output's tap name is a <see cref="SignalCollisionKind.DuplicateOutput"/>,
+    /// and an output candidate equal to an input's name is a cross-role collision too.
+    /// Duplicate-output wins when both apply — the same-role conflict is the plainer one.
+    /// </summary>
+    /// <param name="gateGroups">The canvas's gate groups (persisted assignment carrying groups).</param>
+    /// <param name="editedGroup">The group the edited pin belongs to.</param>
+    /// <param name="pinName">The edited pin's name within <paramref name="editedGroup"/>.</param>
+    /// <param name="isInput">True when the edited pin plays an input role, false for an output.</param>
+    /// <param name="candidateName">The signal name being typed; whitespace-only or empty never collides.</param>
+    /// <returns>What the candidate would collide with, or <see cref="SignalCollisionKind.None"/>.</returns>
+    public static SignalCollisionKind Classify(
+        IReadOnlyList<ComponentGroup> gateGroups,
+        ComponentGroup editedGroup,
+        string pinName,
+        bool isInput,
+        string candidateName)
+    {
+        var candidate = candidateName.Trim();
+        if (candidate.Length == 0)
+            return SignalCollisionKind.None;
+
+        var outputTaps = new Dictionary<string, List<(ComponentGroup Group, string Pin)>>();
+        var inputs = new HashSet<string>();
+        foreach (var group in gateGroups)
+            CollectNames(group, outputTaps, inputs);
+
+        if (isInput)
+            return outputTaps.ContainsKey(candidate)
+                ? SignalCollisionKind.CrossRole
+                : SignalCollisionKind.None;
+
+        if (outputTaps.TryGetValue(candidate, out var taps)
+            && taps.Any(tap => !ReferenceEquals(tap.Group, editedGroup) || tap.Pin != pinName))
+            return SignalCollisionKind.DuplicateOutput;
+        return inputs.Contains(candidate)
+            ? SignalCollisionKind.CrossRole
+            : SignalCollisionKind.None;
+    }
+
+    /// <summary>Registers one group's effective input and output tap names the way the builder derives them.</summary>
+    private static void CollectNames(
+        ComponentGroup group,
+        IDictionary<string, List<(ComponentGroup Group, string Pin)>> outputTaps,
+        ISet<string> inputs)
+    {
+        var assignment = group.TruthTablePinAssignment;
+        if (assignment == null)
+            return;
+        foreach (var pin in assignment.InputPinNames)
+            inputs.Add(SignalOrRaw(assignment.InputSignalNames, pin, group.GroupName));
+        foreach (var pin in assignment.OutputPinNames)
+        {
+            var tapName = SignalOrRaw(assignment.OutputSignalNames, pin, group.GroupName);
+            if (!outputTaps.TryGetValue(tapName, out var taps))
+                outputTaps[tapName] = taps = new List<(ComponentGroup, string)>();
+            taps.Add((group, pin));
+        }
+    }
+
+    /// <summary>The pin's signal name when it carries one, else its raw <c>&lt;gate&gt;.&lt;pin&gt;</c> name.</summary>
+    private static string SignalOrRaw(
+        IReadOnlyDictionary<string, string>? signalNames, string pinName, string gateName) =>
+        signalNames != null && signalNames.TryGetValue(pinName, out var signal)
+            ? signal
+            : $"{gateName}.{pinName}";
+}

--- a/UnitTests/Analysis/LogicAnalysis/TruthTableViewModelCollisionHintTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/TruthTableViewModelCollisionHintTests.cs
@@ -1,0 +1,272 @@
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Live signal-name collision hints in the Truth Table panel (issue #1071): while a
+/// name is typed into an input or output signal field, the row warns the moment it
+/// collides across the canvas's gate groups — two outputs sharing one name (output
+/// names never merge) or a name spanning both an input and an output (cross-role).
+/// Same-named inputs merge by design and stay silent. The hint mirrors what
+/// <see cref="LogicNetworkBuilder"/> rejects at build time, and the pairing theory
+/// below asserts exactly that: every warned constellation throws on build, every
+/// silent one builds.
+/// </summary>
+public class TruthTableViewModelCollisionHintTests
+{
+    private readonly Dictionary<string, ComponentGroup> _groups = new();
+    private DesignCanvasViewModel _canvas = null!;
+
+    [Fact]
+    public void InputName_EqualToOtherGateOutputSignal_ShowsCrossRoleHint()
+    {
+        TwoNotGatesOnCanvas("SUM", "INV");
+        NamePin("SUM", "S", input: false);
+        var vm = Configure("INV");
+
+        vm.InputPins.Single(p => p.PinName == "A").SignalName = "S";
+
+        var warning = vm.InputPins.Single(p => p.PinName == "A").SignalWarning;
+        warning.ShouldNotBeNullOrEmpty("the name spans an input and an output — the build would reject it");
+        warning.ShouldContain("'S'");
+    }
+
+    [Fact]
+    public void InputName_EqualToRawOutputTap_ShowsCrossRoleHint()
+    {
+        TwoNotGatesOnCanvas("SUM", "INV");
+        var vm = Configure("INV");
+
+        vm.InputPins.Single(p => p.PinName == "A").SignalName = "SUM.Y";
+
+        vm.InputPins.Single(p => p.PinName == "A").SignalWarning.ShouldNotBeNullOrEmpty(
+            "an input named like the raw <gate>.<pin> tap is the same cross-role collision the builder rejects");
+    }
+
+    [Fact]
+    public void OutputName_EqualToOtherGateOutputSignal_ShowsDuplicateOutputHint()
+    {
+        TwoNotGatesOnCanvas("SUM", "CARRY");
+        NamePin("SUM", "S", input: false);
+        var vm = Configure("CARRY");
+
+        vm.OutputPins.Single(p => p.PinName == "Y").SignalName = "S";
+
+        var warning = vm.OutputPins.Single(p => p.PinName == "Y").SignalWarning;
+        warning.ShouldNotBeNullOrEmpty("two outputs sharing one tap name never merge");
+        warning.ShouldContain("'S'");
+    }
+
+    [Fact]
+    public void OutputName_EqualToOtherGateInputSignal_ShowsCrossRoleHint()
+    {
+        TwoNotGatesOnCanvas("SUM", "INV");
+        NamePin("SUM", "A", input: true);
+        var vm = Configure("INV");
+
+        vm.OutputPins.Single(p => p.PinName == "Y").SignalName = "A";
+
+        vm.OutputPins.Single(p => p.PinName == "Y").SignalWarning.ShouldNotBeNullOrEmpty(
+            "the output side of a name spanning both roles warns just the same");
+    }
+
+    [Fact]
+    public void TwoInputs_SameSignalName_StaySilent()
+    {
+        TwoNotGatesOnCanvas("INV1", "INV2");
+        NamePin("INV1", "S", input: true);
+        var vm = Configure("INV2");
+
+        vm.InputPins.Single(p => p.PinName == "A").SignalName = "S";
+
+        vm.InputPins.Single(p => p.PinName == "A").SignalWarning.ShouldBeEmpty(
+            "same-named inputs are the intentional merging — no warning");
+    }
+
+    [Fact]
+    public void SameGroup_TwoOutputsSharingName_ShowsDuplicateOutputHint()
+    {
+        TwoNotGatesOnCanvas("ADDER", "OTHER");
+        var y2 = new PhysicalPin { Name = "Y2", ParentComponent = Group("ADDER") };
+        Group("ADDER").PhysicalPins.Add(y2);
+        Group("ADDER").AddExternalPin(new GroupPin { Name = "Y2", InternalPin = y2 });
+        Group("ADDER").TruthTablePinAssignment!.OutputPinNames.Add("Y2");
+        var vm = Configure("ADDER");
+        vm.OutputPins.Single(p => p.PinName == "Y").SignalName = "S";
+
+        vm.OutputPins.Single(p => p.PinName == "Y2").SignalName = "S";
+
+        vm.OutputPins.Single(p => p.PinName == "Y2").SignalWarning.ShouldNotBeNullOrEmpty(
+            "two outputs of the same gate sharing one name collide too");
+        vm.OutputPins.Single(p => p.PinName == "Y").SignalWarning.ShouldNotBeNullOrEmpty(
+            "the first output's row reflects the collision as well");
+    }
+
+    [Fact]
+    public void ClearingTheName_ClearsTheHint()
+    {
+        TwoNotGatesOnCanvas("SUM", "INV");
+        NamePin("SUM", "S", input: false);
+        var vm = Configure("INV");
+        var pin = vm.InputPins.Single(p => p.PinName == "A");
+        pin.SignalName = "S";
+        pin.SignalWarning.ShouldNotBeNullOrEmpty();
+
+        pin.SignalName = "";
+
+        pin.SignalWarning.ShouldBeEmpty("no name — nothing to collide");
+    }
+
+    [Fact]
+    public void RenamingAwayFromCollision_ClearsTheHint()
+    {
+        TwoNotGatesOnCanvas("SUM", "INV");
+        NamePin("SUM", "S", input: false);
+        var vm = Configure("INV");
+        var pin = vm.InputPins.Single(p => p.PinName == "A");
+        pin.SignalName = "S";
+        pin.SignalWarning.ShouldNotBeNullOrEmpty();
+
+        pin.SignalName = "Ain";
+
+        pin.SignalWarning.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Warning_DoesNotBlockTheWrite_SavingStaysAllowed()
+    {
+        TwoNotGatesOnCanvas("SUM", "INV");
+        NamePin("SUM", "S", input: false);
+        var vm = Configure("INV");
+
+        vm.InputPins.Single(p => p.PinName == "A").SignalName = "S";
+
+        Group("INV").TruthTablePinAssignment!.InputSignalNames.ShouldBe(
+            new Dictionary<string, string> { ["A"] = "S" },
+            "the warning is advisory — the name still writes through to the persisted assignment");
+    }
+
+    /// <summary>
+    /// Panel hint vs. builder verdict, paired per constellation: every warned state
+    /// throws on build, every silent state builds (acceptance 2).
+    /// </summary>
+    [Theory]
+    [InlineData("DuplicateOutputs", true, true)]
+    [InlineData("CrossRole", true, true)]
+    [InlineData("SameNameInputs", false, false)]
+    [InlineData("UniqueNames", false, false)]
+    public void PanelHint_MirrorsBuilderVerdict(string constellation, bool expectWarning, bool expectBuildThrow)
+    {
+        TwoNotGatesOnCanvas("INV1", "INV2");
+        var vm = Configure("INV2");
+        PinSelectionViewModel edited;
+        switch (constellation)
+        {
+            case "DuplicateOutputs":
+                NamePin("INV1", "S", input: false);
+                edited = vm.OutputPins.Single(p => p.PinName == "Y");
+                edited.SignalName = "S";
+                break;
+            case "CrossRole":
+                NamePin("INV1", "S", input: false);
+                edited = vm.InputPins.Single(p => p.PinName == "A");
+                edited.SignalName = "S";
+                break;
+            case "SameNameInputs":
+                NamePin("INV1", "S", input: true);
+                edited = vm.InputPins.Single(p => p.PinName == "A");
+                edited.SignalName = "S";
+                break;
+            default:
+                NamePin("INV1", "Sum", input: false);
+                edited = vm.InputPins.Single(p => p.PinName == "A");
+                edited.SignalName = "CarryIn";
+                break;
+        }
+
+        (edited.SignalWarning.Length > 0).ShouldBe(expectWarning,
+            $"constellation {constellation}: the panel hint state");
+        void Build() => new LogicNetworkBuilder().Build(
+            new[] { GateInstance("INV1"), GateInstance("INV2") },
+            Array.Empty<WaveguideConnection>());
+        if (expectBuildThrow)
+            Should.Throw<ArgumentException>(Build);
+        else
+            Should.NotThrow(Build);
+    }
+
+    private ComponentGroup Group(string name) => _groups[name];
+
+    /// <summary>Two persisted NOT-shaped gates placed on one shared canvas.</summary>
+    private void TwoNotGatesOnCanvas(string firstName, string secondName)
+    {
+        _canvas = new DesignCanvasViewModel();
+        foreach (var name in new[] { firstName, secondName })
+        {
+            var group = CreateNotGroup(name);
+            _groups[name] = group;
+            _canvas.AddComponent(group);
+        }
+    }
+
+    /// <summary>Names one gate's A input or Y output through the panel, the way the user would.</summary>
+    private void NamePin(string gateName, string signal, bool input)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var groupVm = canvas.AddComponent(Group(gateName));
+        canvas.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, canvas);
+        (input ? vm.InputPins : vm.OutputPins).Single(p => p.PinName == (input ? "A" : "Y")).SignalName = signal;
+        Group(gateName).TruthTablePinAssignment.ShouldNotBeNull(
+            "the naming went through — the group carries a persisted assignment");
+    }
+
+    /// <summary>Configures the Truth Table panel for the named gate on the shared canvas.</summary>
+    private TruthTableViewModel Configure(string gateName)
+    {
+        var groupVm = _canvas.Components.Single(c => ReferenceEquals(c.Component, Group(gateName)));
+        _canvas.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, canvas: _canvas);
+        return vm;
+    }
+
+    /// <summary>The gate instance the assembler would build from the group's persisted roles.</summary>
+    private LogicGateInstance GateInstance(string gateName)
+    {
+        var roles = Group(gateName).TruthTablePinAssignment!;
+        return new LogicGateInstance(
+            Group(gateName),
+            PinnedGateTables.NotGate(),
+            new GateRoleAssignment(
+                roles.InputPinNames, roles.OutputPinNames, roles.BiasPinNames, roles.Threshold,
+                roles.InputSignalNames, roles.OutputSignalNames));
+    }
+
+    /// <summary>A bare NOT-shaped group with persisted roles but no signal names yet.</summary>
+    private static ComponentGroup CreateNotGroup(string groupName)
+    {
+        var group = new ComponentGroup(groupName);
+        foreach (var pinName in new[] { "A", "BIAS", "Y" })
+        {
+            var physicalPin = new PhysicalPin { Name = pinName, ParentComponent = group };
+            group.PhysicalPins.Add(physicalPin);
+            group.AddExternalPin(new GroupPin { Name = pinName, InternalPin = physicalPin });
+        }
+        group.TruthTablePinAssignment = new TruthTablePinAssignment
+        {
+            InputPinNames = new List<string> { "A" },
+            OutputPinNames = new List<string> { "Y" },
+            BiasPinNames = new List<string> { "BIAS" },
+            Threshold = PinnedGateTables.NotThreshold,
+        };
+        return group;
+    }
+}

--- a/UnitTests/UI/TruthTablePanelRenderTests.cs
+++ b/UnitTests/UI/TruthTablePanelRenderTests.cs
@@ -5,6 +5,7 @@ using Avalonia.VisualTree;
 using CAP.Avalonia.Controls;
 using CAP.Avalonia.Services.Localization;
 using CAP.Avalonia.Views.Panels;
+using CAP_Core.Components.Core;
 using Shouldly;
 using UnitTests.Analysis.LogicAnalysis;
 using UnitTests.Helpers;
@@ -39,6 +40,8 @@ public class TruthTablePanelRenderTests
         "TruthTable.Cancel",
         "TruthTable.Signal",
         "TruthTable.SignalWatermark",
+        "TruthTable.SignalWarnCrossRole",
+        "TruthTable.SignalWarnDuplicateOutput",
         "TruthTableHelp.Title",
         "TruthTableHelp.Intro",
         "TruthTableHelp.ThresholdTitle",
@@ -157,6 +160,48 @@ public class TruthTablePanelRenderTests
     }
 
     /// <summary>
+    /// A signal name colliding across the design (issue #1071) shows the localized
+    /// inline hint under the field: naming an input like another gate's output raises
+    /// the cross-role warning at typing time.
+    /// </summary>
+    [AvaloniaFact]
+    public void TruthTablePanel_CollidingSignalName_ShowsInlineWarning()
+    {
+        Window? window = null;
+        try
+        {
+            var canvas = new CAP.Avalonia.ViewModels.Canvas.DesignCanvasViewModel();
+            var sumVm = canvas.AddComponent(CreateNotGateWithPersistedRoles("SUM"));
+            var invVm = canvas.AddComponent(CreateNotGateWithPersistedRoles("INV"));
+            var vm = MainViewModelTestHelper.CreateMainViewModel(canvas: canvas);
+
+            canvas.Selection.SelectSingle(sumVm);
+            vm.RightPanel.TruthTable.ConfigureForSelection(sumVm, canvas);
+            vm.RightPanel.TruthTable.OutputPins.Single(p => p.PinName == "Y").SignalName = "S";
+
+            canvas.Selection.SelectSingle(invVm);
+            vm.RightPanel.TruthTable.ConfigureForSelection(invVm, canvas);
+            vm.RightPanel.TruthTable.InputPins.Single(p => p.PinName == "A").SignalName = "S";
+
+            var panel = new TruthTablePanel { DataContext = vm };
+            window = new Window { Width = 460, Height = 700, Content = panel };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var expected = string.Format(
+                LocalizationService.Instance.Translate("TruthTable.SignalWarnCrossRole"), "S");
+            panel.GetVisualDescendants().OfType<TextBlock>()
+                .Any(t => t.Text == expected)
+                .ShouldBeTrue("the colliding input row must show the cross-role hint inline");
+        }
+        finally
+        {
+            window?.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
     /// Every new truth-table key exists with a non-empty value in all five shipped languages,
     /// and no non-English language silently falls back to the English text.
     /// </summary>
@@ -179,5 +224,25 @@ public class TruthTablePanelRenderTests
                         $"{language.Code} must not fall back to English for {key}");
             }
         }
+    }
+
+    /// <summary>A bare NOT-shaped group with persisted roles but no signal names yet.</summary>
+    private static ComponentGroup CreateNotGateWithPersistedRoles(string groupName)
+    {
+        var group = new ComponentGroup(groupName);
+        foreach (var pinName in new[] { "A", "BIAS", "Y" })
+        {
+            var physicalPin = new PhysicalPin { Name = pinName, ParentComponent = group };
+            group.PhysicalPins.Add(physicalPin);
+            group.AddExternalPin(new GroupPin { Name = pinName, InternalPin = physicalPin });
+        }
+        group.TruthTablePinAssignment = new TruthTablePinAssignment
+        {
+            InputPinNames = new List<string> { "A" },
+            OutputPinNames = new List<string> { "Y" },
+            BiasPinNames = new List<string> { "BIAS" },
+            Threshold = PinnedGateTables.NotThreshold,
+        };
+        return group;
     }
 }


### PR DESCRIPTION
Automated implementation for #1071

That's the full suite I already processed — 6219 passed / 0 failed. Issue #1071 is complete: committed on `agent/issue-1071-1787161180` (based on dev-ki) and pushed.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 0
- **Estimated cost:** $0.0000 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>