### PR TITLE
E2E journey test across the sequential Logic panel slices (#1120)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayExit": "Zurück zu Live",
   "LogicPanel.Registers": "Register:",
   "LogicPanel.StepClock": "Takt weiterschalten",
+  "LogicPanel.ClockDivider": "── Takt {0} ──",
   "LogicPanel.PlaybackPlay": "▶ Abspielen",
   "LogicPanel.PlaybackPause": "⏸ Anhalten",
   "LogicPanelTimelineHelp.ReplayTitle": "Die Welle Schritt für Schritt",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayExit": "Back to live",
   "LogicPanel.Registers": "Registers:",
   "LogicPanel.StepClock": "Step clock",
+  "LogicPanel.ClockDivider": "── clock {0} ──",
   "LogicPanel.PlaybackPlay": "▶ Play",
   "LogicPanel.PlaybackPause": "⏸ Pause",
   "LogicPanelTimelineHelp.ReplayTitle": "Step through the ripple",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayExit": "Volver en vivo",
   "LogicPanel.Registers": "Registros:",
   "LogicPanel.StepClock": "Avanzar un ciclo de reloj",
+  "LogicPanel.ClockDivider": "── reloj {0} ──",
   "LogicPanel.PlaybackPlay": "▶ Reproducir",
   "LogicPanel.PlaybackPause": "⏸ Pausa",
   "LogicPanelTimelineHelp.ReplayTitle": "Recorre la onda paso a paso",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayExit": "ライブ状態に戻る",
   "LogicPanel.Registers": "レジスタ:",
   "LogicPanel.StepClock": "クロックを1ステップ進める",
+  "LogicPanel.ClockDivider": "── クロック {0} ──",
   "LogicPanel.PlaybackPlay": "▶ 再生",
   "LogicPanel.PlaybackPause": "⏸ 一時停止",
   "LogicPanelTimelineHelp.ReplayTitle": "波紋をステップでたどる",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -1402,6 +1402,7 @@
   "LogicPanel.ReplayExit": "返回实时状态",
   "LogicPanel.Registers": "寄存器:",
   "LogicPanel.StepClock": "时钟单步",
+  "LogicPanel.ClockDivider": "── 时钟 {0} ──",
   "LogicPanel.PlaybackPlay": "▶ 播放",
   "LogicPanel.PlaybackPause": "⏸ 暂停",
   "LogicPanelTimelineHelp.ReplayTitle": "逐步观看波纹传播",

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.Registers.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.Registers.cs
@@ -27,10 +27,12 @@ public partial class LogicPanelViewModel
     /// <summary>
     /// Advances every register by one clock: each register samples its inputs from
     /// the settled network and commits them, then the panel re-settles and refreshes
-    /// the gate-output list and the canvas badges from the new state. The toggle
-    /// timeline is discarded along the way — it described the pre-step settling and
-    /// no longer matches the visible state (timeline integration of step events is
-    /// a separate slice).
+    /// the gate-output list and the canvas badges from the new state. The step's
+    /// commit and ripple entries join the toggle timeline behind a "clock #k"
+    /// divider (issue #1110), so the execution visualizer shows the clocked network
+    /// advancing — inputs settled → clock → registers committed → outputs rippled.
+    /// A step also exits replay: the badges show the new live state, and a frozen
+    /// pre-step instant would otherwise stay highlighted while the state moved on.
     /// </summary>
     [RelayCommand(CanExecute = nameof(HasRegisters))]
     private void StepClock()
@@ -41,11 +43,15 @@ public partial class LogicPanelViewModel
         // timeline's replay artifact re-evaluates the before-toggle bits on every
         // input change, so the last captured state can describe stale inputs.
         // Re-settle with the visible inputs first: the step must sample what the
-        // user actually sees.
+        // user actually sees. The pre-step result is also the replay before-state
+        // of a timeline the step starts.
         var bits = Inputs.ToDictionary(input => input.PinName, input => input.IsOn);
-        _network.Evaluate(bits);
-        _network.Step();
+        var preStepResult = _network.Evaluate(bits);
+        var stepEvents = _network.Step();
+        StopPlayback();
+        SelectedTimelineEvent = null;
         ReEvaluate();
+        AppendClockStepEvents(stepEvents, preStepResult);
         RefreshRegisterStates();
     }
 

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.Timeline.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicPanelViewModel.Timeline.cs
@@ -16,10 +16,14 @@ public partial class LogicPanelViewModel
 {
     private IReadOnlyDictionary<string, bool>? _previousInputBits;
 
+    /// <summary>How many clock steps have appended their entries to the current timeline.</summary>
+    private int _clockStepCount;
+
     /// <summary>
-    /// The switch events of the last input toggle, in <see cref="LogicEventTimeline"/>
-    /// order (time, then gate id, then pin). Empty before the first toggle and after
-    /// a toggle that changed no gate output.
+    /// The switch events of the last input toggle plus the entries of every clock
+    /// step since (issue #1110), in <see cref="LogicEventTimeline"/> order (time,
+    /// then gate id, then pin). Empty before the first toggle or step and after a
+    /// toggle that changed no gate output.
     /// </summary>
     public ObservableCollection<LogicTimelineEventViewModel> TimelineEvents { get; } = new();
 
@@ -31,7 +35,9 @@ public partial class LogicPanelViewModel
     /// Computes the switch events between the last shown input assignment and
     /// <paramref name="currentBits"/> and replaces the displayed timeline. The
     /// first call after a build only records the baseline — no toggle has happened
-    /// yet, so the timeline stays empty. A new toggle also exits replay: the badges
+    /// yet, so the timeline stays empty. A re-evaluation with unchanged bits (the
+    /// re-settle after a clock step) is no toggle at all: the timeline, including
+    /// the step's entries, stays. A new toggle also exits replay: the badges
     /// already show the new live end state, and the before-bits of the previous
     /// toggle no longer describe the network.
     /// </summary>
@@ -44,6 +50,8 @@ public partial class LogicPanelViewModel
             _previousInputBits = currentBits;
             return;
         }
+        if (BitsEqual(_previousInputBits, currentBits))
+            return;
 
         var events = LogicEventTimeline.Compute(_network, _previousInputBits, currentBits);
         _replayBeforeResult = _network.Evaluate(_previousInputBits);
@@ -54,9 +62,53 @@ public partial class LogicPanelViewModel
             TimelineEvents.Add(new LogicTimelineEventViewModel(e));
         HasTimelineEvents = TimelineEvents.Count > 0;
         _previousInputBits = currentBits;
+        _clockStepCount = 0;
         PreviousTimelineEventCommand.NotifyCanExecuteChanged();
         NextTimelineEventCommand.NotifyCanExecuteChanged();
     }
+
+    /// <summary>
+    /// Appends one clock step's entries (issue #1110) behind the entries of the
+    /// preceding settle phase: a "clock #k" divider opens the block, the commit
+    /// entries land at the timeline's current end time, and the downstream ripple
+    /// follows with non-decreasing times. A quiet clock (no committed output
+    /// changed) leaves the timeline untouched. Replay stays consistent across the
+    /// boundary: the before-state of an empty timeline is the pre-step settling
+    /// <paramref name="preStepResult"/>; a timeline that already has entries keeps
+    /// its original before-state, since the step's events continue from it.
+    /// </summary>
+    private void AppendClockStepEvents(
+        IReadOnlyList<LogicSwitchEvent> stepEvents,
+        IReadOnlyDictionary<string, bool> preStepResult)
+    {
+        if (stepEvents.Count == 0)
+            return;
+        if (TimelineEvents.Count == 0)
+            _replayBeforeResult = preStepResult;
+        _clockStepCount++;
+        var offset = TimelineEvents.Count == 0 ? 0.0 : TimelineEvents[^1].Event.TimePicoseconds;
+        var divider = string.Format(Translate("LogicPanel.ClockDivider"), _clockStepCount);
+        var isBlockFirst = true;
+        foreach (var e in stepEvents)
+        {
+            // The divider label rides on the block's first row — it is display
+            // metadata, so the row itself stays a normal selectable event.
+            TimelineEvents.Add(new LogicTimelineEventViewModel(
+                e with { TimePicoseconds = e.TimePicoseconds + offset })
+            {
+                ClockBoundaryText = isBlockFirst ? divider : "",
+            });
+            isBlockFirst = false;
+        }
+        HasTimelineEvents = true;
+        PreviousTimelineEventCommand.NotifyCanExecuteChanged();
+        NextTimelineEventCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>Two input assignments are equal when every named bit matches.</summary>
+    private static bool BitsEqual(
+        IReadOnlyDictionary<string, bool> a, IReadOnlyDictionary<string, bool> b) =>
+        a.Count == b.Count && a.All(pair => b.TryGetValue(pair.Key, out var bit) && bit == pair.Value);
 
     /// <summary>Discards the displayed timeline, the input baseline, and any active replay.</summary>
     private void ClearTimeline()
@@ -64,6 +116,7 @@ public partial class LogicPanelViewModel
         TimelineEvents.Clear();
         HasTimelineEvents = false;
         _previousInputBits = null;
+        _clockStepCount = 0;
         ClearReplay();
     }
 }

--- a/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicTimelineEventViewModel.cs
+++ b/CAP.Avalonia/ViewModels/Analysis/LogicAnalysis/LogicTimelineEventViewModel.cs
@@ -37,6 +37,18 @@ public partial class LogicTimelineEventViewModel : ObservableObject
     public string TransitionText => IsRising ? "0→1" : "1→0";
 
     /// <summary>
+    /// The "clock #k" divider label shown above this row when it is the first entry
+    /// a clock step appended (issue #1110): the boundary between the preceding settle
+    /// phase and the register commit. Empty for settle-phase rows, so the timeline
+    /// reads "inputs settled → clock → registers committed → outputs rippled".
+    /// Display metadata only — the row stays a normal selectable event for replay.
+    /// </summary>
+    public string ClockBoundaryText { get; init; } = "";
+
+    /// <summary>True when this row opens a clock-step block behind a divider label.</summary>
+    public bool HasClockBoundary => ClockBoundaryText.Length > 0;
+
+    /// <summary>
     /// True while this row is the replayed event (issue #1058): the panel highlights the
     /// row and the canvas badges show the network state at this event's time.
     /// </summary>

--- a/CAP.Avalonia/Views/Panels/LogicPanel.axaml
+++ b/CAP.Avalonia/Views/Panels/LogicPanel.axaml
@@ -302,15 +302,24 @@
                                 Classes.selected="{Binding IsSelected}"
                                 Command="{Binding $parent[ItemsControl].DataContext.RightPanel.Logic.SelectTimelineEventCommand}"
                                 CommandParameter="{Binding}">
-                            <StackPanel Orientation="Horizontal" Margin="0,1">
-                                <TextBlock Text="{Binding TimeText}" Foreground="#cfe0ff"
-                                           FontFamily="Consolas" FontSize="11" Width="70" VerticalAlignment="Center"/>
-                                <TextBlock Text="{Binding GatePinText}" Foreground="LightGray"
-                                           FontFamily="Consolas" FontSize="11" Width="110" VerticalAlignment="Center"/>
-                                <TextBlock Text="{Binding TransitionText}" FontFamily="Consolas" FontSize="11" FontWeight="Bold"
-                                           Foreground="LightGreen" IsVisible="{Binding IsRising}"/>
-                                <TextBlock Text="{Binding TransitionText}" FontFamily="Consolas" FontSize="11" FontWeight="Bold"
-                                           Foreground="Gray" IsVisible="{Binding IsRising, Converter={x:Static BoolConverters.Not}}"/>
+                            <StackPanel>
+                                <!-- Clock-step boundary (#1110): the divider label rides on the
+                                     first row a Step appended, so the timeline reads
+                                     "inputs settled → clock → registers committed → outputs rippled". -->
+                                <TextBlock Text="{Binding ClockBoundaryText}" Foreground="#e6c860"
+                                           FontFamily="Consolas" FontSize="10" FontWeight="Bold"
+                                           Margin="0,4,0,0"
+                                           IsVisible="{Binding HasClockBoundary}"/>
+                                <StackPanel Orientation="Horizontal" Margin="0,1">
+                                    <TextBlock Text="{Binding TimeText}" Foreground="#cfe0ff"
+                                               FontFamily="Consolas" FontSize="11" Width="70" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding GatePinText}" Foreground="LightGray"
+                                               FontFamily="Consolas" FontSize="11" Width="110" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding TransitionText}" FontFamily="Consolas" FontSize="11" FontWeight="Bold"
+                                               Foreground="LightGreen" IsVisible="{Binding IsRising}"/>
+                                    <TextBlock Text="{Binding TransitionText}" FontFamily="Consolas" FontSize="11" FontWeight="Bold"
+                                               Foreground="Gray" IsVisible="{Binding IsRising, Converter={x:Static BoolConverters.Not}}"/>
+                                </StackPanel>
                             </StackPanel>
                         </Button>
                     </DataTemplate>

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicEventTimeline.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicEventTimeline.cs
@@ -22,11 +22,13 @@ public sealed record LogicSwitchEvent(
 /// switches at <c>max(arrival over its inputs) + gateDelay</c>, where an arrival
 /// is the driver's switch time plus that wire's delay (a driver that never
 /// switches contributes a stable arrival of 0). Gates whose output value does
-/// not change emit no event. Register gates emit no events at all: their outputs
+/// not change emit no event. Register gates emit no settle events: their outputs
 /// hold the committed state through the settling and only advance on an explicit
-/// clock step, which a combinational toggle timeline does not model. This slice
-/// models exactly one switch per pin — no glitch/hazard modeling — and reuses the
-/// evaluator's <see cref="LogicNetworkEvaluator.GateDelaysPicoseconds"/> and
+/// clock step, whose commit entries and downstream ripple
+/// (<see cref="ComputeRegisterRipple"/>) <see cref="LogicNetworkEvaluator.Step"/>
+/// returns itself. This slice models exactly one switch per pin per phase — no
+/// glitch/hazard modeling — and reuses the evaluator's
+/// <see cref="LogicNetworkEvaluator.GateDelaysPicoseconds"/> and
 /// <see cref="LogicNetworkEvaluator.WireDelaysPicoseconds"/> without recomputing
 /// any physics.
 /// </summary>
@@ -57,8 +59,47 @@ public static class LogicEventTimeline
 
         var before = network.EvaluateGateOutputs(previousInputs);
         var after = network.EvaluateGateOutputs(nextInputs);
+        return ComputeSwitchEvents(network, before, after, seeds: null);
+    }
 
-        var switchTimes = new Dictionary<LogicPinRef, double>();
+    /// <summary>
+    /// Computes the downstream ripple of a clock commit: the register outputs in
+    /// <paramref name="changedRegisterPins"/> switch at the clock edge (t = 0) and
+    /// the combinational gates settle after them. Times are relative to the edge,
+    /// so every ripple event sits at a non-negative time after the commit entries.
+    /// </summary>
+    /// <param name="network">The network to walk; supplies gates, wiring, and delays.</param>
+    /// <param name="before">The settled gate outputs just before the commit.</param>
+    /// <param name="after">The settled gate outputs just after the commit.</param>
+    /// <param name="changedRegisterPins">The register output pins that switched at the edge.</param>
+    /// <returns>The ripple events in <see cref="Compute"/> order; empty when nothing downstream switched.</returns>
+    internal static IReadOnlyList<LogicSwitchEvent> ComputeRegisterRipple(
+        LogicNetworkEvaluator network,
+        IReadOnlyDictionary<LogicPinRef, bool> before,
+        IReadOnlyDictionary<LogicPinRef, bool> after,
+        IReadOnlyCollection<LogicPinRef> changedRegisterPins)
+    {
+        var seeds = new Dictionary<LogicPinRef, double>();
+        foreach (var pin in changedRegisterPins)
+            seeds[pin] = 0.0;
+        return ComputeSwitchEvents(network, before, after, seeds);
+    }
+
+    /// <summary>
+    /// The shared event walk: one event per non-register output pin whose settled
+    /// value differs between <paramref name="before"/> and <paramref name="after"/>,
+    /// timed at <c>max(arrival over its inputs) + gateDelay</c>. <paramref name="seeds"/>
+    /// pre-seeds switch times of pins that switched at t = 0 without being walked
+    /// (the committed register outputs of a clock step); a null seed set is the
+    /// input-toggle case, where only the stable-from-t = 0 network inputs drive.
+    /// </summary>
+    private static IReadOnlyList<LogicSwitchEvent> ComputeSwitchEvents(
+        LogicNetworkEvaluator network,
+        IReadOnlyDictionary<LogicPinRef, bool> before,
+        IReadOnlyDictionary<LogicPinRef, bool> after,
+        Dictionary<LogicPinRef, double>? seeds)
+    {
+        var switchTimes = seeds ?? new Dictionary<LogicPinRef, double>();
         var events = new List<LogicSwitchEvent>();
         foreach (var gateId in network.EvaluationOrder)
         {

--- a/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Registers.cs
+++ b/Connect-A-Pic-Core/Analysis/LogicAnalysis/LogicNetworkEvaluator.Registers.cs
@@ -39,18 +39,27 @@ public sealed partial class LogicNetworkEvaluator
     /// same pre-step state (simultaneous commit, D-FF semantics), and the network
     /// is re-settled afterwards, so consecutive steps advance consecutive clocks.
     /// </summary>
+    /// <returns>
+    /// The timeline entries of the step, relative to the clock edge at t = 0: one
+    /// commit entry per register output pin that changed (gate id, pin, new bit),
+    /// then the downstream ripple of the post-commit settling in
+    /// <see cref="LogicEventTimeline"/> order — nothing is recomputed, this is what
+    /// the step just did. Empty when no committed output changed (a quiet clock)
+    /// or when the network has no registers at all.
+    /// </returns>
     /// <exception cref="InvalidOperationException">
     /// <see cref="Evaluate"/> was never called — there is no settled state to sample.
     /// </exception>
-    public void Step()
+    public IReadOnlyList<LogicSwitchEvent> Step()
     {
         if (_lastInputBits == null || _lastSettledOutputs == null)
             throw new InvalidOperationException(
                 "Step() requires a settled network: call Evaluate at least once before the " +
                 "first Step, so the register inputs have values to sample.");
         if (_registerGateIds.Count == 0)
-            return;
+            return Array.Empty<LogicSwitchEvent>();
 
+        var settledBefore = _lastSettledOutputs;
         var sampled = new Dictionary<LogicPinRef, bool>();
         foreach (var gateId in _registerGateIds)
         {
@@ -67,11 +76,23 @@ public sealed partial class LogicNetworkEvaluator
             }
         }
 
+        var changed = new List<LogicPinRef>();
         foreach (var (pin, bit) in sampled)
         {
+            if (_committedRegisterOutputs[pin] != bit)
+                changed.Add(pin);
             _committedRegisterOutputs[pin] = bit;
         }
         _lastSettledOutputs = EvaluateGateOutputs(_lastInputBits);
+        if (changed.Count == 0)
+            return Array.Empty<LogicSwitchEvent>();
+
+        var commits = changed
+            .OrderBy(pin => pin.GateId, StringComparer.Ordinal)
+            .ThenBy(pin => pin.PinName, StringComparer.Ordinal)
+            .Select(pin => new LogicSwitchEvent(0.0, pin.GateId, pin.PinName, _committedRegisterOutputs[pin]));
+        var ripple = LogicEventTimeline.ComputeRegisterRipple(this, settledBefore, _lastSettledOutputs, changed);
+        return commits.Concat(ripple).ToList();
     }
 
     /// <summary>

--- a/UnitTests/Analysis/LogicAnalysis/LogicNetworkStepTimelineTests.cs
+++ b/UnitTests/Analysis/LogicAnalysis/LogicNetworkStepTimelineTests.cs
@@ -1,0 +1,190 @@
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Analysis.LogicAnalysis;
+
+/// <summary>
+/// The clock step as a timeline source (issue #1110, rung 5 visualizer):
+/// <see cref="LogicNetworkEvaluator.Step"/> returns the entries the execution
+/// visualizer appends — one commit entry per register output pin that changed
+/// (at the clock edge, t = 0) and the downstream ripple of the post-commit
+/// settling after it, all relative to the edge. Covered at the net-list level:
+/// a D-flip-flop (commit only), the register + inverter toggle loop (commit plus
+/// ripple with real delays), the cross-coupled NAND SR latch (both commits land
+/// on the same edge), the quiet clock (no change, no entries), and the purely
+/// combinational network (never any clock entries).
+/// </summary>
+public class LogicNetworkStepTimelineTests
+{
+    private const double InverterGateDelayPs = 5.0;
+    private const double RegisterToInverterWirePs = 2.0;
+
+    [Fact]
+    public void Step_DFlipFlop_CommitsTheSampledInputAsOneEdgeEntry()
+    {
+        var network = DFlipFlop();
+        network.Evaluate(Bits(("d", true)));
+
+        var entries = network.Step();
+
+        entries.ShouldBe(new[] { new LogicSwitchEvent(0.0, "reg", "Y", true) },
+            "the D-flip-flop's commit lands at the clock edge — no downstream logic, no ripple");
+    }
+
+    [Fact]
+    public void Step_ToggleLoop_CommitEntryPrecedesTheRippleWithArrivalTimes()
+    {
+        var network = ToggleLoop();
+
+        network.Evaluate(Bits(("x", false)));
+        var first = network.Step();
+
+        first.ShouldBe(new[]
+            {
+                new LogicSwitchEvent(0.0, "reg", "Y", true),
+                new LogicSwitchEvent(RegisterToInverterWirePs + InverterGateDelayPs, "inv", "Y", false),
+            },
+            "the register commits at the edge; the inverter follows after wire + gate delay");
+
+        var second = network.Step();
+        second.ShouldBe(new[]
+            {
+                new LogicSwitchEvent(0.0, "reg", "Y", false),
+                new LogicSwitchEvent(RegisterToInverterWirePs + InverterGateDelayPs, "inv", "Y", true),
+            },
+            "the next clock flips the loop back — again commit first, ripple after");
+    }
+
+    [Fact]
+    public void Step_SrLatch_BothCrossCoupledCommitsLandOnTheSameEdge()
+    {
+        var network = SrLatch();
+        network.Evaluate(Bits(("s", false), ("r", true)));
+
+        var first = network.Step();
+        first.ShouldBe(new[]
+            {
+                new LogicSwitchEvent(0.0, "qGate", "Y", true),
+                new LogicSwitchEvent(0.0, "qbGate", "Y", true),
+            },
+            "both NAND registers sample the powered-up 0/0 and commit 1 — the latch's transient");
+
+        var second = network.Step();
+        second.ShouldBe(new[] { new LogicSwitchEvent(0.0, "qbGate", "Y", false) },
+            "the second clock settles the latch: Q̄ falls while Q holds (NAND(S̄=0, …) = 1 is unchanged)");
+    }
+
+    [Fact]
+    public void Step_QuietClock_RecordsNoEntriesButKeepsTheState()
+    {
+        var network = SrLatch();
+        network.Evaluate(Bits(("s", false), ("r", true)));
+        network.Step();
+        network.Step();
+
+        network.Step().ShouldBeEmpty("holding inputs change nothing — a quiet clock has nothing to record");
+        network.Step().ShouldBeEmpty();
+        network.Evaluate(Bits(("s", true), ("r", true)))["q"].ShouldBeTrue("the latch still holds its state");
+    }
+
+    [Fact]
+    public void Step_PurelyCombinationalNetwork_NeverProducesClockEntries()
+    {
+        var network = new LogicNetworkEvaluator(
+            new[] { "d" },
+            new Dictionary<string, LogicGateModel> { ["inv"] = PinnedGateTables.NotGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.NetworkInput("d"),
+            },
+            new Dictionary<string, LogicPinRef> { ["q"] = new("inv", "Y") });
+        network.Evaluate(Bits(("d", true)));
+
+        network.Step().ShouldBeEmpty("no registers — clocking is meaningless");
+        network.Step().ShouldBeEmpty();
+    }
+
+    /// <summary>One buffer register with D as its only network input and Q as its tap.</summary>
+    private static LogicNetworkEvaluator DFlipFlop() =>
+        new(
+            new[] { "d" },
+            new Dictionary<string, LogicGateModel> { ["reg"] = BufferGate() },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("reg", "A")] = new LogicNetDriver.NetworkInput("d"),
+            },
+            new Dictionary<string, LogicPinRef> { ["q"] = new("reg", "Y") },
+            registerGateIds: new[] { "reg" });
+
+    /// <summary>
+    /// The toggle loop reg = NOT(reg) once clocked, with a real delay on the
+    /// register → inverter wire and on the inverter itself, so the ripple's
+    /// arrival times are exercised (the declared input "x" drives nothing, but
+    /// Evaluate still requires its bit).
+    /// </summary>
+    private static LogicNetworkEvaluator ToggleLoop() =>
+        new(
+            new[] { "x" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["reg"] = BufferGate(),
+                ["inv"] = PinnedGateTables.NotGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("reg", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("inv", "Y")),
+                [new LogicPinRef("inv", "A")] = new LogicNetDriver.GateOutput(new LogicPinRef("reg", "Y")),
+            },
+            new Dictionary<string, LogicPinRef> { ["q"] = new("reg", "Y") },
+            gateDelays: new Dictionary<string, double> { ["inv"] = InverterGateDelayPs },
+            wireDelays: new Dictionary<LogicWireEdge, double>
+            {
+                [new LogicWireEdge(new LogicPinRef("reg", "Y"), new LogicPinRef("inv", "A"))] =
+                    RegisterToInverterWirePs,
+            },
+            registerGateIds: new[] { "reg" });
+
+    /// <summary>
+    /// Two cross-coupled NAND gates, both designated registers: Q = NAND(S̄, Q̄),
+    /// Q̄ = NAND(R̄, Q) with active-low set/reset — the classic SR latch.
+    /// </summary>
+    private static LogicNetworkEvaluator SrLatch() =>
+        new(
+            new[] { "s", "r" },
+            new Dictionary<string, LogicGateModel>
+            {
+                ["qGate"] = PinnedGateTables.NandGate(),
+                ["qbGate"] = PinnedGateTables.NandGate(),
+            },
+            new Dictionary<LogicPinRef, LogicNetDriver>
+            {
+                [new LogicPinRef("qGate", "A")] = new LogicNetDriver.NetworkInput("s"),
+                [new LogicPinRef("qGate", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("qbGate", "Y")),
+                [new LogicPinRef("qbGate", "A")] = new LogicNetDriver.NetworkInput("r"),
+                [new LogicPinRef("qbGate", "B")] = new LogicNetDriver.GateOutput(new LogicPinRef("qGate", "Y")),
+            },
+            new Dictionary<string, LogicPinRef>
+            {
+                ["q"] = new("qGate", "Y"),
+                ["qb"] = new("qbGate", "Y"),
+            },
+            registerGateIds: new[] { "qGate", "qbGate" });
+
+    /// <summary>The D-flip-flop's combinational core: a buffer, Y = A.</summary>
+    private static LogicGateModel BufferGate()
+    {
+        var inputs = new[] { "A" };
+        var rows = new[] { false, true }
+            .Select(bit => new TruthTableRow(
+                new Dictionary<string, bool> { ["A"] = bit },
+                new Dictionary<string, LogicOutputValue> { ["Y"] = new(bit, bit ? 0.5 : 0.0) }))
+            .ToArray();
+        return LogicGateModel.FromTruthTable(
+            new TruthTable("Buffer", inputs, new[] { "Y" }, 0.25, PinnedGateTables.WavelengthNm, rows));
+    }
+
+    /// <summary>Builds an input-bit dictionary from (name, bit) pairs.</summary>
+    private static Dictionary<string, bool> Bits(params (string Name, bool Bit)[] bits) =>
+        bits.ToDictionary(pair => pair.Name, pair => pair.Bit);
+}

--- a/UnitTests/Integration/LogicPanelStepTimelineTests.cs
+++ b/UnitTests/Integration/LogicPanelStepTimelineTests.cs
@@ -1,0 +1,239 @@
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using Shouldly;
+using UnitTests.Analysis.LogicAnalysis;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// ViewModel tests for clock steps on the Logic panel's event timeline (issue
+/// #1110, rung 5 visualizer): on the shipped <c>examples/Logic Gate SR-Latch.lun</c>,
+/// pulling S̄ low and stepping appends a "clock #k" divider plus one commit entry
+/// per changed register output; the next step's entries follow with non-decreasing
+/// times. Replay and auto-play walk across the clock boundary with the invariant
+/// of issue #1058 — the badges at t_k equal the before-state plus every event
+/// with time ≤ t_k, mirror-derived from a fresh network without the panel. A
+/// quiet clock appends nothing, and a purely combinational network never shows
+/// clock entries.
+/// </summary>
+public class LogicPanelStepTimelineTests : IClassFixture<LogicGateSrLatchExampleTests.SrLatchFixture>
+{
+    private const string SetSignal = "S̄";
+    private const string ResetSignal = "R̄";
+    private const double OrThreshold = 0.25;
+
+    private readonly LogicGateSrLatchExampleTests.SrLatchFixture _fixture;
+
+    /// <summary>Attaches the shared SR-latch fixture.</summary>
+    public LogicPanelStepTimelineTests(LogicGateSrLatchExampleTests.SrLatchFixture fixture) =>
+        _fixture = fixture;
+
+    [Fact]
+    public async Task StepClock_SrLatch_CommitEntriesAppearBehindClockDividers()
+    {
+        var vm = await BuildLatchAtRest();
+        vm.TimelineEvents.ShouldBeEmpty("an all-register network produces no settle events");
+
+        vm.Inputs.Single(i => i.PinName == SetSignal).IsOn = false;
+        vm.TimelineEvents.ShouldBeEmpty("registers hold — pulling S̄ low switches nothing yet");
+
+        vm.StepClockCommand.Execute(null);
+
+        vm.TimelineEvents.Count.ShouldBe(2, "both cross-coupled NAND registers commit on the first edge");
+        var qCommit = vm.TimelineEvents[0];
+        qCommit.HasClockBoundary.ShouldBeTrue("a clock divider opens the step's block");
+        qCommit.ClockBoundaryText.ShouldNotBeNullOrEmpty();
+        qCommit.Event.GateId.ShouldBe("NANDQ");
+        qCommit.Event.OutputPin.ShouldBe("Y");
+        qCommit.Event.NewValue.ShouldBeTrue("Q commits to 1 — the latch is set");
+        vm.TimelineEvents[1].HasClockBoundary.ShouldBeFalse("only the block's first row carries the divider");
+        vm.TimelineEvents[1].Event.GateId.ShouldBe("NANDQB");
+        vm.TimelineEvents[1].Event.NewValue.ShouldBeTrue("Q̄ commits to 1 as well — the first edge's transient");
+
+        vm.StepClockCommand.Execute(null);
+
+        vm.TimelineEvents.Count.ShouldBe(3, "the second clock settles the latch: only Q̄ falls");
+        var settle = vm.TimelineEvents[2];
+        settle.HasClockBoundary.ShouldBeTrue("the second step opens its own divider");
+        settle.ClockBoundaryText.ShouldNotBe(qCommit.ClockBoundaryText, "the divider counts the clocks");
+        settle.Event.GateId.ShouldBe("NANDQB");
+        settle.Event.NewValue.ShouldBeFalse();
+        var times = vm.TimelineEvents.Select(e => e.Event.TimePicoseconds).ToList();
+        times.ShouldBe(times.OrderBy(t => t).ToList(),
+            "clock blocks append after the preceding entries with non-decreasing times");
+        vm.RegisterStates.Single(r => r.GateName == "NANDQ").BitsText.ShouldBe("Y = 1");
+        vm.RegisterStates.Single(r => r.GateName == "NANDQB").BitsText.ShouldBe("Y = 0");
+    }
+
+    [Fact]
+    public async Task StepClock_QuietClock_AppendsNothing()
+    {
+        var vm = await BuildLatchAtRest();
+        vm.Inputs.Single(i => i.PinName == SetSignal).IsOn = false;
+        vm.StepClockCommand.Execute(null);
+        vm.StepClockCommand.Execute(null);
+        var entries = vm.TimelineEvents.ToList();
+
+        vm.StepClockCommand.Execute(null);
+
+        vm.TimelineEvents.SequenceEqual(entries).ShouldBeTrue(
+            "a quiet clock has nothing to record — not even a divider");
+    }
+
+    [Fact]
+    public async Task Replay_AcrossTwoClockSteps_BadgesMatchDerivedStateAtEachInstant()
+    {
+        var vm = await BuildLatchAtRest();
+        vm.Inputs.Single(i => i.PinName == SetSignal).IsOn = false;
+        vm.StepClockCommand.Execute(null);
+        vm.StepClockCommand.Execute(null);
+        var beforeState = await MirrorBeforeState();
+
+        for (var k = 0; k < vm.TimelineEvents.Count; k++)
+        {
+            vm.SelectTimelineEventCommand.Execute(vm.TimelineEvents[k]);
+            BadgesShouldShow(
+                StateAt(beforeState, vm.TimelineEvents, vm.TimelineEvents[k].Event.TimePicoseconds),
+                $"event {k} across the clock boundary freezes the badges at its t_k");
+        }
+
+        vm.ExitReplayCommand.Execute(null);
+        BadgesShouldShow(
+            StateAt(beforeState, vm.TimelineEvents, double.MaxValue),
+            "back to live shows the settled post-step state: before-state plus every event");
+    }
+
+    [Fact]
+    public async Task Playback_TicksAcrossTheClockBoundary()
+    {
+        var vm = await BuildLatchAtRest();
+        vm.Inputs.Single(i => i.PinName == SetSignal).IsOn = false;
+        vm.StepClockCommand.Execute(null);
+        vm.StepClockCommand.Execute(null);
+
+        vm.TogglePlaybackCommand.Execute(null);
+        vm.SelectedTimelineEvent.ShouldBe(vm.TimelineEvents[0], "play starts at the first commit");
+
+        vm.AdvancePlaybackTick();
+        vm.AdvancePlaybackTick();
+        vm.SelectedTimelineEvent.ShouldBe(vm.TimelineEvents[2],
+            "the tick walks straight across the clock divider — display metadata, not a barrier");
+        vm.TimelineEvents[2].HasClockBoundary.ShouldBeTrue();
+
+        vm.AdvancePlaybackTick();
+        vm.IsPlaying.ShouldBeFalse("the tick after the last event ends playback in the live state");
+    }
+
+    [Fact]
+    public async Task Timeline_PurelyCombinationalNetwork_NeverShowsClockEntries()
+    {
+        var canvas = new DesignCanvasViewModel();
+        canvas.Components.Add(new ComponentViewModel(CombinationalOrGate("OR1")));
+        var vm = new LogicPanelViewModel();
+        vm.Configure(canvas);
+        await vm.BuildNetworkCommand.ExecuteAsync(null);
+        vm.HasNetwork.ShouldBeTrue(vm.StatusText);
+
+        vm.Inputs.Single(i => i.PinName == "OR1.a").IsOn = true;
+
+        vm.TimelineEvents.ShouldNotBeEmpty("the toggle ripples through the gate");
+        vm.TimelineEvents.ShouldAllBe(
+            row => !row.HasClockBoundary,
+            "no clock divider can appear — the network has no registers to clock");
+        vm.StepClockCommand.CanExecute(null).ShouldBeFalse();
+    }
+
+    /// <summary>Builds the latch's network on the fixture canvas and rests both active-low inputs high.</summary>
+    private async Task<LogicPanelViewModel> BuildLatchAtRest()
+    {
+        var vm = new LogicPanelViewModel();
+        vm.Configure(_fixture.Canvas);
+        await vm.BuildNetworkCommand.ExecuteAsync(null);
+        vm.HasNetwork.ShouldBeTrue(vm.StatusText);
+        vm.HasRegisters.ShouldBeTrue("both NAND gates of the latch are designated registers");
+        vm.Inputs.Single(i => i.PinName == SetSignal).IsOn = true;
+        vm.Inputs.Single(i => i.PinName == ResetSignal).IsOn = true;
+        return vm;
+    }
+
+    /// <summary>
+    /// The settled state the displayed timeline starts from, derived from a fresh
+    /// mirror network (registers power up cleared, S̄ pulled low, R̄ resting high)
+    /// — never from the panel under test.
+    /// </summary>
+    private async Task<Dictionary<string, bool>> MirrorBeforeState()
+    {
+        var mirror = await LogicGateMuxExampleTests.AssembleNetwork(_fixture.Canvas);
+        return ByGatePin(mirror, mirror.Evaluate(_fixture.InputBits(set: false, reset: true)));
+    }
+
+    /// <summary>Re-keys a tap-keyed evaluation result by raw <c>gate.pin</c> (see issue #1046).</summary>
+    private static Dictionary<string, bool> ByGatePin(
+        LogicNetworkEvaluator network, IReadOnlyDictionary<string, bool> tapKeyed) =>
+        network.OutputTaps.ToDictionary(
+            tap => $"{tap.Value.GateId}.{tap.Value.PinName}", tap => tapKeyed[tap.Key]);
+
+    /// <summary>
+    /// The independently derived state at time t: the before-state plus the new
+    /// value of every displayed event whose time is ≤ t — the rule of issue #1058
+    /// re-derived in test code without touching the ViewModel's replay path.
+    /// </summary>
+    private static Dictionary<string, bool> StateAt(
+        IReadOnlyDictionary<string, bool> beforeState,
+        IEnumerable<LogicTimelineEventViewModel> displayedEvents,
+        double timePicoseconds)
+    {
+        var state = new Dictionary<string, bool>(beforeState);
+        foreach (var row in displayedEvents)
+        {
+            if (row.Event.TimePicoseconds > timePicoseconds)
+                break;
+            state[$"{row.Event.GateId}.{row.Event.OutputPin}"] = row.Event.NewValue;
+        }
+        return state;
+    }
+
+    /// <summary>
+    /// The output-pin badges currently on the canvas, keyed <c>gate.pin</c>. Named
+    /// input chips (issue #1051) carry the live input bits, not gate output
+    /// states — replay derivations exclude them.
+    /// </summary>
+    private Dictionary<string, bool> BadgeStates() =>
+        _fixture.Canvas.LogicGateStates.Badges
+            .Where(IsOutputChip)
+            .ToDictionary(b => $"{b.GroupName}.{b.PinName}", b => b.IsOne);
+
+    /// <summary>True for a chip on a gate's output tap — anonymous or named (issue #1067).</summary>
+    private bool IsOutputChip(LogicGateBadgeViewModel badge) =>
+        _fixture.Network.OutputTaps.Values.Any(
+            p => p.GateId == badge.GroupName && p.PinName == badge.PinName);
+
+    /// <summary>Asserts the canvas badges show exactly the expected pin states.</summary>
+    private void BadgesShouldShow(IReadOnlyDictionary<string, bool> expected, string because)
+    {
+        var actual = BadgeStates();
+        actual.Count.ShouldBe(expected.Count, because);
+        foreach (var (tap, bit) in expected)
+            actual[tap].ShouldBe(bit, $"{tap}: {because}");
+    }
+
+    /// <summary>A combinational combiner group with the OR-reading assignment persisted.</summary>
+    private static ComponentGroup CombinationalOrGate(string groupName)
+    {
+        var group = LogicGateFixtureFactory.CreateCombinerGroup();
+        group.GroupName = groupName;
+        group.TruthTablePinAssignment = new TruthTablePinAssignment
+        {
+            InputPinNames = new List<string> { "a", "b" },
+            OutputPinNames = new List<string> { "y" },
+            BiasPinNames = new List<string>(),
+            Threshold = OrThreshold,
+            IsRegister = false,
+        };
+        group.EnsureSMatrixComputed();
+        return group;
+    }
+}

--- a/UnitTests/Integration/SequentialJourneyE2ETests.cs
+++ b/UnitTests/Integration/SequentialJourneyE2ETests.cs
@@ -1,0 +1,242 @@
+using System.Globalization;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis.BusView;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Kill-review E2E over the merged sequential batch (issue #1120): one user journey
+/// across the slices that shipped individually — register core (#1093), toggle UI
+/// (#1104), Step button (#1105), 2-bit counter (#1114) and step-timeline entries
+/// (#1110). Each slice carries its own tests, but no test walked the journey across
+/// all of them at the panel layer — and seams between individually-green slices are
+/// where honesty breaks (the black-hole-import lesson of #1001/#1005). The journey,
+/// headless at the panel layer (no rendering): (1) load the shipped
+/// <c>examples/Logic Gate Counter 2-bit.lun</c> through the real load path
+/// (<c>FileOperationsViewModel.LoadDesignFromPathAsync</c>, via the fixture), (2)
+/// assemble the network through <see cref="LogicPanelViewModel"/> exactly as the
+/// panel's build button does, (3) read the register readout and rest the one named
+/// toggle <c>S̄</c> high, (4) press Step five times — the bus row <c>C</c> counts
+/// 1, 2, 3, 0, 1 (wrap included) while every step appends a "clock #k" divider block
+/// whose commit entries open the block and whose ripple times never decrease, (5)
+/// replay backwards across a clock boundary — the badges match the mirror-derived
+/// state at every t_k (pattern of <c>LogicPanelStepTimelineTests</c>), and (6) save
+/// through the real save path, reload, re-assemble: the register readout, signal
+/// names and bus rows are identical and stepping resumes the count from power-up
+/// (00). A failing step here is a defect finding, not a test to weaken.
+/// </summary>
+public class SequentialJourneyE2ETests : IClassFixture<LogicGateCounter2BitExampleTests.CounterFixture>
+{
+    private const string PresetSignal = "S̄";
+    private const string CountBusPrefix = "C";
+    private static readonly int[] ExpectedCounts = { 1, 2, 3, 0, 1 };
+
+    private readonly LogicGateCounter2BitExampleTests.CounterFixture _fixture;
+
+    /// <summary>Attaches the shared counter fixture.</summary>
+    public SequentialJourneyE2ETests(LogicGateCounter2BitExampleTests.CounterFixture fixture) =>
+        _fixture = fixture;
+
+    /// <summary>The resting input bits: the active-low preset toggle stays high while counting.</summary>
+    private static Dictionary<string, bool> RestingBits() => new() { [PresetSignal] = true };
+
+    [Fact]
+    public async Task CounterJourney_OpenStepWatchReplaySaveLoad_PanelLevel()
+    {
+        // (1) The example loads through the real load path (fixture init ran
+        // FileOperationsViewModel.LoadDesignFromPathAsync) with every gate group.
+        _fixture.Groups.Select(g => g.GroupName).ShouldBe(
+            new[] { "Q0", "COPY0", "COPY0X", "X0", "R0", "S0", "COPY1", "COPYX", "Q1" },
+            ignoreOrder: true,
+            customMessage: "step 1: the shipped 2-bit counter loads through the real load path");
+        _fixture.Canvas.Connections.Count.ShouldBe(13, "step 1: every counter wire loads");
+
+        // (2) The panel assembles the network through the same command the build button runs.
+        var vm = await BuildPanel(_fixture.Canvas);
+        vm.HasNetwork.ShouldBeTrue($"step 2: the panel's build assembles the counter — {vm.StatusText}");
+
+        // (3) The register readout lists Q0/Q1 powered up cleared; the single named
+        // input toggle S̄ rests on without switching anything (registers hold).
+        vm.HasRegisters.ShouldBeTrue("step 3: the counter carries registers, so the panel shows the Step button");
+        vm.RegisterStates.Select(r => r.GateName).ShouldBe(new[] { "Q0", "Q1" },
+            "step 3: the register readout lists both counter stages");
+        vm.RegisterStates.ShouldAllBe(r => r.BitsText == "Y = 0",
+            "step 3: both registers power up cleared (C1C0 = 00)");
+        vm.Inputs.Select(i => i.PinName).ShouldBe(new[] { PresetSignal },
+            "step 3: the counter's one network input reads as the named toggle S̄");
+        vm.Inputs[0].IsOn = true;
+        vm.TimelineEvents.ShouldBeEmpty("step 3: resting S̄ high switches nothing — the registers hold");
+
+        // (4) Five clock steps: the bus row C counts 1, 2, 3, 0, 1 (wrap included);
+        // each step appends a "clock #k" divider block with the register commits at
+        // the block start and non-decreasing ripple times across the whole timeline.
+        var countBus = BusOf(vm);
+        countBus.Members.Select(m => m.PinName).ShouldBe(new[] { "C0", "C1" },
+            "step 4: the committed count bits group into one bus row C (C0 = LSB)");
+        var previousDivider = "";
+        for (var k = 1; k <= ExpectedCounts.Length; k++)
+        {
+            var rowsBefore = vm.TimelineEvents.Count;
+            vm.StepClockCommand.Execute(null);
+            var count = ExpectedCounts[k - 1];
+
+            countBus.DecimalValue.ShouldBe(count,
+                $"step 4.{k}: after clock #{k} the bus row C shows the decimal count");
+            countBus.HeaderText.ShouldBe(
+                $"C = {count.ToString(CultureInfo.InvariantCulture)} ({Convert.ToString(count, 2).PadLeft(2, '0')})",
+                $"step 4.{k}: the bus header reads the count as a number");
+            vm.RegisterStates.Single(r => r.GateName == "Q0").BitsText.ShouldBe($"Y = {count & 1}",
+                $"step 4.{k}: Q0 commits the low bit");
+            vm.RegisterStates.Single(r => r.GateName == "Q1").BitsText.ShouldBe($"Y = {(count >> 1) & 1}",
+                $"step 4.{k}: Q1 commits the high bit");
+
+            var block = vm.TimelineEvents.Skip(rowsBefore).ToList();
+            block.ShouldNotBeEmpty($"step 4.{k}: clock #{k} appends its block to the timeline");
+            block[0].HasClockBoundary.ShouldBeTrue($"step 4.{k}: a clock divider opens the step's block");
+            block[0].ClockBoundaryText.ShouldContain("──",
+                customMessage: $"step 4.{k}: the divider renders as a separator line");
+            block[0].ClockBoundaryText.ShouldContain($" {k} ",
+                customMessage: $"step 4.{k}: the divider counts the clocks");
+            block[0].ClockBoundaryText.ShouldNotBe(previousDivider,
+                $"step 4.{k}: every clock's divider reads differently");
+            block[0].Event.GateId.ShouldBeOneOf("Q0", "Q1",
+                $"step 4.{k}: a register commit entry sits at the block start, right behind the divider");
+            block.Skip(1).ShouldAllBe(row => !row.HasClockBoundary,
+                $"step 4.{k}: only the block's first row carries the divider");
+            var times = vm.TimelineEvents.Select(e => e.Event.TimePicoseconds).ToList();
+            times.ShouldBe(times.OrderBy(t => t).ToList(),
+                $"step 4.{k}: ripple times never decrease across clock blocks");
+            previousDivider = block[0].ClockBoundaryText;
+        }
+
+        // (5) Replay backwards across the clock boundaries: at every t_k the badges
+        // show the mirror-derived state — before-state plus every event with time ≤
+        // t_k, derived from the fixture's fresh (never clocked) network, not the panel.
+        var beforeState = ByGatePin(_fixture.Network, _fixture.Network.Evaluate(RestingBits()));
+        vm.SelectTimelineEventCommand.Execute(vm.TimelineEvents[^1]);
+        vm.IsReplayActive.ShouldBeTrue("step 5: selecting a timeline row enters replay");
+        var crossedClockBoundary = false;
+        for (var k = vm.TimelineEvents.Count - 1; k >= 0; k--)
+        {
+            BadgesShouldShow(
+                StateAt(beforeState, vm.TimelineEvents, vm.TimelineEvents[k].Event.TimePicoseconds),
+                $"step 5: replaying event {k} freezes the badges at its t_k");
+            if (k > 0)
+            {
+                crossedClockBoundary |= vm.TimelineEvents[k].HasClockBoundary;
+                vm.PreviousTimelineEventCommand.Execute(null);
+                vm.SelectedTimelineEvent.ShouldBe(vm.TimelineEvents[k - 1],
+                    "step 5: the previous button walks one event earlier, across clock dividers");
+            }
+        }
+        crossedClockBoundary.ShouldBeTrue("step 5: the backward walk crossed at least one clock boundary");
+        vm.ExitReplayCommand.Execute(null);
+        vm.IsReplayActive.ShouldBeFalse("step 5: leaving replay returns to the live state");
+        BadgesShouldShow(StateAt(beforeState, vm.TimelineEvents, double.MaxValue),
+            "step 5: back to live shows the settled post-step state: before-state plus every event");
+
+        // (6) Save → load → re-assemble: the register readout, signal names and bus
+        // rows are identical, and stepping resumes the count from power-up (00).
+        var savedPath = await _fixture.SaveToTempFile();
+        try
+        {
+            var reloaded = await BuildPanel(
+                await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath));
+            reloaded.RegisterStates.Select(r => r.GateName)
+                .ShouldBe(vm.RegisterStates.Select(r => r.GateName).ToArray(),
+                    "step 6: the register readout is identical after the save → load round trip");
+            reloaded.RegisterStates.ShouldAllBe(r => r.BitsText == "Y = 0",
+                "step 6: the reloaded counter powers up cleared again");
+            reloaded.Inputs.Select(i => i.PinName).ShouldBe(vm.Inputs.Select(i => i.PinName).ToArray(),
+                "step 6: the input signal name survives the round trip");
+            reloaded.Outputs.Select(o => o.PinName).ShouldBe(vm.Outputs.Select(o => o.PinName).ToArray(),
+                "step 6: every output signal name survives the round trip");
+            reloaded.OutputRows.Select(RowSignature).ShouldBe(vm.OutputRows.Select(RowSignature).ToArray(),
+                "step 6: the bus rows are identical after the round trip");
+
+            var reloadedBus = BusOf(reloaded);
+            reloadedBus.DecimalValue.ShouldBe(0, "step 6: the count restarts at power-up (00)");
+            reloaded.Inputs[0].IsOn = true;
+            reloaded.StepClockCommand.Execute(null);
+            reloadedBus.DecimalValue.ShouldBe(1, "step 6: stepping resumes the count — 00 → 01");
+            reloaded.StepClockCommand.Execute(null);
+            reloadedBus.DecimalValue.ShouldBe(2, "step 6: …and counts on — 01 → 10");
+        }
+        finally
+        {
+            if (File.Exists(savedPath)) File.Delete(savedPath);
+        }
+    }
+
+    /// <summary>Builds the panel VM over <paramref name="canvas"/> exactly as the UI's build button does.</summary>
+    private static async Task<LogicPanelViewModel> BuildPanel(DesignCanvasViewModel canvas)
+    {
+        var vm = new LogicPanelViewModel();
+        vm.Configure(canvas);
+        await vm.BuildNetworkCommand.ExecuteAsync(null);
+        return vm;
+    }
+
+    /// <summary>The output bus row of the count bits (<c>C0</c>/<c>C1</c>).</summary>
+    private static LogicSignalBusOutputViewModel BusOf(LogicPanelViewModel vm) =>
+        vm.OutputRows.OfType<LogicSignalBusOutputViewModel>().Single(b => b.Prefix == CountBusPrefix);
+
+    /// <summary>A bus row's structural signature: prefix and member taps, or the plain row's tap.</summary>
+    private static string RowSignature(LogicOutputRowViewModel row) => row switch
+    {
+        LogicSignalBusOutputViewModel bus =>
+            $"bus:{bus.Prefix}({string.Join(",", bus.Members.Select(m => m.PinName))})",
+        LogicNetworkOutputViewModel single => $"row:{single.PinName}",
+        _ => throw new InvalidOperationException($"Unknown output row type {row.GetType().Name}."),
+    };
+
+    /// <summary>Re-keys a tap-keyed evaluation result by raw <c>gate.pin</c> (see issue #1046).</summary>
+    private static Dictionary<string, bool> ByGatePin(
+        LogicNetworkEvaluator network, IReadOnlyDictionary<string, bool> tapKeyed) =>
+        network.OutputTaps.ToDictionary(
+            tap => $"{tap.Value.GateId}.{tap.Value.PinName}", tap => tapKeyed[tap.Key]);
+
+    /// <summary>
+    /// The independently derived state at time t: the before-state plus the new
+    /// value of every displayed event whose time is ≤ t — the rule of issue #1058
+    /// re-derived in test code without touching the ViewModel's replay path.
+    /// </summary>
+    private static Dictionary<string, bool> StateAt(
+        IReadOnlyDictionary<string, bool> beforeState,
+        IEnumerable<LogicTimelineEventViewModel> displayedEvents,
+        double timePicoseconds)
+    {
+        var state = new Dictionary<string, bool>(beforeState);
+        foreach (var row in displayedEvents)
+        {
+            if (row.Event.TimePicoseconds > timePicoseconds)
+                break;
+            state[$"{row.Event.GateId}.{row.Event.OutputPin}"] = row.Event.NewValue;
+        }
+        return state;
+    }
+
+    /// <summary>The output-pin badges currently on the canvas, keyed <c>gate.pin</c> (named input chips excluded).</summary>
+    private Dictionary<string, bool> BadgeStates() =>
+        _fixture.Canvas.LogicGateStates.Badges
+            .Where(IsOutputChip)
+            .ToDictionary(b => $"{b.GroupName}.{b.PinName}", b => b.IsOne);
+
+    /// <summary>True for a chip on a gate's output tap — anonymous or named (issue #1067).</summary>
+    private bool IsOutputChip(LogicGateBadgeViewModel badge) =>
+        _fixture.Network.OutputTaps.Values.Any(
+            p => p.GateId == badge.GroupName && p.PinName == badge.PinName);
+
+    /// <summary>Asserts the canvas badges show exactly the expected pin states.</summary>
+    private void BadgesShouldShow(IReadOnlyDictionary<string, bool> expected, string because)
+    {
+        var actual = BadgeStates();
+        actual.Count.ShouldBe(expected.Count, because);
+        foreach (var (tap, bit) in expected)
+            actual[tap].ShouldBe(bit, $"{tap}: {because}");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `UnitTests/Integration/SequentialJourneyE2ETests.cs`: one panel-level journey over the merged sequential batch (register core #1093, toggle UI #1104, Step button #1105, counter #1114, step-timeline #1110) — each numbered journey step is a distinct assertion block naming the step.
- Journey: load `Logic Gate Counter 2-bit.lun` via `FileOperationsViewModel.LoadDesignFromPathAsync` → build via the panel's `BuildNetworkCommand` → register readout Q0/Q1 + named toggle S̄ resting on → 5× `StepClockCommand` (bus row C reads 1, 2, 3, 0, 1, wrap included; each step appends a `── clock #k ──` divider block with register commits at the block start and non-decreasing ripple times) → replay backwards across clock boundaries, badges equal the mirror-derived state at every t_k (pattern from `LogicPanelStepTimelineTests`) → `SaveDesignAsCommand` → reload → re-assemble: readout/signal names/bus rows identical, counting resumes from power-up (00).
- No production code changes; every journey step passed as specified — no defect findings to report.
- Branch is stacked on PR #1117's head (issue states the dependency); its diff shrinks to the single new test file once #1117 merges to `dev-ki`.

## Test plan
- [x] `SequentialJourneyE2ETests` green (1/1)
- [x] LogicPanel (59), LogicGate (130), LogicNetwork (135), LogicEventTimeline (18) groups green
- [x] Full non-Slow suite green: 6344 passed, 0 failed, 14 skipped (external-tool-gated)
- [ ] Manual verification after vacation: perform the same journey by hand once