### PR TITLE
Agent: SR latch example from two cross-coupled NAND registers (#1100)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -355,6 +355,7 @@
   "Examples.NotGate.Description": "Dein erstes Logikgatter: ein NOT aus einem einzigen NAND.",
   "Examples.OrGate.Description": "Baue ein OR-Gatter aus NOT- und AND-Bausteinen.",
   "Examples.RippleCarryAdder.Description": "Reihe Volladdierer zu einem 4-Bit-Ripple-Carry-Addierer — 344 Gatter, ein Ergebnis.",
+  "Examples.SrLatch.Description": "Zwei kreuzgekoppelte NAND-Register merken sich ein Bit — deine erste Speicherschaltung.",
   "ErrorConsole.ClearTip": "Konsole leeren",
   "ErrorConsole.CopyAllTip": "Alle Einträge in die Zwischenablage kopieren",
   "ErrorConsole.Title": "Fehlerkonsole",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -355,6 +355,7 @@
   "Examples.NotGate.Description": "Your first logic gate: a NOT built from a single NAND.",
   "Examples.OrGate.Description": "Build an OR gate from NOT and AND building blocks.",
   "Examples.RippleCarryAdder.Description": "Chain full adders into a 4-bit ripple-carry adder — 344 gates, one result.",
+  "Examples.SrLatch.Description": "Two cross-coupled NAND registers remember one bit — your first memory circuit.",
   "ErrorConsole.ClearTip": "Clear console",
   "ErrorConsole.CopyAllTip": "Copy all entries to clipboard",
   "ErrorConsole.Title": "Error Console",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -355,6 +355,7 @@
   "Examples.NotGate.Description": "Tu primera puerta lógica: un NOT construido con una sola NAND.",
   "Examples.OrGate.Description": "Construye una puerta OR a partir de bloques NOT y AND.",
   "Examples.RippleCarryAdder.Description": "Encadena sumadores completos en un sumador de 4 bits con acarreo encadenado: 344 puertas, un resultado.",
+  "Examples.SrLatch.Description": "Dos registros NAND acoplados en cruz recuerdan un bit: tu primer circuito de memoria.",
   "ErrorConsole.ClearTip": "Limpiar la consola",
   "ErrorConsole.CopyAllTip": "Copiar todas las entradas al portapapeles",
   "ErrorConsole.Title": "Consola de errores",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -355,6 +355,7 @@
   "Examples.NotGate.Description": "最初の論理ゲート:NAND 1つで作るNOT。",
   "Examples.OrGate.Description": "NOTとANDのブロックからORゲートを作る。",
   "Examples.RippleCarryAdder.Description": "全加算器を連ねて4ビット・リップルキャリー加算器へ — 344ゲートで1つの結果。",
+  "Examples.SrLatch.Description": "2つのNANDレジスタを交差結合して1ビットを記憶する — 初めてのメモリ回路。",
   "ErrorConsole.ClearTip": "コンソールをクリア",
   "ErrorConsole.CopyAllTip": "すべてのエントリをクリップボードにコピー",
   "ErrorConsole.Title": "エラーコンソール",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -355,6 +355,7 @@
   "Examples.NotGate.Description": "你的第一个逻辑门:用一个 NAND 搭建 NOT。",
   "Examples.OrGate.Description": "用 NOT 和 AND 模块搭建 OR 门。",
   "Examples.RippleCarryAdder.Description": "把全加器串成 4 位行波进位加法器——344 个门,一个结果。",
+  "Examples.SrLatch.Description": "两个交叉耦合的 NAND 寄存器记住一个比特——你的第一个存储电路。",
   "ErrorConsole.ClearTip": "清空控制台",
   "ErrorConsole.CopyAllTip": "将所有条目复制到剪贴板",
   "ErrorConsole.Title": "错误控制台",

--- a/UnitTests/Integration/LogicGateSrLatchExampleTests.cs
+++ b/UnitTests/Integration/LogicGateSrLatchExampleTests.cs
@@ -1,0 +1,220 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Pinned tests for the shipped <c>examples/Logic Gate SR-Latch.lun</c> (issue #1100,
+/// rung 4/5 — the first sequential stone of the NAND game): two cross-coupled NAND
+/// gates of the shipped NOT/NAND gate, both designated registers, wired to the
+/// textbook active-low SR latch Q = NAND(S̄, Q̄), Q̄ = NAND(R̄, Q). The file loads
+/// through the real load path, every group carries its persisted
+/// <see cref="TruthTablePinAssignment"/> with the register designation, and the
+/// merged <see cref="LogicNetworkAssembler"/> (#988) turns the loaded design into the
+/// evaluable network: the set/reset toggles read <c>S̄</c> and <c>R̄</c> through the
+/// persisted signal names (issue #1025), the taps read <c>Q</c> and <c>Q̄</c>, and the
+/// set → hold → reset → hold sequence replays exactly the semantics pinned in
+/// <c>LogicNetworkRegisterTests.Evaluate_SrLatchFromCrossCoupledNandRegisters_HoldsStateAcrossSteps</c>.
+/// </summary>
+public class LogicGateSrLatchExampleTests : IClassFixture<LogicGateSrLatchExampleTests.SrLatchFixture>
+{
+    private const double NandThreshold = 0.125;
+
+    private const string SetSignal = "S̄";
+    private const string ResetSignal = "R̄";
+    private const string QTap = "Q";
+    private const string QBarTap = "Q̄";
+
+    private static readonly string[] GateNames = { "NANDQ", "NANDQB" };
+
+    /// <summary>The persisted input signal names per gate group (issue #1025).</summary>
+    private static readonly Dictionary<string, Dictionary<string, string>> ExpectedInputSignalNames = new()
+    {
+        ["NANDQ"] = new() { ["A"] = SetSignal },
+        ["NANDQB"] = new() { ["A"] = ResetSignal },
+    };
+
+    /// <summary>The persisted output signal names per gate group.</summary>
+    private static readonly Dictionary<string, Dictionary<string, string>> ExpectedOutputSignalNames = new()
+    {
+        ["NANDQ"] = new() { ["Y"] = QTap },
+        ["NANDQB"] = new() { ["Y"] = QBarTap },
+    };
+
+    private readonly SrLatchFixture _fixture;
+
+    /// <summary>Attaches the shared SR-latch fixture.</summary>
+    public LogicGateSrLatchExampleTests(SrLatchFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Example_LoadsOnlyTopLevelGateGroups_EachRegisterDesignatedWithPersistedRoles()
+    {
+        _fixture.Canvas.Components.ShouldAllBe(
+            c => c.Component is ComponentGroup,
+            "the SR latch contains only top-level gate groups");
+        _fixture.Canvas.Connections.Count.ShouldBe(2,
+            "two cross-coupling wires join the two gates: Q → NANDQB.B and Q̄ → NANDQ.B");
+
+        var groups = _fixture.Groups;
+        groups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+        foreach (var group in groups)
+        {
+            var roles = group.TruthTablePinAssignment.ShouldNotBeNull(
+                $"group '{group.GroupName}' must ship its persisted pin roles");
+            roles.InputPinNames.ShouldBe(new[] { "A", "B" });
+            roles.OutputPinNames.ShouldBe(new[] { "Y" });
+            roles.BiasPinNames.ShouldBe(new[] { "BIAS" });
+            roles.Threshold.ShouldBe(NandThreshold);
+            roles.IsRegister.ShouldBeTrue(
+                $"group '{group.GroupName}' must ship the register designation (issue #1100)");
+            roles.InputSignalNames.ShouldBe(ExpectedInputSignalNames[group.GroupName],
+                $"group '{group.GroupName}' ships its network-signal identity (issue #1025)");
+            roles.OutputSignalNames.ShouldBe(ExpectedOutputSignalNames[group.GroupName],
+                $"group '{group.GroupName}' ships its named output tap");
+            group.Description.ShouldContain("logic layer", Case.Sensitive,
+                "every gate carries the education note about logic-layer composition");
+            group.Description.ShouldContain("register", Case.Sensitive,
+                "every gate carries the register designation note");
+            group.Description.ShouldContain("0.125");
+        }
+    }
+
+    [Fact]
+    public void AssembledNetwork_ExposesSetAndResetTogglesNamedOutputsAndRegisterState()
+    {
+        _fixture.Network.InputPinNames.ShouldBe(new[] { ResetSignal, SetSignal }, ignoreOrder: true,
+            customMessage: "the signal names merge the set/reset pins into one toggle each (issue #1025)");
+        _fixture.Network.OutputPinNames.ShouldBe(new[] { QTap, QBarTap }, ignoreOrder: true,
+            customMessage: "the named outputs replace the raw gate-pin taps");
+        _fixture.Network.RegisterState.Keys.ShouldBe(
+            new[] { new LogicPinRef("NANDQ", "Y"), new LogicPinRef("NANDQB", "Y") }, ignoreOrder: true,
+            customMessage: "both gates power up with their committed output cleared");
+    }
+
+    [Fact]
+    public void StepSequence_SetHoldResetHold_ReplaysThePinnedRegisterSemantics()
+    {
+        var network = _fixture.Network;
+
+        // Set (active-low S̄): Q rises, Q̄ falls — and then holds while both
+        // inputs rest at 1.
+        network.Evaluate(_fixture.InputBits(set: false, reset: true));
+        network.Step();
+        network.Step();
+        network.Evaluate(_fixture.InputBits(set: true, reset: true))[QTap].ShouldBeTrue("the latch is set");
+        network.Evaluate(_fixture.InputBits(set: true, reset: true))[QBarTap].ShouldBeFalse();
+
+        network.Step();
+        network.Step();
+        network.Evaluate(_fixture.InputBits(set: true, reset: true))[QTap].ShouldBeTrue(
+            "resting inputs hold the set state");
+
+        // Reset (active-low R̄): Q falls, Q̄ rises — and holds again.
+        network.Evaluate(_fixture.InputBits(set: true, reset: false));
+        network.Step();
+        network.Step();
+        network.Evaluate(_fixture.InputBits(set: true, reset: true))[QTap].ShouldBeFalse("the latch is reset");
+        network.Evaluate(_fixture.InputBits(set: true, reset: true))[QBarTap].ShouldBeTrue();
+
+        network.Step();
+        network.Step();
+        network.Evaluate(_fixture.InputBits(set: true, reset: true))[QTap].ShouldBeFalse(
+            "resting inputs hold the reset state");
+    }
+
+    [Fact]
+    public async Task SaveLoadRoundTrip_ReAssembledNetwork_YieldsTheSameLatch()
+    {
+        var savedPath = await _fixture.SaveToTempFile();
+        try
+        {
+            var reloadedCanvas = await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath);
+
+            var reloadedGroups = LogicGateHalfAdderExampleTests.GroupsOf(reloadedCanvas);
+            reloadedGroups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+            reloadedGroups.ShouldAllBe(g => g.TruthTablePinAssignment != null,
+                "the persisted pin roles must survive the save → load round trip");
+            foreach (var group in reloadedGroups)
+            {
+                group.TruthTablePinAssignment!.IsRegister.ShouldBeTrue(
+                    $"the register designation of '{group.GroupName}' must survive the save → load round trip");
+                group.TruthTablePinAssignment!.InputSignalNames.ShouldBe(
+                    ExpectedInputSignalNames[group.GroupName],
+                    $"the input signal names of '{group.GroupName}' must survive the save → load round trip (#1025)");
+                group.TruthTablePinAssignment!.OutputSignalNames.ShouldBe(
+                    ExpectedOutputSignalNames[group.GroupName],
+                    $"the output signal names of '{group.GroupName}' must survive the save → load round trip");
+            }
+            reloadedCanvas.Connections.Count.ShouldBe(2,
+                "both cross-coupling wires must survive the save → load round trip");
+
+            var reloaded = await LogicGateMuxExampleTests.AssembleNetwork(reloadedCanvas);
+            reloaded.InputPinNames.ShouldBe(_fixture.Network.InputPinNames);
+            reloaded.OutputPinNames.ShouldBe(_fixture.Network.OutputPinNames);
+            reloaded.RegisterState.Keys.ShouldBe(_fixture.Network.RegisterState.Keys, ignoreOrder: true,
+                customMessage: "the re-assembled network must carry the same register state elements");
+        }
+        finally
+        {
+            if (File.Exists(savedPath)) File.Delete(savedPath);
+        }
+    }
+
+    /// <summary>
+    /// Shared fixture: loads the shipped example once and assembles its logic network
+    /// (each extraction is a real simulation run), so every fact asserts against the
+    /// same loaded design and assembled network.
+    /// </summary>
+    public class SrLatchFixture : IAsyncLifetime
+    {
+        private const string ExampleFileName = "Logic Gate SR-Latch.lun";
+
+        /// <summary>Laser wavelength the persisted roles were extracted at.</summary>
+        public const int WavelengthNm = 1550;
+
+        /// <summary>The canvas the shipped example loaded onto.</summary>
+        public DesignCanvasViewModel Canvas { get; private set; } = null!;
+
+        /// <summary>The loaded top-level gate groups, in file order.</summary>
+        public List<ComponentGroup> Groups { get; private set; } = null!;
+
+        /// <summary>The logic network assembled from the loaded design.</summary>
+        public LogicNetworkEvaluator Network { get; private set; } = null!;
+
+        /// <summary>Loads the shipped example and assembles its logic network.</summary>
+        public async Task InitializeAsync()
+        {
+            var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+            Canvas = await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+            Groups = LogicGateHalfAdderExampleTests.GroupsOf(Canvas);
+            Network = await LogicGateMuxExampleTests.AssembleNetwork(Canvas);
+        }
+
+        /// <summary>No shared state to release.</summary>
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        /// <summary>The network input bits for one set/reset pair — one bit per signal.</summary>
+        public Dictionary<string, bool> InputBits(bool set, bool reset) =>
+            new() { [SetSignal] = set, [ResetSignal] = reset };
+
+        /// <summary>Saves the loaded design through the real save path and returns the file path.</summary>
+        public async Task<string> SaveToTempFile()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"sr-latch-{Guid.NewGuid():N}.lun");
+            var saveVm = LogicGateHalfAdderExampleTests.CreateFileOperations(Canvas);
+            var dialog = new Mock<IFileDialogService>();
+            dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(path);
+            saveVm.FileDialogService = dialog.Object;
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+            File.Exists(path).ShouldBeTrue("the real save path must write the temp .lun");
+            return path;
+        }
+    }
+}

--- a/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
+++ b/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
@@ -51,6 +51,23 @@ public class ExamplesManifestLocalizationTests
             .ShouldBe(entries.Count, "manifest ranks must be unique to keep the ladder order deterministic");
     }
 
+    [Fact]
+    public void CuratedLadder_ListsTheSrLatch_AfterTheFourBitAdder()
+    {
+        var ladder = new CAP.Avalonia.Services.ExampleDesignsService().GetExamples()
+            .Where(example => example.DescriptionKey != null)
+            .ToList();
+
+        var adderIndex = ladder.FindIndex(example => example.Name == "Logic Gate 4-Bit Adder");
+        adderIndex.ShouldBeGreaterThanOrEqualTo(0, "the 4-bit adder rung must stay curated");
+
+        var latchIndex = ladder.FindIndex(example => example.Name == "Logic Gate SR-Latch");
+        latchIndex.ShouldBeGreaterThan(adderIndex,
+            "the SR latch is the first sequential rung — it follows the datapath rungs");
+        ladder[latchIndex].Level.ShouldBe("Sequential");
+        ladder[latchIndex].DescriptionKey.ShouldBe("Examples.SrLatch.Description");
+    }
+
     private static List<ManifestEntry> ReadManifestEntries()
     {
         var manifestPath = Path.Combine(FindRepoRoot(), "examples", "examples.json");

--- a/examples/Logic Gate SR-Latch.lun
+++ b/examples/Logic Gate SR-Latch.lun
@@ -1,0 +1,703 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 1,
+      "EndPinName": "B",
+      "StartComponentId": "group_a17c3f0e4b1d4d35a54f5c3a4d9e2f01",
+      "EndComponentId": "group_b28d4a1f5c2e4e46b65a6d4b5e0a3f12",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 1,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_b28d4a1f5c2e4e46b65a6d4b5e0a3f12",
+      "EndComponentId": "group_a17c3f0e4b1d4d35a54f5c3a4d9e2f01",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    }
+  ],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "NANDQ",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate, designated a register (IsRegister). Role in the SR latch: the Q-side gate of two cross-coupled NAND registers, Q = NAND(S\u0304, Q\u0304) with the set input active low \u2014 pull S\u0304 to 0 and Q rises to 1 and stays there. Its B pin reads the other gate's committed output Q\u0304 through the cross-coupling wire; only an explicit clock step samples the loop and commits new state (D-semantics), which is what makes this feedback cycle legal. The whole latch composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_a17c3f0e4b1d4d35a54f5c3a4d9e2f01",
+        "IdGuid": "5f8e2a3c-9d4b-4c1a-8e6f-1a2b3c4d5e01",
+        "ChildComponentGuids": [
+          "11111111-1111-4111-8111-111111111101",
+          "11111111-1111-4111-8111-111111111102",
+          "11111111-1111-4111-8111-111111111103",
+          "11111111-1111-4111-8111-111111111104",
+          "11111111-1111-4111-8111-111111111105",
+          "11111111-1111-4111-8111-111111111106"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_1a2b3c4d5e6f47018a9b0c1d2e3f4001",
+          "input_1a2b3c4d5e6f47018a9b0c1d2e3f4002",
+          "combine_2b3c4d5e6f47018a9b0c1d2e3f4003",
+          "phase_2b3c4d5e6f47018a9b0c1d2e3f4004",
+          "recombine_2b3c4d5e6f47018a9b0c1d2e3f4005",
+          "output_2b3c4d5e6f47018a9b0c1d2e3f4006"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "6a7b8c9d-0e1f-4a2b-8c3d-4e5f6a7b0101",
+            "StartComponentId": "input_1a2b3c4d5e6f47018a9b0c1d2e3f4001",
+            "StartComponentGuid": "11111111-1111-4111-8111-111111111101",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_2b3c4d5e6f47018a9b0c1d2e3f4003",
+            "EndComponentGuid": "11111111-1111-4111-8111-111111111103",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6a7b8c9d-0e1f-4a2b-8c3d-4e5f6a7b0102",
+            "StartComponentId": "input_1a2b3c4d5e6f47018a9b0c1d2e3f4002",
+            "StartComponentGuid": "11111111-1111-4111-8111-111111111102",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_2b3c4d5e6f47018a9b0c1d2e3f4003",
+            "EndComponentGuid": "11111111-1111-4111-8111-111111111103",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6a7b8c9d-0e1f-4a2b-8c3d-4e5f6a7b0103",
+            "StartComponentId": "combine_2b3c4d5e6f47018a9b0c1d2e3f4003",
+            "StartComponentGuid": "11111111-1111-4111-8111-111111111103",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_2b3c4d5e6f47018a9b0c1d2e3f4005",
+            "EndComponentGuid": "11111111-1111-4111-8111-111111111105",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6a7b8c9d-0e1f-4a2b-8c3d-4e5f6a7b0104",
+            "StartComponentId": "phase_2b3c4d5e6f47018a9b0c1d2e3f4004",
+            "StartComponentGuid": "11111111-1111-4111-8111-111111111104",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_2b3c4d5e6f47018a9b0c1d2e3f4005",
+            "EndComponentGuid": "11111111-1111-4111-8111-111111111105",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6a7b8c9d-0e1f-4a2b-8c3d-4e5f6a7b0105",
+            "StartComponentId": "recombine_2b3c4d5e6f47018a9b0c1d2e3f4005",
+            "StartComponentGuid": "11111111-1111-4111-8111-111111111105",
+            "StartPinName": "out1",
+            "EndComponentId": "output_2b3c4d5e6f47018a9b0c1d2e3f4006",
+            "EndComponentGuid": "11111111-1111-4111-8111-111111111106",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0101",
+            "Name": "A",
+            "InternalComponentId": "input_1a2b3c4d5e6f47018a9b0c1d2e3f4001",
+            "InternalComponentGuid": "11111111-1111-4111-8111-111111111101",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0102",
+            "Name": "B",
+            "InternalComponentId": "input_1a2b3c4d5e6f47018a9b0c1d2e3f4002",
+            "InternalComponentGuid": "11111111-1111-4111-8111-111111111102",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0103",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_2b3c4d5e6f47018a9b0c1d2e3f4004",
+            "InternalComponentGuid": "11111111-1111-4111-8111-111111111104",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0104",
+            "Name": "Y",
+            "InternalComponentId": "output_2b3c4d5e6f47018a9b0c1d2e3f4006",
+            "InternalComponentGuid": "11111111-1111-4111-8111-111111111106",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_1a2b3c4d5e6f47018a9b0c1d2e3f4001",
+          "ComponentGuid": "11111111-1111-4111-8111-111111111101",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_1a2b3c4d5e6f47018a9b0c1d2e3f4002",
+          "ComponentGuid": "11111111-1111-4111-8111-111111111102",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_2b3c4d5e6f47018a9b0c1d2e3f4003",
+          "ComponentGuid": "11111111-1111-4111-8111-111111111103",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_2b3c4d5e6f47018a9b0c1d2e3f4004",
+          "ComponentGuid": "11111111-1111-4111-8111-111111111104",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_2b3c4d5e6f47018a9b0c1d2e3f4005",
+          "ComponentGuid": "11111111-1111-4111-8111-111111111105",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_2b3c4d5e6f47018a9b0c1d2e3f4006",
+          "ComponentGuid": "11111111-1111-4111-8111-111111111106",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "InputSignalNames": {
+          "A": "S\u0304"
+        },
+        "OutputSignalNames": {
+          "Y": "Q"
+        },
+        "IsRegister": true
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "NANDQB",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate, designated a register (IsRegister). Role in the SR latch: the Q\u0304-side gate of two cross-coupled NAND registers, Q\u0304 = NAND(R\u0304, Q) with the reset input active low \u2014 pull R\u0304 to 0 and Q\u0304 rises to 1 (Q falls to 0) and stays there. Its B pin reads the other gate's committed output Q through the cross-coupling wire; only an explicit clock step samples the loop and commits new state (D-semantics), which is what makes this feedback cycle legal. The whole latch composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_b28d4a1f5c2e4e46b65a6d4b5e0a3f12",
+        "IdGuid": "6a9f3b4d-0e5c-4d2b-9f7a-2b3c4d5e6f02",
+        "ChildComponentGuids": [
+          "22222222-2222-4222-8222-222222222201",
+          "22222222-2222-4222-8222-222222222202",
+          "22222222-2222-4222-8222-222222222203",
+          "22222222-2222-4222-8222-222222222204",
+          "22222222-2222-4222-8222-222222222205",
+          "22222222-2222-4222-8222-222222222206"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 400,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_3c4d5e6f47018a9b0c1d2e3f4007a1",
+          "input_3c4d5e6f47018a9b0c1d2e3f4007a2",
+          "combine_4d5e6f47018a9b0c1d2e3f4007a3",
+          "phase_4d5e6f47018a9b0c1d2e3f4007a4",
+          "recombine_4d5e6f47018a9b0c1d2e3f4007a5",
+          "output_4d5e6f47018a9b0c1d2e3f4007a6"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0201",
+            "StartComponentId": "input_3c4d5e6f47018a9b0c1d2e3f4007a1",
+            "StartComponentGuid": "22222222-2222-4222-8222-222222222201",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_4d5e6f47018a9b0c1d2e3f4007a3",
+            "EndComponentGuid": "22222222-2222-4222-8222-222222222203",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0202",
+            "StartComponentId": "input_3c4d5e6f47018a9b0c1d2e3f4007a2",
+            "StartComponentGuid": "22222222-2222-4222-8222-222222222202",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_4d5e6f47018a9b0c1d2e3f4007a3",
+            "EndComponentGuid": "22222222-2222-4222-8222-222222222203",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0203",
+            "StartComponentId": "combine_4d5e6f47018a9b0c1d2e3f4007a3",
+            "StartComponentGuid": "22222222-2222-4222-8222-222222222203",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_4d5e6f47018a9b0c1d2e3f4007a5",
+            "EndComponentGuid": "22222222-2222-4222-8222-222222222205",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0204",
+            "StartComponentId": "phase_4d5e6f47018a9b0c1d2e3f4007a4",
+            "StartComponentGuid": "22222222-2222-4222-8222-222222222204",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_4d5e6f47018a9b0c1d2e3f4007a5",
+            "EndComponentGuid": "22222222-2222-4222-8222-222222222205",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "7b8c9d0e-1f2a-4b3c-8d4e-5f6a7b8c0205",
+            "StartComponentId": "recombine_4d5e6f47018a9b0c1d2e3f4007a5",
+            "StartComponentGuid": "22222222-2222-4222-8222-222222222205",
+            "StartPinName": "out1",
+            "EndComponentId": "output_4d5e6f47018a9b0c1d2e3f4007a6",
+            "EndComponentGuid": "22222222-2222-4222-8222-222222222206",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "8c9d0e1f-2a3b-4c4d-8e5f-6a7b8c9d0201",
+            "Name": "A",
+            "InternalComponentId": "input_3c4d5e6f47018a9b0c1d2e3f4007a1",
+            "InternalComponentGuid": "22222222-2222-4222-8222-222222222201",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8c9d0e1f-2a3b-4c4d-8e5f-6a7b8c9d0202",
+            "Name": "B",
+            "InternalComponentId": "input_3c4d5e6f47018a9b0c1d2e3f4007a2",
+            "InternalComponentGuid": "22222222-2222-4222-8222-222222222202",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8c9d0e1f-2a3b-4c4d-8e5f-6a7b8c9d0203",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_4d5e6f47018a9b0c1d2e3f4007a4",
+            "InternalComponentGuid": "22222222-2222-4222-8222-222222222204",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8c9d0e1f-2a3b-4c4d-8e5f-6a7b8c9d0204",
+            "Name": "Y",
+            "InternalComponentId": "output_4d5e6f47018a9b0c1d2e3f4007a6",
+            "InternalComponentGuid": "22222222-2222-4222-8222-222222222206",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_3c4d5e6f47018a9b0c1d2e3f4007a1",
+          "ComponentGuid": "22222222-2222-4222-8222-222222222201",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_3c4d5e6f47018a9b0c1d2e3f4007a2",
+          "ComponentGuid": "22222222-2222-4222-8222-222222222202",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_4d5e6f47018a9b0c1d2e3f4007a3",
+          "ComponentGuid": "22222222-2222-4222-8222-222222222203",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_4d5e6f47018a9b0c1d2e3f4007a4",
+          "ComponentGuid": "22222222-2222-4222-8222-222222222204",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_4d5e6f47018a9b0c1d2e3f4007a5",
+          "ComponentGuid": "22222222-2222-4222-8222-222222222205",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_4d5e6f47018a9b0c1d2e3f4007a6",
+          "ComponentGuid": "22222222-2222-4222-8222-222222222206",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 400,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "InputSignalNames": {
+          "A": "R\u0304"
+        },
+        "OutputSignalNames": {
+          "Y": "Q\u0304"
+        },
+        "IsRegister": true
+      }
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-20",
+      "Modified": "2026-08-20T04:30:00.0000000Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -7,6 +7,7 @@
     { "file": "Logic Gate Half Adder.lun", "rank": 50, "level": "Adders", "descriptionKey": "Examples.HalfAdder.Description" },
     { "file": "Logic Gate Full Adder.lun", "rank": 60, "level": "Adders", "descriptionKey": "Examples.FullAdder.Description" },
     { "file": "Logic Gate MUX.lun", "rank": 70, "level": "Datapath", "descriptionKey": "Examples.Mux.Description" },
-    { "file": "Logic Gate 4-Bit Adder.lun", "rank": 80, "level": "Datapath", "descriptionKey": "Examples.RippleCarryAdder.Description" }
+    { "file": "Logic Gate 4-Bit Adder.lun", "rank": 80, "level": "Datapath", "descriptionKey": "Examples.RippleCarryAdder.Description" },
+    { "file": "Logic Gate SR-Latch.lun", "rank": 90, "level": "Sequential", "descriptionKey": "Examples.SrLatch.Description" }
   ]
 }


### PR DESCRIPTION
## What & why

Issue #1100 — rung 4/5 of the NAND-game ladder on the Home screen: the register core (#1086/PR #1093) was proven by unit tests, but no shipped example let a user *load* a sequential circuit. This ships the first sequential rung: the classic **SR latch from two cross-coupled NAND gates**, built from the same shipped NOT/NAND gate as the existing ladder examples (education is the product — roadmap principle 1; personas: Priya's students, Ingrid demo).

- **New `examples/Logic Gate SR-Latch.lun`**: two cross-coupled NAND gate groups (`NANDQ`, `NANDQB`), both designated registers (`IsRegister`), wired Q → NANDQB.B and Q̄ → NANDQ.B. Persisted signal names use the active-low convention the hint text explains: inputs `S̄`/`R̄`, outputs `Q`/`Q̄` (Q = NAND(S̄, Q̄), Q̄ = NAND(R̄, Q)). Each group description documents the role, the D-semantics step behavior that makes the feedback cycle legal, and the logic-layer composition note.
- **Manifest entry** in `examples/examples.json` (rank 90, after the 4-bit adder; new `"Sequential"` level string) + localized one-line description `Examples.SrLatch.Description` in all 5 languages (de, en, es, ja, zh-Hans).
- **Pinned tests** mirroring the MUX example pattern (real load path, not fixtures) in `UnitTests/Integration/LogicGateSrLatchExampleTests.cs`:
  - loads through the real load path → both groups carry persisted roles **and the register designation** → assemble via `LogicNetworkAssembler` → the network exposes exactly the `S̄`/`R̄` toggles, the named `Q`/`Q̄` taps, and both register state elements
  - Step-sequence: **set → hold → reset → hold**, replaying exactly the semantics pinned in `LogicNetworkRegisterTests.Evaluate_SrLatchFromCrossCoupledNandRegisters_HoldsStateAcrossSteps`
  - save → load through the real save path → re-assembly equivalence (roles, register designations, signal names, cross-coupling wires all survive)
- `ExamplesManifestLocalizationTests` extended: the SR latch must appear in the curated ladder via the real `ExampleDesignsService` path, ranked after the 4-bit adder with level `"Sequential"` (acceptance criterion 1).

## How it was tested

- `dotnet build CAP.Desktop/CAP.Desktop.csproj` — clean, 0 warnings, 0 errors.
- Targeted: `LogicGateSrLatchExampleTests` (4 tests), extended `ExamplesManifestLocalizationTests` (3 tests), `ExampleDesignFilesTests`, `ExampleDesignsServiceTests`, `LocalizationCoverageTests` — all green.
- Full filtered suite (`dotnet test UnitTests/UnitTests.csproj --filter "Category!=Slow"`):

Local suite: 6284 passed, 0 failed

## Manual verification after vacation

1. Open Lunima → Home screen → the ladder now shows **Logic Gate SR-Latch** (level *Sequential*) after the 4-bit adder, with the localized one-line description.
2. Load the example, open the Logic panel.
3. Use the Step button (#1099) to clock the latch: pull `S̄` low and step → watch `Q` rise to 1; return `S̄` high and step → `Q` holds. Pull `R̄` low and step → `Q` falls to 0; return `R̄` high and step → `Q` holds.
