### PR TITLE
Agent: 2-bit counter example from toggle registers (#1102)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "Gruppen-Bearbeitungsmodus verlassen und zur Hauptzeichenfläche zurückkehren (ESC-Taste)",
   "EditMode.Title": "GRUPPEN-BEARBEITUNGSMODUS",
   "Examples.Alu.Description": "Eine 1-Bit-ALU: Das Op-Bit wählt, ob das Ergebnis das AND oder das OR der Eingänge ist.",
+  "Examples.Counter2bit.Description": "Ein 2-Bit-Zähler: Drücke Step und sieh zu, wie C1C0 0, 1, 2, 3 zählt — die Schaltung läuft.",
   "Examples.AndGate.Description": "Kombiniere zwei NAND-Gatter zu einem AND-Gatter.",
   "Examples.FullAdder.Description": "Addiere zwei Bits plus Übertrag — der Baustein jedes Rechners.",
   "Examples.HalfAdder.Description": "Addiere zwei Bits — deine erste Rechenschaltung.",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "Exit group edit mode and return to main canvas (ESC key)",
   "EditMode.Title": "GROUP EDIT MODE",
   "Examples.Alu.Description": "A 1-bit ALU: the Op bit selects whether the result is the AND or the OR of the inputs.",
+  "Examples.Counter2bit.Description": "A 2-bit counter: press Step and watch C1C0 count 0, 1, 2, 3 — the circuit runs.",
   "Examples.AndGate.Description": "Combine two NAND gates into an AND gate.",
   "Examples.FullAdder.Description": "Add two bits plus a carry-in — the building block of every computer.",
   "Examples.HalfAdder.Description": "Add two bits — your first arithmetic circuit.",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "Salir del modo de edición de grupo y volver al lienzo principal (tecla ESC)",
   "EditMode.Title": "MODO DE EDICIÓN DE GRUPO",
   "Examples.Alu.Description": "Una ALU de 1 bit: el bit Op elige si el resultado es el AND o el OR de las entradas.",
+  "Examples.Counter2bit.Description": "Un contador de 2 bits: pulsa Step y observa cómo C1C0 cuenta 0, 1, 2, 3 — el circuito funciona.",
   "Examples.AndGate.Description": "Combina dos puertas NAND en una puerta AND.",
   "Examples.FullAdder.Description": "Suma dos bits más el acarreo: el bloque fundamental de todo ordenador.",
   "Examples.HalfAdder.Description": "Suma dos bits: tu primer circuito aritmético.",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "グループ編集モードを終了してメインキャンバスに戻る (ESC キー)",
   "EditMode.Title": "グループ編集モード",
   "Examples.Alu.Description": "1ビットALU:Opビットが結果を入力のANDにするかORにするかを選ぶ。",
+  "Examples.Counter2bit.Description": "2ビットカウンタ:Stepを押すとC1C0が0、1、2、3とカウントする — 回路が動き出す。",
   "Examples.AndGate.Description": "2つのNANDゲートを組み合わせてANDゲートを作る。",
   "Examples.FullAdder.Description": "2ビットとキャリー入力を加算する — あらゆるコンピュータの基本ブロック。",
   "Examples.HalfAdder.Description": "2ビットを加算する — 初めての算術回路。",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "退出组编辑模式并返回主画布（ESC 键）",
   "EditMode.Title": "组编辑模式",
   "Examples.Alu.Description": "1 位 ALU:Op 位选择结果是输入的 AND 还是 OR。",
+  "Examples.Counter2bit.Description": "2 位计数器:按下 Step,观看 C1C0 依次计出 0、1、2、3——电路动起来了。",
   "Examples.AndGate.Description": "把两个 NAND 门组合成一个 AND 门。",
   "Examples.FullAdder.Description": "把两个比特连同进位相加——每台计算机的基本构件。",
   "Examples.HalfAdder.Description": "把两个比特相加——你的第一个算术电路。",

--- a/UnitTests/Integration/LogicGateCounter2BitExampleTests.cs
+++ b/UnitTests/Integration/LogicGateCounter2BitExampleTests.cs
@@ -1,0 +1,287 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Pinned tests for the shipped <c>examples/Logic Gate Counter 2-bit.lun</c> (issue
+/// #1102, rung 5 of the NAND game — the datapath stone after the SR latch): a 2-bit
+/// toggle (ripple) counter built from the shipped NOT/NAND gate plus 1×2 MMI splitter
+/// copy gates. Stage 0 is the simplest toggle: the NAND register Q0 reads its own
+/// committed output C0 back, so D0 = NAND(C0, S̄) = NOT(C0) once the active-low
+/// preset toggle <c>S̄</c> (the network's one input, resting at 1) stays high —
+/// the register <em>is</em> the inverter. Stage 1 is the textbook 4-NAND XOR whose
+/// final NAND is the register Q1 itself: with X = NAND(C0, C1), R = NAND(C0, X),
+/// S = NAND(C1, X), the committed next state is NAND(R, S) = C0 ⊕ C1, so C1 flips
+/// exactly when C0 wraps from 1 back to 0. Because every register samples the same
+/// settled pre-step state and commits simultaneously (D-semantics), each
+/// <see cref="LogicNetworkEvaluator.Step"/> is one full clock tick, counting
+/// C1C0 = 00 → 01 → 10 → 11 → 00. Every waveguide serves exactly one output pin and
+/// one input pin (connecting a pin removes any older wire of it), so the committed
+/// bits and the XOR pivot X fan out through the copy gates COPY0/COPY0X/COPY1/COPYX
+/// — one waveguide carries exactly one signal, and each arm takes half the power,
+/// comfortably above threshold. The file loads through the real load path, every
+/// group carries its persisted <see cref="TruthTablePinAssignment"/> with the named
+/// output taps <c>C0</c>, <c>C1</c>, <c>X</c>, <c>R</c> and <c>S</c>, and the merged
+/// <see cref="LogicNetworkAssembler"/> (#988) turns the loaded design into the
+/// evaluable network the sequence below pins.
+/// </summary>
+public class LogicGateCounter2BitExampleTests
+    : IClassFixture<LogicGateCounter2BitExampleTests.CounterFixture>
+{
+    private const double NotThreshold = 0.375;
+    private const double NandThreshold = 0.125;
+
+    private const string LowBitTap = "C0";
+    private const string HighBitTap = "C1";
+    private const string PresetSignal = "S̄";
+
+    private static readonly string[] GateNames =
+        { "Q0", "COPY0", "COPY0X", "X0", "R0", "S0", "COPY1", "COPYX", "Q1" };
+    private static readonly string[] RegisterNames = { "Q0", "Q1" };
+    private static readonly string[] CopyNames = { "COPY0", "COPY0X", "COPY1", "COPYX" };
+
+    /// <summary>The persisted output signal names per named gate group — the counter's named taps.</summary>
+    private static readonly Dictionary<string, Dictionary<string, string>> ExpectedOutputSignalNames = new()
+    {
+        ["Q0"] = new() { ["Y"] = LowBitTap },
+        ["X0"] = new() { ["Y"] = "X" },
+        ["R0"] = new() { ["Y"] = "R" },
+        ["S0"] = new() { ["Y"] = "S" },
+        ["Q1"] = new() { ["Y"] = HighBitTap },
+    };
+
+    private readonly CounterFixture _fixture;
+
+    /// <summary>Attaches the shared counter fixture.</summary>
+    public LogicGateCounter2BitExampleTests(CounterFixture fixture) => _fixture = fixture;
+
+    /// <summary>The resting input bits: the active-low preset toggle is never pulled while counting.</summary>
+    private static Dictionary<string, bool> RestingInputBits() => new() { [PresetSignal] = true };
+
+    [Fact]
+    public void Example_LoadsOnlyTopLevelGateGroups_WithPersistedRolesAndRegisterDesignations()
+    {
+        _fixture.Canvas.Components.ShouldAllBe(
+            c => c.Component is ComponentGroup,
+            "the 2-bit counter contains only top-level gate groups");
+        _fixture.Canvas.Connections.Count.ShouldBe(13,
+            "thirteen wires fan the committed bits and the XOR pivot through the copy gates — " +
+            "every waveguide keeps one driver and one load");
+
+        var groups = _fixture.Groups;
+        groups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+        foreach (var group in groups)
+        {
+            var roles = group.TruthTablePinAssignment.ShouldNotBeNull(
+                $"group '{group.GroupName}' must ship its persisted pin roles");
+            if (CopyNames.Contains(group.GroupName))
+            {
+                roles.InputPinNames.ShouldBe(new[] { "A" });
+                roles.OutputPinNames.ShouldBe(new[] { "Y1", "Y2" });
+                roles.BiasPinNames.ShouldBeEmpty();
+                roles.Threshold.ShouldBe(NotThreshold);
+                roles.IsRegister.ShouldBeFalse("a copy gate is combinational");
+            }
+            else
+            {
+                roles.InputPinNames.ShouldBe(new[] { "A", "B" });
+                roles.OutputPinNames.ShouldBe(new[] { "Y" });
+                roles.BiasPinNames.ShouldBe(new[] { "BIAS" });
+                roles.Threshold.ShouldBe(NandThreshold);
+                roles.IsRegister.ShouldBe(RegisterNames.Contains(group.GroupName),
+                    $"the register designation of '{group.GroupName}' (issue #1098)");
+            }
+            if (ExpectedOutputSignalNames.TryGetValue(group.GroupName, out var namedOutputs))
+            {
+                roles.OutputSignalNames.ShouldBe(namedOutputs,
+                    $"group '{group.GroupName}' ships its named output tap");
+            }
+            group.Description.ShouldContain("logic layer", Case.Sensitive,
+                "every gate carries the education note about logic-layer composition");
+        }
+
+        _fixture.Groups.Single(g => g.GroupName == "Q0").TruthTablePinAssignment!
+            .InputSignalNames.ShouldBe(new Dictionary<string, string> { ["B"] = PresetSignal },
+                "Q0's second input ships the active-low preset signal name (issue #1025)");
+        foreach (var register in RegisterNames)
+        {
+            _fixture.Groups.Single(g => g.GroupName == register).Description
+                .ShouldContain("register", Case.Sensitive,
+                    "every register carries the designation note");
+        }
+    }
+
+    [Fact]
+    public void AssembledNetwork_ExposesThePresetToggleNamedTapsAndTwoRegisters()
+    {
+        _fixture.Network.InputPinNames.ShouldBe(new[] { PresetSignal },
+            customMessage: "Q0's preset pin stays unconnected as the network's only input S̄ — " +
+                "a logic network must expose at least one input");
+        _fixture.Network.OutputPinNames.ShouldBe(
+            new[] { LowBitTap, HighBitTap, "X", "R", "S" }
+                .Concat(CopyNames.SelectMany(name => new[] { $"{name}.Y1", $"{name}.Y2" })),
+            ignoreOrder: true,
+            customMessage: "five named taps replace the raw gate-pin names; the copy gates stay readable as raw taps");
+        _fixture.Network.RegisterState.Keys.ShouldBe(
+            new[] { new LogicPinRef("Q0", "Y"), new LogicPinRef("Q1", "Y") }, ignoreOrder: true,
+            customMessage: "both stages power up as state elements, committed outputs cleared");
+    }
+
+    [Fact]
+    public void StepSequence_CountsZeroToThreeAndWraps()
+    {
+        AssertCountsZeroToThreeAndWraps(_fixture.Network);
+    }
+
+    [Fact]
+    public void StepSequence_ActiveLowPresetPulse_ForcesTheLowBitHigh()
+    {
+        var network = _fixture.Network;
+
+        network.Evaluate(RestingInputBits());
+        network.Step();
+        network.Evaluate(RestingInputBits())[LowBitTap].ShouldBeTrue(
+            "S̄ resting: stage 0 toggles — C1C0 = 01");
+
+        network.Evaluate(RestingInputBits());
+        network.Step();
+        var wrapped = network.Evaluate(RestingInputBits());
+        wrapped[HighBitTap].ShouldBeTrue();
+        wrapped[LowBitTap].ShouldBeFalse("counting on: C1C0 = 10 after C0 wrapped");
+
+        network.Evaluate(new Dictionary<string, bool> { [PresetSignal] = false });
+        network.Step();
+        network.Evaluate(RestingInputBits())[LowBitTap].ShouldBeTrue(
+            "pulling S̄ to 0 for one step presets C0 to 1 regardless of the toggling");
+    }
+
+    /// <summary>
+    /// Asserts the pinned counting sequence against one assembled network: power-up
+    /// at C1C0 = 00, then 00 → 01 → 10 → 11 → 00 over four clock steps.
+    /// </summary>
+    private static void AssertCountsZeroToThreeAndWraps(LogicNetworkEvaluator network)
+    {
+        network.Evaluate(RestingInputBits())[HighBitTap].ShouldBeFalse();
+        network.Evaluate(RestingInputBits())[LowBitTap].ShouldBeFalse(
+            "powered up cleared: C1C0 = 00");
+
+        foreach (var (expectedC1, expectedC0) in new[]
+                 {
+                     (false, true),   // 01 — stage 0 toggled
+                     (true, false),   // 10 — C0 wrapped 1 → 0, stage 1 toggled
+                     (true, true),    // 11
+                     (false, false),  // 00 — both wrapped
+                 })
+        {
+            network.Step();
+            var settled = network.Evaluate(RestingInputBits());
+            settled[HighBitTap].ShouldBe(expectedC1, "after the step C1C0 must read the next count");
+            settled[LowBitTap].ShouldBe(expectedC0, "after the step C1C0 must read the next count");
+            settled["X"].ShouldBe(!(expectedC0 && expectedC1), "the XOR pivot stays readable as a tap");
+            settled["R"].ShouldBe(!(expectedC0 && !(expectedC0 && expectedC1)), "the C0 arm stays readable");
+            settled["S"].ShouldBe(!(expectedC1 && !(expectedC0 && expectedC1)), "the C1 arm stays readable");
+        }
+    }
+
+    [Fact]
+    public async Task SaveLoadRoundTrip_ReAssembledNetwork_YieldsTheSameCounter()
+    {
+        var savedPath = await _fixture.SaveToTempFile();
+        try
+        {
+            var reloadedCanvas = await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath);
+
+            var reloadedGroups = LogicGateHalfAdderExampleTests.GroupsOf(reloadedCanvas);
+            reloadedGroups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+            reloadedGroups.ShouldAllBe(g => g.TruthTablePinAssignment != null,
+                "the persisted pin roles must survive the save → load round trip");
+            foreach (var group in reloadedGroups)
+            {
+                var roles = group.TruthTablePinAssignment!;
+                roles.IsRegister.ShouldBe(RegisterNames.Contains(group.GroupName),
+                    $"the register designation of '{group.GroupName}' must survive the save → load round trip");
+                var expectedInputs = CopyNames.Contains(group.GroupName)
+                    ? new[] { "A" } : new[] { "A", "B" };
+                roles.InputPinNames.ToArray().ShouldBe(expectedInputs,
+                    customMessage: $"the input roles of '{group.GroupName}' must survive the save → load round trip");
+                if (ExpectedOutputSignalNames.TryGetValue(group.GroupName, out var namedOutputs))
+                {
+                    roles.OutputSignalNames.ShouldBe(namedOutputs,
+                        $"the output signal names of '{group.GroupName}' must survive the save → load round trip");
+                }
+            }
+            reloadedGroups.Single(g => g.GroupName == "Q0").TruthTablePinAssignment!.InputSignalNames
+                .ShouldBe(new Dictionary<string, string> { ["B"] = PresetSignal },
+                    "the preset signal name of Q0.B must survive the save → load round trip (#1025)");
+            reloadedCanvas.Connections.Count.ShouldBe(13,
+                "every counter wire must survive the save → load round trip");
+
+            var reloaded = await LogicGateMuxExampleTests.AssembleNetwork(reloadedCanvas);
+            reloaded.InputPinNames.ShouldBe(_fixture.Network.InputPinNames);
+            reloaded.OutputPinNames.ShouldBe(_fixture.Network.OutputPinNames);
+            reloaded.RegisterState.Keys.ShouldBe(_fixture.Network.RegisterState.Keys, ignoreOrder: true,
+                customMessage: "the re-assembled network must carry the same register state elements");
+
+            AssertCountsZeroToThreeAndWraps(reloaded);
+        }
+        finally
+        {
+            if (File.Exists(savedPath)) File.Delete(savedPath);
+        }
+    }
+
+    /// <summary>
+    /// Shared fixture: loads the shipped example once and assembles its logic network
+    /// (each extraction is a real simulation run), so every fact asserts against the
+    /// same loaded design and assembled network.
+    /// </summary>
+    public class CounterFixture : IAsyncLifetime
+    {
+        private const string ExampleFileName = "Logic Gate Counter 2-bit.lun";
+
+        /// <summary>Laser wavelength the persisted roles were extracted at.</summary>
+        public const int WavelengthNm = 1550;
+
+        /// <summary>The canvas the shipped example loaded onto.</summary>
+        public DesignCanvasViewModel Canvas { get; private set; } = null!;
+
+        /// <summary>The loaded top-level gate groups, in file order.</summary>
+        public List<ComponentGroup> Groups { get; private set; } = null!;
+
+        /// <summary>The logic network assembled from the loaded design.</summary>
+        public LogicNetworkEvaluator Network { get; private set; } = null!;
+
+        /// <summary>Loads the shipped example and assembles its logic network.</summary>
+        public async Task InitializeAsync()
+        {
+            var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+            Canvas = await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+            Groups = LogicGateHalfAdderExampleTests.GroupsOf(Canvas);
+            Network = await LogicGateMuxExampleTests.AssembleNetwork(Canvas);
+        }
+
+        /// <summary>No shared state to release.</summary>
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        /// <summary>Saves the loaded design through the real save path and returns the file path.</summary>
+        public async Task<string> SaveToTempFile()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"counter-2bit-{Guid.NewGuid():N}.lun");
+            var saveVm = LogicGateHalfAdderExampleTests.CreateFileOperations(Canvas);
+            var dialog = new Mock<IFileDialogService>();
+            dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(path);
+            saveVm.FileDialogService = dialog.Object;
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+            File.Exists(path).ShouldBeTrue("the real save path must write the temp .lun");
+            return path;
+        }
+    }
+}

--- a/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
+++ b/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
@@ -68,6 +68,24 @@ public class ExamplesManifestLocalizationTests
         ladder[latchIndex].DescriptionKey.ShouldBe("Examples.SrLatch.Description");
     }
 
+    [Fact]
+    public void CuratedLadder_ListsTheCounter2Bit_AfterTheSrLatch()
+    {
+        var ladder = new CAP.Avalonia.Services.ExampleDesignsService().GetExamples()
+            .Where(example => example.DescriptionKey != null)
+            .ToList();
+
+        var latchIndex = ladder.FindIndex(example => example.Name == "Logic Gate SR-Latch");
+        latchIndex.ShouldBeGreaterThanOrEqualTo(0, "the SR latch rung must stay curated");
+
+        var counterIndex = ladder.FindIndex(example => example.Name == "Logic Gate Counter 2-bit");
+        counterIndex.ShouldBeGreaterThan(latchIndex,
+            "the 2-bit counter is the sequential rung after the latch — " +
+            "the datapath stone that makes the circuit run");
+        ladder[counterIndex].Level.ShouldBe("Sequential");
+        ladder[counterIndex].DescriptionKey.ShouldBe("Examples.Counter2bit.Description");
+    }
+
     private static List<ManifestEntry> ReadManifestEntries()
     {
         var manifestPath = Path.Combine(FindRepoRoot(), "examples", "examples.json");

--- a/examples/Logic Gate Counter 2-bit.lun
+++ b/examples/Logic Gate Counter 2-bit.lun
@@ -1,0 +1,2668 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 1,
+      "EndPinName": "A",
+      "StartComponentId": "group_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a4",
+      "EndComponentId": "group_b2s12a3b4c5d6e7f8a9b0c1d2e3f4",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 1,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_b2s12a3b4c5d6e7f8a9b0c1d2e3f4",
+      "EndComponentId": "group_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a4",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 1,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 2,
+      "EndPinName": "A",
+      "StartComponentId": "group_b2s12a3b4c5d6e7f8a9b0c1d2e3f4",
+      "EndComponentId": "group_c3s23a4b5c6d7e8f9a0b1c2d3e4",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 2,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 3,
+      "EndPinName": "A",
+      "StartComponentId": "group_c3s23a4b5c6d7e8f9a0b1c2d3e4",
+      "EndComponentId": "group_d4x04a5b6c7d8e9f0a1b2c3d4e5f6",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 2,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 4,
+      "EndPinName": "A",
+      "StartComponentId": "group_c3s23a4b5c6d7e8f9a0b1c2d3e4",
+      "EndComponentId": "group_e5r05a6b7c8d9e0f1a2b3c4d5e6f7",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 8,
+      "StartPinName": "Y",
+      "EndComponentIndex": 6,
+      "EndPinName": "A",
+      "StartComponentId": "group_c9q19b0c1d2e3f4a5b6c7d8e9f0ab",
+      "EndComponentId": "group_a7t17a8b9c0d1e2f3a4b5c6d7e8",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 6,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 3,
+      "EndPinName": "B",
+      "StartComponentId": "group_a7t17a8b9c0d1e2f3a4b5c6d7e8",
+      "EndComponentId": "group_d4x04a5b6c7d8e9f0a1b2c3d4e5f6",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 6,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 5,
+      "EndPinName": "A",
+      "StartComponentId": "group_a7t17a8b9c0d1e2f3a4b5c6d7e8",
+      "EndComponentId": "group_f6s06a7b8c9d0e1f2a3b4c5d6e7f8",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 3,
+      "StartPinName": "Y",
+      "EndComponentIndex": 7,
+      "EndPinName": "A",
+      "StartComponentId": "group_d4x04a5b6c7d8e9f0a1b2c3d4e5f6",
+      "EndComponentId": "group_b8u28a9b0c1d2e3f4a5b6c7d8e9",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 7,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 4,
+      "EndPinName": "B",
+      "StartComponentId": "group_b8u28a9b0c1d2e3f4a5b6c7d8e9",
+      "EndComponentId": "group_e5r05a6b7c8d9e0f1a2b3c4d5e6f7",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 7,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 5,
+      "EndPinName": "B",
+      "StartComponentId": "group_b8u28a9b0c1d2e3f4a5b6c7d8e9",
+      "EndComponentId": "group_f6s06a7b8c9d0e1f2a3b4c5d6e7f8",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 4,
+      "StartPinName": "Y",
+      "EndComponentIndex": 8,
+      "EndPinName": "A",
+      "StartComponentId": "group_e5r05a6b7c8d9e0f1a2b3c4d5e6f7",
+      "EndComponentId": "group_c9q19b0c1d2e3f4a5b6c7d8e9f0ab",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 5,
+      "StartPinName": "Y",
+      "EndComponentIndex": 8,
+      "EndPinName": "B",
+      "StartComponentId": "group_f6s06a7b8c9d0e1f2a3b4c5d6e7f8",
+      "EndComponentId": "group_c9q19b0c1d2e3f4a5b6c7d8e9f0ab",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    }
+  ],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "Q0",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate, designated a register (IsRegister). Role in the 2-bit counter: count bit C0. Input A reads the committed C0 back through the copy splitter, input B stays the unconnected active-low preset toggle S̄ (a logic network must expose at least one input) — it rests at 1 while counting, and a 0-pulse forces C0 to 1 on the next step. NAND(C0, 1) = NOT(C0), so every clock step flips C0: the register is its own inverter. Only an explicit clock step samples the inputs and commits the new state (D-semantics) — that is what makes the feedback loop legal. The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a4",
+        "IdGuid": "11000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "11000001-0000-4000-8000-000000000001",
+          "11000002-0000-4000-8000-000000000002",
+          "11000003-0000-4000-8000-000000000003",
+          "11000004-0000-4000-8000-000000000004",
+          "11000005-0000-4000-8000-000000000005",
+          "11000006-0000-4000-8000-000000000006"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a401",
+          "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a402",
+          "combine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a403",
+          "phase_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a404",
+          "recombine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a405",
+          "output_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a406"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "11000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a401",
+            "StartComponentGuid": "11000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a403",
+            "EndComponentGuid": "11000003-0000-4000-8000-000000000003",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "11000012-0000-4000-8000-000000000012",
+            "StartComponentId": "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a402",
+            "StartComponentGuid": "11000002-0000-4000-8000-000000000002",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a403",
+            "EndComponentGuid": "11000003-0000-4000-8000-000000000003",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "11000013-0000-4000-8000-000000000013",
+            "StartComponentId": "combine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a403",
+            "StartComponentGuid": "11000003-0000-4000-8000-000000000003",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a405",
+            "EndComponentGuid": "11000005-0000-4000-8000-000000000005",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "11000014-0000-4000-8000-000000000014",
+            "StartComponentId": "phase_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a404",
+            "StartComponentGuid": "11000004-0000-4000-8000-000000000004",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a405",
+            "EndComponentGuid": "11000005-0000-4000-8000-000000000005",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "11000015-0000-4000-8000-000000000015",
+            "StartComponentId": "recombine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a405",
+            "StartComponentGuid": "11000005-0000-4000-8000-000000000005",
+            "StartPinName": "out1",
+            "EndComponentId": "output_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a406",
+            "EndComponentGuid": "11000006-0000-4000-8000-000000000006",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "11000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a401",
+            "InternalComponentGuid": "11000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "11000022-0000-4000-8000-000000000022",
+            "Name": "B",
+            "InternalComponentId": "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a402",
+            "InternalComponentGuid": "11000002-0000-4000-8000-000000000002",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "11000023-0000-4000-8000-000000000023",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a404",
+            "InternalComponentGuid": "11000004-0000-4000-8000-000000000004",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "11000024-0000-4000-8000-000000000024",
+            "Name": "Y",
+            "InternalComponentId": "output_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a406",
+            "InternalComponentGuid": "11000006-0000-4000-8000-000000000006",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a401",
+          "ComponentGuid": "11000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a402",
+          "ComponentGuid": "11000002-0000-4000-8000-000000000002",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a403",
+          "ComponentGuid": "11000003-0000-4000-8000-000000000003",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a404",
+          "ComponentGuid": "11000004-0000-4000-8000-000000000004",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a405",
+          "ComponentGuid": "11000005-0000-4000-8000-000000000005",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_a1q01a2b3c4d5e6f7a8b9c0d1e2f3a406",
+          "ComponentGuid": "11000006-0000-4000-8000-000000000006",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "InputSignalNames": {
+          "B": "S̄"
+        },
+        "OutputSignalNames": {
+          "Y": "C0"
+        },
+        "IsRegister": true
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "COPY0",
+        "Description": "1x2 MMI Splitter copy gate (input A, outputs Y1 and Y2, threshold 0.375) built from the Demo PDK's MMI splitter. Role in the 2-bit counter: one waveguide carries exactly one signal, so the committed C0 fans out optically — each output arm takes half the power, comfortably above threshold, and drives the register's own feedback and the second copy stage COPY0X. The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_b2s12a3b4c5d6e7f8a9b0c1d2e3f4",
+        "IdGuid": "22000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "22000001-0000-4000-8000-000000000001",
+          "22000002-0000-4000-8000-000000000002",
+          "22000003-0000-4000-8000-000000000003",
+          "22000004-0000-4000-8000-000000000004"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 400,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_b2s12a3b4c5d6e7f8a9b0c1d2e3f401",
+          "split_b2s12a3b4c5d6e7f8a9b0c1d2e3f402",
+          "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f403",
+          "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f404"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "22000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_b2s12a3b4c5d6e7f8a9b0c1d2e3f401",
+            "StartComponentGuid": "22000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "split_b2s12a3b4c5d6e7f8a9b0c1d2e3f402",
+            "EndComponentGuid": "22000002-0000-4000-8000-000000000002",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "22000012-0000-4000-8000-000000000012",
+            "StartComponentId": "split_b2s12a3b4c5d6e7f8a9b0c1d2e3f402",
+            "StartComponentGuid": "22000002-0000-4000-8000-000000000002",
+            "StartPinName": "out1",
+            "EndComponentId": "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f403",
+            "EndComponentGuid": "22000003-0000-4000-8000-000000000003",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "22000013-0000-4000-8000-000000000013",
+            "StartComponentId": "split_b2s12a3b4c5d6e7f8a9b0c1d2e3f402",
+            "StartComponentGuid": "22000002-0000-4000-8000-000000000002",
+            "StartPinName": "out2",
+            "EndComponentId": "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f404",
+            "EndComponentGuid": "22000004-0000-4000-8000-000000000004",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "22000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_b2s12a3b4c5d6e7f8a9b0c1d2e3f401",
+            "InternalComponentGuid": "22000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "22000022-0000-4000-8000-000000000022",
+            "Name": "Y1",
+            "InternalComponentId": "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f403",
+            "InternalComponentGuid": "22000003-0000-4000-8000-000000000003",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "22000023-0000-4000-8000-000000000023",
+            "Name": "Y2",
+            "InternalComponentId": "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f404",
+            "InternalComponentGuid": "22000004-0000-4000-8000-000000000004",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_b2s12a3b4c5d6e7f8a9b0c1d2e3f401",
+          "ComponentGuid": "22000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_b2s12a3b4c5d6e7f8a9b0c1d2e3f402",
+          "ComponentGuid": "22000002-0000-4000-8000-000000000002",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f403",
+          "ComponentGuid": "22000003-0000-4000-8000-000000000003",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_b2s12a3b4c5d6e7f8a9b0c1d2e3f404",
+          "ComponentGuid": "22000004-0000-4000-8000-000000000004",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 400,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "COPY0X",
+        "Description": "1x2 MMI Splitter copy gate (input A, outputs Y1 and Y2, threshold 0.375) built from the Demo PDK's MMI splitter. Role in the 2-bit counter: one waveguide carries exactly one signal, so the committed C0 (once more) fans out optically — each output arm takes half the power, comfortably above threshold, and drives the two XOR arms that read the straight C0 (X0.A and R0.A). The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_c3s23a4b5c6d7e8f9a0b1c2d3e4",
+        "IdGuid": "33000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "33000001-0000-4000-8000-000000000001",
+          "33000002-0000-4000-8000-000000000002",
+          "33000003-0000-4000-8000-000000000003",
+          "33000004-0000-4000-8000-000000000004"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 700,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_c3s23a4b5c6d7e8f9a0b1c2d3e401",
+          "split_c3s23a4b5c6d7e8f9a0b1c2d3e402",
+          "output_c3s23a4b5c6d7e8f9a0b1c2d3e403",
+          "output_c3s23a4b5c6d7e8f9a0b1c2d3e404"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "33000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_c3s23a4b5c6d7e8f9a0b1c2d3e401",
+            "StartComponentGuid": "33000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "split_c3s23a4b5c6d7e8f9a0b1c2d3e402",
+            "EndComponentGuid": "33000002-0000-4000-8000-000000000002",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "33000012-0000-4000-8000-000000000012",
+            "StartComponentId": "split_c3s23a4b5c6d7e8f9a0b1c2d3e402",
+            "StartComponentGuid": "33000002-0000-4000-8000-000000000002",
+            "StartPinName": "out1",
+            "EndComponentId": "output_c3s23a4b5c6d7e8f9a0b1c2d3e403",
+            "EndComponentGuid": "33000003-0000-4000-8000-000000000003",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "33000013-0000-4000-8000-000000000013",
+            "StartComponentId": "split_c3s23a4b5c6d7e8f9a0b1c2d3e402",
+            "StartComponentGuid": "33000002-0000-4000-8000-000000000002",
+            "StartPinName": "out2",
+            "EndComponentId": "output_c3s23a4b5c6d7e8f9a0b1c2d3e404",
+            "EndComponentGuid": "33000004-0000-4000-8000-000000000004",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "33000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_c3s23a4b5c6d7e8f9a0b1c2d3e401",
+            "InternalComponentGuid": "33000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "33000022-0000-4000-8000-000000000022",
+            "Name": "Y1",
+            "InternalComponentId": "output_c3s23a4b5c6d7e8f9a0b1c2d3e403",
+            "InternalComponentGuid": "33000003-0000-4000-8000-000000000003",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "33000023-0000-4000-8000-000000000023",
+            "Name": "Y2",
+            "InternalComponentId": "output_c3s23a4b5c6d7e8f9a0b1c2d3e404",
+            "InternalComponentGuid": "33000004-0000-4000-8000-000000000004",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_c3s23a4b5c6d7e8f9a0b1c2d3e401",
+          "ComponentGuid": "33000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_c3s23a4b5c6d7e8f9a0b1c2d3e402",
+          "ComponentGuid": "33000002-0000-4000-8000-000000000002",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_c3s23a4b5c6d7e8f9a0b1c2d3e403",
+          "ComponentGuid": "33000003-0000-4000-8000-000000000003",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_c3s23a4b5c6d7e8f9a0b1c2d3e404",
+          "ComponentGuid": "33000004-0000-4000-8000-000000000004",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 700,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "X0",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the 2-bit counter: the pivot X = NAND(C0, C1) of the textbook 4-NAND XOR that computes the next C1 — with R = NAND(C0, X), S = NAND(C1, X) and the register as the final NAND, C1' = NAND(R, S) = C0 XOR C1. The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_d4x04a5b6c7d8e9f0a1b2c3d4e5f6",
+        "IdGuid": "44000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "44000001-0000-4000-8000-000000000001",
+          "44000002-0000-4000-8000-000000000002",
+          "44000003-0000-4000-8000-000000000003",
+          "44000004-0000-4000-8000-000000000004",
+          "44000005-0000-4000-8000-000000000005",
+          "44000006-0000-4000-8000-000000000006"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 1000,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f601",
+          "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f602",
+          "combine_d4x04a5b6c7d8e9f0a1b2c3d4e5f603",
+          "phase_d4x04a5b6c7d8e9f0a1b2c3d4e5f604",
+          "recombine_d4x04a5b6c7d8e9f0a1b2c3d4e5f605",
+          "output_d4x04a5b6c7d8e9f0a1b2c3d4e5f606"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "44000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f601",
+            "StartComponentGuid": "44000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_d4x04a5b6c7d8e9f0a1b2c3d4e5f603",
+            "EndComponentGuid": "44000003-0000-4000-8000-000000000003",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "44000012-0000-4000-8000-000000000012",
+            "StartComponentId": "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f602",
+            "StartComponentGuid": "44000002-0000-4000-8000-000000000002",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_d4x04a5b6c7d8e9f0a1b2c3d4e5f603",
+            "EndComponentGuid": "44000003-0000-4000-8000-000000000003",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "44000013-0000-4000-8000-000000000013",
+            "StartComponentId": "combine_d4x04a5b6c7d8e9f0a1b2c3d4e5f603",
+            "StartComponentGuid": "44000003-0000-4000-8000-000000000003",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_d4x04a5b6c7d8e9f0a1b2c3d4e5f605",
+            "EndComponentGuid": "44000005-0000-4000-8000-000000000005",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "44000014-0000-4000-8000-000000000014",
+            "StartComponentId": "phase_d4x04a5b6c7d8e9f0a1b2c3d4e5f604",
+            "StartComponentGuid": "44000004-0000-4000-8000-000000000004",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_d4x04a5b6c7d8e9f0a1b2c3d4e5f605",
+            "EndComponentGuid": "44000005-0000-4000-8000-000000000005",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "44000015-0000-4000-8000-000000000015",
+            "StartComponentId": "recombine_d4x04a5b6c7d8e9f0a1b2c3d4e5f605",
+            "StartComponentGuid": "44000005-0000-4000-8000-000000000005",
+            "StartPinName": "out1",
+            "EndComponentId": "output_d4x04a5b6c7d8e9f0a1b2c3d4e5f606",
+            "EndComponentGuid": "44000006-0000-4000-8000-000000000006",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "44000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f601",
+            "InternalComponentGuid": "44000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "44000022-0000-4000-8000-000000000022",
+            "Name": "B",
+            "InternalComponentId": "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f602",
+            "InternalComponentGuid": "44000002-0000-4000-8000-000000000002",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "44000023-0000-4000-8000-000000000023",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_d4x04a5b6c7d8e9f0a1b2c3d4e5f604",
+            "InternalComponentGuid": "44000004-0000-4000-8000-000000000004",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "44000024-0000-4000-8000-000000000024",
+            "Name": "Y",
+            "InternalComponentId": "output_d4x04a5b6c7d8e9f0a1b2c3d4e5f606",
+            "InternalComponentGuid": "44000006-0000-4000-8000-000000000006",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f601",
+          "ComponentGuid": "44000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_d4x04a5b6c7d8e9f0a1b2c3d4e5f602",
+          "ComponentGuid": "44000002-0000-4000-8000-000000000002",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_d4x04a5b6c7d8e9f0a1b2c3d4e5f603",
+          "ComponentGuid": "44000003-0000-4000-8000-000000000003",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_d4x04a5b6c7d8e9f0a1b2c3d4e5f604",
+          "ComponentGuid": "44000004-0000-4000-8000-000000000004",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_d4x04a5b6c7d8e9f0a1b2c3d4e5f605",
+          "ComponentGuid": "44000005-0000-4000-8000-000000000005",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_d4x04a5b6c7d8e9f0a1b2c3d4e5f606",
+          "ComponentGuid": "44000006-0000-4000-8000-000000000006",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 1000,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "OutputSignalNames": {
+          "Y": "X"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "R0",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the 2-bit counter: the C0 arm R = NAND(C0, X) of the textbook 4-NAND XOR feeding count bit C1. The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_e5r05a6b7c8d9e0f1a2b3c4d5e6f7",
+        "IdGuid": "55000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "55000001-0000-4000-8000-000000000001",
+          "55000002-0000-4000-8000-000000000002",
+          "55000003-0000-4000-8000-000000000003",
+          "55000004-0000-4000-8000-000000000004",
+          "55000005-0000-4000-8000-000000000005",
+          "55000006-0000-4000-8000-000000000006"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 1300,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f701",
+          "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f702",
+          "combine_e5r05a6b7c8d9e0f1a2b3c4d5e6f703",
+          "phase_e5r05a6b7c8d9e0f1a2b3c4d5e6f704",
+          "recombine_e5r05a6b7c8d9e0f1a2b3c4d5e6f705",
+          "output_e5r05a6b7c8d9e0f1a2b3c4d5e6f706"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "55000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f701",
+            "StartComponentGuid": "55000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_e5r05a6b7c8d9e0f1a2b3c4d5e6f703",
+            "EndComponentGuid": "55000003-0000-4000-8000-000000000003",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "55000012-0000-4000-8000-000000000012",
+            "StartComponentId": "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f702",
+            "StartComponentGuid": "55000002-0000-4000-8000-000000000002",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_e5r05a6b7c8d9e0f1a2b3c4d5e6f703",
+            "EndComponentGuid": "55000003-0000-4000-8000-000000000003",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "55000013-0000-4000-8000-000000000013",
+            "StartComponentId": "combine_e5r05a6b7c8d9e0f1a2b3c4d5e6f703",
+            "StartComponentGuid": "55000003-0000-4000-8000-000000000003",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_e5r05a6b7c8d9e0f1a2b3c4d5e6f705",
+            "EndComponentGuid": "55000005-0000-4000-8000-000000000005",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "55000014-0000-4000-8000-000000000014",
+            "StartComponentId": "phase_e5r05a6b7c8d9e0f1a2b3c4d5e6f704",
+            "StartComponentGuid": "55000004-0000-4000-8000-000000000004",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_e5r05a6b7c8d9e0f1a2b3c4d5e6f705",
+            "EndComponentGuid": "55000005-0000-4000-8000-000000000005",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "55000015-0000-4000-8000-000000000015",
+            "StartComponentId": "recombine_e5r05a6b7c8d9e0f1a2b3c4d5e6f705",
+            "StartComponentGuid": "55000005-0000-4000-8000-000000000005",
+            "StartPinName": "out1",
+            "EndComponentId": "output_e5r05a6b7c8d9e0f1a2b3c4d5e6f706",
+            "EndComponentGuid": "55000006-0000-4000-8000-000000000006",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "55000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f701",
+            "InternalComponentGuid": "55000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "55000022-0000-4000-8000-000000000022",
+            "Name": "B",
+            "InternalComponentId": "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f702",
+            "InternalComponentGuid": "55000002-0000-4000-8000-000000000002",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "55000023-0000-4000-8000-000000000023",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_e5r05a6b7c8d9e0f1a2b3c4d5e6f704",
+            "InternalComponentGuid": "55000004-0000-4000-8000-000000000004",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "55000024-0000-4000-8000-000000000024",
+            "Name": "Y",
+            "InternalComponentId": "output_e5r05a6b7c8d9e0f1a2b3c4d5e6f706",
+            "InternalComponentGuid": "55000006-0000-4000-8000-000000000006",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f701",
+          "ComponentGuid": "55000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_e5r05a6b7c8d9e0f1a2b3c4d5e6f702",
+          "ComponentGuid": "55000002-0000-4000-8000-000000000002",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_e5r05a6b7c8d9e0f1a2b3c4d5e6f703",
+          "ComponentGuid": "55000003-0000-4000-8000-000000000003",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_e5r05a6b7c8d9e0f1a2b3c4d5e6f704",
+          "ComponentGuid": "55000004-0000-4000-8000-000000000004",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_e5r05a6b7c8d9e0f1a2b3c4d5e6f705",
+          "ComponentGuid": "55000005-0000-4000-8000-000000000005",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_e5r05a6b7c8d9e0f1a2b3c4d5e6f706",
+          "ComponentGuid": "55000006-0000-4000-8000-000000000006",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 1300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "OutputSignalNames": {
+          "Y": "R"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "S0",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the 2-bit counter: the C1 arm S = NAND(C1, X) of the textbook 4-NAND XOR feeding count bit C1. The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_f6s06a7b8c9d0e1f2a3b4c5d6e7f8",
+        "IdGuid": "66000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "66000001-0000-4000-8000-000000000001",
+          "66000002-0000-4000-8000-000000000002",
+          "66000003-0000-4000-8000-000000000003",
+          "66000004-0000-4000-8000-000000000004",
+          "66000005-0000-4000-8000-000000000005",
+          "66000006-0000-4000-8000-000000000006"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 1600,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f801",
+          "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f802",
+          "combine_f6s06a7b8c9d0e1f2a3b4c5d6e7f803",
+          "phase_f6s06a7b8c9d0e1f2a3b4c5d6e7f804",
+          "recombine_f6s06a7b8c9d0e1f2a3b4c5d6e7f805",
+          "output_f6s06a7b8c9d0e1f2a3b4c5d6e7f806"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "66000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f801",
+            "StartComponentGuid": "66000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_f6s06a7b8c9d0e1f2a3b4c5d6e7f803",
+            "EndComponentGuid": "66000003-0000-4000-8000-000000000003",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "66000012-0000-4000-8000-000000000012",
+            "StartComponentId": "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f802",
+            "StartComponentGuid": "66000002-0000-4000-8000-000000000002",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_f6s06a7b8c9d0e1f2a3b4c5d6e7f803",
+            "EndComponentGuid": "66000003-0000-4000-8000-000000000003",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "66000013-0000-4000-8000-000000000013",
+            "StartComponentId": "combine_f6s06a7b8c9d0e1f2a3b4c5d6e7f803",
+            "StartComponentGuid": "66000003-0000-4000-8000-000000000003",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_f6s06a7b8c9d0e1f2a3b4c5d6e7f805",
+            "EndComponentGuid": "66000005-0000-4000-8000-000000000005",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "66000014-0000-4000-8000-000000000014",
+            "StartComponentId": "phase_f6s06a7b8c9d0e1f2a3b4c5d6e7f804",
+            "StartComponentGuid": "66000004-0000-4000-8000-000000000004",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_f6s06a7b8c9d0e1f2a3b4c5d6e7f805",
+            "EndComponentGuid": "66000005-0000-4000-8000-000000000005",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "66000015-0000-4000-8000-000000000015",
+            "StartComponentId": "recombine_f6s06a7b8c9d0e1f2a3b4c5d6e7f805",
+            "StartComponentGuid": "66000005-0000-4000-8000-000000000005",
+            "StartPinName": "out1",
+            "EndComponentId": "output_f6s06a7b8c9d0e1f2a3b4c5d6e7f806",
+            "EndComponentGuid": "66000006-0000-4000-8000-000000000006",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "66000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f801",
+            "InternalComponentGuid": "66000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "66000022-0000-4000-8000-000000000022",
+            "Name": "B",
+            "InternalComponentId": "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f802",
+            "InternalComponentGuid": "66000002-0000-4000-8000-000000000002",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "66000023-0000-4000-8000-000000000023",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_f6s06a7b8c9d0e1f2a3b4c5d6e7f804",
+            "InternalComponentGuid": "66000004-0000-4000-8000-000000000004",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "66000024-0000-4000-8000-000000000024",
+            "Name": "Y",
+            "InternalComponentId": "output_f6s06a7b8c9d0e1f2a3b4c5d6e7f806",
+            "InternalComponentGuid": "66000006-0000-4000-8000-000000000006",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f801",
+          "ComponentGuid": "66000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_f6s06a7b8c9d0e1f2a3b4c5d6e7f802",
+          "ComponentGuid": "66000002-0000-4000-8000-000000000002",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_f6s06a7b8c9d0e1f2a3b4c5d6e7f803",
+          "ComponentGuid": "66000003-0000-4000-8000-000000000003",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_f6s06a7b8c9d0e1f2a3b4c5d6e7f804",
+          "ComponentGuid": "66000004-0000-4000-8000-000000000004",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_f6s06a7b8c9d0e1f2a3b4c5d6e7f805",
+          "ComponentGuid": "66000005-0000-4000-8000-000000000005",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_f6s06a7b8c9d0e1f2a3b4c5d6e7f806",
+          "ComponentGuid": "66000006-0000-4000-8000-000000000006",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 1600,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "OutputSignalNames": {
+          "Y": "S"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "COPY1",
+        "Description": "1x2 MMI Splitter copy gate (input A, outputs Y1 and Y2, threshold 0.375) built from the Demo PDK's MMI splitter. Role in the 2-bit counter: one waveguide carries exactly one signal, so the committed C1 fans out optically — each output arm takes half the power, comfortably above threshold, and drives the two XOR arms that read the straight C1 (X0.B and S0.A). The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_a7t17a8b9c0d1e2f3a4b5c6d7e8",
+        "IdGuid": "77000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "77000001-0000-4000-8000-000000000001",
+          "77000002-0000-4000-8000-000000000002",
+          "77000003-0000-4000-8000-000000000003",
+          "77000004-0000-4000-8000-000000000004"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 1900,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_a7t17a8b9c0d1e2f3a4b5c6d7e801",
+          "split_a7t17a8b9c0d1e2f3a4b5c6d7e802",
+          "output_a7t17a8b9c0d1e2f3a4b5c6d7e803",
+          "output_a7t17a8b9c0d1e2f3a4b5c6d7e804"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "77000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_a7t17a8b9c0d1e2f3a4b5c6d7e801",
+            "StartComponentGuid": "77000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "split_a7t17a8b9c0d1e2f3a4b5c6d7e802",
+            "EndComponentGuid": "77000002-0000-4000-8000-000000000002",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "77000012-0000-4000-8000-000000000012",
+            "StartComponentId": "split_a7t17a8b9c0d1e2f3a4b5c6d7e802",
+            "StartComponentGuid": "77000002-0000-4000-8000-000000000002",
+            "StartPinName": "out1",
+            "EndComponentId": "output_a7t17a8b9c0d1e2f3a4b5c6d7e803",
+            "EndComponentGuid": "77000003-0000-4000-8000-000000000003",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "77000013-0000-4000-8000-000000000013",
+            "StartComponentId": "split_a7t17a8b9c0d1e2f3a4b5c6d7e802",
+            "StartComponentGuid": "77000002-0000-4000-8000-000000000002",
+            "StartPinName": "out2",
+            "EndComponentId": "output_a7t17a8b9c0d1e2f3a4b5c6d7e804",
+            "EndComponentGuid": "77000004-0000-4000-8000-000000000004",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "77000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_a7t17a8b9c0d1e2f3a4b5c6d7e801",
+            "InternalComponentGuid": "77000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "77000022-0000-4000-8000-000000000022",
+            "Name": "Y1",
+            "InternalComponentId": "output_a7t17a8b9c0d1e2f3a4b5c6d7e803",
+            "InternalComponentGuid": "77000003-0000-4000-8000-000000000003",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "77000023-0000-4000-8000-000000000023",
+            "Name": "Y2",
+            "InternalComponentId": "output_a7t17a8b9c0d1e2f3a4b5c6d7e804",
+            "InternalComponentGuid": "77000004-0000-4000-8000-000000000004",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_a7t17a8b9c0d1e2f3a4b5c6d7e801",
+          "ComponentGuid": "77000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_a7t17a8b9c0d1e2f3a4b5c6d7e802",
+          "ComponentGuid": "77000002-0000-4000-8000-000000000002",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_a7t17a8b9c0d1e2f3a4b5c6d7e803",
+          "ComponentGuid": "77000003-0000-4000-8000-000000000003",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_a7t17a8b9c0d1e2f3a4b5c6d7e804",
+          "ComponentGuid": "77000004-0000-4000-8000-000000000004",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 1900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "COPYX",
+        "Description": "1x2 MMI Splitter copy gate (input A, outputs Y1 and Y2, threshold 0.375) built from the Demo PDK's MMI splitter. Role in the 2-bit counter: one waveguide carries exactly one signal, so the committed X = NAND(C0, C1) fans out optically — each output arm takes half the power, comfortably above threshold, and drives the R and S arms of the XOR. The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_b8u28a9b0c1d2e3f4a5b6c7d8e9",
+        "IdGuid": "88000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "88000001-0000-4000-8000-000000000001",
+          "88000002-0000-4000-8000-000000000002",
+          "88000003-0000-4000-8000-000000000003",
+          "88000004-0000-4000-8000-000000000004"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 2200,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_b8u28a9b0c1d2e3f4a5b6c7d8e901",
+          "split_b8u28a9b0c1d2e3f4a5b6c7d8e902",
+          "output_b8u28a9b0c1d2e3f4a5b6c7d8e903",
+          "output_b8u28a9b0c1d2e3f4a5b6c7d8e904"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "88000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_b8u28a9b0c1d2e3f4a5b6c7d8e901",
+            "StartComponentGuid": "88000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "split_b8u28a9b0c1d2e3f4a5b6c7d8e902",
+            "EndComponentGuid": "88000002-0000-4000-8000-000000000002",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "88000012-0000-4000-8000-000000000012",
+            "StartComponentId": "split_b8u28a9b0c1d2e3f4a5b6c7d8e902",
+            "StartComponentGuid": "88000002-0000-4000-8000-000000000002",
+            "StartPinName": "out1",
+            "EndComponentId": "output_b8u28a9b0c1d2e3f4a5b6c7d8e903",
+            "EndComponentGuid": "88000003-0000-4000-8000-000000000003",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "88000013-0000-4000-8000-000000000013",
+            "StartComponentId": "split_b8u28a9b0c1d2e3f4a5b6c7d8e902",
+            "StartComponentGuid": "88000002-0000-4000-8000-000000000002",
+            "StartPinName": "out2",
+            "EndComponentId": "output_b8u28a9b0c1d2e3f4a5b6c7d8e904",
+            "EndComponentGuid": "88000004-0000-4000-8000-000000000004",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "88000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_b8u28a9b0c1d2e3f4a5b6c7d8e901",
+            "InternalComponentGuid": "88000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "88000022-0000-4000-8000-000000000022",
+            "Name": "Y1",
+            "InternalComponentId": "output_b8u28a9b0c1d2e3f4a5b6c7d8e903",
+            "InternalComponentGuid": "88000003-0000-4000-8000-000000000003",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "88000023-0000-4000-8000-000000000023",
+            "Name": "Y2",
+            "InternalComponentId": "output_b8u28a9b0c1d2e3f4a5b6c7d8e904",
+            "InternalComponentGuid": "88000004-0000-4000-8000-000000000004",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_b8u28a9b0c1d2e3f4a5b6c7d8e901",
+          "ComponentGuid": "88000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_b8u28a9b0c1d2e3f4a5b6c7d8e902",
+          "ComponentGuid": "88000002-0000-4000-8000-000000000002",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_b8u28a9b0c1d2e3f4a5b6c7d8e903",
+          "ComponentGuid": "88000003-0000-4000-8000-000000000003",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_b8u28a9b0c1d2e3f4a5b6c7d8e904",
+          "ComponentGuid": "88000004-0000-4000-8000-000000000004",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 2200,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "Q1",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate, designated a register (IsRegister). Role in the 2-bit counter: count bit C1, and at the same time the final NAND of the textbook 4-NAND XOR. Its inputs read the settled arms R = NAND(C0, X) and S = NAND(C1, X) with X = NAND(C0, C1), so the committed next state is NAND(R, S) = C0 XOR C1 — C1 flips exactly when C0 wraps from 1 back to 0. Because all registers sample the same settled pre-step state and commit simultaneously (D-semantics), C1C0 counts 00, 01, 10, 11, 00, one count per clock step. The whole counter composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_c9q19b0c1d2e3f4a5b6c7d8e9f0ab",
+        "IdGuid": "99000000-0000-4000-8000-000000000000",
+        "ChildComponentGuids": [
+          "99000001-0000-4000-8000-000000000001",
+          "99000002-0000-4000-8000-000000000002",
+          "99000003-0000-4000-8000-000000000003",
+          "99000004-0000-4000-8000-000000000004",
+          "99000005-0000-4000-8000-000000000005",
+          "99000006-0000-4000-8000-000000000006"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 2500,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab01",
+          "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab02",
+          "combine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab03",
+          "phase_c9q19b0c1d2e3f4a5b6c7d8e9f0ab04",
+          "recombine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab05",
+          "output_c9q19b0c1d2e3f4a5b6c7d8e9f0ab06"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "99000011-0000-4000-8000-000000000011",
+            "StartComponentId": "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab01",
+            "StartComponentGuid": "99000001-0000-4000-8000-000000000001",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab03",
+            "EndComponentGuid": "99000003-0000-4000-8000-000000000003",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "99000012-0000-4000-8000-000000000012",
+            "StartComponentId": "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab02",
+            "StartComponentGuid": "99000002-0000-4000-8000-000000000002",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab03",
+            "EndComponentGuid": "99000003-0000-4000-8000-000000000003",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "99000013-0000-4000-8000-000000000013",
+            "StartComponentId": "combine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab03",
+            "StartComponentGuid": "99000003-0000-4000-8000-000000000003",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab05",
+            "EndComponentGuid": "99000005-0000-4000-8000-000000000005",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "99000014-0000-4000-8000-000000000014",
+            "StartComponentId": "phase_c9q19b0c1d2e3f4a5b6c7d8e9f0ab04",
+            "StartComponentGuid": "99000004-0000-4000-8000-000000000004",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab05",
+            "EndComponentGuid": "99000005-0000-4000-8000-000000000005",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "99000015-0000-4000-8000-000000000015",
+            "StartComponentId": "recombine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab05",
+            "StartComponentGuid": "99000005-0000-4000-8000-000000000005",
+            "StartPinName": "out1",
+            "EndComponentId": "output_c9q19b0c1d2e3f4a5b6c7d8e9f0ab06",
+            "EndComponentGuid": "99000006-0000-4000-8000-000000000006",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "99000021-0000-4000-8000-000000000021",
+            "Name": "A",
+            "InternalComponentId": "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab01",
+            "InternalComponentGuid": "99000001-0000-4000-8000-000000000001",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "99000022-0000-4000-8000-000000000022",
+            "Name": "B",
+            "InternalComponentId": "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab02",
+            "InternalComponentGuid": "99000002-0000-4000-8000-000000000002",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "99000023-0000-4000-8000-000000000023",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_c9q19b0c1d2e3f4a5b6c7d8e9f0ab04",
+            "InternalComponentGuid": "99000004-0000-4000-8000-000000000004",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "99000024-0000-4000-8000-000000000024",
+            "Name": "Y",
+            "InternalComponentId": "output_c9q19b0c1d2e3f4a5b6c7d8e9f0ab06",
+            "InternalComponentGuid": "99000006-0000-4000-8000-000000000006",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab01",
+          "ComponentGuid": "99000001-0000-4000-8000-000000000001",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_c9q19b0c1d2e3f4a5b6c7d8e9f0ab02",
+          "ComponentGuid": "99000002-0000-4000-8000-000000000002",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab03",
+          "ComponentGuid": "99000003-0000-4000-8000-000000000003",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_c9q19b0c1d2e3f4a5b6c7d8e9f0ab04",
+          "ComponentGuid": "99000004-0000-4000-8000-000000000004",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_c9q19b0c1d2e3f4a5b6c7d8e9f0ab05",
+          "ComponentGuid": "99000005-0000-4000-8000-000000000005",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_c9q19b0c1d2e3f4a5b6c7d8e9f0ab06",
+          "ComponentGuid": "99000006-0000-4000-8000-000000000006",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 2500,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "OutputSignalNames": {
+          "Y": "C1"
+        },
+        "IsRegister": true
+      }
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-20",
+      "Modified": "2026-08-20T04:30:00.0000000Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -9,6 +9,7 @@
     { "file": "Logic Gate MUX.lun", "rank": 70, "level": "Datapath", "descriptionKey": "Examples.Mux.Description" },
     { "file": "Logic Gate 4-Bit Adder.lun", "rank": 80, "level": "Datapath", "descriptionKey": "Examples.RippleCarryAdder.Description" },
     { "file": "Logic Gate ALU 1-bit.lun", "rank": 85, "level": "Datapath", "descriptionKey": "Examples.Alu.Description" },
-    { "file": "Logic Gate SR-Latch.lun", "rank": 90, "level": "Sequential", "descriptionKey": "Examples.SrLatch.Description" }
+    { "file": "Logic Gate SR-Latch.lun", "rank": 90, "level": "Sequential", "descriptionKey": "Examples.SrLatch.Description" },
+    { "file": "Logic Gate Counter 2-bit.lun", "rank": 100, "level": "Sequential", "descriptionKey": "Examples.Counter2bit.Description" }
   ]
 }


### PR DESCRIPTION
## What & why

Shipped example **`examples/Logic Gate Counter 2-bit.lun`**: the first *counting* circuit of the NAND-game ladder (rung 5, Sequential, rank 100 — right after the SR latch #1100). A 2-bit toggle (ripple) counter built from the shipped NOT/NAND gate plus 1×2 MMI splitter copy gates:

- **Stage 0** — the NAND register `Q0` reads its own committed output `C0` back: `D0 = NAND(C0, S̄) = NOT(C0)` with the active-low preset toggle `S̄` (the network's one input, #1025) resting at 1. The register *is* its own inverter, so `C0` flips every clock step.
- **Stage 1** — the textbook 4-NAND XOR whose final NAND is the register `Q1` itself: `X = NAND(C0, C1)`, `R = NAND(C0, X)`, `S = NAND(C1, X)`, so the committed next state is `NAND(R, S) = C0 ⊕ C1` and `C1` flips exactly when `C0` wraps 1 → 0.
- Every register samples the same settled pre-step state and commits simultaneously (D-semantics, #1093), so each **Step()** is one full clock tick: **C1C0 counts 00 → 01 → 10 → 11 → 00**.

One design constraint shaped the circuit: every waveguide serves exactly one output pin and one input pin (connecting a pin removes any older wire — pinned by `ExampleDesignFilesTests.EveryExample_LoadsExactlyWhatItDeclares`), so committed bits and the XOR pivot `X` fan out through the copy gates `COPY0/COPY0X/COPY1/COPYX` — one waveguide carries exactly one signal, each splitter arm takes half the power, comfortably above threshold. Outputs are named `C0`/`C1` so the bus view (#1068) shows the decimal count; composition stays at the logic layer (every gate's truth table extracted once in isolation — no passive optical cascade, per the examples' education note).

Manifest entry at rank 100 (Sequential) with the one-line description localized in all five languages; `ExamplesManifestLocalizationTests` gains the ladder assertion (counter after the SR latch).

Depends only on merged core (#1093); independent of #1098–#1100 follow-ups.

## How it was tested

Pinned integration tests (`UnitTests/Integration/LogicGateCounter2BitExampleTests.cs`, following the existing example-test pattern): load through the real load path → every group ships its persisted pin roles, register designations and signal names → assemble through the merged `LogicNetworkAssembler` (#988) → **Step sequence counts 00 → 01 → 10 → 11 → 00** with the XOR taps `X`/`R`/`S` asserted per step → active-low preset pulse forces `C0` → save → load → re-assembly yields the identical network (roles, names, all 13 wires, both registers) and replays the same counting sequence.

Local suite: 6333 passed, 0 failed

## Manual verification after vacation

1. Start Lunima, open the Home screen → the counter example appears as the second sequential rung (after the SR latch) with its localized one-liner.
2. Open the example and press **Step** (#1099) repeatedly — watch the bus view (#1068) count C1C0 = 0, 1, 2, 3 and wrap to 0.
3. Pull the `S̄` toggle of register Q0 low for one step: C0 presets to 1 regardless of the count, then counting resumes.

Tools: none of the optional token-saving tools were used this session (smart_test.py/semantic_search.py unavailable; used plain `dotnet test --filter` tails instead).