### PR TITLE
Agent: backfill persisted pin roles into the three pre-#986 gate examples (#1141)

### DIFF
--- a/UnitTests/Integration/LogicExamplesSweepTests.cs
+++ b/UnitTests/Integration/LogicExamplesSweepTests.cs
@@ -31,20 +31,6 @@ public class LogicExamplesSweepTests
     /// <summary>File-name prefix that marks a manifest entry as a logic example.</summary>
     private const string LogicExampleFilePrefix = "Logic Gate";
 
-    /// <summary>
-    /// Rung-4 gate-builder examples that predate the persisted pin-roles seam (#986):
-    /// their groups ship without <c>TruthTablePinAssignment</c>, so the assembler
-    /// reports "no logic gate in the design" — reported on issue #1130 as a finding.
-    /// Once the .lun files carry persisted roles, delete the entries: the sweep then
-    /// covers them with no other edit.
-    /// </summary>
-    private static readonly HashSet<string> KnownExamplesWithoutPersistedPinRoles = new()
-    {
-        "Logic Gate NOT-NAND.lun",
-        "Logic Gate AND-from-NAND.lun",
-        "Logic Gate OR-AND.lun",
-    };
-
     /// <summary>Manifest file inside the examples directory.</summary>
     private const string ManifestFileName = "examples.json";
 
@@ -65,8 +51,6 @@ public class LogicExamplesSweepTests
         var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), exampleFileName);
         File.Exists(path).ShouldBeTrue(
             $"manifest entry '{exampleFileName}' must point at a shipped example file");
-        if (KnownExamplesWithoutPersistedPinRoles.Contains(exampleFileName))
-            return;
 
         var canvas = new DesignCanvasViewModel();
         var errorConsole = new ErrorConsoleService();

--- a/UnitTests/Integration/LogicGateAndFromNandExampleTests.cs
+++ b/UnitTests/Integration/LogicGateAndFromNandExampleTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Export;
 using CAP.Avalonia.ViewModels.Library;
@@ -104,8 +105,48 @@ public class LogicGateAndFromNandExampleTests
         AssertRow(table, 3, expectedBit: false, expectedPower: ExtinguishedPower);
     }
 
+    /// <summary>
+    /// The persisted pin roles and signal names make the example build in the Logic
+    /// panel without any manual role assignment: toggles A and B drive the cascaded
+    /// gate and its output tap reads the AND table.
+    /// </summary>
+    [Fact]
+    public async Task LogicPanel_Toggles_ReproduceAndTable()
+    {
+        var canvas = await LoadGateOnCanvas();
+        var panel = new LogicPanelViewModel();
+        panel.Configure(canvas);
+        await panel.BuildNetworkCommand.ExecuteAsync(null);
+
+        panel.HasNetwork.ShouldBeTrue(
+            $"the persisted pin roles must assemble in the Logic panel: {panel.StatusText}");
+        panel.Inputs.Select(i => i.PinName).ShouldBe(InputsAb, ignoreOrder: true,
+            customMessage: "the persisted signal names A and B become the panel toggles");
+        panel.Outputs.Count.ShouldBe(1, "the single gate exposes exactly one output tap");
+
+        EvaluatePanel(panel, a: false, b: false).ShouldBeFalse("AND: A=0 B=0 must read 0");
+        EvaluatePanel(panel, a: true, b: false).ShouldBeFalse("AND: A=1 B=0 must read 0");
+        EvaluatePanel(panel, a: false, b: true).ShouldBeFalse("AND: A=0 B=1 must read 0");
+        EvaluatePanel(panel, a: true, b: true).ShouldBeTrue("AND: A=1 B=1 must read 1");
+    }
+
+    /// <summary>Sets the A/B toggles and returns the single output tap's evaluated bit.</summary>
+    private static bool EvaluatePanel(LogicPanelViewModel panel, bool a, bool b)
+    {
+        panel.Inputs.Single(i => i.PinName == "A").IsOn = a;
+        panel.Inputs.Single(i => i.PinName == "B").IsOn = b;
+        return panel.Outputs.Single().IsOne;
+    }
+
     /// <summary>Loads the shipped example through the real load path and returns its group.</summary>
     private static async Task<ComponentGroup> LoadGateGroup()
+    {
+        var canvas = await LoadGateOnCanvas();
+        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns the canvas.</summary>
+    private static async Task<DesignCanvasViewModel> LoadGateOnCanvas()
     {
         var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
         var canvas = new DesignCanvasViewModel();
@@ -123,7 +164,7 @@ public class LogicGateAndFromNandExampleTests
         (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
             $"the shipped example '{ExampleFileName}' must load through the real load path");
 
-        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+        return canvas;
     }
 
     /// <summary>Extracts the gate's truth table at the given analog→digital threshold.</summary>

--- a/UnitTests/Integration/LogicGateExampleTests.cs
+++ b/UnitTests/Integration/LogicGateExampleTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CAP.Avalonia.Commands;
 using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
 using CAP.Avalonia.ViewModels.Canvas;
 using CAP.Avalonia.ViewModels.Export;
 using CAP.Avalonia.ViewModels.Library;
@@ -77,8 +78,48 @@ public class LogicGateExampleTests
         AssertRow(table, a: true, b: true, expectedBit: true, expectedPower: 1.0);
     }
 
+    /// <summary>
+    /// The persisted pin roles and signal names make the example build in the Logic
+    /// panel without any manual role assignment: toggles A and B drive the gate and
+    /// its output tap reads the OR table at the persisted threshold 0.25.
+    /// </summary>
+    [Fact]
+    public async Task LogicPanel_Toggles_ReproduceOrTable()
+    {
+        var canvas = await LoadGateOnCanvas();
+        var panel = new LogicPanelViewModel();
+        panel.Configure(canvas);
+        await panel.BuildNetworkCommand.ExecuteAsync(null);
+
+        panel.HasNetwork.ShouldBeTrue(
+            $"the persisted pin roles must assemble in the Logic panel: {panel.StatusText}");
+        panel.Inputs.Select(i => i.PinName).ShouldBe(InputPins, ignoreOrder: true,
+            customMessage: "the persisted signal names A and B become the panel toggles");
+        panel.Outputs.Count.ShouldBe(1, "the single gate exposes exactly one output tap");
+
+        EvaluatePanel(panel, a: false, b: false).ShouldBeFalse("OR: A=0 B=0 must read 0");
+        EvaluatePanel(panel, a: true, b: false).ShouldBeTrue("OR: A=1 B=0 must read 1");
+        EvaluatePanel(panel, a: false, b: true).ShouldBeTrue("OR: A=0 B=1 must read 1");
+        EvaluatePanel(panel, a: true, b: true).ShouldBeTrue("OR: A=1 B=1 must read 1");
+    }
+
+    /// <summary>Sets the A/B toggles and returns the single output tap's evaluated bit.</summary>
+    private static bool EvaluatePanel(LogicPanelViewModel panel, bool a, bool b)
+    {
+        panel.Inputs.Single(i => i.PinName == "A").IsOn = a;
+        panel.Inputs.Single(i => i.PinName == "B").IsOn = b;
+        return panel.Outputs.Single().IsOne;
+    }
+
     /// <summary>Loads the shipped example through the real load path and returns its group.</summary>
     private static async Task<ComponentGroup> LoadGateGroup()
+    {
+        var canvas = await LoadGateOnCanvas();
+        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+    }
+
+    /// <summary>Loads the shipped example through the real load path and returns the canvas.</summary>
+    private static async Task<DesignCanvasViewModel> LoadGateOnCanvas()
     {
         var library = new ObservableCollection<ComponentTemplate>(TestPdkLoader.LoadAllTemplates());
         var canvas = new DesignCanvasViewModel();
@@ -96,7 +137,7 @@ public class LogicGateExampleTests
         (await fileOps.LoadDesignFromPathAsync(examplePath)).ShouldBeTrue(
             $"the shipped example '{ExampleFileName}' must load through the real load path");
 
-        return canvas.Components.Select(c => c.Component).OfType<ComponentGroup>().Single();
+        return canvas;
     }
 
     /// <summary>Extracts the gate's truth table at the given analog→digital threshold.</summary>

--- a/UnitTests/Integration/LogicGateNotNandExampleTests.cs
+++ b/UnitTests/Integration/LogicGateNotNandExampleTests.cs
@@ -109,6 +109,7 @@ public class LogicGateNotNandExampleTests
         vm.Rows.Count.ShouldBe(2);
         AssertPanelRow(vm, "0", expectedBit: true, expectedPowerText: "0.50");
         AssertPanelRow(vm, "1", expectedBit: false, expectedPowerText: "0.25");
+        await ResetToShippedAssignment(vm);
     }
 
     [Fact]
@@ -126,6 +127,39 @@ public class LogicGateNotNandExampleTests
     }
 
     /// <summary>
+    /// The persisted pin roles and signal names make the example build in the Logic
+    /// panel without any manual role assignment: toggles A and B drive the single
+    /// gate and its output tap reads the NAND table.
+    /// </summary>
+    [Fact]
+    public async Task LogicPanel_Toggles_ReproduceNandTable()
+    {
+        var canvas = await LoadGateOnCanvas();
+        var panel = new LogicPanelViewModel();
+        panel.Configure(canvas);
+        await panel.BuildNetworkCommand.ExecuteAsync(null);
+
+        panel.HasNetwork.ShouldBeTrue(
+            $"the persisted pin roles must assemble in the Logic panel: {panel.StatusText}");
+        panel.Inputs.Select(i => i.PinName).ShouldBe(InputsAb, ignoreOrder: true,
+            customMessage: "the persisted signal names A and B become the panel toggles");
+        panel.Outputs.Count.ShouldBe(1, "the single gate exposes exactly one output tap");
+
+        EvaluatePanel(panel, a: false, b: false).ShouldBeTrue("NAND: A=0 B=0 must read 1");
+        EvaluatePanel(panel, a: true, b: false).ShouldBeTrue("NAND: A=1 B=0 must read 1");
+        EvaluatePanel(panel, a: false, b: true).ShouldBeTrue("NAND: A=0 B=1 must read 1");
+        EvaluatePanel(panel, a: true, b: true).ShouldBeFalse("NAND: A=1 B=1 must read 0");
+    }
+
+    /// <summary>Sets the A/B toggles and returns the single output tap's evaluated bit.</summary>
+    private static bool EvaluatePanel(LogicPanelViewModel panel, bool a, bool b)
+    {
+        panel.Inputs.Single(i => i.PinName == "A").IsOn = a;
+        panel.Inputs.Single(i => i.PinName == "B").IsOn = b;
+        return panel.Outputs.Single().IsOne;
+    }
+
+    /// <summary>
     /// Drives the shipped example through the Truth Table panel's ViewModel exactly as
     /// the interactive flow does: select the group, tick the pins, set the threshold,
     /// run the Extract command.
@@ -139,14 +173,27 @@ public class LogicGateNotNandExampleTests
         var vm = new TruthTableViewModel();
         vm.ConfigureForSelection(groupVm, canvas);
         vm.IsGroupSelected.ShouldBeTrue("the loaded gate group must activate the panel");
-        foreach (var name in inputs)
-            vm.InputPins.Single(p => p.PinName == name).IsChecked = true;
+        // The persisted roles prefill the checks: uncheck every input the reading
+        // does not enumerate (the NOT reading drops B), then tick the wanted ones.
+        foreach (var pin in vm.InputPins)
+            pin.IsChecked = inputs.Contains(pin.PinName);
         vm.OutputPins.Single(p => p.PinName == "Y").IsChecked = true;
         vm.BiasPins.Single(p => p.PinName == "BIAS").IsChecked = true;
         vm.Threshold = threshold;
 
         await vm.ExtractCommand.ExecuteAsync(null);
         return vm;
+    }
+
+    /// <summary>Seeds the assignment the file ships (NAND roles, unnamed pins).</summary>
+    private static async Task ResetToShippedAssignment(TruthTableViewModel vm)
+    {
+        vm.InputPins.Single(p => p.PinName == "B").IsChecked = true;
+        vm.InputPins.Single(p => p.PinName == "A").SignalName = "";
+        vm.InputPins.Single(p => p.PinName == "B").SignalName = "";
+        vm.Threshold = NandThreshold;
+        await vm.ExtractCommand.ExecuteAsync(null);
+        vm.HasResult.ShouldBeTrue("re-seeding the shipped assignment must succeed");
     }
 
     /// <summary>Asserts one panel row's output bit and its displayed raw power.</summary>

--- a/UnitTests/Integration/LogicNetworkAssemblerExampleTests.cs
+++ b/UnitTests/Integration/LogicNetworkAssemblerExampleTests.cs
@@ -82,6 +82,7 @@ public class LogicNetworkAssemblerExampleTests : IDisposable
         var nand = await LoadGateWithPersistedRoles(NandGateId, NandInputs, NandThreshold);
         var plain = SingleGateGroup(await LoadGateOnCanvas());
         plain.GroupName = "PLAIN";
+        plain.TruthTablePinAssignment = null;
 
         var network = await new LogicNetworkAssembler().AssembleAsync(
             new Component[] { nand, plain }, Array.Empty<WaveguideConnection>(), WavelengthNm);
@@ -100,6 +101,7 @@ public class LogicNetworkAssemblerExampleTests : IDisposable
     public async Task AssembleAsync_DesignWithoutGateGroups_ThrowsAReadableError()
     {
         var plain = SingleGateGroup(await LoadGateOnCanvas());
+        plain.TruthTablePinAssignment = null;
 
         var error = await Should.ThrowAsync<InvalidOperationException>(
             () => new LogicNetworkAssembler().AssembleAsync(
@@ -110,9 +112,11 @@ public class LogicNetworkAssemblerExampleTests : IDisposable
 
     /// <summary>
     /// Delivers one gate group the way Jonas gets it: the shipped example is loaded,
-    /// its truth table extracted through the real panel flow (which seeds the persisted
-    /// assignment), saved, and reloaded — the reloaded group carries roles and threshold
-    /// from the file, not from this test.
+    /// its truth table extracted through the real panel flow (which re-seeds the
+    /// persisted assignment), saved, and reloaded — the reloaded group carries roles
+    /// and threshold from the file, not from this test. The shipped file names the
+    /// A/B signals since #1141; the flow under test predates signal identity, so the
+    /// roles are re-extracted with unnamed pins like any pre-#1033 extraction.
     /// </summary>
     private async Task<ComponentGroup> LoadGateWithPersistedRoles(
         string gateId, string[] inputPinNames, double threshold)
@@ -142,12 +146,16 @@ public class LogicNetworkAssemblerExampleTests : IDisposable
         var vm = new TruthTableViewModel();
         vm.ConfigureForSelection(groupVm, canvas);
         vm.IsGroupSelected.ShouldBeTrue("the loaded gate group must activate the panel");
-        foreach (var name in inputPinNames)
-        {
-            vm.InputPins.Single(p => p.PinName == name).IsChecked = true;
-        }
+        // The persisted roles prefill the checks: uncheck every input the reading
+        // does not enumerate (the NOT reading drops B), then tick the wanted ones.
+        foreach (var pin in vm.InputPins)
+            pin.IsChecked = inputPinNames.Contains(pin.PinName);
         vm.OutputPins.Single(p => p.PinName == Outputs[0]).IsChecked = true;
         vm.BiasPins.Single(p => p.PinName == Biases[0]).IsChecked = true;
+        // Clear the shipped A/B signal names (#1141): the pre-#1033 flow under test
+        // assembles raw <gate>.<pin> input names, not signal-merged ones.
+        foreach (var pin in vm.InputPins)
+            pin.SignalName = "";
         vm.Threshold = threshold;
         await vm.ExtractCommand.ExecuteAsync(null);
         vm.HasResult.ShouldBeTrue("the extraction that seeds persistence must succeed");

--- a/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
+++ b/UnitTests/Integration/TruthTablePinAssignmentPersistenceTests.cs
@@ -22,8 +22,10 @@ namespace UnitTests.Integration;
 /// (issue #981): whatever the panel last successfully extracted with — input pins
 /// in bit order, output pins, bias pins, threshold — survives save → load, the panel
 /// prefills on group selection, and extraction reproduces the pinned table without
-/// any manual role re-assignment. Legacy files without the new block keep loading
-/// exactly as before.
+/// any manual role re-assignment. The shipped example has carried its NAND reading
+/// since issue #1141, so the manual seeding extraction clears the shipped signal
+/// names to reproduce the pre-#1033 flow; legacy files without the block keep
+/// loading exactly as before.
 /// </summary>
 public class TruthTablePinAssignmentPersistenceTests : IDisposable
 {
@@ -291,20 +293,23 @@ public class TruthTablePinAssignmentPersistenceTests : IDisposable
     [Fact]
     public async Task LegacyFile_WithoutTruthTableBlock_LoadsWithNullAssignment()
     {
-        // The shipped example predates the persistence block — it is the legacy case.
-        var canvas = await LoadGateOnCanvas();
-        SingleGateGroup(canvas).TruthTablePinAssignment.ShouldBeNull(
+        // A legacy .lun (no TruthTablePinAssignment block) loads with no assignment,
+        // and saving the untouched design must not invent a block: no assignment →
+        // nothing persisted, no format noise.
+        var group = TestComponentFactory.CreateComponentGroup("LegacyGroup");
+        var canvas = new DesignCanvasViewModel();
+        canvas.Components.Add(new ComponentViewModel(group));
+        group.TruthTablePinAssignment.ShouldBeNull(
             "legacy .lun files load with no truth-table assignment attached");
 
-        // Saving and reloading the untouched legacy design must not invent a block:
-        // no assignment → nothing persisted, no format noise.
         await Save(canvas);
         var fileText = File.ReadAllText(_designFilePath);
         fileText.ShouldNotContain("TruthTablePinAssignment", Case.Sensitive,
             "a never-extracted group persists no truth-table block");
 
         var reloaded = await LoadFromDisk();
-        SingleGateGroup(reloaded).TruthTablePinAssignment.ShouldBeNull();
+        reloaded.Components.Select(c => c.Component).OfType<ComponentGroup>()
+            .Single().TruthTablePinAssignment.ShouldBeNull();
     }
 
     [Fact]
@@ -451,6 +456,9 @@ public class TruthTablePinAssignmentPersistenceTests : IDisposable
     /// <summary>
     /// Drives the loaded example through the Truth Table panel's ViewModel exactly as
     /// the interactive flow does — this is what populates the persisted assignment.
+    /// The shipped file carries named A/B signal fields since #1141; the pre-#1033
+    /// flow these tests pin starts from unnamed pins, so the seeding extraction
+    /// clears the shipped names first.
     /// </summary>
     private static async Task ExtractNandThroughPanel(DesignCanvasViewModel canvas)
     {
@@ -463,6 +471,8 @@ public class TruthTablePinAssignmentPersistenceTests : IDisposable
             vm.InputPins.Single(p => p.PinName == name).IsChecked = true;
         vm.OutputPins.Single(p => p.PinName == "Y").IsChecked = true;
         vm.BiasPins.Single(p => p.PinName == "BIAS").IsChecked = true;
+        foreach (var name in NandInputs)
+            vm.InputPins.Single(p => p.PinName == name).SignalName = "";
         vm.Threshold = NandThreshold;
         await vm.ExtractCommand.ExecuteAsync(null);
         vm.HasResult.ShouldBeTrue("the manual extraction that seeds persistence must succeed");

--- a/examples/Logic Gate AND-from-NAND.lun
+++ b/examples/Logic Gate AND-from-NAND.lun
@@ -463,7 +463,25 @@
         }
       ],
       "CanvasX": 95,
-      "CanvasY": 100
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS",
+          "BIAS2"
+        ],
+        "Threshold": 0.25,
+        "InputSignalNames": {
+          "A": "A",
+          "B": "B"
+        }
+      }
     }
   ],
   "Metadata": {

--- a/examples/Logic Gate NOT-NAND.lun
+++ b/examples/Logic Gate NOT-NAND.lun
@@ -314,7 +314,24 @@
         }
       ],
       "CanvasX": 95,
-      "CanvasY": 100
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "InputSignalNames": {
+          "A": "A",
+          "B": "B"
+        }
+      }
     }
   ],
   "Metadata": {

--- a/examples/Logic Gate OR-AND.lun
+++ b/examples/Logic Gate OR-AND.lun
@@ -221,7 +221,22 @@
         }
       ],
       "CanvasX": 95,
-      "CanvasY": 100
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.25,
+        "InputSignalNames": {
+          "A": "A",
+          "B": "B"
+        }
+      }
     }
   ],
   "Metadata": {


### PR DESCRIPTION
## What & why

The E2E sweep over all shipped logic examples (#1130 / PR #1137) had to skip three examples via `KnownExamplesWithoutPersistedPinRoles` because they predate the persisted pin-roles seam (#986): their gate groups ship no `TruthTablePinAssignment`, so the Logic panel's Build fails with "no logic gate in the design". A student opening a shipped Home example and pressing Build hit a dead end on exactly the entry-level examples (Jonas/university persona).

This PR backfills the persisted pin roles (+ threshold) and human signal names into the three examples, the same way the newer examples (Half Adder #987, Bit #1119, Register #1133) carry them, following the #1034 backfill pattern:

- `examples/Logic Gate NOT-NAND.lun` — NAND reading: inputs A/B, output Y, bias BIAS, threshold 0.125
- `examples/Logic Gate AND-from-NAND.lun` — AND reading: inputs A/B, output Y, biases BIAS + BIAS2, threshold 0.25
- `examples/Logic Gate OR-AND.lun` — OR reading: inputs A/B, output Y, no bias, threshold 0.25

Each carries `InputSignalNames` {A, B}, so the Logic panel shows named toggles. The `KnownExamplesWithoutPersistedPinRoles` skip set in `LogicExamplesSweepTests.cs` is deleted — the sweep now covers all logic examples with no other edit and is the acceptance test. Each example additionally pins its gate's truth table through the Logic panel toggles (one fact per example, in the existing per-example test classes).

Data + tests only — no production-code change; localized descriptions unchanged.

## Follow-on test adjustments (consequences of the backfill)

- `LogicGateNotNandExampleTests` / `TruthTablePinAssignmentPersistenceTests` / `LogicNetworkAssemblerExampleTests` drive the NOT-NAND example through the pre-signal-identity extraction flow (they assert unnamed `<gate>.<pin>` network inputs and byte-clean legacy saves); they now clear the shipped signal names first, exactly as a pre-#1033 user flow did.
- `LegacyFile_WithoutTruthTableBlock_LoadsWithNullAssignment` used the NOT-NAND example as its no-block legacy case — it now uses a synthetic group, since the example intentionally carries the block.
- `LogicNetworkAssemblerExampleTests`' "plain group" fixtures explicitly null the assignment, since the loaded example now brings one.

## How it was tested

- Sweep theory `LogicExamplesSweepTests.LogicExample_LoadsAssemblesAndEvaluatesCleanly` runs over every manifest logic example with an empty skip list — all green, including the three previously skipped files (load with zero dropped connections / zero error-console entries, assemble, settle-evaluate with named inputs and outputs).
- New pinned facts: `LogicGateNotNandExampleTests.LogicPanel_Toggles_ReproduceNandTable`, `LogicGateAndFromNandExampleTests.LogicPanel_Toggles_ReproduceAndTable`, `LogicGateExampleTests.LogicPanel_Toggles_ReproduceOrTable` — each builds the example in the Logic panel and drives the A/B toggles through all four rows.
- Full filtered suite (`dotnet test UnitTests/UnitTests.csproj --filter "Category!=Slow"`).

Local suite: 6429 passed, 0 failed