### PR TITLE
Agent: Router: terminal-approach arc crosses a neighbouring waveguide at shared destination ports — PathSmoother geometry is collision-unchecked (split from #704, bug 3)

### DIFF
--- a/Connect-A-Pic-Core/Routing/AStarPathfinder/PathSmoother.cs
+++ b/Connect-A-Pic-Core/Routing/AStarPathfinder/PathSmoother.cs
@@ -116,8 +116,21 @@ public class PathSmoother
         }
 
         // GEOMETRIC TERMINAL APPROACH - STRICT VALIDATION
+        int bodySegmentCount = routedPath.Segments.Count;
         bool terminalSuccess = AppendTerminalApproach(
             routedPath, ref x, ref y, ref currentAngle, endX, endY, endEntryAngle);
+
+        // The A* search stops GoalTolerance cells before the pin, so the terminal
+        // approach is produced purely geometrically and can cross a neighbouring
+        // waveguide or component body without a crossing component — an overlap
+        // that has no optical model and would silently reach GDS export. Validate
+        // the new segments against the same grid state the body path was planned
+        // on; pin-corridor cells are legitimately clear, anything else blocked
+        // means the approach dips into foreign geometry.
+        if (terminalSuccess && TerminalApproachCollidesWithObstacle(routedPath, bodySegmentCount))
+        {
+            terminalSuccess = false;
+        }
 
         if (!terminalSuccess)
         {
@@ -126,6 +139,21 @@ public class PathSmoother
         }
 
         return routedPath;
+    }
+
+    /// <summary>
+    /// True when any segment added by <see cref="AppendTerminalApproach"/> (everything
+    /// past <paramref name="bodySegmentCount"/>) enters a blocked cell. Segment endpoints
+    /// are skipped — they sit in pin corridors cleared for this route.
+    /// </summary>
+    private bool TerminalApproachCollidesWithObstacle(RoutedPath path, int bodySegmentCount)
+    {
+        for (int i = bodySegmentCount; i < path.Segments.Count; i++)
+        {
+            if (SegmentGridCollision.IsSegmentBlocked(_grid, path.Segments[i]))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Routing/SegmentGridCollision.cs
+++ b/Connect-A-Pic-Core/Routing/SegmentGridCollision.cs
@@ -1,0 +1,63 @@
+using CAP_Core.Routing.AStarPathfinder;
+
+namespace CAP_Core.Routing;
+
+/// <summary>
+/// Cell-level collision check between path segments and a pathfinding grid.
+/// Shared by the path smoother's terminal-approach validation and any other caller
+/// that needs to test whether a segment enters blocked cells. Segment endpoints are
+/// skipped because they legitimately sit in pin corridors cleared for the route.
+/// </summary>
+public static class SegmentGridCollision
+{
+    /// <summary>
+    /// True when the segment (straight or bend) enters a blocked cell.
+    /// </summary>
+    public static bool IsSegmentBlocked(PathfindingGrid grid, PathSegment segment)
+    {
+        if (segment is StraightSegment straight)
+        {
+            return IsLineBlocked(grid, straight.StartPoint.X, straight.StartPoint.Y,
+                                 straight.EndPoint.X, straight.EndPoint.Y);
+        }
+        if (segment is BendSegment bend)
+        {
+            return IsArcBlocked(grid, bend);
+        }
+        return false;
+    }
+
+    /// <summary>True when a straight line enters a blocked cell (endpoints skipped).</summary>
+    public static bool IsLineBlocked(PathfindingGrid grid, double x1, double y1, double x2, double y2)
+    {
+        double dx = x2 - x1;
+        double dy = y2 - y1;
+        double length = Math.Sqrt(dx * dx + dy * dy);
+        if (length < 0.001) return false;
+
+        dx /= length;
+        dy /= length;
+
+        double stepSize = grid.CellSizeMicrometers * 0.5;
+        double margin = grid.CellSizeMicrometers;
+
+        for (double t = margin; t < length - margin; t += stepSize)
+        {
+            var (gx, gy) = grid.PhysicalToGrid(x1 + dx * t, y1 + dy * t);
+            if (grid.IsBlocked(gx, gy)) return true;
+        }
+        return false;
+    }
+
+    /// <summary>True when an arc enters a blocked cell (endpoints skipped).</summary>
+    public static bool IsArcBlocked(PathfindingGrid grid, BendSegment bend)
+    {
+        var samples = ArcSampling.SamplePoints(bend, grid.CellSizeMicrometers * 0.5).ToList();
+        for (int i = 1; i < samples.Count - 1; i++)
+        {
+            var (gx, gy) = grid.PhysicalToGrid(samples[i].X, samples[i].Y);
+            if (grid.IsBlocked(gx, gy)) return true;
+        }
+        return false;
+    }
+}

--- a/UnitTests/Routing/Issue704ReproRoutingTests.cs
+++ b/UnitTests/Routing/Issue704ReproRoutingTests.cs
@@ -23,7 +23,7 @@ public class Issue704ReproRoutingTests
     /// <summary>Taper pin o1 absolute position from the repro files.</summary>
     private const double TaperPinY = 816.626565747488;
 
-    [Fact(Skip = "terminal-approach collision check requires ownership-aware grid cells; retracted from this PR")]
+    [Fact]
     public void OverlappingWaveguidesRepro_NeighboringPortRoutes_DoNotSilentlyOverlap()
     {
         // Geometry of overlappingwaveguides.lun: the Taper pin sits 5.9 µm below


### PR DESCRIPTION
Automated implementation for #1078

Acknowledged — the successful full-suite run (5321 passed, 0 failed, 14 pre-existing skips). Task complete.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 130,258
- **Estimated cost:** $0.0729 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>