### PR TITLE
Agent: Truth Table panel register toggle — designate a gate group as a state element (#1098)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -1282,6 +1282,8 @@
   "TruthTable.Inputs": "Eingänge (max. 4):",
   "TruthTable.NoGroupSelected": "Wähle genau eine Gruppe aus, um zu sehen, ob sie sich wie ein Logikgatter verhält.",
   "TruthTable.Outputs": "Ausgänge:",
+  "TruthTable.Register": "Register (Zustandselement)",
+  "TruthTable.RegisterHint": "Ausgänge halten ihren übernommenen Wert; erst der Step im Logik-Panel tastet die Eingänge ab und übernimmt sie. Eine Rückkopplung ist nur über ein Register erlaubt — so entsteht ein Latch.",
   "TruthTable.Signal": "Signalname:",
   "TruthTable.SignalWarnCrossRole": "„{0}“ benennt sowohl einen Eingang als auch einen Ausgang — der Netzwerk-Build lehnt Namen ab, die zwei Rollen überspannen.",
   "TruthTable.SignalWarnDuplicateOutput": "Der Ausgang eines anderen Gatters verwendet „{0}“ bereits — Ausgangsnamen müssen eindeutig sein.",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -1282,6 +1282,8 @@
   "TruthTable.Inputs": "Inputs (max 4):",
   "TruthTable.NoGroupSelected": "Select exactly one group to see whether it behaves like a logic gate.",
   "TruthTable.Outputs": "Outputs:",
+  "TruthTable.Register": "Register (state element)",
+  "TruthTable.RegisterHint": "Outputs hold their committed value; the Logic panel's Step samples the inputs and commits them. A feedback loop is legal only through a register — that is how you build a latch.",
   "TruthTable.Signal": "Signal:",
   "TruthTable.SignalWarnCrossRole": "'{0}' names both an input and an output — the network build rejects a name spanning two roles.",
   "TruthTable.SignalWarnDuplicateOutput": "Another gate's output already uses '{0}' — output names must be unique.",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -1282,6 +1282,8 @@
   "TruthTable.Inputs": "Entradas (máx. 4):",
   "TruthTable.NoGroupSelected": "Selecciona exactamente un grupo para ver si se comporta como una puerta lógica.",
   "TruthTable.Outputs": "Salidas:",
+  "TruthTable.Register": "Registro (elemento de estado)",
+  "TruthTable.RegisterHint": "Las salidas mantienen su valor confirmado; el Step del panel Lógica muestrea las entradas y las confirma. Un bucle de realimentación solo es válido a través de un registro — así se construye un latch.",
   "TruthTable.Signal": "Señal:",
   "TruthTable.SignalWarnCrossRole": "\"{0}\" nombra tanto una entrada como una salida — el ensamblado de la red rechaza un nombre que abarca dos roles.",
   "TruthTable.SignalWarnDuplicateOutput": "La salida de otra puerta ya usa \"{0}\" — los nombres de salida deben ser únicos.",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -1282,6 +1282,8 @@
   "TruthTable.Inputs": "入力（最大 4）:",
   "TruthTable.NoGroupSelected": "グループを 1 つだけ選択すると、論理ゲートとして振る舞うか確認できます。",
   "TruthTable.Outputs": "出力:",
+  "TruthTable.Register": "レジスタ（状態要素）",
+  "TruthTable.RegisterHint": "出力は確定した値を保持します。ロジックパネルのステップが入力をサンプリングして確定します。フィードバックループはレジスタ経由でのみ有効です — これがラッチの作り方です。",
   "TruthTable.Signal": "信号:",
   "TruthTable.SignalWarnCrossRole": "「{0}」は入力と出力の両方を指しています — 二つの役割にまたがる名前はネットワークのビルドで拒否されます。",
   "TruthTable.SignalWarnDuplicateOutput": "別のゲートの出力がすでに「{0}」を使用しています — 出力名は一意にする必要があります。",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -1282,6 +1282,8 @@
   "TruthTable.Inputs": "输入（最多 4 个）:",
   "TruthTable.NoGroupSelected": "仅选中一个分组,即可查看它是否表现得像一个逻辑门。",
   "TruthTable.Outputs": "输出:",
+  "TruthTable.Register": "寄存器（状态元件）",
+  "TruthTable.RegisterHint": "输出保持已提交的值；逻辑面板中的“步进”会对输入采样并提交。反馈回路只有通过寄存器才合法——这就是构建锁存器的方法。",
   "TruthTable.Signal": "信号:",
   "TruthTable.SignalWarnCrossRole": "“{0}”同时用作输入和输出的名称——网络构建会拒绝跨两种角色的名称。",
   "TruthTable.SignalWarnDuplicateOutput": "另一个门的输出已使用“{0}”——输出名称必须唯一。",

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
@@ -41,7 +41,9 @@ public partial class TruthTableViewModel
             // extraction must not overwrite the last good one. Signal names (#1025,
             // #1046) ride along for pins that keep their role: re-extracting must not
             // silently drop the signal identity a design carries. The register
-            // designation (#1086) rides along the same way.
+            // designation (#1086) comes from the panel's toggle: it mirrors the
+            // previous assignment after the selection prefill, and a toggle made
+            // before the first extraction persists here for the first time (#1098).
             var previous = _group.TruthTablePinAssignment;
             _group.TruthTablePinAssignment = new TruthTablePinAssignment
             {
@@ -51,7 +53,7 @@ public partial class TruthTableViewModel
                 Threshold = Threshold,
                 InputSignalNames = PreservedSignalNames(previous?.InputSignalNames, inputs),
                 OutputSignalNames = PreservedSignalNames(previous?.OutputSignalNames, outputs),
-                IsRegister = previous?.IsRegister ?? false,
+                IsRegister = IsRegister,
             };
             SignalNamesVisible = true;
             StatusText = string.Format(Translate("Analysis.TruthTable.Complete"), table.Rows.Count);

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Register.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Register.cs
@@ -1,0 +1,36 @@
+using CAP_Core.Components.Core;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+
+/// <summary>
+/// Register-designation half of <see cref="TruthTableViewModel"/>: the "Register
+/// (state element)" toggle in the Truth Table panel binds the persisted
+/// <see cref="TruthTablePinAssignment.IsRegister"/> flag of the selected group
+/// (issue #1098, UI slice of #1086). A register-designated gate's outputs hold
+/// their committed value while the network settles; only an explicit step samples
+/// its inputs and commits them (D-semantics), and a feedback cycle is legal exactly
+/// when it passes through such a gate. The toggle writes through to the group's
+/// persisted assignment as soon as one exists; before the first extraction it is
+/// pure intent the extraction persists alongside the pin roles.
+/// </summary>
+public partial class TruthTableViewModel
+{
+    /// <summary>
+    /// True when the selected group is designated a behavioral register state
+    /// element. Mirrored from the persisted assignment on selection; user edits
+    /// write back into it (or ride into the assignment the extraction creates).
+    /// </summary>
+    [ObservableProperty]
+    private bool _isRegister;
+
+    /// <summary>Writes the toggle through to the group's persisted assignment, when one exists.</summary>
+    partial void OnIsRegisterChanged(bool value)
+    {
+        if (_revertingPinCheck)
+            return;
+        var assignment = _group?.TruthTablePinAssignment;
+        if (assignment != null)
+            assignment.IsRegister = value;
+    }
+}

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.cs
@@ -101,6 +101,15 @@ public partial class TruthTableViewModel : ObservableObject
         Rows.Clear();
         StatusText = "";
         BiasSummaryText = "";
+        _revertingPinCheck = true;
+        try
+        {
+            IsRegister = _group?.TruthTablePinAssignment?.IsRegister ?? false;
+        }
+        finally
+        {
+            _revertingPinCheck = false;
+        }
         RebuildPinLists();
         PrefillFromPersistedAssignment();
         SignalNamesVisible = IsGroupSelected && _group?.TruthTablePinAssignment != null;

--- a/CAP.Avalonia/Views/Panels/TruthTablePanel.axaml
+++ b/CAP.Avalonia/Views/Panels/TruthTablePanel.axaml
@@ -140,6 +140,14 @@
             </StackPanel>
             <TextBlock Text="{Binding RightPanel.TruthTable.WavelengthText}" Foreground="Gray" FontSize="10" Margin="0,0,0,5"/>
 
+            <!-- Register designation (#1098): the group's persisted IsRegister flag —
+                 feedback loops through the network are legal only via a register. -->
+            <CheckBox Content="{loc:Localize TruthTable.Register}"
+                      IsChecked="{Binding RightPanel.TruthTable.IsRegister}"
+                      Foreground="LightGray" FontSize="11" Margin="0,4,0,0"/>
+            <TextBlock Text="{loc:Localize TruthTable.RegisterHint}" Foreground="Gray" FontSize="9"
+                       TextWrapping="Wrap" Margin="24,1,0,5"/>
+
             <StackPanel Orientation="Horizontal" Margin="0,5,0,5">
                 <Button Content="{loc:Localize TruthTable.Extract}"
                         Command="{Binding RightPanel.TruthTable.ExtractCommand}"

--- a/UnitTests/Analysis/LogicAnalysis/TruthTableViewModelRegisterTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/TruthTableViewModelRegisterTests.cs
@@ -1,0 +1,205 @@
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Connections;
+using CAP_Core.Components.Core;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The "Register (state element)" toggle in the Truth Table panel (issue #1098, UI
+/// slice of #1086): it binds the persisted <see cref="TruthTablePinAssignment.IsRegister"/>
+/// flag of the selected group — prefilled from the assignment on selection, written
+/// through on toggle, and carried into the assignment the extraction creates. A
+/// network built from a group toggled as register accepts a feedback loop;
+/// untoggling restores the honest combinational-cycle rejection.
+/// </summary>
+public class TruthTableViewModelRegisterTests
+{
+    private const double OrThreshold = 0.25;
+
+    [Fact]
+    public async Task Toggle_AfterExtraction_WritesThroughToThePersistedAssignment()
+    {
+        var (vm, group) = await ConfigureExtractedCombiner();
+
+        vm.IsRegister.ShouldBeFalse("a fresh extraction designates no register");
+        group.TruthTablePinAssignment!.IsRegister.ShouldBeFalse();
+
+        vm.IsRegister = true;
+        group.TruthTablePinAssignment!.IsRegister.ShouldBeTrue(
+            "the toggle writes through to the persisted assignment");
+
+        vm.IsRegister = false;
+        group.TruthTablePinAssignment!.IsRegister.ShouldBeFalse(
+            "untoggling clears the designation");
+    }
+
+    [Fact]
+    public void ConfigureForSelection_PersistedRegisterDesignation_PrefillsTheToggle()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        group.TruthTablePinAssignment = PersistedOrRoles(isRegister: true);
+
+        var vm = Configure(group);
+
+        vm.IsRegister.ShouldBeTrue("the persisted designation prefills the toggle");
+        vm.IsRegister = false;
+        group.TruthTablePinAssignment.IsRegister.ShouldBeFalse(
+            "a user edit after the prefill writes back into the persisted assignment");
+    }
+
+    [Fact]
+    public void ConfigureForSelection_SwitchingToAPlainGroup_ResetsTheToggle()
+    {
+        var registerGroup = LogicGateFixtureFactory.CreateCombinerGroup();
+        registerGroup.TruthTablePinAssignment = PersistedOrRoles(isRegister: true);
+        var plainGroup = LogicGateFixtureFactory.CreateCombinerGroup();
+        var canvas = new DesignCanvasViewModel();
+        var vm = new TruthTableViewModel();
+
+        vm.ConfigureForSelection(new ComponentViewModel(registerGroup), canvas);
+        vm.IsRegister.ShouldBeTrue();
+
+        vm.ConfigureForSelection(new ComponentViewModel(plainGroup), canvas);
+        vm.IsRegister.ShouldBeFalse(
+            "a group without designation must not inherit the previous group's toggle");
+    }
+
+    [Fact]
+    public async Task Toggle_BeforeFirstExtraction_PersistsWithTheExtractedAssignment()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        var vm = Configure(group);
+        vm.IsRegister = true;
+        group.TruthTablePinAssignment.ShouldBeNull(
+            "before the first extraction there is nothing to attach the flag to");
+
+        CheckOrRoles(vm);
+        await vm.ExtractCommand.ExecuteAsync(null);
+
+        vm.HasResult.ShouldBeTrue("the extraction must succeed");
+        group.TruthTablePinAssignment!.IsRegister.ShouldBeTrue(
+            "the toggle intent rides into the assignment the extraction persists");
+    }
+
+    [Fact]
+    public async Task ReExtraction_PreservesTheRegisterDesignation()
+    {
+        var (vm, group) = await ConfigureExtractedCombiner();
+        vm.IsRegister = true;
+
+        await vm.ExtractCommand.ExecuteAsync(null);
+
+        vm.HasResult.ShouldBeTrue("the re-extraction must succeed");
+        group.TruthTablePinAssignment!.IsRegister.ShouldBeTrue(
+            "re-extraction must not strip the designation");
+        vm.IsRegister.ShouldBeTrue("the toggle keeps mirroring the persisted flag");
+    }
+
+    [Fact]
+    public async Task FeedbackLoop_RegisterToggledThroughPanel_Assembles_UntoggleRestoresCycleRejection()
+    {
+        var first = CombinerAsOrGate("OR1");
+        var second = CombinerAsOrGate("OR2");
+        var connections = FeedbackLoop(first, second);
+
+        var rejected = await Should.ThrowAsync<InvalidOperationException>(
+            () => Assemble(first, second, connections));
+        // The honestly combinational loop keeps its cycle rejection.
+        rejected.Message.ShouldContain("sequential logic is not supported");
+
+        ToggleRegisterThroughPanel(second, value: true);
+        var network = await Assemble(first, second, connections);
+        network.RegisterState.Keys.ShouldBe(new[] { new LogicPinRef("OR2", "y") },
+            "the panel toggled the designation the assembler builds the register from");
+
+        ToggleRegisterThroughPanel(second, value: false);
+        var rejectedAgain = await Should.ThrowAsync<InvalidOperationException>(
+            () => Assemble(first, second, connections));
+        // Untoggling restores the honest combinational-cycle rejection.
+        rejectedAgain.Message.ShouldContain("cycle");
+    }
+
+    /// <summary>Toggles the panel's register checkbox over the group, as the user would.</summary>
+    private static void ToggleRegisterThroughPanel(ComponentGroup group, bool value)
+    {
+        var vm = Configure(group);
+        vm.IsRegister.ShouldBe(!value, "the toggle starts at the persisted designation");
+        vm.IsRegister = value;
+        group.TruthTablePinAssignment!.IsRegister.ShouldBe(value,
+            "the toggle writes through to the persisted assignment");
+    }
+
+    /// <summary>Configures the panel for the group and returns the ViewModel.</summary>
+    private static TruthTableViewModel Configure(ComponentGroup group)
+    {
+        var canvas = new DesignCanvasViewModel();
+        var component = new ComponentViewModel(group);
+        canvas.Selection.SelectSingle(component);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(component, canvas);
+        return vm;
+    }
+
+    /// <summary>Runs the combiner fixture through a real extraction, seeding the persisted assignment.</summary>
+    private static async Task<(TruthTableViewModel Vm, ComponentGroup Group)> ConfigureExtractedCombiner()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        var vm = Configure(group);
+        CheckOrRoles(vm);
+        await vm.ExtractCommand.ExecuteAsync(null);
+        vm.HasResult.ShouldBeTrue("the extraction seeds the persisted assignment");
+        return (vm, group);
+    }
+
+    /// <summary>Ticks the combiner's OR reading: a and b as inputs, y as output.</summary>
+    private static void CheckOrRoles(TruthTableViewModel vm)
+    {
+        vm.InputPins.Single(p => p.PinName == "a").IsChecked = true;
+        vm.InputPins.Single(p => p.PinName == "b").IsChecked = true;
+        vm.OutputPins.Single(p => p.PinName == "y").IsChecked = true;
+        vm.Threshold = OrThreshold;
+    }
+
+    /// <summary>The combiner's OR-reading assignment in its persisted form.</summary>
+    private static TruthTablePinAssignment PersistedOrRoles(bool isRegister) => new()
+    {
+        InputPinNames = new List<string> { "a", "b" },
+        OutputPinNames = new List<string> { "y" },
+        BiasPinNames = new List<string>(),
+        Threshold = OrThreshold,
+        IsRegister = isRegister,
+    };
+
+    /// <summary>A combiner group carrying the persisted OR reading, ready for assembly.</summary>
+    private static ComponentGroup CombinerAsOrGate(string groupName)
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        group.GroupName = groupName;
+        group.TruthTablePinAssignment = PersistedOrRoles(isRegister: false);
+        group.EnsureSMatrixComputed();
+        return group;
+    }
+
+    /// <summary>The cross-wired feedback loop: OR1.y → OR2.a and OR2.y → OR1.a.</summary>
+    private static WaveguideConnection[] FeedbackLoop(ComponentGroup first, ComponentGroup second) =>
+        new[] { Connect(first, "y", second, "a"), Connect(second, "y", first, "a") };
+
+    /// <summary>Runs the assembler at the fixture wavelength.</summary>
+    private static Task<LogicNetworkEvaluator> Assemble(
+        ComponentGroup first, ComponentGroup second, IReadOnlyList<WaveguideConnection> connections) =>
+        new LogicNetworkAssembler().AssembleAsync(
+            new Component[] { first, second }, connections, LogicGateFixtureFactory.WavelengthNm);
+
+    /// <summary>A design connection between two gate groups' external pins.</summary>
+    private static WaveguideConnection Connect(
+        ComponentGroup from, string fromPin, ComponentGroup to, string toPin) =>
+        new() { StartPin = Pin(from, fromPin), EndPin = Pin(to, toPin) };
+
+    /// <summary>Looks up a group's connectable external pin.</summary>
+    private static PhysicalPin Pin(ComponentGroup group, string name) =>
+        group.PhysicalPins.Single(p => p.Name == name);
+}

--- a/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
+++ b/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
@@ -333,6 +333,62 @@ public class TruthTablePinAssignmentPersistenceTests : IDisposable
     }
 
     [Fact]
+    public async Task RoundTrip_RegisterToggledThroughPanel_SurvivesSaveAndReload()
+    {
+        // Issue #1098: the register toggle in the Truth Table panel writes the
+        // persisted designation, and save → load → panel reopen mirrors it back.
+        var canvas = await LoadGateOnCanvas();
+        await ExtractNandThroughPanel(canvas);
+
+        var groupVm = canvas.Components.Single(c => c.Component is ComponentGroup);
+        canvas.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, canvas);
+        vm.IsRegister.ShouldBeFalse("a freshly extracted gate designates no register");
+        vm.IsRegister = true;
+        SingleGateGroup(canvas).TruthTablePinAssignment!.IsRegister.ShouldBeTrue(
+            "the toggle writes through to the persisted assignment");
+
+        await Save(canvas);
+        File.ReadAllText(_designFilePath).ShouldContain("\"IsRegister\": true", Case.Sensitive);
+
+        var reloaded = await LoadFromDisk();
+        var saved = SingleGateGroup(reloaded).TruthTablePinAssignment.ShouldNotBeNull();
+        saved.IsRegister.ShouldBeTrue("the designation rides the save → load round trip");
+
+        // …and the reopened panel prefills the toggle from the file.
+        var reloadedGroupVm = reloaded.Components.Single(c => c.Component is ComponentGroup);
+        reloaded.Selection.SelectSingle(reloadedGroupVm);
+        var reloadedVm = new TruthTableViewModel();
+        reloadedVm.ConfigureForSelection(reloadedGroupVm, reloaded);
+        reloadedVm.IsRegister.ShouldBeTrue("the reopened panel prefills the toggle from the file");
+
+        reloadedVm.IsRegister = false;
+        saved.IsRegister.ShouldBeFalse("untoggling clears the persisted designation again");
+    }
+
+    [Fact]
+    public async Task RoundTrip_RegisterToggledThroughPanel_SurvivesReExtraction()
+    {
+        // Issue #1098: re-extracting the truth table rewrites the persisted
+        // assignment — the toggled register designation must ride along.
+        var canvas = await LoadGateOnCanvas();
+        await ExtractNandThroughPanel(canvas);
+
+        var groupVm = canvas.Components.Single(c => c.Component is ComponentGroup);
+        canvas.Selection.SelectSingle(groupVm);
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(groupVm, canvas);
+        vm.IsRegister = true;
+
+        await vm.ExtractCommand.ExecuteAsync(null);
+        vm.HasResult.ShouldBeTrue("the re-extraction must succeed");
+
+        SingleGateGroup(canvas).TruthTablePinAssignment.ShouldNotBeNull()
+            .IsRegister.ShouldBeTrue("re-extraction must not strip the designation");
+    }
+
+    [Fact]
     public async Task RoundTrip_GateWithoutRegisterDesignation_PersistsNoRegisterFlag()
     {
         // Issue #1086: a plain combinational gate writes no register flag — the

--- a/UnitTests/UI/TruthTablePanelRenderTests.cs
+++ b/UnitTests/UI/TruthTablePanelRenderTests.cs
@@ -32,6 +32,8 @@ public class TruthTablePanelRenderTests
         "TruthTable.NoGroupSelected",
         "TruthTable.Inputs",
         "TruthTable.Outputs",
+        "TruthTable.Register",
+        "TruthTable.RegisterHint",
         "TruthTable.Bias",
         "TruthTable.BiasSummary",
         "TruthTable.Threshold",
@@ -119,7 +121,8 @@ public class TruthTablePanelRenderTests
                 .Any(t => t.Text == hint)
                 .ShouldBeTrue("the panel must explain that exactly one group needs to be selected");
             panel.GetVisualDescendants().OfType<CheckBox>()
-                .ShouldBeEmpty("no group selected — no pin checkboxes");
+                .Where(c => c.IsEffectivelyVisible)
+                .ShouldBeEmpty("no group selected — no pin checkboxes rendered");
         }
         finally
         {
@@ -148,9 +151,12 @@ public class TruthTablePanelRenderTests
             Dispatcher.UIThread.RunJobs();
 
             var checkBoxes = panel.GetVisualDescendants().OfType<CheckBox>().ToList();
-            checkBoxes.Count.ShouldBe(9, "3 external pins offered as inputs, as outputs, and as bias");
+            checkBoxes.Count.ShouldBe(10, "3 external pins offered as inputs, as outputs, and as bias, plus the register toggle");
             checkBoxes.Select(c => c.Content?.ToString()).ShouldContain("a");
             checkBoxes.Select(c => c.Content?.ToString()).ShouldContain("y");
+            var registerLabel = LocalizationService.Instance.Translate("TruthTable.Register");
+            checkBoxes.Select(c => c.Content?.ToString()).ShouldContain(registerLabel,
+                "the register toggle renders with its localized label");
         }
         finally
         {


### PR DESCRIPTION
## What & why

PR #1093 shipped the behavioral register state element (`TruthTablePinAssignment.IsRegister`, two-phase Evaluate/Step() D-semantics), but the flag could only be set by hand-editing the .lun — no user could build a latch. This PR adds the missing UI hook (issue #1098, UI slice of #1086):

- A **"Register (state element)"** checkbox in the Truth Table panel, directly under the threshold control, bound to the persisted `IsRegister` designation of the selected gate group.
- The toggle prefills from the persisted assignment on selection, writes through on every change, and — toggled before the first extraction — rides into the assignment the extraction persists. Re-extraction preserves the designation.
- A short plain-language hint under the toggle explains the D-semantics (outputs hold their committed value; the Logic panel's Step samples inputs and commits) and that a feedback loop is legal only through a register — that is how you build a latch.
- i18n complete in all 5 languages (de/en/es/ja/zh-Hans).

## How it was tested

- New `TruthTableViewModelRegisterTests` (6 tests): toggle writes through to the persisted assignment, persisted flag prefills the toggle, group switch resets it, toggle-before-extraction persists with the extraction, re-extraction preserves the flag, and a panel-toggled group's feedback loop assembles while untoggling restores the honest combinational-cycle rejection.
- New round-trip tests in `TruthTablePinAssignmentPersistenceTests`: register designation toggled through the panel survives save → load → panel prefill, and survives re-extraction.
- `TruthTablePanelRenderTests` updated: the new checkbox renders with its localized label; the register keys are asserted translated in all five languages.
- `LocalizationCompleteness`/`LocalizationCoverage` suites green; no hardcoded strings.
- `dotnet build` green.

Local suite: 6287 passed, 0 failed (14 skipped)

## Manual verification after vacation

1. Open the "Logic Gate NOT-NAND" example, select the gate group.
2. Re-extract (or reopen) the Truth Table panel — the roles prefill.
3. Toggle **Register (state element)**, save the file, reload it, select the group again — the toggle reappears checked.
4. Wire a feedback loop between two register-designated gates — the Logic panel accepts it; untoggle Register and the network build rejects the loop as a combinational cycle again.

Tools: python smart_test.py unavailable on this machine (no Python installed); tests run via the mandated filtered `dotnet test` invocation instead.