### PR TITLE
Agent: Example: load-enabled register bit (the NAND2TETRIS 'Bit') — MUX in front of a register (rung 5)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "Gruppen-Bearbeitungsmodus verlassen und zur Hauptzeichenfläche zurückkehren (ESC-Taste)",
   "EditMode.Title": "GRUPPEN-BEARBEITUNGSMODUS",
   "Examples.Alu.Description": "Eine 1-Bit-ALU: Das Op-Bit wählt, ob das Ergebnis das AND oder das OR der Eingänge ist.",
+  "Examples.Bit.Description": "Ein Speicherbit: Setze Load und drücke Step — das Bit speichert Din und hält den Wert.",
   "Examples.Counter2bit.Description": "Ein 2-Bit-Zähler: Drücke Step und sieh zu, wie C1C0 0, 1, 2, 3 zählt — die Schaltung läuft.",
   "Examples.AndGate.Description": "Kombiniere zwei NAND-Gatter zu einem AND-Gatter.",
   "Examples.FullAdder.Description": "Addiere zwei Bits plus Übertrag — der Baustein jedes Rechners.",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "Exit group edit mode and return to main canvas (ESC key)",
   "EditMode.Title": "GROUP EDIT MODE",
   "Examples.Alu.Description": "A 1-bit ALU: the Op bit selects whether the result is the AND or the OR of the inputs.",
+  "Examples.Bit.Description": "A memory bit: set Load and step the clock — the bit stores Din and holds it.",
   "Examples.Counter2bit.Description": "A 2-bit counter: press Step and watch C1C0 count 0, 1, 2, 3 — the circuit runs.",
   "Examples.AndGate.Description": "Combine two NAND gates into an AND gate.",
   "Examples.FullAdder.Description": "Add two bits plus a carry-in — the building block of every computer.",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "Salir del modo de edición de grupo y volver al lienzo principal (tecla ESC)",
   "EditMode.Title": "MODO DE EDICIÓN DE GRUPO",
   "Examples.Alu.Description": "Una ALU de 1 bit: el bit Op elige si el resultado es el AND o el OR de las entradas.",
+  "Examples.Bit.Description": "Un bit de memoria: activa Load y pulsa Step — el bit almacena Din y lo mantiene.",
   "Examples.Counter2bit.Description": "Un contador de 2 bits: pulsa Step y observa cómo C1C0 cuenta 0, 1, 2, 3 — el circuito funciona.",
   "Examples.AndGate.Description": "Combina dos puertas NAND en una puerta AND.",
   "Examples.FullAdder.Description": "Suma dos bits más el acarreo: el bloque fundamental de todo ordenador.",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "グループ編集モードを終了してメインキャンバスに戻る (ESC キー)",
   "EditMode.Title": "グループ編集モード",
   "Examples.Alu.Description": "1ビットALU:Opビットが結果を入力のANDにするかORにするかを選ぶ。",
+  "Examples.Bit.Description": "メモリビット:LoadをセットしてStepを押す — ビットはDinを記憶し保持する。",
   "Examples.Counter2bit.Description": "2ビットカウンタ:Stepを押すとC1C0が0、1、2、3とカウントする — 回路が動き出す。",
   "Examples.AndGate.Description": "2つのNANDゲートを組み合わせてANDゲートを作る。",
   "Examples.FullAdder.Description": "2ビットとキャリー入力を加算する — あらゆるコンピュータの基本ブロック。",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -348,6 +348,7 @@
   "EditMode.ExitTip": "退出组编辑模式并返回主画布（ESC 键）",
   "EditMode.Title": "组编辑模式",
   "Examples.Alu.Description": "1 位 ALU:Op 位选择结果是输入的 AND 还是 OR。",
+  "Examples.Bit.Description": "存储位:置位 Load 并按下 Step——该位存入 Din 并保持。",
   "Examples.Counter2bit.Description": "2 位计数器:按下 Step,观看 C1C0 依次计出 0、1、2、3——电路动起来了。",
   "Examples.AndGate.Description": "把两个 NAND 门组合成一个 AND 门。",
   "Examples.FullAdder.Description": "把两个比特连同进位相加——每台计算机的基本构件。",

--- a/UnitTests/Integration/LogicGateBitExampleTests.cs
+++ b/UnitTests/Integration/LogicGateBitExampleTests.cs
@@ -1,0 +1,245 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Pinned tests for the shipped <c>examples/Logic Gate Bit.lun</c> (issue
+/// #1119, rung 5 of the NAND game — the NAND2TETRIS Bit between the SR latch
+/// and the counter): the textbook load-enabled register bit D = MUX(Load, Q, Din)
+/// in front of a register. The combinational front-end reads exactly like the
+/// shipped MUX (issue #1059): NOT1 inverts Load, NANDA is the hold arm
+/// NAND(Q, NOT(Load)), NANDB is the load arm NAND(Din, Load), and Out closes the
+/// multiplexer as NAND(NANDA.Y, NANDB.Y) = (Q AND NOT(Load)) OR (Din AND Load).
+/// Out is designated a register (issue #1098), so while the network settles its
+/// output pin keeps reading the last committed Q — the feedback wire Out.Y →
+/// NANDA.A forms no combinational loop — and only
+/// <see cref="LogicNetworkEvaluator.Step"/> samples the settled D and commits it
+/// as the new Q (D-semantics). Every waveguide serves exactly one output pin and
+/// one input pin; the only fan-out (Load onto NOT1.A and NANDB.A) happens at the
+/// logic layer, where the persisted signal names (issue #1025) merge the two
+/// unconnected pins into the single network toggle <c>Load</c> — exactly the two
+/// toggles <c>Din</c> and <c>Load</c>, one named output <c>Q</c>. The file loads
+/// through the real load path, every group carries its persisted
+/// <see cref="TruthTablePinAssignment"/>, and the merged
+/// <see cref="LogicNetworkAssembler"/> (#988) turns the loaded design into the
+/// evaluable network the sequence below pins.
+/// </summary>
+public class LogicGateBitExampleTests
+    : IClassFixture<LogicGateBitExampleTests.BitFixture>
+{
+    private const double NotThreshold = 0.375;
+    private const double NandThreshold = 0.125;
+
+    private const string DinSignal = "Din";
+    private const string LoadSignal = "Load";
+    private const string QTap = "Q";
+    private const string RegisterName = "Out";
+
+    private static readonly string[] GateNames = { "NOT1", "NANDA", "NANDB", "Out" };
+
+    /// <summary>The persisted input signal names per gate group (issue #1025); null = no named pins.</summary>
+    private static readonly Dictionary<string, Dictionary<string, string>?> ExpectedInputSignalNames = new()
+    {
+        ["NOT1"] = new() { ["A"] = LoadSignal },
+        ["NANDA"] = null,
+        ["NANDB"] = new() { ["A"] = LoadSignal, ["B"] = DinSignal },
+        ["Out"] = null,
+    };
+
+    private readonly BitFixture _fixture;
+
+    /// <summary>Attaches the shared bit fixture.</summary>
+    public LogicGateBitExampleTests(BitFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Example_LoadsOnlyTopLevelGateGroups_WithPersistedRolesAndTheRegisterDesignation()
+    {
+        _fixture.Canvas.Components.ShouldAllBe(
+            c => c.Component is ComponentGroup,
+            "the load-enabled bit contains only top-level gate groups");
+        _fixture.Canvas.Connections.Count.ShouldBe(4,
+            "four wires join the four gates: the two MUX arms into Out, the select inversion, " +
+            "and the register feedback Out.Y → NANDA.A — every waveguide keeps one driver and one load");
+
+        var groups = _fixture.Groups;
+        groups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+        foreach (var group in groups)
+        {
+            var roles = group.TruthTablePinAssignment.ShouldNotBeNull(
+                $"group '{group.GroupName}' must ship its persisted pin roles");
+            var isNot = group.GroupName == "NOT1";
+            roles.InputPinNames.ShouldBe(isNot ? new[] { "A" } : new[] { "A", "B" });
+            roles.OutputPinNames.ShouldBe(new[] { "Y" });
+            roles.BiasPinNames.ShouldBe(new[] { "BIAS" });
+            roles.Threshold.ShouldBe(isNot ? NotThreshold : NandThreshold);
+            roles.IsRegister.ShouldBe(group.GroupName == RegisterName,
+                $"the register designation of '{group.GroupName}' (issue #1098) — only Out stores the bit");
+            roles.InputSignalNames.ShouldBe(ExpectedInputSignalNames[group.GroupName],
+                $"group '{group.GroupName}' ships its network-signal identity (issue #1025)");
+            group.Description.ShouldContain("logic layer", Case.Sensitive,
+                "every gate carries the education note about logic-layer composition");
+            group.Description.ShouldContain(isNot ? "0.375" : "0.125");
+        }
+
+        _fixture.Groups.Single(g => g.GroupName == RegisterName).TruthTablePinAssignment!
+            .OutputSignalNames.ShouldBe(new Dictionary<string, string> { ["Y"] = QTap },
+                "the register ships the named output tap Q (issue #1025)");
+        _fixture.Groups.Single(g => g.GroupName == RegisterName).Description
+            .ShouldContain("register", Case.Sensitive,
+                "the register carries the designation note");
+    }
+
+    [Fact]
+    public void AssembledNetwork_ExposesDinAndLoadTogglesTheNamedQAndTheRegisterState()
+    {
+        _fixture.Network.InputPinNames.ShouldBe(new[] { DinSignal, LoadSignal }, ignoreOrder: true,
+            customMessage: "the signal names merge the three unconnected operand pins into exactly " +
+                "two network inputs (issue #1025) — Load drives NOT1.A and NANDB.A without a wire");
+        _fixture.Network.OutputPinNames.ShouldBe(
+            new[] { QTap, "NOT1.Y", "NANDA.Y", "NANDB.Y" }, ignoreOrder: true,
+            customMessage: "the named tap Q replaces the register's raw gate-pin name; " +
+                "the combinational gates stay readable as raw taps");
+        _fixture.Network.RegisterState.Keys.ShouldBe(
+            new[] { new LogicPinRef(RegisterName, "Y") }, ignoreOrder: true,
+            customMessage: "the bit powers up as one state element, committed output cleared");
+    }
+
+    [Fact]
+    public void StepSequence_LoadStoreHoldAndLoadZero_ReplaysTheBitSemantics()
+    {
+        AssertLoadStoreHoldAndLoadZero(_fixture.Network);
+    }
+
+    /// <summary>
+    /// Asserts the pinned bit sequence against one assembled network: power-up
+    /// cleared, then Load=1 stores Din=1, Load=0 holds the 1 across two steps
+    /// while Din rests low, and Load=1 stores Din=0.
+    /// </summary>
+    private static void AssertLoadStoreHoldAndLoadZero(LogicNetworkEvaluator network)
+    {
+        network.Evaluate(Bits(load: true, din: true))[QTap].ShouldBeFalse(
+            "powered up cleared: Q reads the committed 0, not the combinational D");
+
+        network.Step();
+        var stored = network.Evaluate(Bits(load: true, din: true));
+        stored[QTap].ShouldBeTrue("Load=1: the step stores Din=1");
+        stored["NOT1.Y"].ShouldBeFalse("the select inversion stays readable as a tap");
+        stored["NANDB.Y"].ShouldBeFalse("the load arm passes Din while Load is high");
+
+        network.Evaluate(Bits(load: false, din: false));
+        network.Step();
+        network.Step();
+        var held = network.Evaluate(Bits(load: false, din: false));
+        held[QTap].ShouldBeTrue(
+            "Load=0: the bit holds its stored 1 across two steps while Din rests low");
+        held["NANDA.Y"].ShouldBeFalse("the hold arm passes the committed Q while Load is low");
+        held["NANDB.Y"].ShouldBeTrue("the load arm blocks Din while Load is low");
+
+        network.Evaluate(Bits(load: true, din: false));
+        network.Step();
+        network.Evaluate(Bits(load: true, din: false))[QTap].ShouldBeFalse(
+            "Load=1: the step stores Din=0");
+    }
+
+    [Fact]
+    public async Task SaveLoadRoundTrip_ReAssembledNetwork_YieldsTheSameBit()
+    {
+        var savedPath = await _fixture.SaveToTempFile();
+        try
+        {
+            var reloadedCanvas = await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath);
+
+            var reloadedGroups = LogicGateHalfAdderExampleTests.GroupsOf(reloadedCanvas);
+            reloadedGroups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+            reloadedGroups.ShouldAllBe(g => g.TruthTablePinAssignment != null,
+                "the persisted pin roles must survive the save → load round trip");
+            foreach (var group in reloadedGroups)
+            {
+                var roles = group.TruthTablePinAssignment!;
+                roles.IsRegister.ShouldBe(group.GroupName == RegisterName,
+                    $"the register designation of '{group.GroupName}' must survive the save → load round trip");
+                roles.InputPinNames.ToArray().ShouldBe(
+                    group.GroupName == "NOT1" ? new[] { "A" } : new[] { "A", "B" },
+                    customMessage: $"the input roles of '{group.GroupName}' must survive the save → load round trip");
+                roles.InputSignalNames.ShouldBe(ExpectedInputSignalNames[group.GroupName],
+                    $"the input signal names of '{group.GroupName}' must survive the save → load round trip (#1025)");
+            }
+            reloadedGroups.Single(g => g.GroupName == RegisterName).TruthTablePinAssignment!
+                .OutputSignalNames.ShouldBe(new Dictionary<string, string> { ["Y"] = QTap },
+                    "the named output tap Q must survive the save → load round trip (#1025)");
+            reloadedCanvas.Connections.Count.ShouldBe(4,
+                "every bit wire — the feedback included — must survive the save → load round trip");
+
+            var reloaded = await LogicGateMuxExampleTests.AssembleNetwork(reloadedCanvas);
+            reloaded.InputPinNames.ShouldBe(_fixture.Network.InputPinNames);
+            reloaded.OutputPinNames.ShouldBe(_fixture.Network.OutputPinNames);
+            reloaded.RegisterState.Keys.ShouldBe(_fixture.Network.RegisterState.Keys, ignoreOrder: true,
+                customMessage: "the re-assembled network must carry the same register state element");
+
+            AssertLoadStoreHoldAndLoadZero(reloaded);
+        }
+        finally
+        {
+            if (File.Exists(savedPath)) File.Delete(savedPath);
+        }
+    }
+
+    /// <summary>The network input bits for one Load/Din pair — one bit per signal (issue #1025).</summary>
+    private static Dictionary<string, bool> Bits(bool load, bool din) =>
+        new() { [DinSignal] = din, [LoadSignal] = load };
+
+    /// <summary>
+    /// Shared fixture: loads the shipped example once and assembles its logic network
+    /// (each extraction is a real simulation run), so every fact asserts against the
+    /// same loaded design and assembled network.
+    /// </summary>
+    public class BitFixture : IAsyncLifetime
+    {
+        private const string ExampleFileName = "Logic Gate Bit.lun";
+
+        /// <summary>Laser wavelength the persisted roles were extracted at.</summary>
+        public const int WavelengthNm = 1550;
+
+        /// <summary>The canvas the shipped example loaded onto.</summary>
+        public DesignCanvasViewModel Canvas { get; private set; } = null!;
+
+        /// <summary>The loaded top-level gate groups, in file order.</summary>
+        public List<ComponentGroup> Groups { get; private set; } = null!;
+
+        /// <summary>The logic network assembled from the loaded design.</summary>
+        public LogicNetworkEvaluator Network { get; private set; } = null!;
+
+        /// <summary>Loads the shipped example and assembles its logic network.</summary>
+        public async Task InitializeAsync()
+        {
+            var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+            Canvas = await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+            Groups = LogicGateHalfAdderExampleTests.GroupsOf(Canvas);
+            Network = await LogicGateMuxExampleTests.AssembleNetwork(Canvas);
+        }
+
+        /// <summary>No shared state to release.</summary>
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        /// <summary>Saves the loaded design through the real save path and returns the file path.</summary>
+        public async Task<string> SaveToTempFile()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"bit-{Guid.NewGuid():N}.lun");
+            var saveVm = LogicGateHalfAdderExampleTests.CreateFileOperations(Canvas);
+            var dialog = new Mock<IFileDialogService>();
+            dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(path);
+            saveVm.FileDialogService = dialog.Object;
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+            File.Exists(path).ShouldBeTrue("the real save path must write the temp .lun");
+            return path;
+        }
+    }
+}

--- a/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
+++ b/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
@@ -69,6 +69,27 @@ public class ExamplesManifestLocalizationTests
     }
 
     [Fact]
+    public void CuratedLadder_ListsTheBit_BetweenTheSrLatchAndTheCounter()
+    {
+        var ladder = new CAP.Avalonia.Services.ExampleDesignsService().GetExamples()
+            .Where(example => example.DescriptionKey != null)
+            .ToList();
+
+        var latchIndex = ladder.FindIndex(example => example.Name == "Logic Gate SR-Latch");
+        latchIndex.ShouldBeGreaterThanOrEqualTo(0, "the SR latch rung must stay curated");
+
+        var bitIndex = ladder.FindIndex(example => example.Name == "Logic Gate Bit");
+        bitIndex.ShouldBeGreaterThan(latchIndex,
+            "the load-enabled bit is the NAND2TETRIS Bit — it slots between the SR latch and the counter");
+        ladder[bitIndex].Level.ShouldBe("Sequential");
+        ladder[bitIndex].DescriptionKey.ShouldBe("Examples.Bit.Description");
+
+        var counterIndex = ladder.FindIndex(example => example.Name == "Logic Gate Counter 2-bit");
+        counterIndex.ShouldBeGreaterThan(bitIndex,
+            "the 2-bit counter builds on the register bit — it stays the rung after the Bit");
+    }
+
+    [Fact]
     public void CuratedLadder_ListsTheCounter2Bit_AfterTheSrLatch()
     {
         var ladder = new CAP.Avalonia.Services.ExampleDesignsService().GetExamples()

--- a/examples/Logic Gate Bit.lun
+++ b/examples/Logic Gate Bit.lun
@@ -1,0 +1,1371 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 1,
+      "EndPinName": "B",
+      "StartComponentId": "group_7a2223163d864b6a94a79dca3aeb6421",
+      "EndComponentId": "group_aad453a76a114178a4e406e4d969fccb",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 2,
+      "StartPinName": "Y",
+      "EndComponentIndex": 3,
+      "EndPinName": "B",
+      "StartComponentId": "group_3a677ab2a4144ba2a9730787c4b221fb",
+      "EndComponentId": "group_a341ac6ebd6e498b8342b7a72a72fed0",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 1,
+      "StartPinName": "Y",
+      "EndComponentIndex": 3,
+      "EndPinName": "A",
+      "StartComponentId": "group_aad453a76a114178a4e406e4d969fccb",
+      "EndComponentId": "group_a341ac6ebd6e498b8342b7a72a72fed0",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 3,
+      "StartPinName": "Y",
+      "EndComponentIndex": 1,
+      "EndPinName": "A",
+      "StartComponentId": "group_a341ac6ebd6e498b8342b7a72a72fed0",
+      "EndComponentId": "group_aad453a76a114178a4e406e4d969fccb",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    }
+  ],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "NOT1",
+        "Description": "NOT reading (input A, BIAS constantly on, threshold 0.375) of the shipped 'Logic Gate NOT-NAND' gate. Role in the load-enabled bit: select inversion, Y = NOT(Load), feeding NANDA.B \u2014 the hold arm of the multiplexer in front of the register. The fan-out of Load onto NOT1 and NANDB happens at the logic layer: both unconnected pins share the persisted signal name Load, so one network toggle drives them without a waveguide. The whole bit composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_7a2223163d864b6a94a79dca3aeb6421",
+        "IdGuid": "f8509386-729e-4fd3-95eb-86e927c139a8",
+        "ChildComponentGuids": [
+          "d1914af8-ce43-44cb-a419-9894734b941b",
+          "42ad461a-9551-4078-a6fc-d39256d08c2c",
+          "73dd0822-3d4e-4e36-8422-4b630d6a1da6",
+          "dab25d8a-023b-4948-b544-10a3bed598c2",
+          "fea4213d-5495-4741-a7f1-9512484578da",
+          "719c5687-a1d8-41a9-9749-7bfbce719f53"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_db7b288d2ec043fd9d171caf1b5bae6d",
+          "input_2db77e9cf2b64c5b99874aeed0b09a16",
+          "combine_b843d439ddff4f289c942a6d082fbb2f",
+          "phase_b5a560cc5a9346bb9354c9f0aa8e1e7a",
+          "recombine_fb3d9c8f57194558ae484dacd6356673",
+          "output_2d4e8b1ee0f54307920d0a365651997f"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "5c1fcf22-ddc1-4933-b4e6-a6b4008deb0e",
+            "StartComponentId": "input_db7b288d2ec043fd9d171caf1b5bae6d",
+            "StartComponentGuid": "d1914af8-ce43-44cb-a419-9894734b941b",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_b843d439ddff4f289c942a6d082fbb2f",
+            "EndComponentGuid": "73dd0822-3d4e-4e36-8422-4b630d6a1da6",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f43f3a83-f89a-4cc1-be97-da76a2c3ff66",
+            "StartComponentId": "input_2db77e9cf2b64c5b99874aeed0b09a16",
+            "StartComponentGuid": "42ad461a-9551-4078-a6fc-d39256d08c2c",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_b843d439ddff4f289c942a6d082fbb2f",
+            "EndComponentGuid": "73dd0822-3d4e-4e36-8422-4b630d6a1da6",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "4cecf9e0-7b57-469e-afc8-eff567b40bce",
+            "StartComponentId": "combine_b843d439ddff4f289c942a6d082fbb2f",
+            "StartComponentGuid": "73dd0822-3d4e-4e36-8422-4b630d6a1da6",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_fb3d9c8f57194558ae484dacd6356673",
+            "EndComponentGuid": "fea4213d-5495-4741-a7f1-9512484578da",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "147070ae-4c33-4c91-ac84-fdea044a7748",
+            "StartComponentId": "phase_b5a560cc5a9346bb9354c9f0aa8e1e7a",
+            "StartComponentGuid": "dab25d8a-023b-4948-b544-10a3bed598c2",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_fb3d9c8f57194558ae484dacd6356673",
+            "EndComponentGuid": "fea4213d-5495-4741-a7f1-9512484578da",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "fd670f4a-25e3-4f03-8be6-ab2060062519",
+            "StartComponentId": "recombine_fb3d9c8f57194558ae484dacd6356673",
+            "StartComponentGuid": "fea4213d-5495-4741-a7f1-9512484578da",
+            "StartPinName": "out1",
+            "EndComponentId": "output_2d4e8b1ee0f54307920d0a365651997f",
+            "EndComponentGuid": "719c5687-a1d8-41a9-9749-7bfbce719f53",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "8778c3b6-9dee-4849-ac76-2c2fbd143fb3",
+            "Name": "A",
+            "InternalComponentId": "input_db7b288d2ec043fd9d171caf1b5bae6d",
+            "InternalComponentGuid": "d1914af8-ce43-44cb-a419-9894734b941b",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "bbd75c2e-48b8-404c-8f9c-9b8c41127080",
+            "Name": "B",
+            "InternalComponentId": "input_2db77e9cf2b64c5b99874aeed0b09a16",
+            "InternalComponentGuid": "42ad461a-9551-4078-a6fc-d39256d08c2c",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "4af88cdf-7325-4ff8-a31b-bca13406dca6",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_b5a560cc5a9346bb9354c9f0aa8e1e7a",
+            "InternalComponentGuid": "dab25d8a-023b-4948-b544-10a3bed598c2",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "5feb3433-043d-48ad-9662-e1d7b20f5d17",
+            "Name": "Y",
+            "InternalComponentId": "output_2d4e8b1ee0f54307920d0a365651997f",
+            "InternalComponentGuid": "719c5687-a1d8-41a9-9749-7bfbce719f53",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_db7b288d2ec043fd9d171caf1b5bae6d",
+          "ComponentGuid": "d1914af8-ce43-44cb-a419-9894734b941b",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_2db77e9cf2b64c5b99874aeed0b09a16",
+          "ComponentGuid": "42ad461a-9551-4078-a6fc-d39256d08c2c",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_b843d439ddff4f289c942a6d082fbb2f",
+          "ComponentGuid": "73dd0822-3d4e-4e36-8422-4b630d6a1da6",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_b5a560cc5a9346bb9354c9f0aa8e1e7a",
+          "ComponentGuid": "dab25d8a-023b-4948-b544-10a3bed598c2",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_fb3d9c8f57194558ae484dacd6356673",
+          "ComponentGuid": "fea4213d-5495-4741-a7f1-9512484578da",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_2d4e8b1ee0f54307920d0a365651997f",
+          "ComponentGuid": "719c5687-a1d8-41a9-9749-7bfbce719f53",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.375,
+        "InputSignalNames": {
+          "A": "Load"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "NANDA",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the load-enabled bit: the hold arm, Y = NAND(Q, NOT(Load)) \u2014 while Load rests low it passes the committed bit Q back toward the register, while Load is high it blocks it. Its A pin reads the register's committed output Q through the feedback wire; only an explicit clock step samples the loop and commits new state (D-semantics), which is what makes this feedback cycle legal. The whole bit composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_aad453a76a114178a4e406e4d969fccb",
+        "IdGuid": "6cd62246-8b93-4a6c-9d81-3786eca70cbd",
+        "ChildComponentGuids": [
+          "e0f4a33d-68e2-4ac7-b6e3-2c0adffc3a8c",
+          "b0462cf5-88b9-4658-8e21-f0257b9dcd89",
+          "b2439891-de22-4bb5-afeb-8831470f719e",
+          "faec5fa3-36df-4c5f-9bf2-633535fd6462",
+          "a9e92edb-d6a9-4df6-bd13-bc38efbe7c86",
+          "467e2760-215b-454f-a444-d8b443b0200e"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_455d1b5cef1b4507b3cc22f8fc7dc7a1",
+          "input_35ca297c46744589887f05b36e042234",
+          "combine_7ff5b23534ee4e86a24fd7f3e2f8ec92",
+          "phase_b21c0021bd984608bf215a7509cfb2e3",
+          "recombine_aa8e5b3972de45eb8b1835282baa15e6",
+          "output_4de8d585053346f997c38cd192e58875"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "48c320c8-6ebf-4db2-94a2-d248fab30eb2",
+            "StartComponentId": "input_455d1b5cef1b4507b3cc22f8fc7dc7a1",
+            "StartComponentGuid": "e0f4a33d-68e2-4ac7-b6e3-2c0adffc3a8c",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_7ff5b23534ee4e86a24fd7f3e2f8ec92",
+            "EndComponentGuid": "b2439891-de22-4bb5-afeb-8831470f719e",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "eacc35f7-e61b-4087-aa43-8089314a3aa0",
+            "StartComponentId": "input_35ca297c46744589887f05b36e042234",
+            "StartComponentGuid": "b0462cf5-88b9-4658-8e21-f0257b9dcd89",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_7ff5b23534ee4e86a24fd7f3e2f8ec92",
+            "EndComponentGuid": "b2439891-de22-4bb5-afeb-8831470f719e",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "c31f1108-ea89-4ecb-b22e-d660a4ac00e2",
+            "StartComponentId": "combine_7ff5b23534ee4e86a24fd7f3e2f8ec92",
+            "StartComponentGuid": "b2439891-de22-4bb5-afeb-8831470f719e",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_aa8e5b3972de45eb8b1835282baa15e6",
+            "EndComponentGuid": "a9e92edb-d6a9-4df6-bd13-bc38efbe7c86",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "d5e24b7f-a122-4c22-ad58-8cb421c47def",
+            "StartComponentId": "phase_b21c0021bd984608bf215a7509cfb2e3",
+            "StartComponentGuid": "faec5fa3-36df-4c5f-9bf2-633535fd6462",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_aa8e5b3972de45eb8b1835282baa15e6",
+            "EndComponentGuid": "a9e92edb-d6a9-4df6-bd13-bc38efbe7c86",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "7c5829d5-a7e5-44ae-a016-57d5d99d1ced",
+            "StartComponentId": "recombine_aa8e5b3972de45eb8b1835282baa15e6",
+            "StartComponentGuid": "a9e92edb-d6a9-4df6-bd13-bc38efbe7c86",
+            "StartPinName": "out1",
+            "EndComponentId": "output_4de8d585053346f997c38cd192e58875",
+            "EndComponentGuid": "467e2760-215b-454f-a444-d8b443b0200e",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "5d44ed5f-2f82-4da0-9477-61ae188788b9",
+            "Name": "A",
+            "InternalComponentId": "input_455d1b5cef1b4507b3cc22f8fc7dc7a1",
+            "InternalComponentGuid": "e0f4a33d-68e2-4ac7-b6e3-2c0adffc3a8c",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "83894c86-6f2d-454f-95ff-8c71b55e0627",
+            "Name": "B",
+            "InternalComponentId": "input_35ca297c46744589887f05b36e042234",
+            "InternalComponentGuid": "b0462cf5-88b9-4658-8e21-f0257b9dcd89",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "f110908e-879c-463b-89dc-8effe22f1c80",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_b21c0021bd984608bf215a7509cfb2e3",
+            "InternalComponentGuid": "faec5fa3-36df-4c5f-9bf2-633535fd6462",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "e6b455cc-5f4c-444a-9fd2-5fc208d5238f",
+            "Name": "Y",
+            "InternalComponentId": "output_4de8d585053346f997c38cd192e58875",
+            "InternalComponentGuid": "467e2760-215b-454f-a444-d8b443b0200e",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_455d1b5cef1b4507b3cc22f8fc7dc7a1",
+          "ComponentGuid": "e0f4a33d-68e2-4ac7-b6e3-2c0adffc3a8c",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_35ca297c46744589887f05b36e042234",
+          "ComponentGuid": "b0462cf5-88b9-4658-8e21-f0257b9dcd89",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_7ff5b23534ee4e86a24fd7f3e2f8ec92",
+          "ComponentGuid": "b2439891-de22-4bb5-afeb-8831470f719e",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_b21c0021bd984608bf215a7509cfb2e3",
+          "ComponentGuid": "faec5fa3-36df-4c5f-9bf2-633535fd6462",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_aa8e5b3972de45eb8b1835282baa15e6",
+          "ComponentGuid": "a9e92edb-d6a9-4df6-bd13-bc38efbe7c86",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_4de8d585053346f997c38cd192e58875",
+          "ComponentGuid": "467e2760-215b-454f-a444-d8b443b0200e",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 500,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "NANDB",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate. Role in the load-enabled bit: the load arm, Y = NAND(Din, Load) \u2014 while Load is high it passes the new input Din toward the register, while Load rests low it blocks it. Both pins stay unconnected on the canvas: the persisted signal names Load and Din merge them into the network toggles of the same name. The whole bit composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_3a677ab2a4144ba2a9730787c4b221fb",
+        "IdGuid": "cef526aa-2d27-446c-a3a2-6cd52f546072",
+        "ChildComponentGuids": [
+          "bb593b90-206b-4ade-bc9d-aa1d0aba4c42",
+          "fd00c4a4-9558-4843-abb0-1bffdf042bb4",
+          "a1dfa53a-1c3c-460a-a212-cc1d3879c246",
+          "0b08b7ae-66ff-4f16-b8c4-69a0a19b476d",
+          "f3068c41-6aca-4898-be20-47b75710eb7e",
+          "23ee42db-b4ad-4544-bf2d-c11e4e5d29b5"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 400,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_50aa43ad9613490793d094488576d15f",
+          "input_38a1e2e6f1184d7ab0442280f9a4847c",
+          "combine_0d1ef73c531940d39a172533057a2022",
+          "phase_d447559b95e242a8a07e994740ee26ba",
+          "recombine_2bfa0191a1ed45638481461698d1488f",
+          "output_8c5a595031b444b0971e05bc4c25cd47"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "dede8338-f453-4d9b-9dcd-0fda41dc7849",
+            "StartComponentId": "input_50aa43ad9613490793d094488576d15f",
+            "StartComponentGuid": "bb593b90-206b-4ade-bc9d-aa1d0aba4c42",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_0d1ef73c531940d39a172533057a2022",
+            "EndComponentGuid": "a1dfa53a-1c3c-460a-a212-cc1d3879c246",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "c00bf17d-da5b-45a9-930b-d66018fa8072",
+            "StartComponentId": "input_38a1e2e6f1184d7ab0442280f9a4847c",
+            "StartComponentGuid": "fd00c4a4-9558-4843-abb0-1bffdf042bb4",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_0d1ef73c531940d39a172533057a2022",
+            "EndComponentGuid": "a1dfa53a-1c3c-460a-a212-cc1d3879c246",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "92880eaa-19f5-4df2-abf4-3fc7c74c94cb",
+            "StartComponentId": "combine_0d1ef73c531940d39a172533057a2022",
+            "StartComponentGuid": "a1dfa53a-1c3c-460a-a212-cc1d3879c246",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_2bfa0191a1ed45638481461698d1488f",
+            "EndComponentGuid": "f3068c41-6aca-4898-be20-47b75710eb7e",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "31e6b6da-9898-4cfe-9e15-ad1ac9982f85",
+            "StartComponentId": "phase_d447559b95e242a8a07e994740ee26ba",
+            "StartComponentGuid": "0b08b7ae-66ff-4f16-b8c4-69a0a19b476d",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_2bfa0191a1ed45638481461698d1488f",
+            "EndComponentGuid": "f3068c41-6aca-4898-be20-47b75710eb7e",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "dd774022-3e41-479f-984e-7f1070dc1d33",
+            "StartComponentId": "recombine_2bfa0191a1ed45638481461698d1488f",
+            "StartComponentGuid": "f3068c41-6aca-4898-be20-47b75710eb7e",
+            "StartPinName": "out1",
+            "EndComponentId": "output_8c5a595031b444b0971e05bc4c25cd47",
+            "EndComponentGuid": "23ee42db-b4ad-4544-bf2d-c11e4e5d29b5",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "8026eb04-e1ec-4d7f-8897-23276fa79efa",
+            "Name": "A",
+            "InternalComponentId": "input_50aa43ad9613490793d094488576d15f",
+            "InternalComponentGuid": "bb593b90-206b-4ade-bc9d-aa1d0aba4c42",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "6ecf8c1b-408b-40d5-abdf-5fc028015400",
+            "Name": "B",
+            "InternalComponentId": "input_38a1e2e6f1184d7ab0442280f9a4847c",
+            "InternalComponentGuid": "fd00c4a4-9558-4843-abb0-1bffdf042bb4",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "c6ab26dc-4e46-4d4f-85aa-9f0f211f89ca",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_d447559b95e242a8a07e994740ee26ba",
+            "InternalComponentGuid": "0b08b7ae-66ff-4f16-b8c4-69a0a19b476d",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "dd6b68a2-02d1-4cd4-9f5f-dafa251cf1c6",
+            "Name": "Y",
+            "InternalComponentId": "output_8c5a595031b444b0971e05bc4c25cd47",
+            "InternalComponentGuid": "23ee42db-b4ad-4544-bf2d-c11e4e5d29b5",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_50aa43ad9613490793d094488576d15f",
+          "ComponentGuid": "bb593b90-206b-4ade-bc9d-aa1d0aba4c42",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_38a1e2e6f1184d7ab0442280f9a4847c",
+          "ComponentGuid": "fd00c4a4-9558-4843-abb0-1bffdf042bb4",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_0d1ef73c531940d39a172533057a2022",
+          "ComponentGuid": "a1dfa53a-1c3c-460a-a212-cc1d3879c246",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_d447559b95e242a8a07e994740ee26ba",
+          "ComponentGuid": "0b08b7ae-66ff-4f16-b8c4-69a0a19b476d",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_2bfa0191a1ed45638481461698d1488f",
+          "ComponentGuid": "f3068c41-6aca-4898-be20-47b75710eb7e",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_8c5a595031b444b0971e05bc4c25cd47",
+          "ComponentGuid": "23ee42db-b4ad-4544-bf2d-c11e4e5d29b5",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 400,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "InputSignalNames": {
+          "A": "Load",
+          "B": "Din"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "Out",
+        "Description": "NAND reading (inputs A and B, BIAS constantly on, threshold 0.125) of the shipped 'Logic Gate NOT-NAND' gate, designated a register (IsRegister). Role in the load-enabled bit: the storage element, the NAND2TETRIS Bit itself. Its combinational reading computes D = NAND(NANDA.Y, NANDB.Y) = (Q AND NOT(Load)) OR (Din AND Load) \u2014 the textbook multiplexer in front of a register \u2014 and the clock step commits D as the new Q: with Load high the bit stores Din, with Load low it holds its last value. While the network settles, the output pin keeps reading the last committed Q, so the feedback wire into NANDA.A forms no combinational loop. The whole bit composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction \u2014 there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_a341ac6ebd6e498b8342b7a72a72fed0",
+        "IdGuid": "f5cf74e0-a66d-45ee-92fb-63d056a2aef3",
+        "ChildComponentGuids": [
+          "305f0f64-7225-4a94-90cc-ba35dbcac7b3",
+          "9ad79eed-c34b-421c-a27f-7be0d0bb4c49",
+          "d0de2ada-c443-4ab9-9f72-5354bdcb6a23",
+          "b4aecd26-77a3-4365-a646-81f177938c2a",
+          "22da74ae-7755-40eb-9a4e-8693d2d6c2f8",
+          "71d7e73b-276c-44aa-9bb1-fb2e4885486a"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_f70e9ded140941b2bccb2f5fdf248344",
+          "input_ff646cc4387d40cd835ae097c32dfd7a",
+          "combine_95af303193ef404c925a45297b8ab3a4",
+          "phase_915196b2d8354160b5afa70539edb91a",
+          "recombine_b3f5ba350d134c31a7263bddf98f769f",
+          "output_f42fb7cc8e7c4a9bae6f0912998ff680"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "d193b150-e9a2-4eb9-bd57-01e672ca5f20",
+            "StartComponentId": "input_f70e9ded140941b2bccb2f5fdf248344",
+            "StartComponentGuid": "305f0f64-7225-4a94-90cc-ba35dbcac7b3",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_95af303193ef404c925a45297b8ab3a4",
+            "EndComponentGuid": "d0de2ada-c443-4ab9-9f72-5354bdcb6a23",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "c2e52bca-6370-4d87-8906-afd47a9d79e7",
+            "StartComponentId": "input_ff646cc4387d40cd835ae097c32dfd7a",
+            "StartComponentGuid": "9ad79eed-c34b-421c-a27f-7be0d0bb4c49",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_95af303193ef404c925a45297b8ab3a4",
+            "EndComponentGuid": "d0de2ada-c443-4ab9-9f72-5354bdcb6a23",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "bc6e02c0-0497-42d8-974a-8913327b4471",
+            "StartComponentId": "combine_95af303193ef404c925a45297b8ab3a4",
+            "StartComponentGuid": "d0de2ada-c443-4ab9-9f72-5354bdcb6a23",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_b3f5ba350d134c31a7263bddf98f769f",
+            "EndComponentGuid": "22da74ae-7755-40eb-9a4e-8693d2d6c2f8",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "fa276600-2316-4596-b0df-9ae554c299d7",
+            "StartComponentId": "phase_915196b2d8354160b5afa70539edb91a",
+            "StartComponentGuid": "b4aecd26-77a3-4365-a646-81f177938c2a",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_b3f5ba350d134c31a7263bddf98f769f",
+            "EndComponentGuid": "22da74ae-7755-40eb-9a4e-8693d2d6c2f8",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "2ea29c75-8f8a-4c73-bf96-e04a1fc5cc5f",
+            "StartComponentId": "recombine_b3f5ba350d134c31a7263bddf98f769f",
+            "StartComponentGuid": "22da74ae-7755-40eb-9a4e-8693d2d6c2f8",
+            "StartPinName": "out1",
+            "EndComponentId": "output_f42fb7cc8e7c4a9bae6f0912998ff680",
+            "EndComponentGuid": "71d7e73b-276c-44aa-9bb1-fb2e4885486a",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "efb99c0b-1835-4bee-a86d-297f0f937cbd",
+            "Name": "A",
+            "InternalComponentId": "input_f70e9ded140941b2bccb2f5fdf248344",
+            "InternalComponentGuid": "305f0f64-7225-4a94-90cc-ba35dbcac7b3",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a27157ea-1b30-42aa-9e04-dd5ead3386cd",
+            "Name": "B",
+            "InternalComponentId": "input_ff646cc4387d40cd835ae097c32dfd7a",
+            "InternalComponentGuid": "9ad79eed-c34b-421c-a27f-7be0d0bb4c49",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "28429730-3cb9-413c-8abb-cc32f8bd9def",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_915196b2d8354160b5afa70539edb91a",
+            "InternalComponentGuid": "b4aecd26-77a3-4365-a646-81f177938c2a",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "864fbb04-1ff5-487c-bd89-f503ba646c1d",
+            "Name": "Y",
+            "InternalComponentId": "output_f42fb7cc8e7c4a9bae6f0912998ff680",
+            "InternalComponentGuid": "71d7e73b-276c-44aa-9bb1-fb2e4885486a",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_f70e9ded140941b2bccb2f5fdf248344",
+          "ComponentGuid": "305f0f64-7225-4a94-90cc-ba35dbcac7b3",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "input_ff646cc4387d40cd835ae097c32dfd7a",
+          "ComponentGuid": "9ad79eed-c34b-421c-a27f-7be0d0bb4c49",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        },
+        {
+          "Identifier": "combine_95af303193ef404c925a45297b8ab3a4",
+          "ComponentGuid": "d0de2ada-c443-4ab9-9f72-5354bdcb6a23",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_915196b2d8354160b5afa70539edb91a",
+          "ComponentGuid": "b4aecd26-77a3-4365-a646-81f177938c2a",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_b3f5ba350d134c31a7263bddf98f769f",
+          "ComponentGuid": "22da74ae-7755-40eb-9a4e-8693d2d6c2f8",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_f42fb7cc8e7c4a9bae6f0912998ff680",
+          "ComponentGuid": "71d7e73b-276c-44aa-9bb1-fb2e4885486a",
+          "TemplateName": "Straight Waveguide 100\u00b5m",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100\u00b5m"
+        }
+      ],
+      "CanvasX": 900,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "OutputSignalNames": {
+          "Y": "Q"
+        },
+        "IsRegister": true
+      }
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-20",
+      "Modified": "2026-08-20T00:00:00.0000000Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -10,6 +10,7 @@
     { "file": "Logic Gate 4-Bit Adder.lun", "rank": 80, "level": "Datapath", "descriptionKey": "Examples.RippleCarryAdder.Description" },
     { "file": "Logic Gate ALU 1-bit.lun", "rank": 85, "level": "Datapath", "descriptionKey": "Examples.Alu.Description" },
     { "file": "Logic Gate SR-Latch.lun", "rank": 90, "level": "Sequential", "descriptionKey": "Examples.SrLatch.Description" },
+    { "file": "Logic Gate Bit.lun", "rank": 95, "level": "Sequential", "descriptionKey": "Examples.Bit.Description" },
     { "file": "Logic Gate Counter 2-bit.lun", "rank": 100, "level": "Sequential", "descriptionKey": "Examples.Counter2bit.Description" }
   ]
 }


### PR DESCRIPTION
Automated implementation for #1119

That's the full-suite run I already consumed — **6338 passed / 0 failed / 14 skipped (env-gated), 8m15s**. Results were incorporated into the final verification, and the change set is committed on `agent/issue-1119-1787240817` (710f5f3a). Nothing further to do.


## [AGENT] Agent Stats

- **Sessions:** 1
- **Total turns:** 0
- **Total tokens:** 100,888
- **Estimated cost:** $0.0565 USD

**Custom Tools Used:** None


---
🤖 *Generated by the Autonomous Issue Agent (Claude Code).*

<details><summary><b>How to steer this agent</b> (labels &amp; comments)</summary>

**On an issue:**
- `agent-task` — the agent picks it up and implements it
- `complex` — bigger budget + a UX design pass + a step-by-step screenshot walkthrough, and runs the coder on the premium Claude model
- **Cost tier** (coder model): `eco` = cheapest · *(no tier label)* = repo default · `claudeapi` = force premium Claude
- `Team branch: team/x` — branch off `team/x` and target the PR at it (auto-created if missing)

**On this PR:**
- Comment `@agent <request>` — the agent implements your feedback on this branch and replies with a report + updated screenshots
</details>