### PR TITLE
Agent: Logic layer register state element — feedback cycles through registers are legal (#1086)

### DIFF
--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
@@ -40,7 +40,8 @@ public partial class TruthTableViewModel
             // save → load round trip prefills the panel — a cancelled or failed
             // extraction must not overwrite the last good one. Signal names (#1025,
             // #1046) ride along for pins that keep their role: re-extracting must not
-            // silently drop the signal identity a design carries.
+            // silently drop the signal identity a design carries. The register
+            // designation (#1086) rides along the same way.
             var previous = _group.TruthTablePinAssignment;
             _group.TruthTablePinAssignment = new TruthTablePinAssignment
             {
@@ -50,6 +51,7 @@ public partial class TruthTableViewModel
                 Threshold = Threshold,
                 InputSignalNames = PreservedSignalNames(previous?.InputSignalNames, inputs),
                 OutputSignalNames = PreservedSignalNames(previous?.OutputSignalNames, outputs),
+                IsRegister = previous?.IsRegister ?? false,
             };
             SignalNamesVisible = true;
             StatusText = string.Format(Translate("Analysis.TruthTable.Complete"), table.Rows.Count);

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/GateRoleAssignment.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/GateRoleAssignment.cs
@@ -24,13 +24,20 @@ namespace CAP_Core.Analysis.LogicAnalysis;
 /// adder's sum reads <c>S</c>, its carry <c>Cout</c>. Names never merge (every tap
 /// is one gate output) and must be unique across the network. Null when unused.
 /// </param>
+/// <param name="IsRegister">
+/// Designates the gate as a behavioral register state element: its outputs hold
+/// their last committed value during combinational settling, its inputs are sampled
+/// and committed only on an explicit clock step, and a feedback cycle through it is
+/// legal. See <see cref="TruthTablePinAssignment.IsRegister"/>.
+/// </param>
 public sealed record GateRoleAssignment(
     IReadOnlyList<string> InputPinNames,
     IReadOnlyList<string> OutputPinNames,
     IReadOnlyList<string> BiasPinNames,
     double PowerThreshold,
     IReadOnlyDictionary<string, string>? InputSignalNames = null,
-    IReadOnlyDictionary<string, string>? OutputSignalNames = null);
+    IReadOnlyDictionary<string, string>? OutputSignalNames = null,
+    bool IsRegister = false);
 
 /// <summary>
 /// One top-level gate group on the canvas together with its logic-level model and

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicEventTimeline.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicEventTimeline.cs
@@ -22,9 +22,11 @@ public sealed record LogicSwitchEvent(
 /// switches at <c>max(arrival over its inputs) + gateDelay</c>, where an arrival
 /// is the driver's switch time plus that wire's delay (a driver that never
 /// switches contributes a stable arrival of 0). Gates whose output value does
-/// not change emit no event. This slice models exactly one switch per pin — no
-/// glitch/hazard modeling — and reuses the evaluator's
-/// <see cref="LogicNetworkEvaluator.GateDelaysPicoseconds"/> and
+/// not change emit no event. Register gates emit no events at all: their outputs
+/// hold the committed state through the settling and only advance on an explicit
+/// clock step, which a combinational toggle timeline does not model. This slice
+/// models exactly one switch per pin — no glitch/hazard modeling — and reuses the
+/// evaluator's <see cref="LogicNetworkEvaluator.GateDelaysPicoseconds"/> and
 /// <see cref="LogicNetworkEvaluator.WireDelaysPicoseconds"/> without recomputing
 /// any physics.
 /// </summary>
@@ -53,13 +55,15 @@ public static class LogicEventTimeline
         network.ValidateInputBits(previousInputs);
         network.ValidateInputBits(nextInputs);
 
-        var before = EvaluateAllGateOutputs(network, previousInputs);
-        var after = EvaluateAllGateOutputs(network, nextInputs);
+        var before = network.EvaluateGateOutputs(previousInputs);
+        var after = network.EvaluateGateOutputs(nextInputs);
 
         var switchTimes = new Dictionary<LogicPinRef, double>();
         var events = new List<LogicSwitchEvent>();
         foreach (var gateId in network.EvaluationOrder)
         {
+            if (network.IsRegisterGate(gateId))
+                continue;
             var gate = network.Gates[gateId];
             var arrival = LatestInputArrival(network, gateId, switchTimes);
             var switchTime = arrival + network.GateDelaysPicoseconds[gateId];
@@ -104,35 +108,5 @@ public static class LogicEventTimeline
                 latest = arrival;
         }
         return latest;
-    }
-
-    /// <summary>
-    /// Evaluates every gate output pin (not just the network taps) for one input
-    /// assignment, walking the same topological order <see cref="LogicNetworkEvaluator.Evaluate"/>
-    /// uses.
-    /// </summary>
-    private static IReadOnlyDictionary<LogicPinRef, bool> EvaluateAllGateOutputs(
-        LogicNetworkEvaluator network,
-        IReadOnlyDictionary<string, bool> inputBits)
-    {
-        var outputs = new Dictionary<LogicPinRef, bool>();
-        foreach (var gateId in network.EvaluationOrder)
-        {
-            var gate = network.Gates[gateId];
-            var gateInputs = new Dictionary<string, bool>(gate.InputPinNames.Count);
-            foreach (var pinName in gate.InputPinNames)
-            {
-                var load = new LogicPinRef(gateId, pinName);
-                gateInputs[pinName] = network.InputWiring[load] switch
-                {
-                    LogicNetDriver.NetworkInput input => inputBits[input.PinName],
-                    LogicNetDriver.GateOutput source => outputs[source.Pin],
-                    _ => throw new InvalidOperationException("Unsupported driver type."),
-                };
-            }
-            foreach (var (pinName, bit) in gate.Evaluate(gateInputs))
-                outputs[new LogicPinRef(gateId, pinName)] = bit;
-        }
-        return outputs;
     }
 }

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkAssembler.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkAssembler.cs
@@ -96,7 +96,8 @@ public sealed class LogicNetworkAssembler
             persisted.BiasPinNames,
             persisted.Threshold,
             persisted.InputSignalNames,
-            persisted.OutputSignalNames);
+            persisted.OutputSignalNames,
+            persisted.IsRegister);
         var table = await _extractor.ExtractAsync(
             group,
             roles.InputPinNames,

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkBuilder.cs
@@ -51,7 +51,10 @@ public sealed partial class LogicNetworkBuilder
     /// A gate id is duplicated, a role assignment does not match its model or group,
     /// or a connection is logically invalid. The message names the offending pins.
     /// </exception>
-    /// <exception cref="InvalidOperationException">The derived wiring forms a cycle.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The derived wiring forms a cycle that passes through no register-designated
+    /// gate (<see cref="GateRoleAssignment.IsRegister"/>).
+    /// </exception>
     public LogicNetworkEvaluator Build(
         IReadOnlyList<LogicGateInstance> gates,
         IReadOnlyList<WaveguideConnection> connections,
@@ -197,7 +200,12 @@ public sealed partial class LogicNetworkBuilder
 
         ThrowOnInputOutputNameCollision(inputMembers, outputTaps);
 
-        return new LogicNetworkEvaluator(networkInputs, models, wiring, outputTaps, delays, wireDelays);
+        var registerGateIds = contexts
+            .Where(context => context.Instance.Roles.IsRegister)
+            .Select(context => context.GateId)
+            .ToList();
+        return new LogicNetworkEvaluator(
+            networkInputs, models, wiring, outputTaps, delays, wireDelays, registerGateIds);
     }
 
     /// <summary>

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Registers.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Registers.cs
@@ -1,0 +1,115 @@
+namespace CAP_Core.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Register state half of <see cref="LogicNetworkEvaluator"/>: the gates designated
+/// as behavioral register state elements, their committed output values, and the
+/// explicit clock <see cref="Step"/>. A register's outputs hold their last
+/// committed value while the combinational logic around them settles
+/// (<see cref="LogicNetworkEvaluator.Evaluate"/>); only <see cref="Step"/> samples
+/// the register inputs from the settled network and commits the sampled values as
+/// the new state (D-semantics). All registers commit simultaneously from the same
+/// settled state, so a cross-coupled pair (an SR latch) commits race-free.
+/// This is a deliberate behavioral abstraction at the logic level (roadmap
+/// principle 4): the physical mapping of a register (e.g. an SA-based latch on an
+/// InP platform) comes later — no fake optics. Registers power up cleared
+/// (logic 0 on every output pin) — a documented convention of the behavioral
+/// model, not a physical claim.
+/// </summary>
+public sealed partial class LogicNetworkEvaluator
+{
+    private readonly HashSet<string> _registerGateIds = new();
+    private readonly Dictionary<LogicPinRef, bool> _committedRegisterOutputs = new();
+    private IReadOnlyDictionary<string, bool>? _lastInputBits;
+    private IReadOnlyDictionary<LogicPinRef, bool>? _lastSettledOutputs;
+
+    /// <summary>
+    /// The committed state of every register output pin. Empty for a purely
+    /// combinational network. Read-only: the state advances only through
+    /// <see cref="Step"/>.
+    /// </summary>
+    public IReadOnlyDictionary<LogicPinRef, bool> RegisterState => _committedRegisterOutputs;
+
+    /// <summary>Whether the gate is a designated register state element.</summary>
+    internal bool IsRegisterGate(string gateId) => _registerGateIds.Contains(gateId);
+
+    /// <summary>
+    /// Advances the network by one clock step: every register samples its input
+    /// pins from the settled state of the last <see cref="Evaluate"/> call and
+    /// commits the sampled table outputs as its new state. All registers sample the
+    /// same pre-step state (simultaneous commit, D-FF semantics), and the network
+    /// is re-settled afterwards, so consecutive steps advance consecutive clocks.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="Evaluate"/> was never called — there is no settled state to sample.
+    /// </exception>
+    public void Step()
+    {
+        if (_lastInputBits == null || _lastSettledOutputs == null)
+            throw new InvalidOperationException(
+                "Step() requires a settled network: call Evaluate at least once before the " +
+                "first Step, so the register inputs have values to sample.");
+        if (_registerGateIds.Count == 0)
+            return;
+
+        var sampled = new Dictionary<LogicPinRef, bool>();
+        foreach (var gateId in _registerGateIds)
+        {
+            var gate = Gates[gateId];
+            var gateInputBits = new Dictionary<string, bool>(gate.InputPinNames.Count);
+            foreach (var pinName in gate.InputPinNames)
+            {
+                gateInputBits[pinName] = ResolveDriverBit(
+                    _inputWiring[new LogicPinRef(gateId, pinName)], _lastInputBits, _lastSettledOutputs);
+            }
+            foreach (var (pinName, bit) in gate.Evaluate(gateInputBits))
+            {
+                sampled[new LogicPinRef(gateId, pinName)] = bit;
+            }
+        }
+
+        foreach (var (pin, bit) in sampled)
+        {
+            _committedRegisterOutputs[pin] = bit;
+        }
+        _lastSettledOutputs = EvaluateGateOutputs(_lastInputBits);
+    }
+
+    /// <summary>
+    /// Registers the designated register gates and powers their state up cleared.
+    /// Runs before the topological ordering, which skips edges into registers.
+    /// </summary>
+    /// <exception cref="ArgumentException">A register id names no gate of the network.</exception>
+    private void InitializeRegisters(IReadOnlyCollection<string>? registerGateIds)
+    {
+        if (registerGateIds == null)
+            return;
+        foreach (var gateId in registerGateIds)
+        {
+            if (!Gates.ContainsKey(gateId))
+                throw new ArgumentException(
+                    $"The register designation names unknown gate '{gateId}'. " +
+                    $"Known gates: {string.Join(", ", Gates.Keys)}.",
+                    nameof(registerGateIds));
+            _registerGateIds.Add(gateId);
+            foreach (var pinName in Gates[gateId].OutputPinNames)
+            {
+                _committedRegisterOutputs[new LogicPinRef(gateId, pinName)] = false;
+            }
+        }
+    }
+
+    /// <summary>A copy of the committed register outputs, seeding one settling pass.</summary>
+    private Dictionary<LogicPinRef, bool> CommittedRegisterOutputs() => new(_committedRegisterOutputs);
+
+    /// <summary>
+    /// Remembers the settled state <see cref="Step"/> samples from. The input bits
+    /// are copied so a caller mutating its dictionary cannot rewrite history.
+    /// </summary>
+    private void CaptureSettledState(
+        IReadOnlyDictionary<string, bool> inputBits,
+        IReadOnlyDictionary<LogicPinRef, bool> settledOutputs)
+    {
+        _lastInputBits = new Dictionary<string, bool>(inputBits);
+        _lastSettledOutputs = settledOutputs;
+    }
+}

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Timing.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Timing.cs
@@ -127,10 +127,17 @@ public sealed partial class LogicNetworkEvaluator
         return (cumulative[criticalGate], Backtrack(criticalGate, predecessor));
     }
 
-    /// <summary>The slowest arrival at one of this gate's inputs: driver cumulative delay plus wire delay.</summary>
+    /// <summary>
+    /// The slowest arrival at one of this gate's inputs: driver cumulative delay
+    /// plus wire delay. A register gate reports no arrival — its inputs are sampled
+    /// at the clock step, so the register breaks the combinational critical path
+    /// the way its output starts a new one.
+    /// </summary>
     private (double Delay, string? GateId) SlowestDriver(
         string gateId, IReadOnlyDictionary<string, double> cumulative)
     {
+        if (IsRegisterGate(gateId))
+            return (0.0, null);
         var delay = 0.0;
         string? driverId = null;
         foreach (var pinName in Gates[gateId].InputPinNames)

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.cs
@@ -1,14 +1,20 @@
 namespace CAP_Core.Analysis.LogicAnalysis;
 
 /// <summary>
-/// Evaluates a combinational network of <see cref="LogicGateModel"/> instances:
-/// gates wired output→input as a simple net list of (gateId, pin) pairs. The
-/// network is validated and topologically ordered once at construction — cycles
-/// are rejected with a clear exception, since sequential logic is a later rung —
-/// and <see cref="Evaluate"/> then walks the gates in dependency order. Every
-/// stage output is a clean bit taken from the gate's truth table, so the network
-/// has ideal level restoration by construction: arbitrary cascade depth works,
-/// exactly what the passive-linear layer cannot do.
+/// Evaluates a network of <see cref="LogicGateModel"/> instances: gates wired
+/// output→input as a simple net list of (gateId, pin) pairs. The network is
+/// validated and topologically ordered once at construction. A purely combinational
+/// network (a DAG) settles in one <see cref="Evaluate"/> walk in dependency order.
+/// Gates designated as <b>registers</b> turn the evaluation two-phase: their
+/// outputs hold the last committed value while the combinational logic around them
+/// settles, and an explicit <see cref="Step"/> samples their inputs and commits
+/// them (D-semantics) — the behavioral abstraction behind sequential logic
+/// (registers, latches, later a program counter). A feedback cycle is legal exactly
+/// when it passes through at least one register; a cycle through combinational
+/// gates only keeps the honest rejection, since an idealized combinational loop has
+/// no settling order. Every stage output is a clean bit taken from the gate's
+/// truth table, so the network has ideal level restoration by construction:
+/// arbitrary cascade depth works, exactly what the passive-linear layer cannot do.
 /// </summary>
 public sealed partial class LogicNetworkEvaluator
 {
@@ -17,7 +23,7 @@ public sealed partial class LogicNetworkEvaluator
     private readonly IReadOnlyList<string> _evaluationOrder;
 
     /// <summary>
-    /// Assembles and validates a combinational logic network.
+    /// Assembles and validates a logic network.
     /// </summary>
     /// <param name="inputPinNames">Network-level input pin names (at least one, no duplicates).</param>
     /// <param name="gates">The gate instances of the network, keyed by their network-local id.</param>
@@ -35,18 +41,26 @@ public sealed partial class LogicNetworkEvaluator
     /// <see cref="WireDelayCalculator"/>), keyed by the (driver output → load input)
     /// edge; edges without an entry report zero delay.
     /// </param>
+    /// <param name="registerGateIds">
+    /// Optional ids of the gates designated as behavioral register state elements:
+    /// their outputs hold the last committed value during <see cref="Evaluate"/> and
+    /// advance only on <see cref="Step"/>. Feedback cycles through them are legal.
+    /// </param>
     /// <exception cref="ArgumentException">
     /// A gate, pin, or network input is unknown; a gate input is left undriven; or the
     /// wiring is otherwise inconsistent. The message names the offending element.
     /// </exception>
-    /// <exception cref="InvalidOperationException">The wiring forms a cycle.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The wiring forms a cycle that passes through no register gate.
+    /// </exception>
     public LogicNetworkEvaluator(
         IReadOnlyList<string> inputPinNames,
         IReadOnlyDictionary<string, LogicGateModel> gates,
         IReadOnlyDictionary<LogicPinRef, LogicNetDriver> inputWiring,
         IReadOnlyDictionary<string, LogicPinRef> outputTaps,
         IReadOnlyDictionary<string, double>? gateDelays = null,
-        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays = null)
+        IReadOnlyDictionary<LogicWireEdge, double>? wireDelays = null,
+        IReadOnlyCollection<string>? registerGateIds = null)
     {
         InputPinNames = inputPinNames ?? throw new ArgumentNullException(nameof(inputPinNames));
         Gates = gates ?? throw new ArgumentNullException(nameof(gates));
@@ -57,6 +71,7 @@ public sealed partial class LogicNetworkEvaluator
         ValidateGates();
         ValidateWiring();
         ValidateOutputTaps();
+        InitializeRegisters(registerGateIds);
         _evaluationOrder = TopologicalOrder();
         DetectFanOut();
         InitializeTiming(gateDelays, wireDelays);
@@ -81,8 +96,11 @@ public sealed partial class LogicNetworkEvaluator
     internal IReadOnlyList<string> EvaluationOrder => _evaluationOrder;
 
     /// <summary>
-    /// Evaluates the network for one input combination: every gate fires exactly
-    /// once in topological order, reading clean bits and producing clean bits.
+    /// Evaluates the network for one input combination: every combinational gate
+    /// fires exactly once in topological order, reading clean bits and producing
+    /// clean bits. Register gates do not fire — their outputs hold the last value
+    /// committed by <see cref="Step"/> (initially logic 0), so changing a register's
+    /// input never changes its output within a settling phase.
     /// </summary>
     /// <param name="inputBits">One bit per network-level input pin name.</param>
     /// <returns>The bit of every network-level output.</returns>
@@ -93,9 +111,24 @@ public sealed partial class LogicNetworkEvaluator
         if (inputBits == null) throw new ArgumentNullException(nameof(inputBits));
         ValidateInputBits(inputBits);
 
-        var gateOutputs = new Dictionary<LogicPinRef, bool>();
+        var gateOutputs = EvaluateGateOutputs(inputBits);
+        CaptureSettledState(inputBits, gateOutputs);
+        return _outputTaps.ToDictionary(tap => tap.Key, tap => gateOutputs[tap.Value]);
+    }
+
+    /// <summary>
+    /// Settles every gate output pin (not just the network taps) for one validated
+    /// input combination: register outputs enter pre-seeded with their committed
+    /// state and the combinational gates then fire once in topological order.
+    /// Shared with the event-timeline walker so both see the same settled values.
+    /// </summary>
+    internal Dictionary<LogicPinRef, bool> EvaluateGateOutputs(IReadOnlyDictionary<string, bool> inputBits)
+    {
+        var gateOutputs = CommittedRegisterOutputs();
         foreach (var gateId in _evaluationOrder)
         {
+            if (IsRegisterGate(gateId))
+                continue;
             var gate = Gates[gateId];
             var gateInputBits = new Dictionary<string, bool>(gate.InputPinNames.Count);
             foreach (var pinName in gate.InputPinNames)
@@ -109,8 +142,7 @@ public sealed partial class LogicNetworkEvaluator
                 gateOutputs[new LogicPinRef(gateId, pinName)] = bit;
             }
         }
-
-        return _outputTaps.ToDictionary(tap => tap.Key, tap => gateOutputs[tap.Value]);
+        return gateOutputs;
     }
 
     /// <summary>Resolves one driver to its current bit: a network input bit or an already-evaluated gate output.</summary>
@@ -126,16 +158,19 @@ public sealed partial class LogicNetworkEvaluator
         };
 
     /// <summary>
-    /// Orders the gates so every gate fires only after all gates driving its inputs
-    /// have fired (Kahn's algorithm). A network that cannot be fully ordered contains
-    /// a cycle — sequential logic, which this combinational evaluator rejects.
+    /// Orders the gates so every combinational gate fires only after all gates
+    /// driving its inputs have fired (Kahn's algorithm). Edges into a register gate
+    /// take no part in the ordering — the register samples them at the clock step,
+    /// not during settling — so a feedback cycle passing through a register
+    /// resolves. A network that still cannot be fully ordered contains a purely
+    /// combinational cycle, which has no settling order and stays rejected.
     /// </summary>
     private IReadOnlyList<string> TopologicalOrder()
     {
         var dependencies = Gates.Keys.ToDictionary(id => id, _ => new HashSet<string>());
         foreach (var (load, driver) in _inputWiring)
         {
-            if (driver is LogicNetDriver.GateOutput source)
+            if (driver is LogicNetDriver.GateOutput source && !IsRegisterGate(load.GateId))
                 dependencies[load.GateId].Add(source.Pin.GateId);
         }
 

--- a/Connect-A-Pic-Core/Components/Core/TruthTablePinAssignment.cs
+++ b/Connect-A-Pic-Core/Components/Core/TruthTablePinAssignment.cs
@@ -50,6 +50,22 @@ public sealed class TruthTablePinAssignment
     public Dictionary<string, string>? OutputSignalNames { get; set; }
 
     /// <summary>
+    /// Designates the gate as a behavioral <b>register</b> state element (sequential
+    /// logic, rung 5): its outputs hold their last committed value while the network
+    /// settles combinationally, and only an explicit clock step samples its inputs
+    /// and commits them (D-semantics). A feedback cycle is legal exactly when it
+    /// passes through at least one register-designated gate. This is a deliberate
+    /// behavioral abstraction at the logic level (roadmap principle 4) — the physical
+    /// mapping (e.g. an SA-based latch on an InP platform) comes later; no fake optics.
+    /// False for plain combinational gates and for files saved before registers
+    /// existed — the flag is omitted from the .lun unless set, keeping legacy files
+    /// byte-clean.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore(
+        Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public bool IsRegister { get; set; }
+
+    /// <summary>
     /// Creates an independent copy of the assignment: the lists and the signal-name
     /// dictionaries are mutable, so copies of one gate must not share them.
     /// </summary>
@@ -60,6 +76,7 @@ public sealed class TruthTablePinAssignment
         OutputPinNames = new List<string>(OutputPinNames),
         BiasPinNames = new List<string>(BiasPinNames),
         Threshold = Threshold,
+        IsRegister = IsRegister,
         InputSignalNames = InputSignalNames == null
             ? null
             : new Dictionary<string, string>(InputSignalNames),

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkAssemblerRegisterTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkAssemblerRegisterTests.cs
@@ -1,0 +1,108 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Register designation at the design-to-network assembly level: a feedback loop
+/// between two OR gate groups assembles once one of them carries the persisted
+/// register flag on its <see cref="TruthTablePinAssignment"/>, and the very same
+/// loop without the designation keeps the combinational-cycle rejection. The
+/// assembled network then evaluates two-phase — the register gate's output holds
+/// its committed value until <see cref="LogicNetworkEvaluator.Step"/> samples the
+/// loop — straight from the persisted assignment the .lun round trip delivers.
+/// </summary>
+public class LogicNetworkAssemblerRegisterTests
+{
+    private const double OrThreshold = 0.25;
+
+    [Fact]
+    public async Task AssembleAsync_FeedbackLoopThroughDesignatedRegister_AssemblesAndSteps()
+    {
+        var first = OrGate("OR1");
+        var second = OrGate("OR2", isRegister: true);
+        var connections = FeedbackLoop(first, second);
+
+        var network = await Assemble(new Component[] { first, second }, connections);
+
+        network.RegisterState.Keys.ShouldBe(new[] { new LogicPinRef("OR2", "y") },
+            "only the designated gate carries committed state");
+
+        // OR1.y = OR(OR2.y_committed, OR1.b): with OR1.b on, OR1.y rises while the
+        // register output still holds its cleared power-up value.
+        var settled = network.Evaluate(Bits(("OR1.b", true), ("OR2.b", false)));
+        settled["OR1.y"].ShouldBeTrue("the combinational gate settles from the committed 0");
+        settled["OR2.y"].ShouldBeFalse("the register output holds until the step");
+
+        network.Step();
+        var stepped = network.Evaluate(Bits(("OR1.b", true), ("OR2.b", false)));
+        stepped["OR2.y"].ShouldBeTrue("the step sampled OR1.y=1 around the loop and committed it");
+        stepped["OR1.y"].ShouldBeTrue();
+
+        // The committed bit holds the loop on its own once OR1.b goes low again.
+        network.Evaluate(Bits(("OR1.b", false), ("OR2.b", false)))["OR2.y"].ShouldBeTrue(
+            "changing the inputs without a step must not change the committed output");
+    }
+
+    [Fact]
+    public async Task AssembleAsync_SameLoopWithoutRegisterDesignation_KeepsTheCycleRejection()
+    {
+        var first = OrGate("OR1");
+        var second = OrGate("OR2");
+        var connections = FeedbackLoop(first, second);
+
+        var error = await Should.ThrowAsync<InvalidOperationException>(
+            () => Assemble(new Component[] { first, second }, connections));
+
+        error.Message.ShouldContain("cycle");
+        error.Message.ShouldContain("OR1");
+        error.Message.ShouldContain("OR2");
+        error.Message.ShouldContain("sequential logic is not supported");
+    }
+
+    /// <summary>The cross-wired feedback loop: OR1.y → OR2.a and OR2.y → OR1.a.</summary>
+    private static WaveguideConnection[] FeedbackLoop(ComponentGroup first, ComponentGroup second) =>
+        new[] { Connect(first, "y", second, "a"), Connect(second, "y", first, "a") };
+
+    /// <summary>Runs the assembler at the fixture wavelength.</summary>
+    private static Task<LogicNetworkEvaluator> Assemble(
+        IReadOnlyList<Component> components, IReadOnlyList<WaveguideConnection> connections) =>
+        new LogicNetworkAssembler().AssembleAsync(
+            components, connections, LogicGateFixtureFactory.WavelengthNm);
+
+    /// <summary>
+    /// A combiner group with the OR-reading assignment persisted, as a save → load
+    /// round trip would deliver it — optionally carrying the register designation.
+    /// </summary>
+    private static ComponentGroup OrGate(string groupName, bool isRegister = false)
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        group.GroupName = groupName;
+        group.TruthTablePinAssignment = new TruthTablePinAssignment
+        {
+            InputPinNames = new List<string> { "a", "b" },
+            OutputPinNames = new List<string> { "y" },
+            BiasPinNames = new List<string>(),
+            Threshold = OrThreshold,
+            IsRegister = isRegister,
+        };
+        group.EnsureSMatrixComputed();
+        return group;
+    }
+
+    /// <summary>A design connection between two gate groups' external pins.</summary>
+    private static WaveguideConnection Connect(
+        ComponentGroup from, string fromPin, ComponentGroup to, string toPin) =>
+        new() { StartPin = Pin(from, fromPin), EndPin = Pin(to, toPin) };
+
+    /// <summary>Looks up a group's connectable external pin.</summary>
+    private static PhysicalPin Pin(ComponentGroup group, string name) =>
+        group.PhysicalPins.Single(p => p.Name == name);
+
+    /// <summary>Builds an input-bit dictionary from (name, bit) pairs.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkRegisterTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkRegisterTests.cs
@@ -1,0 +1,236 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The register state element of the logic layer (sequential slice 1): a gate
+/// designated as a register holds its committed output through combinational
+/// settling and only an explicit <see cref="LogicNetworkEvaluator.Step"/> samples
+/// and commits its inputs (D-semantics). A feedback cycle is legal exactly when it
+/// passes through at least one register; a purely combinational cycle keeps the
+/// honest rejection. Covered at the net-list level with value-built gate models:
+/// a D-flip-flop (buffer register), an SR latch from two cross-coupled NAND
+/// registers, and the cycle-legality boundary.
+/// </summary>
+public class LogicNetworkRegisterTests
+{
+    [Fact]
+    public void Constructor_FeedbackLoopThroughRegister_Assembles()
+    {
+        var network = ToggleLoop(registerGateIds: new[] { "reg" });
+
+        network.Gates.Keys.ShouldBe(new[] { "reg", "inv" });
+        network.RegisterState.Keys.ShouldBe(new[] { new LogicPinRef("reg", "Y") },
+            "the register powers up with its committed output cleared");
+    }
+
+    [Fact]
+    public void Constructor_SameLoopWithoutRegisterDesignation_KeepsTheCombinationalCycleRejection()
+    {
+        var error = Should.Throw<InvalidOperationException>(() => ToggleLoop(registerGateIds: null));
+
+        error.Message.ShouldContain("cycle");
+        error.Message.ShouldContain("reg");
+        error.Message.ShouldContain("inv");
+        error.Message.ShouldContain("sequential logic is not supported");
+    }
+
+    [Fact]
+    public void Constructor_CombinationalCycleBesideARegister_KeepsTheCombinationalCycleRejection()
+    {
+        // A register elsewhere in the network must not pardon a cycle that passes
+        // through combinational gates only.
+        var error = Should.Throw<InvalidOperationException>(() => new LogicNetworkEvaluator(
+            new[] { "d" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["reg"] = BufferGate(),
+                ["n1"] = PinnedGateTables.NotGate(),
+                ["n2"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("reg", "A")] = new LogicNetDriver.NetworkInput("d"),
+                [new LogicPinRef("n1", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("n2", "Y")),
+                [new LogicPinRef("n2", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("n1", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["q"] = new("reg", "Y") },
+            registerGateIds: new[] { "reg" }));
+
+        error.Message.ShouldContain("cycle");
+        error.Message.ShouldContain("n1");
+        error.Message.ShouldContain("n2");
+        error.Message.ShouldContain("sequential logic is not supported");
+    }
+
+    [Fact]
+    public void Constructor_UnknownRegisterGateId_ThrowsNamingTheGate()
+    {
+        var error = Should.Throw<ArgumentException>(() => new LogicNetworkEvaluator(
+            new[] { "d" },
+            new Dictionary<string, LogicGateModel> { ["reg"] = BufferGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("reg", "A")] = new LogicNetDriver.NetworkInput("d"),
+            },
+            new Dictionary<string, LogicPinRef> { ["q"] = new("reg", "Y") },
+            registerGateIds: new[] { "ghost" }));
+
+        error.Message.ShouldContain("unknown gate 'ghost'");
+        error.Message.ShouldContain("Known gates: reg");
+    }
+
+    [Fact]
+    public void Evaluate_DFlipFlop_HoldsCommittedOutputUntilStepCommitsTheSampledInput()
+    {
+        var network = DFlipFlop();
+
+        network.Evaluate(Bits(("d", true)))["q"].ShouldBeFalse(
+            "a register powers up cleared — D=1 is not committed yet");
+        network.RegisterState[new LogicPinRef("reg", "Y")].ShouldBeFalse();
+
+        network.Step();
+        network.Evaluate(Bits(("d", true)))["q"].ShouldBeTrue(
+            "the step sampled D=1 and committed it");
+
+        network.Evaluate(Bits(("d", false)))["q"].ShouldBeTrue(
+            "changing D without a step must not change the committed output");
+
+        network.Step();
+        network.Evaluate(Bits(("d", false)))["q"].ShouldBeFalse(
+            "the second step commits the new input");
+    }
+
+    [Fact]
+    public void Step_ConsecutiveSteps_AdvanceConsecutiveClocks()
+    {
+        // The toggle loop reg = NOT(reg) through an inverter: every step flips the
+        // committed bit — the feedback cycle the designation made legal. The
+        // declared network input "x" drives nothing (the loop is self-sufficient),
+        // but Evaluate still requires its bit.
+        var network = ToggleLoop(registerGateIds: new[] { "reg" });
+
+        network.Evaluate(Bits(("x", false)))["q"].ShouldBeFalse("powered up cleared");
+        network.Step();
+        network.Evaluate(Bits(("x", false)))["q"].ShouldBeTrue("first clock: NOT(0) committed");
+        network.Step();
+        network.Evaluate(Bits(("x", false)))["q"].ShouldBeFalse("second clock: NOT(1) committed");
+    }
+
+    [Fact]
+    public void Step_BeforeAnyEvaluate_ThrowsTellingTheCallerToSettleFirst()
+    {
+        var error = Should.Throw<InvalidOperationException>(() => DFlipFlop().Step());
+
+        error.Message.ShouldContain("Evaluate");
+    }
+
+    [Fact]
+    public void Evaluate_SrLatchFromCrossCoupledNandRegisters_HoldsStateAcrossSteps()
+    {
+        var network = SrLatch();
+
+        // Set (active-low S): Q rises, Q̄ falls — and then holds while both
+        // inputs rest at 1.
+        network.Evaluate(Bits(("s", false), ("r", true)));
+        network.Step();
+        network.Step();
+        network.Evaluate(Bits(("s", true), ("r", true)))["q"].ShouldBeTrue("the latch is set");
+        network.Evaluate(Bits(("s", true), ("r", true)))["qb"].ShouldBeFalse();
+
+        network.Step();
+        network.Step();
+        network.Evaluate(Bits(("s", true), ("r", true)))["q"].ShouldBeTrue(
+            "resting inputs hold the set state");
+
+        // Reset (active-low R): Q falls, Q̄ rises — and holds again.
+        network.Evaluate(Bits(("s", true), ("r", false)));
+        network.Step();
+        network.Step();
+        network.Evaluate(Bits(("s", true), ("r", true)))["q"].ShouldBeFalse("the latch is reset");
+        network.Evaluate(Bits(("s", true), ("r", true)))["qb"].ShouldBeTrue();
+
+        network.Step();
+        network.Step();
+        network.Evaluate(Bits(("s", true), ("r", true)))["q"].ShouldBeFalse(
+            "resting inputs hold the reset state");
+    }
+
+    /// <summary>One buffer register with D as its only network input and Q as its tap.</summary>
+    private static LogicNetworkEvaluator DFlipFlop() =>
+        new(
+            new[] { "d" },
+            new Dictionary<string, LogicGateModel> { ["reg"] = BufferGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("reg", "A")] = new LogicNetDriver.NetworkInput("d"),
+            },
+            new Dictionary<string, LogicPinRef> { ["q"] = new("reg", "Y") },
+            registerGateIds: new[] { "reg" });
+
+    /// <summary>
+    /// The smallest feedback loop: an inverter wired between the register's output
+    /// and input (reg = NOT(reg) once clocked). Without the register designation
+    /// this is the rejected combinational cycle.
+    /// </summary>
+    private static LogicNetworkEvaluator ToggleLoop(IReadOnlyCollection<string>? registerGateIds) =>
+        new(
+            new[] { "x" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["reg"] = BufferGate(),
+                ["inv"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("reg", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("inv", "Y")),
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("reg", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["q"] = new("reg", "Y") },
+            registerGateIds: registerGateIds);
+
+    /// <summary>
+    /// Two cross-coupled NAND gates, both designated registers: Q = NAND(S, Q̄),
+    /// Q̄ = NAND(R, Q) with active-low set/reset — the classic SR latch.
+    /// </summary>
+    private static LogicNetworkEvaluator SrLatch() =>
+        new(
+            new[] { "s", "r" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["qGate"] = PinnedGateTables.NandGate(),
+                ["qbGate"] = PinnedGateTables.NandGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("qGate", "A")] = new LogicNetDriver.NetworkInput("s"),
+                [new LogicPinRef("qGate", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("qbGate", "Y")),
+                [new LogicPinRef("qbGate", "A")] = new LogicNetDriver.NetworkInput("r"),
+                [new LogicPinRef("qbGate", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("qGate", "Y")),
+            },
+            new Dictionary<string, LogicPinRef>
+            {
+                ["q"] = new("qGate", "Y"),
+                ["qb"] = new("qbGate", "Y"),
+            },
+            registerGateIds: new[] { "qGate", "qbGate" });
+
+    /// <summary>The D-flip-flop's combinational core: a buffer, Y = A.</summary>
+    private static LogicGateModel BufferGate()
+    {
+        var inputs = new[] { "A" };
+        var rows = new[] { false, true }
+            .Select(bit => new TruthTableRow(
+                new Dictionary<string, bool> { ["A"] = bit },
+                new Dictionary<string, LogicOutputValue> { ["Y"] = new(bit, bit ? 0.5 : 0.0) }))
+            .ToArray();
+        return LogicGateModel.FromTruthTable(
+            new TruthTable("Buffer", inputs, new[] { "Y" }, 0.25, PinnedGateTables.WavelengthNm, rows));
+    }
+
+    /// <summary>Builds an input-bit dictionary from (name, bit) pairs.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}

--- a/UnitTests/Components/ComponentGroupCloningTests.cs
+++ b/UnitTests/Components/ComponentGroupCloningTests.cs
@@ -336,7 +336,8 @@ public class ComponentGroupCloningTests
             OutputPinNames = new List<string> { "Y" },
             BiasPinNames = new List<string> { "BIAS" },
             Threshold = 0.125,
-            InputSignalNames = new Dictionary<string, string> { ["A"] = "A" }
+            InputSignalNames = new Dictionary<string, string> { ["A"] = "A" },
+            IsRegister = true
         };
 
         var copy = original.DeepCopy();
@@ -350,6 +351,8 @@ public class ComponentGroupCloningTests
         copiedRoles.BiasPinNames.ShouldBe(original.TruthTablePinAssignment.BiasPinNames);
         copiedRoles.Threshold.ShouldBe(original.TruthTablePinAssignment.Threshold);
         copiedRoles.InputSignalNames.ShouldBe(original.TruthTablePinAssignment.InputSignalNames);
+        copiedRoles.IsRegister.ShouldBeTrue(
+            "a duplicated register gate must stay a register");
 
         copiedRoles.InputPinNames.Add("Mutated");
         original.TruthTablePinAssignment.InputPinNames.Count.ShouldBe(2,

--- a/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
+++ b/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
@@ -7,6 +7,7 @@ using CAP.Avalonia.ViewModels.Export;
 using CAP.Avalonia.ViewModels.Library;
 using CAP.Avalonia.ViewModels.Panels;
 using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
 using CAP_Core.Components.Core;
 using CAP_Core.Export;
 using Moq;
@@ -28,6 +29,7 @@ public class TruthTablePinAssignmentPersistenceTests : IDisposable
 {
     private const string ExampleFileName = "Logic Gate NOT-NAND.lun";
     private const double NandThreshold = 0.125;
+    private const int WavelengthNm = 1550;
     private static readonly string[] NandInputs = { "A", "B" };
     private static readonly string[] NandOutputs = { "Y" };
     private static readonly string[] NandBiases = { "BIAS" };
@@ -303,6 +305,46 @@ public class TruthTablePinAssignmentPersistenceTests : IDisposable
 
         var reloaded = await LoadFromDisk();
         SingleGateGroup(reloaded).TruthTablePinAssignment.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task RoundTrip_RegisterDesignationSurvivesSaveLoadAndReassembly()
+    {
+        // Issue #1086: the register flag rides in the persisted pin-role block like
+        // the roles themselves, and the reloaded designation reaches the assembled
+        // network as committed register state.
+        var canvas = await LoadGateOnCanvas();
+        await ExtractNandThroughPanel(canvas);
+        SingleGateGroup(canvas).TruthTablePinAssignment!.IsRegister = true;
+
+        await Save(canvas);
+        File.ReadAllText(_designFilePath).ShouldContain("\"IsRegister\": true", Case.Sensitive);
+
+        var reloaded = await LoadFromDisk();
+        var group = SingleGateGroup(reloaded);
+        group.TruthTablePinAssignment.ShouldNotBeNull().IsRegister.ShouldBeTrue(
+            "the register designation must be restored on the reloaded group");
+
+        group.EnsureSMatrixComputed();
+        var network = await new LogicNetworkAssembler().AssembleAsync(
+            new Component[] { group }, Array.Empty<WaveguideConnection>(), WavelengthNm);
+        network.RegisterState.Keys.ShouldBe(new[] { new LogicPinRef(group.GroupName, "Y") },
+            "the reloaded designation designates the register in the assembled network");
+    }
+
+    [Fact]
+    public async Task RoundTrip_GateWithoutRegisterDesignation_PersistsNoRegisterFlag()
+    {
+        // Issue #1086: a plain combinational gate writes no register flag — the
+        // default false is omitted, keeping the .lun format free of unused blocks.
+        var canvas = await LoadGateOnCanvas();
+        await ExtractNandThroughPanel(canvas);
+
+        await Save(canvas);
+        var fileText = File.ReadAllText(_designFilePath);
+        fileText.ShouldContain("TruthTablePinAssignment", Case.Sensitive);
+        fileText.ShouldNotContain("IsRegister", Case.Sensitive,
+            "a plain gate persists no register flag — legacy files stay byte-clean");
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

Sequential slice 1 for rung 5 (#1086): the logic layer gains an explicit behavioral **register state element**. Until now `LogicNetworkAssembler`/`LogicNetworkEvaluator` were purely combinational and honestly rejected every feedback cycle — but registers, latches, and eventually a program counter all need state, and the roadmap lists sequential logic as the scoped rung-5 blocker.

- **Designation:** a gate group is designated as a register via `TruthTablePinAssignment.IsRegister` — a flag inside the existing persisted pin-role block (#984 pattern). Chosen because the assignment is already the gate's persisted logic identity: it serializes inline in the .lun, rides through `Copy()` and re-extraction for free, and keeps the designation next to the roles it modifies. The flag is omitted when false (`WhenWritingDefault`), so legacy .lun files stay byte-clean.
- **Two-phase evaluation:** register outputs hold their last committed value during combinational settling (`Evaluate`); an explicit `Step()` on the evaluator samples every register's inputs from the settled state and commits them (D-semantics, simultaneous commit — a cross-coupled pair commits race-free). Registers power up cleared (logic 0), a documented behavioral convention.
- **Cycle legality:** edges into register gates are dropped from the topological ordering, so a cycle is legal iff it passes through at least one register. Pure combinational cycles keep today's exact diagnostic (`...cycle... sequential logic is not supported`).
- **Deliberate behavioral abstraction** (roadmap principle 4, logic level): the XML docs state the physical mapping (e.g. an SA-based latch on an InP platform) comes later — no fake optics.
- Timing/event-timeline stay consistent: a register breaks the combinational critical path (its inputs are sampled at the clock step) and emits no switch events during settling.

Core-only (Recipe B) + one one-liner in `TruthTableViewModel.Extract.cs` so re-extracting a gate's truth table does not silently strip its register designation (same rationale as signal names #1025/#1046). No UI, no example .lun — the Logic-panel clock button and a shipped SR-latch/D-FF example are follow-up issues.

## How it was tested

- `LogicNetworkRegisterTests` (evaluator level): feedback loop through a register assembles; the same loop without designation keeps the existing cycle diagnostic; a combinational cycle next to a register is still rejected; D-FF semantics (D=1 → Q stays 0 until `Step()`, then 1; changing D without a step leaves Q untouched); toggle loop `reg = NOT(reg)` flips once per `Step()`; SR latch from two cross-coupled NAND registers holds set → hold → reset → hold across steps; `Step()` before any `Evaluate` throws a readable error.
- `LogicNetworkAssemblerRegisterTests` (assembly from numeric OR-gate fixtures): the two-gate feedback loop assembles with the persisted register flag and steps around the loop; without the flag it is rejected with the existing diagnostic.
- `TruthTablePinAssignmentPersistenceTests`: register designation survives .lun save → load → re-assembly (the assembled network carries the register's committed state); a plain gate persists no register flag (legacy files byte-clean).
- Existing combinational tests unchanged.

Local suite: 6241 passed, 0 failed

## Manual verification after vacation

None needed at this slice (core-only); the UI follow-up (Logic-panel clock button, shipped SR-latch/D-FF example) will be verified manually.