### PR TITLE
Canvas: register marker on state-element gate groups (#1112)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayTime": "Anzeige bei t = {0:0.0} ps",
   "LogicPanel.ReplayExit": "Zurück zu Live",
   "LogicPanel.Registers": "Register:",
+  "LogicGate.RegisterMarker.Tooltip": "Register: hält seinen übernommenen Ausgang bis zum nächsten Takt-Schritt.",
   "LogicPanel.StepClock": "Takt weiterschalten",
   "LogicPanel.PlaybackPlay": "▶ Abspielen",
   "LogicPanel.PlaybackPause": "⏸ Anhalten",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayTime": "showing t = {0:0.0} ps",
   "LogicPanel.ReplayExit": "Back to live",
   "LogicPanel.Registers": "Registers:",
+  "LogicGate.RegisterMarker.Tooltip": "Register: holds its committed output until the next clock step.",
   "LogicPanel.StepClock": "Step clock",
   "LogicPanel.PlaybackPlay": "▶ Play",
   "LogicPanel.PlaybackPause": "⏸ Pause",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayTime": "mostrando t = {0:0.0} ps",
   "LogicPanel.ReplayExit": "Volver en vivo",
   "LogicPanel.Registers": "Registros:",
+  "LogicGate.RegisterMarker.Tooltip": "Registro: mantiene su salida confirmada hasta el siguiente paso de reloj.",
   "LogicPanel.StepClock": "Avanzar un ciclo de reloj",
   "LogicPanel.PlaybackPlay": "▶ Reproducir",
   "LogicPanel.PlaybackPause": "⏸ Pausa",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayTime": "t = {0:0.0} ps を表示中",
   "LogicPanel.ReplayExit": "ライブ状態に戻る",
   "LogicPanel.Registers": "レジスタ:",
+  "LogicGate.RegisterMarker.Tooltip": "レジスタ: コミットされた出力を次のクロックステップまで保持します。",
   "LogicPanel.StepClock": "クロックを1ステップ進める",
   "LogicPanel.PlaybackPlay": "▶ 再生",
   "LogicPanel.PlaybackPause": "⏸ 一時停止",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayTime": "正在显示 t = {0:0.0} ps",
   "LogicPanel.ReplayExit": "返回实时状态",
   "LogicPanel.Registers": "寄存器:",
+  "LogicGate.RegisterMarker.Tooltip": "寄存器：在下一个时钟步之前保持其已提交的输出。",
   "LogicPanel.StepClock": "时钟单步",
   "LogicPanel.PlaybackPlay": "▶ 播放",
   "LogicPanel.PlaybackPause": "⏸ 暂停",

--- a/CAP.Avalonia/Controls/DesignCanvas.cs
+++ b/CAP.Avalonia/Controls/DesignCanvas.cs
@@ -188,6 +188,9 @@ public class DesignCanvas : Control
             // Logic-state badges (#994) ride on top of the gate groups like the
             // analysis overlay: a chip must never sink under a component fill.
             LogicGateStateBadgeRenderer.Render(context, rc);
+            // Register markers sit at the group's top-left corner, opposite the
+            // badges: visible on load, following the Register toggle live.
+            LogicGateRegisterMarkerRenderer.Render(context, rc);
             _previewRenderer.Render(context, rc);
             // Cut tool overlay: guide lines and insertion candidates sit above
             // components and waveguides so the clickable markers are never obscured.

--- a/CAP.Avalonia/Controls/Rendering/LogicGateRegisterMarkerRenderer.cs
+++ b/CAP.Avalonia/Controls/Rendering/LogicGateRegisterMarkerRenderer.cs
@@ -1,0 +1,87 @@
+using Avalonia;
+using Avalonia.Media;
+using CAP.Avalonia.Services.Localization;
+using CAP_Core.Components.Core;
+using System.Globalization;
+
+namespace CAP.Avalonia.Controls.Rendering;
+
+/// <summary>
+/// Draws the register marker (issue #1112) of every register-designated gate group:
+/// a small rounded "R" chip at the group's top-left corner, in the same dark style
+/// as the live 0/1 badges (<see cref="LogicGateStateBadgeRenderer"/>, issue #994) —
+/// same backing, border, corner radius, and font — so a student can tell at a glance
+/// which groups on the canvas hold state (the SR latch's two NAND registers) and
+/// which are plain combinational gates. The marker reads the persisted
+/// <see cref="TruthTablePinAssignment.IsRegister"/> flag directly, so it renders on
+/// load without a built network and follows the Truth Table panel's Register toggle
+/// (issue #1098) live: the toggle writes the flag and requests a canvas repaint.
+/// Combinational groups, ungrouped components, and imported black-box cells without
+/// the flag get no marker.
+/// </summary>
+internal static class LogicGateRegisterMarkerRenderer
+{
+    private const double MarkerSize = 16;
+    private const double MarkerMargin = 4;
+    private const double MarkerCornerRadius = 3;
+    private const double MarkerFontSize = 11;
+
+    private static readonly Color BackingColor = Color.FromArgb(220, 30, 30, 30);
+    private static readonly Color BorderColor = Color.FromArgb(160, 120, 120, 120);
+    private static readonly Color TextColor = Color.FromRgb(158, 180, 255); // muted blue — distinct from the green/gray badges without fighting them
+
+    private static readonly IBrush BackingBrush = new SolidColorBrush(BackingColor);
+    private static readonly Pen BorderPen = new(new SolidColorBrush(BorderColor), 1);
+    private static readonly IBrush TextBrush = new SolidColorBrush(TextColor);
+
+    /// <summary>The marker glyph — a plain capital R, language-neutral like the 0/1 digits.</summary>
+    internal const string MarkerText = "R";
+
+    /// <summary>
+    /// The marker's tooltip sentence ("Register: holds its committed output until the
+    /// next clock step"), localized through the shipped string tables. Canvas-drawn
+    /// chips cannot carry an Avalonia <c>ToolTip</c>, so the text is exposed here for
+    /// the hover layer to read — and for the localization completeness tests to pin.
+    /// </summary>
+    public static string TooltipText =>
+        LocalizationService.Instance.Translate("LogicGate.RegisterMarker.Tooltip");
+
+    /// <summary>Draws one register marker per register-designated gate group.</summary>
+    /// <param name="context">Drawing context.</param>
+    /// <param name="rc">The render context carrying the canvas ViewModel with the components.</param>
+    public static void Render(DrawingContext context, CanvasRenderContext rc)
+    {
+        foreach (var comp in rc.ViewModel.Components)
+        {
+            if (comp.Component is not ComponentGroup group)
+                continue;
+            if (group.TruthTablePinAssignment?.IsRegister != true)
+                continue;
+
+            DrawMarker(context, ComponentGroupRenderer.CalculateGroupBounds(group));
+        }
+    }
+
+    /// <summary>Draws one chip at the group's top-left corner: dark backing, thin border, centered "R".</summary>
+    private static void DrawMarker(DrawingContext context, Rect groupBounds)
+    {
+        var text = new FormattedText(
+            MarkerText,
+            CultureInfo.InvariantCulture,
+            FlowDirection.LeftToRight,
+            new Typeface("Arial", FontStyle.Normal, FontWeight.Bold),
+            MarkerFontSize,
+            TextBrush);
+
+        var rect = new Rect(
+            groupBounds.Left + MarkerMargin,
+            groupBounds.Top + MarkerMargin,
+            MarkerSize,
+            MarkerSize);
+        context.DrawRectangle(BackingBrush, BorderPen, rect, MarkerCornerRadius, MarkerCornerRadius);
+
+        context.DrawText(text, new Point(
+            rect.Center.X - text.Width / 2,
+            rect.Center.Y - text.Height / 2));
+    }
+}

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Extract.cs
@@ -55,6 +55,9 @@ public partial class TruthTableViewModel
                 OutputSignalNames = PreservedSignalNames(previous?.OutputSignalNames, outputs),
                 IsRegister = IsRegister,
             };
+            // The canvas register marker reads the persisted flag: an extraction can
+            // create or replace it, so the marker must be offered a repaint either way.
+            _canvas?.RepaintRequested?.Invoke();
             SignalNamesVisible = true;
             StatusText = string.Format(Translate("Analysis.TruthTable.Complete"), table.Rows.Count);
         }

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Register.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/TruthTableViewModel.Register.cs
@@ -31,6 +31,11 @@ public partial class TruthTableViewModel
             return;
         var assignment = _group?.TruthTablePinAssignment;
         if (assignment != null)
+        {
             assignment.IsRegister = value;
+            // The canvas register marker reads the persisted flag directly, so a
+            // repaint is all it takes for the toggle to show/hide the marker live.
+            _canvas?.RepaintRequested?.Invoke();
+        }
     }
 }

--- a/UnitTests/Rendering/LogicGateRegisterMarkerRenderTests.cs
+++ b/UnitTests/Rendering/LogicGateRegisterMarkerRenderTests.cs
@@ -1,0 +1,284 @@
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using CAP.Avalonia.Controls;
+using CAP.Avalonia.Controls.Rendering;
+using CAP.Avalonia.Services.Localization;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests.Analysis.LogicAnalysis;
+using UnitTests.Integration;
+using Xunit;
+
+namespace UnitTests.Rendering;
+
+/// <summary>
+/// Render smoke tests for the canvas register markers (issue #1112): every gate group
+/// whose persisted <see cref="TruthTablePinAssignment.IsRegister"/> flag is set draws
+/// a small "R" chip at its top-left corner, in the same dark-chip style as the live
+/// 0/1 badges (issue #994) — so a student sees which groups hold state (the SR latch's
+/// two NAND registers) and which are plain combinational (the half adder's seven
+/// gates). The chip reads the persisted flag directly, so it renders on load without
+/// a built network, and the Truth Table panel's Register toggle (issue #1098) shows
+/// and hides it live through a canvas repaint. Renders the production renderer into a
+/// <see cref="RenderTargetBitmap"/> and samples real pixels — same pattern as
+/// <see cref="LogicGateSignalNameBadgeRenderTests"/>.
+/// </summary>
+public class LogicGateRegisterMarkerRenderTests
+{
+    // Marker layout mirrored from LogicGateRegisterMarkerRenderer: the bitmap origin
+    // sits 10px left and 10px above the group's top-left corner, so the 16×16 chip
+    // spans local x ∈ [14, 30] and local y ∈ [14, 30].
+    private const int BitmapWidth = 40;
+    private const int BitmapHeight = 40;
+    private const int ChipLeft = 14;
+    private const int ChipTop = 14;
+    private const int ChipSize = 16;
+
+    [AvaloniaFact]
+    public async Task SrLatch_RendersExactlyTwoRegisterMarkers()
+    {
+        var canvas = await LoadExample("Logic Gate SR-Latch.lun");
+        var groups = LogicGateHalfAdderExampleTests.GroupsOf(canvas);
+        groups.Select(g => g.GroupName).ShouldBe(new[] { "NANDQ", "NANDQB" }, ignoreOrder: true,
+            customMessage: "the SR latch ships exactly the two cross-coupled NAND registers");
+
+        foreach (var group in groups)
+        {
+            var bounds = ComponentGroupRenderer.CalculateGroupBounds(group);
+            using var bitmap = RenderMarkerCorner(canvas, bounds);
+            var pixels = ReadPixels(bitmap);
+
+            CountPainted(pixels).ShouldBeGreaterThan(0,
+                $"group '{group.GroupName}' is a register — its marker must render");
+            CountBlueText(pixels).ShouldBeGreaterThan(5,
+                $"group '{group.GroupName}' paints its 'R' glyph");
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task HalfAdder_RendersNoRegisterMarker()
+    {
+        var canvas = await LoadExample("Logic Gate Half Adder.lun");
+        var groups = LogicGateHalfAdderExampleTests.GroupsOf(canvas);
+        groups.Count.ShouldBe(7, "the half adder ships seven gates");
+
+        foreach (var group in groups)
+        {
+            var bounds = ComponentGroupRenderer.CalculateGroupBounds(group);
+            using var bitmap = RenderMarkerCorner(canvas, bounds);
+            var pixels = ReadPixels(bitmap);
+
+            CountPainted(pixels).ShouldBe(0,
+                $"group '{group.GroupName}' is combinational — no register marker may render");
+        }
+    }
+
+    [AvaloniaFact]
+    public void ToggleViaTruthTablePanel_AddsAndRemovesTheMarker()
+    {
+        var group = TestComponentFactory.CreateComponentGroup("G");
+        var child = TestComponentFactory.CreateStraightWaveGuide();
+        child.PhysicalX = 0;
+        child.PhysicalY = 0;
+        child.WidthMicrometers = 100;
+        child.HeightMicrometers = 60;
+        group.AddChild(child);
+        group.TruthTablePinAssignment = new TruthTablePinAssignment
+        {
+            InputPinNames = new List<string> { "A", "B" },
+            OutputPinNames = new List<string> { "Y" },
+            BiasPinNames = new List<string> { "BIAS" },
+            Threshold = 0.125,
+            IsRegister = false,
+        };
+        var canvas = new DesignCanvasViewModel();
+        canvas.AddComponent(group);
+        var bounds = ComponentGroupRenderer.CalculateGroupBounds(group);
+
+        // Combinational: no marker.
+        using (var bitmap = RenderMarkerCorner(canvas, bounds))
+            CountPainted(ReadPixels(bitmap)).ShouldBe(0, "a combinational group draws no marker");
+
+        // Toggle on through the panel — the repaint must fire and the marker appear.
+        var component = new ComponentViewModel(group);
+        canvas.Selection.SelectSingle(component);
+        var repaints = 0;
+        canvas.RepaintRequested = () => repaints++;
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(component, canvas);
+
+        vm.IsRegister = true;
+        repaints.ShouldBeGreaterThan(0, "the toggle requests a canvas repaint");
+        group.TruthTablePinAssignment.IsRegister.ShouldBeTrue();
+        using (var bitmap = RenderMarkerCorner(canvas, bounds))
+            CountPainted(ReadPixels(bitmap)).ShouldBeGreaterThan(0, "the designation shows the marker");
+
+        // Toggle off — the repaint fires again and the marker disappears.
+        vm.IsRegister = false;
+        group.TruthTablePinAssignment.IsRegister.ShouldBeFalse();
+        using (var bitmap = RenderMarkerCorner(canvas, bounds))
+            CountPainted(ReadPixels(bitmap)).ShouldBe(0, "clearing the designation hides the marker");
+    }
+
+    [AvaloniaFact]
+    public async Task ToggleBeforeFirstExtraction_ExtractionPersistsAndRepaints_MarkerRenders()
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        var canvas = new DesignCanvasViewModel();
+        canvas.AddComponent(group);
+        var component = new ComponentViewModel(group);
+        canvas.Selection.SelectSingle(component);
+        var repaints = 0;
+        canvas.RepaintRequested = () => repaints++;
+        var vm = new TruthTableViewModel();
+        vm.ConfigureForSelection(component, canvas);
+
+        vm.IsRegister = true;
+        group.TruthTablePinAssignment.ShouldBeNull(
+            "before the first extraction there is nothing to attach the flag to — and nothing to mark");
+
+        vm.InputPins.Single(p => p.PinName == "a").IsChecked = true;
+        vm.InputPins.Single(p => p.PinName == "b").IsChecked = true;
+        vm.OutputPins.Single(p => p.PinName == "y").IsChecked = true;
+        vm.Threshold = 0.25;
+        var repaintsBeforeExtract = repaints;
+        await vm.ExtractCommand.ExecuteAsync(null);
+
+        vm.HasResult.ShouldBeTrue("the extraction must succeed");
+        group.TruthTablePinAssignment!.IsRegister.ShouldBeTrue(
+            "the toggle intent rides into the assignment the extraction persists");
+        repaints.ShouldBeGreaterThan(repaintsBeforeExtract,
+            "persisting the designation through extraction offers the marker a repaint");
+
+        var bounds = ComponentGroupRenderer.CalculateGroupBounds(group);
+        using var bitmap = RenderMarkerCorner(canvas, bounds);
+        CountPainted(ReadPixels(bitmap)).ShouldBeGreaterThan(0,
+            "the pre-extraction toggle shows its marker as soon as the extraction lands");
+    }
+
+    [AvaloniaFact]
+    public void UngroupedComponent_RendersNoMarker()
+    {
+        var canvas = new DesignCanvasViewModel();
+        var lone = TestComponentFactory.CreateStraightWaveGuide();
+        lone.PhysicalX = 0;
+        lone.PhysicalY = 0;
+        lone.WidthMicrometers = 100;
+        lone.HeightMicrometers = 60;
+        canvas.AddComponent(lone);
+
+        var bounds = new Rect(lone.PhysicalX - 10, lone.PhysicalY - 10, 120, 80);
+        using var bitmap = RenderMarkerCorner(canvas, bounds);
+        CountPainted(ReadPixels(bitmap)).ShouldBe(0,
+            "an ungrouped component never carries a register designation");
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("de")]
+    [InlineData("es")]
+    [InlineData("zh-Hans")]
+    [InlineData("ja")]
+    public void MarkerTooltip_IsLocalizedInEveryShippedLanguage(string languageCode)
+    {
+        var service = new LocalizationService();
+        service.SetLanguage(languageCode);
+
+        var text = service.Translate("LogicGate.RegisterMarker.Tooltip");
+
+        text.ShouldNotBeNullOrWhiteSpace($"the tooltip must ship in {languageCode}");
+        text.ShouldNotBe("LogicGate.RegisterMarker.Tooltip",
+            $"the {languageCode} table must translate the key, not echo it");
+    }
+
+    /// <summary>Loads a shipped example through the real load path, without assembling a network.</summary>
+    private static async Task<DesignCanvasViewModel> LoadExample(string fileName)
+    {
+        var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), fileName);
+        return await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+    }
+
+    /// <summary>
+    /// Renders the register markers of <paramref name="canvas"/> into a bitmap whose
+    /// origin sits 10px left and 10px above the group's top-left corner, so the chip
+    /// lands at the local coordinates documented on the class constants.
+    /// </summary>
+    private static RenderTargetBitmap RenderMarkerCorner(DesignCanvasViewModel canvas, Rect groupBounds)
+    {
+        var origin = new Point(groupBounds.Left - 10, groupBounds.Top - 10);
+        var rc = new CanvasRenderContext
+        {
+            ViewModel = canvas,
+            InteractionState = new CanvasInteractionState(),
+            Zoom = 1.0,
+            Bounds = new Rect(origin, new Size(BitmapWidth, BitmapHeight)),
+        };
+        var bitmap = new RenderTargetBitmap(new PixelSize(BitmapWidth, BitmapHeight));
+        using (var ctx = bitmap.CreateDrawingContext())
+        {
+            ctx.FillRectangle(Brushes.Black, new Rect(0, 0, BitmapWidth, BitmapHeight));
+            using (ctx.PushTransform(Matrix.CreateTranslation(-origin.X, -origin.Y)))
+            {
+                LogicGateRegisterMarkerRenderer.Render(ctx, rc);
+            }
+        }
+        return bitmap;
+    }
+
+    /// <summary>Counts every non-black pixel inside the chip area.</summary>
+    private static int CountPainted(byte[] pixels)
+    {
+        var count = 0;
+        for (var y = ChipTop; y < ChipTop + ChipSize; y++)
+        {
+            for (var x = ChipLeft; x < ChipLeft + ChipSize; x++)
+            {
+                var i = (y * BitmapWidth + x) * 4;
+                if (pixels[i] > 15 || pixels[i + 1] > 15 || pixels[i + 2] > 15)
+                    count++;
+            }
+        }
+        return count;
+    }
+
+    /// <summary>Counts pixels of the muted-blue 'R' glyph: blue channel clearly dominates.</summary>
+    private static int CountBlueText(byte[] pixels)
+    {
+        var count = 0;
+        for (var y = ChipTop; y < ChipTop + ChipSize; y++)
+        {
+            for (var x = ChipLeft; x < ChipLeft + ChipSize; x++)
+            {
+                var i = (y * BitmapWidth + x) * 4;
+                var b = pixels[i];
+                var g = pixels[i + 1];
+                var r = pixels[i + 2];
+                if (b > 200 && b > r + 40)
+                    count++;
+            }
+        }
+        return count;
+    }
+
+    private static byte[] ReadPixels(RenderTargetBitmap bitmap)
+    {
+        var stride = BitmapWidth * 4;
+        var buffer = Marshal.AllocHGlobal(stride * BitmapHeight);
+        try
+        {
+            bitmap.CopyPixels(new PixelRect(0, 0, BitmapWidth, BitmapHeight), buffer, stride * BitmapHeight, stride);
+            var bytes = new byte[stride * BitmapHeight];
+            Marshal.Copy(buffer, bytes, 0, bytes.Length);
+            return bytes;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1112. Register-designated gate groups now draw a small rounded **"R" chip** at the group's top-left corner — the same dark-chip visual style as the live 0/1 badges (#994), opposite corner so they never collide. In the SR latch example the two cross-coupled NAND registers are now visibly the state-holding groups; the half adder's seven combinational gates stay clean.

### What changed

- **`LogicGateRegisterMarkerRenderer`** (new, `CAP.Avalonia/Controls/Rendering/`): draws the chip for every `ComponentGroup` whose persisted `TruthTablePinAssignment.IsRegister` is set. Reading the persisted flag directly means the marker renders on load without a built network, and needs no overlay state of its own. Exposes `TooltipText` ("Register: holds its committed output until the next clock step") resolved through `LocalizationService`.
- **`DesignCanvas.Render`**: one new render call right after the badge renderer.
- **Live toggle**: `TruthTableViewModel.OnIsRegisterChanged` and the extraction path (which first persists a pre-toggled designation) now invoke `_canvas?.RepaintRequested?.Invoke()`, so the marker shows/hides without reload.
- **Localization**: `LogicGate.RegisterMarker.Tooltip` added to all 5 shipped string tables (en/de/es/zh-Hans/ja); `LocalizationCompleteness` parity stays green.
- **Tests** (`UnitTests/Rendering/LogicGateRegisterMarkerRenderTests.cs`, 10 tests, headless `RenderTargetBitmap` pixel sampling mirroring #994/#997 badge tests):
  1. SR latch renders exactly 2 markers (NANDQ, NANDQB) ✓
  2. Half adder renders 0 markers ✓
  3. Panel toggle adds/removes the chip without reload ✓
  4. Pre-extraction toggle → extraction persists and repaints → marker appears ✓
  5. Ungrouped component gets no marker ✓
  6. Tooltip key resolves non-empty in all 5 languages ✓

Save/load consistency is pinned by the existing `LogicGateSrLatchExampleTests.SaveLoadRoundTrip_*` test (designation survives round trip) composed with the marker being a pure function of that designation.

### UX decisions

- **Placement**: top-left corner of the group, opposite the 0/1 badges at top-right — adjacent in the group's top strip ("next to the badge") without colliding with the stacked badge rows or the group-name label above the bounds.
- **Color**: muted blue glyph (`#9EB4FF`) on the badge's dark backing — distinct from the green/gray badge bits without introducing a competing accent color.
- **Tooltip**: canvas-drawn chips can't carry an Avalonia `ToolTip`, so the localized sentence is exposed as `LogicGateRegisterMarkerRenderer.TooltipText` for the hover layer and pinned by tests.

### Verification

- `build_errors.py`: 0 errors, 0 warnings.
- `smart_test.py` targeted runs all green: new tests (10), LocalizationCompleteness (11), TruthTableViewModelRegisterTests (6), Rendering (111), Integration (423 pass / 3 klayout-skip), Analysis (710), Controls (87), Services.Localization (66), Services non-GDS/Nazca (206), Architecture (18), ViewModels (759), UI (89 / 5 Slow-skip). Full unfiltered suite exceeds the local 5-min harness window (~8 min per project memory); the heavy GDS/Nazca subprocess slices are orthogonal to this change.

## Test plan

- [x] SR latch → 2 markers (NANDQ, NANDQB)
- [x] Half adder → 0 markers
- [x] Toggle via Truth Table VM adds/removes marker live
- [x] Tooltip localized ×5, completeness green
- [x] Save/load consistency via existing round-trip pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)