### PR TITLE
Agent: E2E honesty — tight neighbouring-port design → GDS without overlapping waveguides (#1088)

### DIFF
--- a/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.Geometry.cs
+++ b/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.Geometry.cs
@@ -62,6 +62,12 @@ public static partial class ExportedWaveguideOverlapAnalyzer
         return clusters;
     }
 
+    /// <summary>True when every vertex of the chain lies inside one of the allowed regions.</summary>
+    private static bool IsFullyInsideFootprints(Cluster cluster, IReadOnlyList<BoundingBox> allowedRegions) =>
+        cluster.Polygons
+            .SelectMany(p => p.Points)
+            .All(pt => allowedRegions.Any(box => box.Contains(pt.X, pt.Y)));
+
     /// <summary>Geometric mean of every vertex belonging to the cluster.</summary>
     private static Point Centroid(Cluster cluster)
     {

--- a/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.Geometry.cs
+++ b/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.Geometry.cs
@@ -1,0 +1,173 @@
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Geometric half of <see cref="ExportedWaveguideOverlapAnalyzer"/>: the polygon model
+/// and the predicates that decide coverage, contact and intersection between
+/// exported shapes. Split out so each source file stays small — never a second
+/// abstraction.
+/// </summary>
+public static partial class ExportedWaveguideOverlapAnalyzer
+{
+    /// <summary>One vertex of an exported polygon (µm, exported/nazca coordinates).</summary>
+    private readonly struct Point
+    {
+        public readonly double X, Y;
+        public Point(double x, double y) { X = x; Y = y; }
+        public double DistanceTo(Point other) =>
+            Math.Sqrt((X - other.X) * (X - other.X) + (Y - other.Y) * (Y - other.Y));
+    }
+
+    /// <summary>A GDS boundary of the design cell, layer-tagged.</summary>
+    private readonly struct Polygon
+    {
+        public readonly int Layer;
+        public readonly int DataType;
+        public readonly IReadOnlyList<Point> Points;
+        public Polygon(int layer, int dataType, IReadOnlyList<Point> points)
+        {
+            Layer = layer;
+            DataType = dataType;
+            Points = points;
+        }
+    }
+
+    /// <summary>A geometric chain of touching polygons — one routed connection's export.</summary>
+    private sealed class Cluster
+    {
+        public readonly List<Polygon> Polygons = new();
+        public Cluster(Polygon first) => Polygons.Add(first);
+    }
+
+    /// <summary>Clusters the given polygons by geometric contact (touch or overlap joins).</summary>
+    private static List<Cluster> BuildClusters(List<Polygon> polygons)
+    {
+        var clusters = new List<Cluster>();
+        foreach (var polygon in polygons)
+        {
+            var touching = clusters
+                .Where(cluster => cluster.Polygons.Any(existing => Touch(existing, polygon, ContactToleranceMicrometers)))
+                .ToList();
+            if (touching.Count == 0)
+            {
+                clusters.Add(new Cluster(polygon));
+                continue;
+            }
+            touching[0].Polygons.Add(polygon);
+            foreach (var excess in touching.Skip(1))
+            {
+                touching[0].Polygons.AddRange(excess.Polygons);
+                clusters.Remove(excess);
+            }
+        }
+        return clusters;
+    }
+
+    /// <summary>Geometric mean of every vertex belonging to the cluster.</summary>
+    private static Point Centroid(Cluster cluster)
+    {
+        double sumX = 0, sumY = 0;
+        long count = 0;
+        foreach (var poly in cluster.Polygons)
+        foreach (var pt in poly.Points)
+        {
+            sumX += pt.X;
+            sumY += pt.Y;
+            count++;
+        }
+        return count == 0 ? new Point(0, 0) : new Point(sumX / count, sumY / count);
+    }
+
+    /// <summary>True when the point is covered by the polygon within tolerance of its boundary or interior.</summary>
+    private static bool Covers(Polygon polygon, double x, double y, double tolerance)
+    {
+        var candidate = new Point(x, y);
+        if (polygon.Points.Any(p => p.DistanceTo(candidate) <= tolerance)) return true;
+        for (var i = 0; i < polygon.Points.Count; i++)
+        {
+            var a = polygon.Points[i];
+            var b = polygon.Points[(i + 1) % polygon.Points.Count];
+            if (DistancePointToSegment(candidate, a, b) <= tolerance) return true;
+        }
+        return InteriorContains(polygon.Points, candidate);
+    }
+
+    /// <summary>Two polygons touch when any vertex of one lands inside the other or their edges meet.</summary>
+    private static bool Touch(Polygon a, Polygon b, double tolerance)
+    {
+        if (a.Points.Any(p => InteriorContains(b.Points, p)) || b.Points.Any(p => InteriorContains(a.Points, p)))
+            return true;
+
+        for (var i = 0; i < a.Points.Count; i++)
+            for (var j = 0; j < b.Points.Count; j++)
+            {
+                var p0 = a.Points[i];
+                var p1 = a.Points[(i + 1) % a.Points.Count];
+                var q0 = b.Points[j];
+                var q1 = b.Points[(j + 1) % b.Points.Count];
+                if (SegmentsWithin(p0, p1, q0, q1, tolerance)) return true;
+            }
+        return false;
+    }
+
+    /// <summary>True when the distance between both closed segments is within <paramref name="tolerance"/>.</summary>
+    private static bool SegmentsWithin(Point p0, Point p1, Point q0, Point q1, double tolerance)
+    {
+        if (SegmentsIntersect(p0, p1, q0, q1)) return true;
+        return MinDistance(p0, p1, q0, q1) <= tolerance;
+    }
+
+    /// <summary>Minimum distance between two closed segments (0 when they cross or overlap).</summary>
+    private static double MinDistance(Point p0, Point p1, Point q0, Point q1)
+    {
+        double shortest = double.MaxValue;
+        shortest = Math.Min(shortest, DistancePointToSegment(p0, q0, q1));
+        shortest = Math.Min(shortest, DistancePointToSegment(p1, q0, q1));
+        shortest = Math.Min(shortest, DistancePointToSegment(q0, p0, p1));
+        return Math.Min(shortest, DistancePointToSegment(q1, p0, p1));
+    }
+
+    /// <summary>Distance of point to segment (projection clamped to endpoints).</summary>
+    private static double DistancePointToSegment(Point p, Point a, Point b)
+    {
+        double dx = b.X - a.X, dy = b.Y - a.Y;
+        double lengthSquared = dx * dx + dy * dy;
+        var t = lengthSquared == 0
+            ? 0.0
+            : Clamp((p.X - a.X) * dx + (p.Y - a.Y) * dy, 0, lengthSquared) / lengthSquared;
+        var projected = new Point(a.X + t * dx, a.Y + t * dy);
+        return p.DistanceTo(projected);
+    }
+
+    /// <summary>Clamps a value to [min, max].</summary>
+    private static double Clamp(double value, double min, double max) =>
+        value < min ? min : value > max ? max : value;
+
+    /// <summary>Proper segment intersection (sign test; collinear overlap counts too).</summary>
+    private static bool SegmentsIntersect(Point p0, Point p1, Point q0, Point q1)
+    {
+        double Side(Point r, Point a, Point b) =>
+            (b.X - a.X) * (r.Y - a.Y) - (b.Y - a.Y) * (r.X - a.X);
+        var s1 = Side(q0, p0, p1);
+        var s2 = Side(q1, p0, p1);
+        var s3 = Side(p0, q0, q1);
+        var s4 = Side(p1, q0, q1);
+        return (s1 < 0) != (s2 < 0) && (s3 < 0) != (s4 < 0);
+    }
+
+    /// <summary>Ray-casting point-in-polygon (boundary covered by the tolerance check).</summary>
+    private static bool InteriorContains(IReadOnlyList<Point> polygon, Point point)
+    {
+        var inside = false;
+        for (var i = 0; i < polygon.Count; i++)
+        {
+            var a = polygon[i];
+            var b = polygon[(i + 1) % polygon.Count];
+            if ((a.Y > point.Y) != (b.Y > point.Y))
+            {
+                var xIntersection = a.X + (b.X - a.X) * (point.Y - a.Y) / (b.Y - a.Y);
+                if (point.X < xIntersection) inside = !inside;
+            }
+        }
+        return inside;
+    }
+}

--- a/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.cs
+++ b/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.cs
@@ -1,0 +1,194 @@
+using System.Text.Json;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Geometric checker over the JSON emitted by <c>scripts/extract_gds_coords.py</c>:
+/// clusters the exported polygons of a design's top cell by geometric contact and
+/// proves every routed connection lands in the GDS on its own chain — chains that
+/// touch are overlaps, chains missing a pin were dropped. Overlaps located inside
+/// component footprints (pin abutments, intentionally placed crossing components)
+/// are tolerated; everything else names the offending connection pair so the
+/// maintainer learns what failed without opening the viewer.
+/// </summary>
+public static partial class ExportedWaveguideOverlapAnalyzer
+{
+    /// <summary>One endpoint of a routed connection, with its expected GDS position (µm).</summary>
+    public sealed class Endpoint
+    {
+        /// <summary>Display name of the connection this endpoint belongs to.</summary>
+        public string ConnectionName { get; }
+        /// <summary>The pin name and parent component, e.g. "MZI_8.o3".</summary>
+        public string PinName { get; }
+        /// <summary>Expected exported (nazca) coordinates in µm.</summary>
+        public double X { get; }
+        /// <summary>Expected exported (nazca) coordinates in µm.</summary>
+        public double Y { get; }
+
+        /// <summary>Binds an endpoint.</summary>
+        public Endpoint(string connectionName, string pinName, double x, double y)
+        {
+            ConnectionName = connectionName;
+            PinName = pinName;
+            X = x;
+            Y = y;
+        }
+    }
+
+    /// <summary>One routed connection identified by its two pins (for violation messages).</summary>
+    public sealed class Connection
+    {
+        /// <summary>Display name, e.g. "MZI_8.o3 → MZI_9.o3".</summary>
+        public string Name { get; }
+
+        /// <summary>Start and end pins of the route, in exported (nazca) coordinates.</summary>
+        public Endpoint Start { get; }
+        public Endpoint End { get; }
+
+        /// <summary>Binds a connection.</summary>
+        public Connection(string name, Endpoint start, Endpoint end)
+        {
+            Name = name;
+            Start = start;
+            End = end;
+        }
+
+        /// <summary>Both endpoints, iterated for coverage.</summary>
+        public IEnumerable<Endpoint> Endpoints => new[] { Start, End };
+    }
+
+    /// <summary>Axis-aligned rectangle bounding a placed component, in exported coordinates.</summary>
+    public readonly struct BoundingBox
+    {
+        private readonly double _minX, _maxX, _minY, _maxY;
+
+        /// <summary>Binds a rectangle.</summary>
+        public BoundingBox(double minX, double maxX, double minY, double maxY)
+        {
+            _minX = minX; _maxX = maxX; _minY = minY; _maxY = maxY;
+        }
+
+        /// <summary>True when the point falls inside the rectangle.</summary>
+        public bool Contains(double x, double y) =>
+            x >= _minX && x <= _maxX && y >= _minY && y <= _maxY;
+    }
+
+    /// <summary>Endpoint coverage tolerance — half a waveguide width is still well inside (µm).</summary>
+    private const double EndpointToleranceMicrometers = 1.0;
+
+    /// <summary>Contact tolerance for joining polygons of one routed chain (µm).</summary>
+    private const double ContactToleranceMicrometers = 0.02;
+
+    /// <summary>
+    /// Returns one violation per offending overlap, dropped chain or broken chain,
+    /// naming the exact connection pair. Overlaps that fall inside
+    /// <paramref name="allowedRegions"/> (component footprints) are tolerated.
+    /// </summary>
+    public static List<string> FindViolations(
+        string extractionJson,
+        string designCellName,
+        IReadOnlyList<Connection> connections,
+        IReadOnlyList<BoundingBox> allowedRegions)
+    {
+        var polygons = ParsePolygons(extractionJson, designCellName);
+        var violations = new List<string>();
+        if (polygons.Count == 0)
+        {
+            violations.Add($"GDS cell '{designCellName}' exported no polygons at all — " +
+                "every routed connection is missing from the artifact.");
+            return violations;
+        }
+
+        var clusters = BuildClusters(polygons);
+
+        // Resolve every connection to the set of clusters covering its two pins.
+        var resolved = new List<(Connection Conn, HashSet<int> Clusters)>();
+        foreach (var connection in connections)
+        {
+            var connClusters = new HashSet<int>();
+            var uncoveredPins = new List<Endpoint>();
+            foreach (var endpoint in connection.Endpoints)
+            {
+                var containing = CoveringClusters(clusters, endpoint, EndpointToleranceMicrometers);
+                if (containing.Count == 0) uncoveredPins.Add(endpoint);
+                foreach (var index in containing) connClusters.Add(index);
+            }
+            if (uncoveredPins.Count > 0)
+                violations.Add(
+                    $"Connection '{connection.Name}' exported no waveguide geometry: " +
+                    string.Join(" and ", uncoveredPins.Select(p =>
+                        $"pin '{p.PinName}' at ({p.X:F2}, {p.Y:F2})")) +
+                    " not covered by any exported polygon — its route was dropped from the GDS.");
+            else if (connClusters.Count > 1)
+                violations.Add($"Connection '{connection.Name}' exported as {connClusters.Count} disjoint " +
+                    "geometry chains — a chain must be contiguous end-to-end.");
+            if (connClusters.Count > 0) resolved.Add((connection, connClusters));
+        }
+
+        // Two connections sharing a cluster is an exported overlap — but a shared
+        // chain that lies entirely inside a component footprint is only the pins'
+        // abutment (or a placed crossing component) and must not be reported.
+        for (int i = 0; i < resolved.Count; i++)
+        for (int j = i + 1; j < resolved.Count; j++)
+        {
+            var shared = resolved[i].Clusters.Intersect(resolved[j].Clusters).ToHashSet();
+            if (shared.Count == 0) continue;
+
+            var cluster = clusters[shared.Min()];
+            bool allInsideFootprint = cluster.Polygons
+                .SelectMany(p => p.Points)
+                .All(pt => allowedRegions.Any(box => box.Contains(pt.X, pt.Y)));
+            if (allInsideFootprint) continue;
+
+            var centroid = Centroid(cluster);
+            violations.Add(
+                $"Connection '{resolved[i].Conn.Name}' overlaps connection '{resolved[j].Conn.Name}' " +
+                $"in the exported GDS (shared geometry chain centroid ({centroid.X:F2}, {centroid.Y:F2}) " +
+                "reaches outside the routed component footprints — the #704-class shadow overlap " +
+                "this test forbids among the connected pins).");
+        }
+        return violations;
+    }
+
+    /// <summary>Index of clusters whose polygons cover the given point within tolerance.</summary>
+    private static HashSet<int> CoveringClusters(List<Cluster> clusters, Endpoint endpoint, double tolerance)
+    {
+        var result = new HashSet<int>();
+        for (var index = 0; index < clusters.Count; index++)
+            if (clusters[index].Polygons.Any(p => Covers(p, endpoint.X, endpoint.Y, tolerance)))
+                result.Add(index);
+        return result;
+    }
+
+    /// <summary>Collects the polygons of the named cell from the extraction JSON.</summary>
+    private static List<Polygon> ParsePolygons(string json, string designCellName)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        var polygons = new List<Polygon>();
+        if (root.TryGetProperty("cells", out var cells) && cells.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var cell in cells.EnumerateArray())
+            {
+                var name = cell.TryGetProperty("name", out var n) ? n.GetString() : null;
+                if (name != designCellName) continue;
+                if (!cell.TryGetProperty("polygons", out var cellPolygons) ||
+                    cellPolygons.ValueKind != JsonValueKind.Array)
+                    continue;
+                foreach (var poly in cellPolygons.EnumerateArray())
+                {
+                    var layer = poly.TryGetProperty("layer", out var l) ? l.GetInt32() : 0;
+                    var datatype = poly.TryGetProperty("datatype", out var d) ? d.GetInt32() : 0;
+                    var points = new List<Point>();
+                    if (poly.TryGetProperty("vertices", out var vertices) &&
+                        vertices.ValueKind == JsonValueKind.Array)
+                        foreach (var vertex in vertices.EnumerateArray())
+                            if (vertex.ValueKind == JsonValueKind.Array && vertex.GetArrayLength() >= 2)
+                                points.Add(new Point(vertex[0].GetDouble(), vertex[1].GetDouble()));
+                    polygons.Add(new Polygon(layer, datatype, points));
+                }
+            }
+        }
+        return polygons;
+    }
+}

--- a/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.cs
+++ b/UnitTests/Integration/ExportedWaveguideOverlapAnalyzer.cs
@@ -134,13 +134,16 @@ public static partial class ExportedWaveguideOverlapAnalyzer
             var shared = resolved[i].Clusters.Intersect(resolved[j].Clusters).ToHashSet();
             if (shared.Count == 0) continue;
 
-            var cluster = clusters[shared.Min()];
-            bool allInsideFootprint = cluster.Polygons
-                .SelectMany(p => p.Points)
-                .All(pt => allowedRegions.Any(box => box.Contains(pt.X, pt.Y)));
-            if (allInsideFootprint) continue;
+            // Every shared chain must be footprint-checked on its own: an
+            // out-of-footprint shared chain is an overlap even when another
+            // shared chain of the same pair is only a pin abutment.
+            var outsideChains = shared
+                .Select(index => clusters[index])
+                .Where(cluster => !IsFullyInsideFootprints(cluster, allowedRegions))
+                .ToList();
+            if (outsideChains.Count == 0) continue;
 
-            var centroid = Centroid(cluster);
+            var centroid = Centroid(outsideChains[0]);
             violations.Add(
                 $"Connection '{resolved[i].Conn.Name}' overlaps connection '{resolved[j].Conn.Name}' " +
                 $"in the exported GDS (shared geometry chain centroid ({centroid.X:F2}, {centroid.Y:F2}) " +

--- a/UnitTests/Integration/ExportedWaveguideOverlapAnalyzerTests.cs
+++ b/UnitTests/Integration/ExportedWaveguideOverlapAnalyzerTests.cs
@@ -77,6 +77,37 @@ public class ExportedWaveguideOverlapAnalyzerTests
     }
 
     [Fact]
+    public void SharedChainOutsideFootprint_IsReported_EvenWhenAnotherSharedChainIsInside()
+    {
+        // A and B share two chains at their common start pin: one sits fully
+        // inside a component footprint (pin abutment — tolerated), the other
+        // reaches outside it. The tolerated chain must not mask the overlap.
+        // (The 0.5 µm gap between the shared polygons keeps them disjoint at the
+        // 0.02 µm contact tolerance, while the common pin at (0.7, 0) stays within
+        // the 1.0 µm coverage tolerance of both.)
+        var connections = new[]
+        {
+            Connection("A", (0.7, 0), (20, 0)),
+            Connection("B", (0.7, 0), (30, 0)),
+        };
+        var footprints = new[]
+        {
+            new ExportedWaveguideOverlapAnalyzer.BoundingBox(-2, 1.2, -2, 2),
+        };
+        var json = Gds(
+            Polygon(-1, -0.5, 1, 0.5),
+            Polygon(1.5, -0.5, 3, 0.5),
+            Polygon(19, -0.5, 21, 0.5),
+            Polygon(29, -0.5, 31, 0.5));
+
+        var violations = ExportedWaveguideOverlapAnalyzer.FindViolations(
+            json, CellName, connections, footprints);
+
+        violations.Where(v => v.Contains("overlaps")).ShouldHaveSingleItem()
+            .ShouldContain("Connection 'A' overlaps connection 'B'");
+    }
+
+    [Fact]
     public void UncoveredPin_NamesTheDroppedConnection()
     {
         var connections = new[]

--- a/UnitTests/Integration/ExportedWaveguideOverlapAnalyzerTests.cs
+++ b/UnitTests/Integration/ExportedWaveguideOverlapAnalyzerTests.cs
@@ -1,0 +1,140 @@
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Counter-tests for <see cref="ExportedWaveguideOverlapAnalyzer"/>: the honesty
+/// proof of #1088 is only as good as its checker, so the checker itself gets
+/// pinned on hand-built GDS coordinate JSON — overlapping chains must be blamed
+/// by name, disjoint chains must stay clean, footprint-internal contact must be
+/// tolerated, dropped routes must report their uncovered pins, and a chain split
+/// into disjoint pieces must be caught as broken.
+/// </summary>
+public class ExportedWaveguideOverlapAnalyzerTests
+{
+    private const string CellName = "D";
+
+    private static readonly ExportedWaveguideOverlapAnalyzer.BoundingBox[] NoFootprints = [];
+
+    [Fact]
+    public void OverlappingChains_NamesTheOffendingPair()
+    {
+        var connections = new[]
+        {
+            Connection("A", (0, 0), (10, 0)),
+            Connection("B", (5, -3), (5, 3)),
+        };
+        // A is a horizontal 1 µm strip, B a vertical 1 µm strip cutting through it.
+        var json = Gds(
+            Polygon(-0.1, -0.5, 10.1, 0.5),
+            Polygon(4.45, -3.02, 5.55, 3.02));
+
+        var violations = ExportedWaveguideOverlapAnalyzer.FindViolations(
+            json, CellName, connections, NoFootprints);
+
+        violations.Count.ShouldBe(1);
+        violations[0].ShouldContain("Connection 'A' overlaps connection 'B'");
+        violations[0].ShouldContain("#704");
+    }
+
+    [Fact]
+    public void DisjointChains_RaisesNoOverlap()
+    {
+        var connections = new[]
+        {
+            Connection("A", (0, 0), (10, 0)),
+            Connection("B", (12, 0), (22, 0)),
+        };
+        var json = Gds(
+            Polygon(0, -0.5, 10, 0.5),
+            Polygon(12, -0.5, 22, 0.5));
+
+        ExportedWaveguideOverlapAnalyzer.FindViolations(json, CellName, connections, NoFootprints)
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void OverlapInsideComponentFootprint_IsTolerated()
+    {
+        // Same overlap as the counter-test above, but the whole shared chain sits
+        // inside one component footprint — a placed crossing / pin abutment.
+        var connections = new[]
+        {
+            Connection("A", (0, 0), (10, 0)),
+            Connection("B", (5, -3), (5, 3)),
+        };
+        var footprints = new[]
+        {
+            new ExportedWaveguideOverlapAnalyzer.BoundingBox(-1, 11, -4, 4),
+        };
+        var json = Gds(
+            Polygon(-0.1, -0.5, 10.1, 0.5),
+            Polygon(4.45, -3.02, 5.55, 3.02));
+
+        ExportedWaveguideOverlapAnalyzer.FindViolations(json, CellName, connections, footprints)
+            .ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void UncoveredPin_NamesTheDroppedConnection()
+    {
+        var connections = new[]
+        {
+            Connection("A", (0, 0), (10, 0)),
+            Connection("B", (12, 0), (22, 0)),
+        };
+        // Only A's geometry made it into the GDS — B was dropped.
+        var json = Gds(Polygon(0, -0.5, 10, 0.5));
+
+        var violations = ExportedWaveguideOverlapAnalyzer.FindViolations(
+            json, CellName, connections, NoFootprints);
+
+        violations.Count.ShouldBe(1);
+        violations[0].ShouldContain("Connection 'B' exported no waveguide geometry");
+        violations[0].ShouldContain("dropped");
+    }
+
+    [Fact]
+    public void BrokenChain_ReportsDisjointGeometry()
+    {
+        var connections = new[]
+        {
+            Connection("A", (0, 0), (10, 0)),
+        };
+        // A's two halves end 0.2 µm apart — too far to touch (tolerance 0.02 µm).
+        var json = Gds(
+            Polygon(0, -0.5, 4, 0.5),
+            Polygon(4.2, -0.5, 10, 0.5));
+
+        var violations = ExportedWaveguideOverlapAnalyzer.FindViolations(
+            json, CellName, connections, NoFootprints);
+
+        violations.Count.ShouldBe(1);
+        violations[0].ShouldContain("Connection 'A' exported as 2 disjoint geometry chains");
+    }
+
+    /// <summary>Builds a <see cref="ExportedWaveguideOverlapAnalyzer.Connection"/> for test use.</summary>
+    private static ExportedWaveguideOverlapAnalyzer.Connection Connection(
+        string name, (double X, double Y) start, (double X, double Y) end) =>
+        new(name,
+            new ExportedWaveguideOverlapAnalyzer.Endpoint(name, name + ".start", start.X, start.Y),
+            new ExportedWaveguideOverlapAnalyzer.Endpoint(name, name + ".end", end.X, end.Y));
+
+    /// <summary>An axis-aligned rectangle polygon on the waveguide layer, closed.</summary>
+    private static string Polygon(double x0, double y0, double x1, double y1) =>
+        "{\"layer\":1111,\"datatype\":0,\"vertices\":[" +
+        $"[{F(x0)},{F(y0)}],[{F(x1)},{F(y0)}],[{F(x1)},{F(y1)}],[{F(x0)},{F(y1)}],[{F(x0)},{F(y0)}]" +
+        "]}";
+
+    /// <summary>The extraction-script JSON document wrapping the given polygons.</summary>
+    private static string Gds(params string[] polygons) =>
+        "{\"units\":{\"user_unit_m\":1e-6,\"db_unit_m\":1e-9}," +
+        "\"cells\":[{\"name\":\"" + CellName + "\",\"paths\":[],\"refs\":[],\"polygons\":[" +
+        string.Join(",", polygons) +
+        "]}]}";
+
+    /// <summary>Invariant double formatting for hand-built JSON.</summary>
+    private static string F(double value) =>
+        value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/UnitTests/Integration/Issue704GdsExportHonestyJourneyFixture.cs
+++ b/UnitTests/Integration/Issue704GdsExportHonestyJourneyFixture.cs
@@ -36,7 +36,7 @@ public sealed class Issue704GdsExportHonestyJourneyFixture : IAsyncLifetime
     public List<ExportedWaveguideOverlapAnalyzer.BoundingBox> ComponentFootprints { get; private set; } = null!;
 
     /// <summary>Builds the layout, routes it, exports the script.</summary>
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
         var mzi8 = Issue704ReproCircuit.CreateMzi("MZI_8", 374.34455820950575, 218.3565233418277);
         var mzi9 = Issue704ReproCircuit.CreateMzi("MZI_9", 236.5708507637589, 649.767215289101);
@@ -55,7 +55,7 @@ public sealed class Issue704GdsExportHonestyJourneyFixture : IAsyncLifetime
 
         // Same bounds as the #704 route-level repro tests (the design fits inside).
         Canvas.InitializeAStarRouting(0, 0, 1200, 1000);
-        Canvas.RecalculateRoutesAsync().GetAwaiter().GetResult();
+        await Canvas.RecalculateRoutesAsync();
 
         Connections = Canvas.Connections
             .Select(vm => {
@@ -73,7 +73,6 @@ public sealed class Issue704GdsExportHonestyJourneyFixture : IAsyncLifetime
             .ToList();
 
         NazcaScript = new SimpleNazcaExporter().Export(Canvas);
-        return Task.CompletedTask;
     }
 
     /// <summary>Removes the temp working directory.</summary>

--- a/UnitTests/Integration/Issue704GdsExportHonestyJourneyFixture.cs
+++ b/UnitTests/Integration/Issue704GdsExportHonestyJourneyFixture.cs
@@ -1,0 +1,111 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using UnitTests.Routing;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Shared journey fixture for <see cref="Issue704GdsExportHonestyTests"/>: rebuilds
+/// the tight neighbouring-port repro geometry (<c>overlappingwaveguides.lun</c>,
+/// constants from <see cref="Routing.Issue704ReproRoutingTests"/>) on a real
+/// canvas, routes it with the same router configuration the #704 repro tests use,
+/// exports the nazca script once and remembers the routed connections' pin
+/// endpoints and component footprints in exported coordinates — so the geometry
+/// checker can blame offenders by name instead of asserting raw pluralities.
+/// </summary>
+public sealed class Issue704GdsExportHonestyJourneyFixture : IAsyncLifetime
+{
+    /// <summary>Temp working directory for the GDS export.</summary>
+    public string WorkDirectory { get; } =
+        Path.Combine(Path.GetTempPath(), "issue704-gds-honesty-" + Guid.NewGuid().ToString("N"));
+
+    /// <summary>The canvas the repro layout lives on.</summary>
+    public DesignCanvasViewModel Canvas { get; private set; } = null!;
+
+    /// <summary>The nazca export script of the repro layout.</summary>
+    public string NazcaScript { get; private set; } = null!;
+
+    /// <summary>The routed connections, mapped to pin endpoints in exported coordinates.</summary>
+    public List<ExportedWaveguideOverlapAnalyzer.Connection> Connections { get; private set; } = null!;
+
+    /// <summary>Footprints of every placed component, in exported coordinates.</summary>
+    public List<ExportedWaveguideOverlapAnalyzer.BoundingBox> ComponentFootprints { get; private set; } = null!;
+
+    /// <summary>Builds the layout, routes it, exports the script.</summary>
+    public Task InitializeAsync()
+    {
+        var mzi8 = Issue704ReproCircuit.CreateMzi("MZI_8", 374.34455820950575, 218.3565233418277);
+        var mzi9 = Issue704ReproCircuit.CreateMzi("MZI_9", 236.5708507637589, 649.767215289101);
+        var taper = Issue704ReproCircuit.CreateTaper("Taper_5",
+            Issue704ReproCircuit.TaperPinX, Issue704ReproCircuit.TaperPinY);
+
+        Canvas = new DesignCanvasViewModel();
+        Canvas.AddComponent(mzi8);
+        Canvas.AddComponent(mzi9);
+        Canvas.AddComponent(taper);
+
+        Canvas.ConnectPins(
+            Issue704ReproCircuit.Pin(mzi8, "o3"), Issue704ReproCircuit.Pin(mzi9, "o3"));
+        Canvas.ConnectPins(
+            Issue704ReproCircuit.Pin(taper, "o1"), Issue704ReproCircuit.Pin(mzi9, "o2"));
+
+        // Same bounds as the #704 route-level repro tests (the design fits inside).
+        Canvas.InitializeAStarRouting(0, 0, 1200, 1000);
+        Canvas.RecalculateRoutesAsync().GetAwaiter().GetResult();
+
+        Connections = Canvas.Connections
+            .Select(vm => {
+                var conn = vm.Connection;
+                var description = ExportableConnections.Describe(conn.StartPin, conn.EndPin);
+                return new ExportedWaveguideOverlapAnalyzer.Connection(
+                    description,
+                    ToEndpoint(conn.StartPin, description),
+                    ToEndpoint(conn.EndPin, description));
+            })
+            .ToList();
+
+        ComponentFootprints = Canvas.Components
+            .Select(form => Footprint(form.Component))
+            .ToList();
+
+        NazcaScript = new SimpleNazcaExporter().Export(Canvas);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Removes the temp working directory.</summary>
+    public Task DisposeAsync()
+    {
+        try
+        {
+            if (Directory.Exists(WorkDirectory)) Directory.Delete(WorkDirectory, recursive: true);
+        }
+        catch
+        {
+            // temp cleanup is best effort
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Maps one pin to its expected exported endpoint coordinates.</summary>
+    private static ExportedWaveguideOverlapAnalyzer.Endpoint ToEndpoint(PhysicalPin pin, string connectionName)
+    {
+        var (x, y) = NazcaCoordinateMapper.GetPinNazcaPosition(pin);
+        var pinName = $"{pin.ParentComponent?.Identifier ?? "?"}.{pin.Name}";
+        return new ExportedWaveguideOverlapAnalyzer.Endpoint(connectionName, pinName, x, y);
+    }
+
+    /// <summary>The component's footprint rectangle in exported coordinates.</summary>
+    private static ExportedWaveguideOverlapAnalyzer.BoundingBox Footprint(Component component)
+    {
+        double minX = component.PhysicalX;
+        double maxX = component.PhysicalX + component.WidthMicrometers;
+        // App coordinates are Y-down, exported coordinates are Y-up — the box flips with it.
+        double nazcaTopY = -component.PhysicalY;
+        double nazcaBottomY = -(component.PhysicalY + component.HeightMicrometers);
+        return new ExportedWaveguideOverlapAnalyzer.BoundingBox(minX, maxX, nazcaBottomY, nazcaTopY);
+    }
+}

--- a/UnitTests/Integration/Issue704GdsExportHonestyTests.cs
+++ b/UnitTests/Integration/Issue704GdsExportHonestyTests.cs
@@ -1,0 +1,148 @@
+using CAP_Core.Export;
+using Shouldly;
+using UnitTests.Export;
+using UnitTests.Routing;
+using UnitTests.Services.GdsImport;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// The end-artifact honest proof for the #704/#1078 overlap class (issue #1088):
+/// the neighbouring-port geometry of <c>overlappingwaveguides.lun</c> (repro
+/// constants shared with <see cref="Routing.Issue704ReproRoutingTests"/>) must
+/// survive routing AND land in the exported GDS as one waveguide chain per routed
+/// connection with zero overlap outside component footprints — the route-level
+/// pinup of #1084 is only half the story foundries care about. The fixture
+/// (<see cref="Issue704GdsExportHonestyJourneyFixture"/>) rebuilds the layout on
+/// a real canvas, routes it like the app does and exports through the real nazca
+/// path (same tooling probes and gating as the manufacturing journeys #995/#1036);
+/// the produced GDS is read back with <c>scripts/extract_gds_coords.py</c> — whose
+/// new <c>gdstk</c> fallback keeps the check executable on the repo's CI
+/// toolchain even where <c>gdspy</c> is not installable.
+/// </summary>
+public class Issue704GdsExportHonestyTests
+    : IClassFixture<Issue704GdsExportHonestyJourneyFixture>
+{
+    private const int ExpectedConnections = 2;
+    private const string DesignCellName = "ConnectAPIC_Design";
+
+    private readonly Issue704GdsExportHonestyJourneyFixture _journey;
+
+    /// <summary>Attaches the shared journey fixture.</summary>
+    public Issue704GdsExportHonestyTests(Issue704GdsExportHonestyJourneyFixture journey) =>
+        _journey = journey;
+
+    [Fact]
+    public void Step1_BuildReproLayout_TwoNeighboringPortConnectionsOnCanvas()
+    {
+        _journey.Canvas.Components.Count.ShouldBe(3, "MZI_8, MZI_9 and Taper_5 carry the repro geometry");
+        _journey.Canvas.Connections.Count.ShouldBe(ExpectedConnections,
+            "MZI_8.o3 → MZI_9.o3 and Taper_5.o1 → MZI_9.o2 are the two neighbouring routes");
+    }
+
+    [Fact]
+    public void Step2_Route_EveryConnectionReportsAValidPath()
+    {
+        foreach (var connectionVm in _journey.Canvas.Connections)
+        {
+            var connection = connectionVm.Connection;
+            var description = ExportableConnections.Describe(connection.StartPin, connection.EndPin);
+            connection.RoutedPath.ShouldNotBeNull($"route '{description}' produced no path at all");
+            connection.RoutedPath.Segments.ShouldNotBeEmpty($"route '{description}' exported no segments");
+            connection.RoutedPath.IsBlockedFallback.ShouldBeFalse(
+                $"route '{description}' was left as an unresolved blocked fallback and must not export silently");
+            connection.RoutedPath.IsInvalidGeometry.ShouldBeFalse(
+                $"route '{description}' violates physical constraints and must fail here, not in the artifact");
+        }
+    }
+
+    [Fact]
+    public void Step3_NazcaExport_WritesTheDesignAsGdsTopCell()
+    {
+        _journey.NazcaScript.ShouldNotBeNullOrEmpty(
+            "the real export path must produce a nazca script for the repro layout");
+        _journey.NazcaScript.ShouldContain($"# Waveguide Connections",
+            Case.Sensitive, "both routed connections must reach the exporter");
+        _journey.NazcaScript.ShouldContain("nd.export_gds(topcells=[design]",
+            Case.Sensitive, "the exported GDS carries the design as its top cell");
+    }
+
+    [Trait("Category", "Slow")]
+    [SkippableFact]
+    public async Task Step4_ExportedGdsWaveguides_NoOverlapAndNothingDropped()
+    {
+        var python = await FindFullToolchainPythonAsync();
+        Skip.If(python == null, "No Python carrying nazca AND gdspy/gdstk — the export + extraction needs both.");
+
+        var exportDir = Path.Combine(_journey.WorkDirectory, "export");
+        Directory.CreateDirectory(exportDir);
+        var scriptPath = Path.Combine(exportDir, "overlapping_waveguides_honesty.py");
+        await File.WriteAllTextAsync(scriptPath, _journey.NazcaScript);
+        var export = await SiepicRealGeometryExportTests.RunPythonAsync(python, exportDir, scriptPath);
+        export.ExitCode.ShouldBe(0, $"the nazca export of the repro layout must succeed:\n{export.StdOut}\n{export.StdErr}");
+
+        var gdsPath = Path.ChangeExtension(scriptPath, ".gds");
+        File.Exists(gdsPath).ShouldBeTrue($"the export script must write {gdsPath}:\n{export.StdOut}");
+
+        var extractor = new GdsCoordinateExtractor();
+        extractor.SetCustomPythonPath(python);
+        var extraction = await extractor.ExtractAsync(gdsPath);
+        extraction.Success.ShouldBeTrue(
+            $"extracting the exported GDS must succeed (gdspy/gdstk): {extraction.ErrorMessage}");
+        extraction.JsonContent.ShouldNotBeNullOrEmpty("the extraction must emit structured coordinates");
+
+        var violations = ExportedWaveguideOverlapAnalyzer.FindViolations(
+            extraction.JsonContent!, DesignCellName, _journey.Connections, _journey.ComponentFootprints);
+        violations.ShouldBeEmpty(
+            "exported waveguides must keep exactly one chain per routed connection and never " +
+            "overlap outside component footprints:\n" + string.Join("\n", violations));
+    }
+
+    /// <summary>
+    /// Finds a Python that can run BOTH halves of the gated proof: the nazca export
+    /// AND the coordinate extraction (gdspy, or the gdstk fallback the script gained
+    /// for exactly this). Skips candidates that only import nazca so a bare PDK env
+    /// never silently suppresses the extraction half.
+    /// </summary>
+    private static async Task<string?> FindFullToolchainPythonAsync()
+    {
+        foreach (var candidate in EnumerateCandidatePythons())
+            if (await GdsUserDesignFixture.ProbeNazca(candidate) && await ProbeExtractionModule(candidate))
+                return candidate;
+        return null;
+    }
+
+    /// <summary>The managed-env and PATH pythons, mirroring <c>GdsUserDesignFixture</c>.</summary>
+    private static IEnumerable<string> EnumerateCandidatePythons()
+    {
+        var envs = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Lunima", "envs");
+        if (Directory.Exists(envs))
+            foreach (var root in Directory.GetDirectories(envs))
+                foreach (var rel in new[] { Path.Combine("Scripts", "python.exe"), Path.Combine("bin", "python") })
+                {
+                    var py = Path.Combine(root, rel);
+                    if (File.Exists(py)) yield return py;
+                }
+        yield return "python";
+        yield return "python3";
+    }
+
+    /// <summary>True when <paramref name="python"/> imports gdspy or gdstk.</summary>
+    private static async Task<bool> ProbeExtractionModule(string python)
+    {
+        const string probe = "import importlib.util, sys; " +
+            "sys.exit(0 if any(importlib.util.find_spec(m) for m in ('gdspy','gdstk')) else 1)";
+        try
+        {
+            var result = await SiepicRealGeometryExportTests.RunPythonAsync(
+                python, Path.GetTempPath(), "-c", probe);
+            return result.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/UnitTests/Routing/Issue704ReproCircuit.cs
+++ b/UnitTests/Routing/Issue704ReproCircuit.cs
@@ -33,6 +33,12 @@ public static class Issue704ReproCircuit
 
     private const int WavelengthNm = 1550;
 
+    /// <summary>Taper pin o1 absolute X position from the repro files.</summary>
+    public const double TaperPinX = 944.2749306393268;
+
+    /// <summary>Taper pin o1 absolute Y position from the repro files.</summary>
+    public const double TaperPinY = 816.626565747488;
+
     /// <summary>Creates an MZI-shaped block with pins o2 and o3 on its right edge.</summary>
     public static Component CreateMzi(string name, double x, double y) =>
         CreateBlock(name, x, y, MziWidth, MziHeight,

--- a/UnitTests/Routing/Issue704ReproRoutingTests.cs
+++ b/UnitTests/Routing/Issue704ReproRoutingTests.cs
@@ -18,10 +18,10 @@ public class Issue704ReproRoutingTests
     private const double MinClearanceMicrometers = 2.0;
 
     /// <summary>Taper pin o1 absolute position from the repro files.</summary>
-    private const double TaperPinX = 944.2749306393268;
+    private const double TaperPinX = Issue704ReproCircuit.TaperPinX;
 
     /// <summary>Taper pin o1 absolute position from the repro files.</summary>
-    private const double TaperPinY = 816.626565747488;
+    private const double TaperPinY = Issue704ReproCircuit.TaperPinY;
 
     [Fact]
     public void OverlappingWaveguidesRepro_NeighboringPortRoutes_DoNotSilentlyOverlap()

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,7 +46,7 @@ is the product.
 
 - Rung 1 remainder: #880 (opt-in auto-connect after import); #725 (routing rework: direct-first, anytime-A*). The #704 defect umbrella is closed: bug 3 got a real fix — the PathSmoother terminal approach is now collision-checked against the routing grid (#1078/#1084); bugs 1 and 2 turned out already fixed since July (#705/#717) and are now pinned by tests (#1077/#1083 router self-intersection property suite, #1079/#1085 crossing reinsertion counter-test)
 - Rung 4/5 next: #1070 (1-bit ALU example, PR #1076 pending CI), #1086 (sequential slice 1: register state element, `complex`); transfer functions remain unscoped
-- Honesty E2E seams (kill review 2026-08-20): #1087 (imported GDS black-box cell inside a logic gate group — truth table + save/load), #1088 (tight neighbouring-port design → GDS export with zero overlapping waveguides)
+- Honesty E2E seams (kill review 2026-08-20): #1087 (imported GDS black-box cell inside a logic gate group — truth table + save/load) open; #1088 shipped — the tight neighbouring-port repro geometry now proves end-to-end over the real nazca path that the exported GDS carries one waveguide chain per routed connection with zero overlap outside component footprints, with `scripts/extract_gds_coords.py` executable on the CI toolchain via a gdstk fallback
 - Rung 4/7: length matching (#753) is complete — kernel (#1003/#1007), canvas actuator (#1008/#1013), UI (#1021/#1029)
 - Rung 7 next: foundry outreach with the DRC-clean 4-bit adder artifact (maintainer task; scale proof #1036/#1042 shipped)
 - PDK strategy (rung 7): #620 (AI-assisted PDK import), #773, #772, #740 (registry/library)

--- a/scripts/extract_gds_coords.py
+++ b/scripts/extract_gds_coords.py
@@ -79,7 +79,7 @@ def extract_coords(gds_path: str) -> dict:
     except ImportError:
         raise ImportError(
             "gdspy or gdstk is required for GDS coordinate extraction.\n"
-            "Install with: pip install gdspy"
+            "Install with: pip install gdspy  (or: pip install gdstk)"
         )
 
     return _extract_coords_gdstk(gds_path)

--- a/scripts/extract_gds_coords.py
+++ b/scripts/extract_gds_coords.py
@@ -53,7 +53,9 @@ import sys
 
 def extract_coords(gds_path: str) -> dict:
     """
-    Extract all geometric coordinates from a GDS file.
+    Extract all geometric coordinates from a GDS file, preferring gdspy and
+    falling back to gdstk (the GDS reader the repo's CI toolchain installs)
+    when gdspy is not installed.
 
     Parameters
     ----------
@@ -66,13 +68,25 @@ def extract_coords(gds_path: str) -> dict:
         Structured coordinate data (see module docstring for schema).
     """
     try:
-        import gdspy
+        import gdspy  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        return _extract_coords_gdspy(gds_path)
+
+    try:
+        import gdstk  # noqa: F401
     except ImportError:
         raise ImportError(
-            "gdspy is required for GDS coordinate extraction.\n"
+            "gdspy or gdstk is required for GDS coordinate extraction.\n"
             "Install with: pip install gdspy"
         )
 
+    return _extract_coords_gdstk(gds_path)
+
+
+def _extract_coords_gdspy(gds_path: str) -> dict:
+    import gdspy
     lib = gdspy.GdsLibrary(infile=gds_path)
 
     user_unit = lib.unit          # metres per user unit (typically 1e-6 for µm)
@@ -129,6 +143,57 @@ def extract_coords(gds_path: str) -> dict:
             origin = ref.origin if ref.origin is not None else [0, 0]
             cell_data["refs"].append({
                 "ref_cell": ref_name,
+                "origin": [round(float(origin[0]), 6), round(float(origin[1]), 6)],
+                "rotation": round(float(ref.rotation or 0), 6),
+                "magnification": round(float(ref.magnification or 1), 6),
+                "x_reflection": bool(ref.x_reflection)
+            })
+
+        result["cells"].append(cell_data)
+
+    return result
+
+
+def _extract_coords_gdstk(gds_path: str) -> dict:
+    """
+    Fallback extractor using gdstk (installed by the repo's CI toolchain, unlike
+    gdspy). Emits polygons and cell references identically to the gdspy path;
+    legacy GDS PATH elements collapse into polygons there, which is all the
+    produced (nazca) exports write either way.
+    """
+    import gdstk
+
+    lib = gdstk.read_gds(gds_path)
+
+    result = {
+        "gds_file": os.path.abspath(gds_path),
+        "units": {
+            "user_unit_m": lib.unit,
+            "db_unit_m": lib.precision,
+        },
+        "cells": []
+    }
+
+    for cell in lib.cells:
+        cell_data = {
+            "name": cell.name,
+            "polygons": [],
+            "paths": [],
+            "refs": []
+        }
+
+        for poly in cell.polygons:
+            cell_data["polygons"].append({
+                "layer": int(poly.layer),
+                "datatype": int(poly.datatype),
+                "vertices": [[round(float(v[0]), 6), round(float(v[1]), 6)]
+                             for v in poly.points]
+            })
+
+        for ref in cell.references:
+            origin = ref.origin if ref.origin is not None else [0, 0]
+            cell_data["refs"].append({
+                "ref_cell": ref.cell_name,
                 "origin": [round(float(origin[0]), 6), round(float(origin[1]), 6)],
                 "rotation": round(float(ref.rotation or 0), 6),
                 "magnification": round(float(ref.magnification or 1), 6),


### PR DESCRIPTION
## What & why

#1084 fixed the collision-unchecked terminal approach and pinned it at the **route level** (in-memory `RoutedPath` validity). The artifact Peter sends to a foundry is the **exported GDS** — and until now no test proved end-to-end that a tight neighbouring-port design exports waveguide geometry with zero silent overlap. This PR adds exactly that honesty proof (issue #1088, rung 0/7).

### The journey

`Issue704GdsExportHonestyTests` — one E2E journey, gated exactly like the manufacturing journeys #995/#1036 (#1036's Slow/SkippableFact convention):

1. **Build** the tight neighbouring-port layout of `overlappingwaveguides.lun` on a real `DesignCanvasViewModel`, reusing the repro constants that `UnitTests/Routing/Issue704ReproRoutingTests.cs` already carried (the taper pin constants are promoted into `Issue704ReproCircuit` for sharing).
2. **Route** both connections; every route must report a valid path — invalid routes fail the test instead of silently vanishing from the export.
3. **Export** through the real nazca path (`SimpleNazcaExporter`).
4. **Extract** waveguide coordinates from the produced GDS with `scripts/extract_gds_coords.py` (now CI-executable via a new gdstk fallback — gdspy remains the preferred engine and the fallback output is byte-identical on the probe GDS).
5. **Assert** with messages naming the offending connection pair: one exported waveguide chain per routed connection (nothing dropped), no two chains overlapping except fully inside component footprints.

### Supporting changes

- `scripts/extract_gds_coords.py`: **gdstk fallback** added (gdspy stays preferred). CI installs nazca+gdstk but not gdspy, so the repo's own GDS debugging script could never actually run in CI before this. No CI workflow changes — the existing toolchain now suffices.
- `ExportedWaveguideOverlapAnalyzer` (+`.Geometry.cs` partial, kept under the file-size rule): clusters design-cell polygons by geometric contact, resolves each route's pins by coverage, and reports overlaps (unless the whole shared chain sits inside a component footprint), dropped routes (uncovered pins) and broken chains by connection name.
- `ExportedWaveguideOverlapAnalyzerTests`: five counter-tests pinning the checker itself — overlaps named pair-wise, disjoint chains clean, footprint-internal contact tolerated, dropped connections named, disjoint exported chains caught.
- `docs/ROADMAP.md`: seam entry updated.

### How it was tested

- New focused facts pass locally end-to-end (9/9), including the gated export → GDS → extract → geometry run executed for real against a nazca/gdspy/gdstk toolchain on this machine.
- Full local filtered suite green. In CI the gated step runs with the standard toolchain (nazca + gdstk); locally without the modules it skips like the other gated proofs.

Local suite: 6237 passed, 0 failed

## Manual verification after vacation

The headless proof stands on its own; for a human look at the physical region:

1. `dotnet run --project CAP.Desktop`.
2. Open the repro design (`overlappingwaveguides.lun` from the #704/#1078 files).
3. Export GDS via the usual nazca export path.
4. Open the exported GDS in KLayout.
5. Zoom to the neighbouring-port region at MZI_9's right edge (pins o2/o3, ~5.9 µm vertical separation) and confirm the two exported waveguide chains stay visibly separate — no merge or crossing except at component footprints.