### PR TITLE
Agent: Load honesty — warn when a .lun drops duplicate-pin connections (#1109)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -574,6 +574,7 @@
   "Library.NoGroupsLoaded": "Keine Gruppen geladen",
   "Library.NoSavedGroups": "Keine gespeicherten Gruppen",
   "Load.PinCalibrationChanged": "Die Pin-Kalibrierung von '{0}' hat sich seit dem Speichern dieses Designs geändert — die betroffenen Routen wurden neu berechnet.",
+  "Load.DuplicatePinConnectionsDropped": "Warnung: {0} Verbindung(en) wurden verworfen, weil ein Pin bereits eine Leitung hatte — diese Datei wurde möglicherweise mit einer neueren Version erstellt oder extern bearbeitet.",
   "MainView.ResetZoom": "Zurücksetzen",
   "MainView.Simulate": "Simulieren (L)",
   "ModeProbe.AutoInstallIncomplete": "Automatische Installation von '{0}' nicht abgeschlossen — Details unter Einstellungen → Python-Umgebung, oder ausführen: pip install {0}",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -574,6 +574,7 @@
   "Library.NoGroupsLoaded": "No groups loaded",
   "Library.NoSavedGroups": "No saved groups",
   "Load.PinCalibrationChanged": "Pin calibration of '{0}' changed since this design was saved — its routes were recalculated.",
+  "Load.DuplicatePinConnectionsDropped": "Warning: {0} connection(s) were dropped because a pin already had a wire — this file may have been produced by a newer version or edited externally.",
   "MainView.ResetZoom": "Reset",
   "MainView.Simulate": "Simulate (L)",
   "ModeProbe.AutoInstallIncomplete": "Auto-install of '{0}' did not complete — see Settings → Python environment for details, or run: pip install {0}",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -574,6 +574,7 @@
   "Library.NoGroupsLoaded": "No hay grupos cargados",
   "Library.NoSavedGroups": "No hay grupos guardados",
   "Load.PinCalibrationChanged": "La calibración de pines de '{0}' cambió desde que se guardó este diseño; sus rutas se recalcularon.",
+  "Load.DuplicatePinConnectionsDropped": "Advertencia: se descartaron {0} conexión(es) porque un pin ya tenía un cable; es posible que este archivo se haya generado con una versión más reciente o se haya editado externamente.",
   "MainView.ResetZoom": "Restablecer",
   "MainView.Simulate": "Simular (L)",
   "ModeProbe.AutoInstallIncomplete": "La instalación automática de '{0}' no se completó: consulta Ajustes → entorno de Python para más detalles, o ejecuta: pip install {0}",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -574,6 +574,7 @@
   "Library.NoGroupsLoaded": "グループが読み込まれていません",
   "Library.NoSavedGroups": "保存されたグループがありません",
   "Load.PinCalibrationChanged": "このデザインの保存後に「{0}」のピン較正が変更されました——該当する配線を再計算しました。",
+  "Load.DuplicatePinConnectionsDropped": "警告：ピンにすでに配線があったため、{0} 本の接続が破棄されました——このファイルは新しいバージョンで作成されたか、外部で編集された可能性があります。",
   "MainView.ResetZoom": "リセット",
   "MainView.Simulate": "シミュレート (L)",
   "ModeProbe.AutoInstallIncomplete": "'{0}' の自動インストールが完了しませんでした — 詳細は 設定 → Python 環境 を確認するか、次を実行: pip install {0}",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -574,6 +574,7 @@
   "Library.NoGroupsLoaded": "未加载任何分组",
   "Library.NoSavedGroups": "没有已保存的分组",
   "Load.PinCalibrationChanged": "自保存此设计以来，“{0}”的引脚校准已更改——其布线已重新计算。",
+  "Load.DuplicatePinConnectionsDropped": "警告：{0} 条连接被丢弃，因为引脚已有连线——此文件可能由更新版本生成或被外部编辑过。",
   "MainView.ResetZoom": "重置",
   "MainView.Simulate": "仿真 (L)",
   "ModeProbe.AutoInstallIncomplete": "'{0}' 的自动安装未完成——详情请见 设置 → Python 环境，或运行：pip install {0}",

--- a/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Panels/FileOperationsViewModel.cs
@@ -68,6 +68,14 @@ public partial class FileOperationsViewModel : ObservableObject
     private readonly HashSet<string> _pinCalibrationMigratedComponents = new(StringComparer.Ordinal);
 
     /// <summary>
+    /// Pin pairs of connections displaced (dropped) during the current load: a later
+    /// connection in the file landed on a pin an earlier connection already occupied
+    /// (replacement-on-connect UX, applied to the file's netlist). Reported once after
+    /// loading so a .lun that wires a pin more than once never shrinks silently.
+    /// </summary>
+    private readonly List<string> _displacedConnectionsDuringLoad = new();
+
+    /// <summary>
     /// Per-component S-matrix overrides loaded from the PIR section of the .lun file,
     /// or added via the S-parameter import feature. Survives save-over-reload cycles.
     /// Keyed by component identifier string; values are the stored S-matrices.
@@ -1021,6 +1029,7 @@ public partial class FileOperationsViewModel : ObservableObject
                 _canvas.ConnectionManager.Clear();
                 _commandManager.ClearHistory();
                 _pinCalibrationMigratedComponents.Clear();
+                _displacedConnectionsDuringLoad.Clear();
 
                 // Design-scoped imported components (#830): restore the sets embedded
                 // in this .lun (replacing the previous design's) and migrate any legacy
@@ -1220,6 +1229,7 @@ public partial class FileOperationsViewModel : ObservableObject
                     _recentProjects?.RecordProject(filePath);
                 }
                 UpdateStatus?.Invoke($"Loaded {Path.GetFileName(filePath)} ({_canvas.Components.Count} components, {_canvas.Connections.Count} connections, {groupCount} groups)");
+                ReportDisplacedConnections();
                 _commandManager.NotifyStateChanged();
 
                 // Rebuild hierarchy tree after loading
@@ -1712,6 +1722,20 @@ public partial class FileOperationsViewModel : ObservableObject
 
         WaveguideConnectionViewModel? connVm;
 
+        // Replacement-on-connect (both endpoints drop their existing wire) is intended
+        // UX interactively, but during load it quietly discards earlier wires from the
+        // file's netlist whenever a pin is wired more than once. Collect what is about
+        // to be displaced so the load report can name it — the wires stay dropped.
+        foreach (var existing in _canvas.Connections
+                     .Where(c => c.Connection.StartPin == startPin || c.Connection.EndPin == startPin
+                                 || c.Connection.StartPin == endPin || c.Connection.EndPin == endPin)
+                     .ToList())
+        {
+            var description = DescribeConnectionForLoadReport(existing.Connection);
+            if (!_displacedConnectionsDuringLoad.Contains(description))
+                _displacedConnectionsDuringLoad.Add(description);
+        }
+
         if (cachedPath != null && cachedPath.IsValid)
         {
             connVm = _canvas.ConnectPinsWithCachedRoute(startPin, endPin, cachedPath);
@@ -1761,6 +1785,38 @@ public partial class FileOperationsViewModel : ObservableObject
         }
         _pinCalibrationMigratedComponents.Clear();
         _ = _canvas.RecalculateRoutesAsync();
+    }
+
+    /// <summary>
+    /// One-line description of a connection for the load report, identifying both
+    /// endpoint pins by component identifier and pin name.
+    /// </summary>
+    private static string DescribeConnectionForLoadReport(WaveguideConnection connection) =>
+        $"{connection.StartPin.ParentComponent?.Identifier}.{connection.StartPin.Name} ↔ "
+        + $"{connection.EndPin.ParentComponent?.Identifier}.{connection.EndPin.Name}";
+
+    /// <summary>
+    /// Surfaces connections that were displaced during the load: a .lun whose netlist
+    /// wires one pin more than once loads only the last wire, simulating a different
+    /// circuit than the file describes. The status bar carries the localized count and
+    /// the error console lists the dropped pin pairs. No dialog, no behavior change —
+    /// clean files report nothing.
+    /// </summary>
+    private void ReportDisplacedConnections()
+    {
+        if (_displacedConnectionsDuringLoad.Count == 0)
+            return;
+
+        var count = _displacedConnectionsDuringLoad.Count;
+        UpdateStatus?.Invoke(string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            Services.Localization.LocalizationService.Instance.Translate("Load.DuplicatePinConnectionsDropped"),
+            count));
+        _errorConsole?.LogWarning(
+            $"{count} connection(s) were dropped while loading because a pin already had a wire "
+            + "(the file may have been produced by a newer version or edited externally): "
+            + string.Join("; ", _displacedConnectionsDuringLoad));
+        _displacedConnectionsDuringLoad.Clear();
     }
 
     /// <summary>

--- a/UnitTests/Integration/DuplicatePinConnectionLoadTests.cs
+++ b/UnitTests/Integration/DuplicatePinConnectionLoadTests.cs
@@ -1,0 +1,242 @@
+using System.Collections.ObjectModel;
+using System.Text.Json.Nodes;
+using CAP.Avalonia.Commands;
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP.Avalonia.ViewModels.Export;
+using CAP.Avalonia.ViewModels.Library;
+using CAP.Avalonia.ViewModels.Panels;
+using CAP_Core;
+using CAP_Core.Components.Core;
+using CAP_Core.Export;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Load honesty (issue #1109): <c>DesignCanvasViewModel.ConnectPins*</c> replaces any
+/// existing wire on both endpoint pins — intended UX interactively, but on file load a
+/// .lun whose netlist wires one pin more than once loads only the last wire, simulating
+/// a different circuit than the file describes. The load must keep that behavior AND
+/// report every displaced connection (status-bar count, error-console pin pairs) instead
+/// of shrinking the netlist silently. Clean files report nothing.
+/// </summary>
+public class DuplicatePinConnectionLoadTests
+{
+    private readonly ObservableCollection<ComponentTemplate> _library =
+        new(TestPdkLoader.LoadAllTemplates());
+
+    [Fact]
+    public async Task Load_OneOutputWiredToTwoInputs_KeepsLastWireAndReportsBothDrops()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"duplicate-pin-{Guid.NewGuid():N}.lun");
+        try
+        {
+            // A real design: source out1 → mmiA.in and source out2 → mmiB.in.
+            var (saveVm, saveCanvas, _) = CreateSetup();
+            var (source, mmiA, mmiB) = PlaceThreeMmis(saveCanvas);
+            var sourceOut1 = source.PhysicalPins.First(p => p.Name == "out1");
+            var sourceOut2 = source.PhysicalPins.First(p => p.Name == "out2");
+            var inA = mmiA.PhysicalPins.First(p => p.Name == "in");
+            var inB = mmiB.PhysicalPins.First(p => p.Name == "in");
+            saveCanvas.ConnectPins(sourceOut1, inA);
+            saveCanvas.ConnectPins(sourceOut2, inB);
+            await SaveToFile(saveVm, tempFile);
+
+            // Simulate a file produced elsewhere: the source's out1 drives BOTH inputs.
+            // Save wrote the surviving wire first, so duplicating its entry with the
+            // input switched to mmiB makes the out1→mmiB.in wire load last and win.
+            var root = JsonNode.Parse(await File.ReadAllTextAsync(tempFile))!;
+            var connections = root["Connections"]!.AsArray();
+            var duplicated = connections[0]!.DeepClone();
+            duplicated["EndComponentId"] = mmiB.Identifier;
+            duplicated["EndPinName"] = "in";
+            connections.Add(duplicated);
+            await File.WriteAllTextAsync(tempFile, root.ToJsonString());
+
+            var (loadVm, loadCanvas, errorConsole) = CreateSetup();
+            string? status = null;
+            loadVm.UpdateStatus = s => status = s;
+            await LoadFromFile(loadVm, tempFile);
+
+            var survivor = loadCanvas.Connections.ShouldHaveSingleItem(
+                "replacement-on-connect still applies during load — only the last wire survives");
+            survivor.Connection.StartPin.Name.ShouldBe("out1",
+                "the surviving wire must start on the doubly-wired output");
+            survivor.Connection.EndPin.ParentComponent!.Identifier.ShouldBe(mmiB.Identifier,
+                "the last connection in the file wins the pin");
+
+            // ConnectPins replaces the wire on BOTH endpoints, so the last wire
+            // displaces out1→mmiA.in (occupied start pin) AND out2→mmiB.in
+            // (occupied end pin) — 2 of the file's 3 wires are lost and the
+            // report must count both.
+            status.ShouldNotBeNull("the load must surface the drop instead of staying silent");
+            status.ShouldContain("2");
+            var warning = errorConsole.Entries.ShouldHaveSingleItem(
+                "the error console lists the dropped connections once").Message;
+            warning.ShouldContain($"{source.Identifier}.out1");
+            warning.ShouldContain($"{mmiA.Identifier}.in");
+            warning.ShouldContain($"{source.Identifier}.out2");
+            warning.ShouldContain($"{mmiB.Identifier}.in");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Load_OneOutputWiredToTwoInputsOnly_ReportsExactlyOneDrop()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"duplicate-pin-only-{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas, _) = CreateSetup();
+            var (source, mmiA, mmiB) = PlaceThreeMmis(saveCanvas);
+            saveCanvas.ConnectPins(
+                source.PhysicalPins.First(p => p.Name == "out1"),
+                mmiA.PhysicalPins.First(p => p.Name == "in"));
+            saveCanvas.ConnectPins(
+                source.PhysicalPins.First(p => p.Name == "out2"),
+                mmiB.PhysicalPins.First(p => p.Name == "in"));
+            await SaveToFile(saveVm, tempFile);
+
+            // A netlist where the source's out1 drives both inputs — and nothing else:
+            // drop the second wire entirely and re-point the duplicated first at mmiB.
+            var root = JsonNode.Parse(await File.ReadAllTextAsync(tempFile))!;
+            var connections = root["Connections"]!.AsArray();
+            var duplicated = connections[0]!.DeepClone();
+            duplicated["EndComponentId"] = mmiB.Identifier;
+            duplicated["EndPinName"] = "in";
+            connections.RemoveAt(1);
+            connections.Add(duplicated);
+            await File.WriteAllTextAsync(tempFile, root.ToJsonString());
+
+            var (loadVm, loadCanvas, errorConsole) = CreateSetup();
+            string? status = null;
+            loadVm.UpdateStatus = s => status = s;
+            await LoadFromFile(loadVm, tempFile);
+
+            loadCanvas.Connections.ShouldHaveSingleItem(
+                "exactly one wire survives when one output drives two inputs");
+            status.ShouldNotBeNull();
+            status.ShouldContain("1");
+            status.ShouldNotContain("2");
+            var warning = errorConsole.Entries.ShouldHaveSingleItem().Message;
+            warning.ShouldContain($"{source.Identifier}.out1");
+            warning.ShouldContain($"{mmiA.Identifier}.in");
+            warning.ShouldNotContain(mmiB.Identifier);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Load_CleanRoundTrippedDesign_ReportsNoDrops()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"clean-load-{Guid.NewGuid():N}.lun");
+        try
+        {
+            var (saveVm, saveCanvas, _) = CreateSetup();
+            var (source, mmiA, mmiB) = PlaceThreeMmis(saveCanvas);
+            saveCanvas.ConnectPins(
+                source.PhysicalPins.First(p => p.Name == "out1"),
+                mmiA.PhysicalPins.First(p => p.Name == "in"));
+            saveCanvas.ConnectPins(
+                source.PhysicalPins.First(p => p.Name == "out2"),
+                mmiB.PhysicalPins.First(p => p.Name == "in"));
+            await SaveToFile(saveVm, tempFile);
+
+            var (loadVm, loadCanvas, errorConsole) = CreateSetup();
+            string? status = null;
+            loadVm.UpdateStatus = s => status = s;
+            await LoadFromFile(loadVm, tempFile);
+
+            loadCanvas.Connections.Count.ShouldBe(2);
+            errorConsole.Entries.ShouldBeEmpty("a clean file must not report any dropped connection");
+            status.ShouldNotBeNull();
+            status.ShouldNotContain("dropped");
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task Load_EveryShippedExample_ReportsNoDrops()
+    {
+        foreach (var examplePath in Directory.GetFiles(ExampleDesignFilesTests.ExamplesDirectory(), "*.lun"))
+        {
+            var (loadVm, _, errorConsole) = CreateSetup();
+            (await loadVm.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
+                $"'{Path.GetFileName(examplePath)}' must load through the real load path");
+
+            errorConsole.Entries.ShouldBeEmpty(
+                $"shipped example '{Path.GetFileName(examplePath)}' must load without dropped connections");
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private (Component Source, Component MmiA, Component MmiB) PlaceThreeMmis(
+        DesignCanvasViewModel canvas)
+    {
+        var mmiTemplate = _library.First(t => t.Name == "1x2 MMI Splitter");
+        var source = Place(mmiTemplate, canvas, "dup_source", 0, 0);
+        var mmiA = Place(mmiTemplate, canvas, "dup_target_a", 400, 0);
+        var mmiB = Place(mmiTemplate, canvas, "dup_target_b", 400, 300);
+        return (source, mmiA, mmiB);
+    }
+
+    private static Component Place(
+        ComponentTemplate template, DesignCanvasViewModel canvas, string identifier, double x, double y)
+    {
+        var component = ComponentTemplates.CreateFromTemplate(template, x, y);
+        component.Identifier = identifier;
+        canvas.AddComponent(component, template.Name);
+        return component;
+    }
+
+    private (FileOperationsViewModel Vm, DesignCanvasViewModel Canvas, ErrorConsoleService ErrorConsole)
+        CreateSetup()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var errorConsole = new ErrorConsoleService();
+        var vm = new FileOperationsViewModel(
+            canvas,
+            new CommandManager(),
+            new SimpleNazcaExporter(),
+            new SaxExporter(),
+            _library,
+            new GdsExportViewModel(new GdsExportService()),
+            new PhotonTorchExportViewModel(new PhotonTorchExporter(), canvas),
+            null!,
+            errorConsole: errorConsole);
+        return (vm, canvas, errorConsole);
+    }
+
+    private static async Task SaveToFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.SaveDesignAsCommand.ExecuteAsync(null);
+        File.Exists(filePath).ShouldBeTrue("the real save path must write the temp .lun");
+    }
+
+    private static async Task LoadFromFile(FileOperationsViewModel vm, string filePath)
+    {
+        var dialog = new Mock<IFileDialogService>();
+        dialog.Setup(f => f.ShowOpenFileDialogAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(filePath);
+        vm.FileDialogService = dialog.Object;
+        await vm.LoadDesignCommand.ExecuteAsync(null);
+    }
+}


### PR DESCRIPTION
## What & why

`DesignCanvasViewModel.ConnectPins/ConnectPinsWithCachedRoute` call `RemoveConnectionsForPin` on **both** endpoints before adding a wire. Interactively that replacement is intended UX — but on file load it means a `.lun` whose netlist wires any pin more than once loads only a subset of its wires (verified in the #1102 exploration: 6 of 9 loaded) with **no warning whatsoever**. The user sees a design that looks loaded but simulates a different circuit — a violation of the simulation-integrity bar (validation over silent assumptions).

This change keeps the replace-on-connect behavior exactly as-is (interactive UX and surviving-wire semantics unchanged) and makes the load honest:

- `FileOperationsViewModel.LoadConnectionFromData` now records every existing canvas connection that a just-loaded connection is about to displace (deduplicated, described as `Component.Identifier.Pin ↔ Component.Identifier.Pin`).
- After the load, `ReportDisplacedConnections()` surfaces the count as a localized status-bar message ("Warning: N connection(s) were dropped because a pin already had a wire — this file may have been produced by a newer version or edited externally") and logs the affected pin pairs to the error console.
- No dialog, no blocking, and clean files report nothing.
- New key `Load.DuplicatePinConnectionsDropped` localized in all 5 languages (de, en, es, ja, zh-Hans); `LocalizationCompleteness` green.

## Acceptance criteria

1. ✅ One output wired to two inputs: exactly one surviving wire (behavior unchanged) and the load reports 1 dropped connection with pin names — pinned by `Load_OneOutputWiredToTwoInputsOnly_ReportsExactlyOneDrop`. A second test documents the both-endpoints semantics precisely: `Load_OneOutputWiredToTwoInputs_KeepsLastWireAndReportsBothDrops` (the last-loaded wire displaces one wire per occupied endpoint).
2. ✅ `Load_EveryShippedExample_ReportsNoDrops` loads every `.lun` in `examples/` through the real load path and asserts no drops and no error-console entries.
3. ✅ Message key localized ×5; `LocalizationCompletenessTests` pass.
4. ✅ Tests use the real save → JSON edit → real load path (`FileOperationsViewModel.SaveDesignAsCommand` / `LoadDesignCommand` / `LoadDesignFromPathAsync`), no fixtures.

## How it was tested

- `dotnet build CAP.Desktop/CAP.Desktop.csproj` — 0 errors.
- New integration tests in `UnitTests/Integration/DuplicatePinConnectionLoadTests.cs` (4 tests), plus `LocalizationCompletenessTests` and `FileSizeLimitTests` — all green.
- Full filtered suite: **Local suite: 6331 passed, 0 failed** (14 skipped, `Category!=Slow`).

## Manual verification after vacation

1. Save any small design with two wires (e.g. one splitter out1 → MMI-A.in, out2 → MMI-B.in).
2. Open the `.lun` in a text editor, duplicate one entry in `Connections`, and point the copy's `EndComponentId`/`EndPinName` at the other target's input pin (so one output drives two inputs).
3. Load the file in Lunima.
4. Expected: the status bar shows the localized warning with the dropped-connection count, and the error console lists the dropped pin pairs; the canvas keeps only the last wire for the doubly-wired pin.
