### PR TITLE
Agent: 2x2 RAM example — the NAND2TETRIS RAM between Register and PC (#1142)

### DIFF
--- a/CAP.Avalonia/Assets/i18n/strings-de.json
+++ b/CAP.Avalonia/Assets/i18n/strings-de.json
@@ -350,6 +350,7 @@
   "Examples.Alu.Description": "Eine 1-Bit-ALU: Das Op-Bit wählt, ob das Ergebnis das AND oder das OR der Eingänge ist.",
   "Examples.Bit.Description": "Ein Speicherbit: Setze Load und drücke Step — das Bit speichert Din und hält den Wert.",
   "Examples.Register2bit.Description": "Ein 2-Bit-Register: Setze D1D0, pulsiere LOAD und drücke Step — das Wort wird gespeichert und gehalten, solange LOAD auf 0 bleibt.",
+  "Examples.Ram2x2.Description": "Ein 2x2-Bit-RAM: ADDR wählt, welches der beiden Wörter speichert und antwortet — der Kern jedes Speichers.",
   "Examples.Counter2bit.Description": "Ein 2-Bit-Zähler: Drücke Step und sieh zu, wie C1C0 0, 1, 2, 3 zählt — die Schaltung läuft.",
   "Examples.Pc2bit.Description": "Ein 2-Bit-Programmzähler: LOAD=0 zählt pro Step hoch, LOAD=1 lädt L1L0 — der NAND2TETRIS-PC.",
   "Examples.AndGate.Description": "Kombiniere zwei NAND-Gatter zu einem AND-Gatter.",

--- a/CAP.Avalonia/Assets/i18n/strings-en.json
+++ b/CAP.Avalonia/Assets/i18n/strings-en.json
@@ -350,6 +350,7 @@
   "Examples.Alu.Description": "A 1-bit ALU: the Op bit selects whether the result is the AND or the OR of the inputs.",
   "Examples.Bit.Description": "A memory bit: set Load and step the clock — the bit stores Din and holds it.",
   "Examples.Register2bit.Description": "A 2-bit register: set D1D0, pulse LOAD and step — the word is stored and held while LOAD rests at 0.",
+  "Examples.Ram2x2.Description": "A 2x2-bit RAM: ADDR selects which of the two words stores and reads — the core of every memory.",
   "Examples.Counter2bit.Description": "A 2-bit counter: press Step and watch C1C0 count 0, 1, 2, 3 — the circuit runs.",
   "Examples.Pc2bit.Description": "A 2-bit program counter: LOAD=0 counts up each Step, LOAD=1 loads L1L0 — the NAND2TETRIS PC.",
   "Examples.AndGate.Description": "Combine two NAND gates into an AND gate.",

--- a/CAP.Avalonia/Assets/i18n/strings-es.json
+++ b/CAP.Avalonia/Assets/i18n/strings-es.json
@@ -350,6 +350,7 @@
   "Examples.Alu.Description": "Una ALU de 1 bit: el bit Op elige si el resultado es el AND o el OR de las entradas.",
   "Examples.Bit.Description": "Un bit de memoria: activa Load y pulsa Step — el bit almacena Din y lo mantiene.",
   "Examples.Register2bit.Description": "Un registro de 2 bits: ajusta D1D0, pulsa LOAD y Step — la palabra se almacena y se mantiene mientras LOAD queda en 0.",
+  "Examples.Ram2x2.Description": "Una RAM de 2x2 bits: ADDR elige cuál de las dos palabras almacena y responde — el núcleo de toda memoria.",
   "Examples.Counter2bit.Description": "Un contador de 2 bits: pulsa Step y observa cómo C1C0 cuenta 0, 1, 2, 3 — el circuito funciona.",
   "Examples.Pc2bit.Description": "Un contador de programa de 2 bits: LOAD=0 cuenta cada Step, LOAD=1 carga L1L0 — el PC de NAND2TETRIS.",
   "Examples.AndGate.Description": "Combina dos puertas NAND en una puerta AND.",

--- a/CAP.Avalonia/Assets/i18n/strings-ja.json
+++ b/CAP.Avalonia/Assets/i18n/strings-ja.json
@@ -350,6 +350,7 @@
   "Examples.Alu.Description": "1ビットALU:Opビットが結果を入力のANDにするかORにするかを選ぶ。",
   "Examples.Bit.Description": "メモリビット:LoadをセットしてStepを押す — ビットはDinを記憶し保持する。",
   "Examples.Register2bit.Description": "2ビットレジスタ:D1D0をセットしてLOADをパルスしStepを押す — ワードが記憶され、LOADが0の間保持される。",
+  "Examples.Ram2x2.Description": "2x2ビットRAM:ADDRが2つのワードのどちらが記憶し応答するかを選ぶ — あらゆるメモリの核心。",
   "Examples.Counter2bit.Description": "2ビットカウンタ:Stepを押すとC1C0が0、1、2、3とカウントする — 回路が動き出す。",
   "Examples.Pc2bit.Description": "2ビットプログラムカウンタ:LOAD=0でStepごとにカウントアップ、LOAD=1でL1L0をロード — NAND2TETRISのPC。",
   "Examples.AndGate.Description": "2つのNANDゲートを組み合わせてANDゲートを作る。",

--- a/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
+++ b/CAP.Avalonia/Assets/i18n/strings-zh-Hans.json
@@ -350,6 +350,7 @@
   "Examples.Alu.Description": "1 位 ALU:Op 位选择结果是输入的 AND 还是 OR。",
   "Examples.Bit.Description": "存储位:置位 Load 并按下 Step——该位存入 Din 并保持。",
   "Examples.Register2bit.Description": "2 位寄存器:设置 D1D0,脉冲 LOAD 并按下 Step——字被存入并在 LOAD 保持为 0 时保持不变。",
+  "Examples.Ram2x2.Description": "2x2 位 RAM:ADDR 选择两个字中哪个存放和回答——每一存储器的核心。",
   "Examples.Counter2bit.Description": "2 位计数器:按下 Step,观看 C1C0 依次计出 0、1、2、3——电路动起来了。",
   "Examples.Pc2bit.Description": "2 位程序计数器:LOAD=0 时每次 Step 递增,LOAD=1 时载入 L1L0——NAND2TETRIS 的 PC。",
   "Examples.AndGate.Description": "把两个 NAND 门组合成一个 AND 门。",

--- a/UnitTests/Integration/LogicGateRam2x2ExampleTests.cs
+++ b/UnitTests/Integration/LogicGateRam2x2ExampleTests.cs
@@ -1,0 +1,388 @@
+using CAP.Avalonia.Services;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis;
+using CAP.Avalonia.ViewModels.Analysis.LogicAnalysis.BusView;
+using CAP.Avalonia.ViewModels.Canvas;
+using CAP_Core.Analysis.LogicAnalysis;
+using CAP_Core.Components.Core;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace UnitTests.Integration;
+
+/// <summary>
+/// Pinned tests for the shipped <c>examples/Logic Gate RAM 2x2.lun</c> (issue #1142,
+/// rung 5 of the NAND game — the NAND2TETRIS 'RAM' slice between the Register #1138
+/// and the PC-with-program): two words x two bits behind one address bit. The write
+/// path demultiplexes LOAD by ADDR (the AND/NOT patterns behind the MUX example #1059):
+/// <c>EN_w = NAND(select_w, LOAD)</c> is the inverted word enable, <c>IW_w = NOT(EN_w)</c>
+/// the true one; each word is the shipped 2-bit Register pattern — hold arm
+/// <c>H = NAND(R, EN)</c>, load arm <c>LE = NAND(D, IW)</c>, register
+/// <c>REG = NAND(H, LE)</c> — with a read-tap copy feeding both the register's own
+/// hold feedback and the read MUX arm. The read path is the shipped 2-to-1 MUX
+/// (#1059) per data bit: <c>MA = NAND(word 0, NOT(ADDR))</c>,
+/// <c>MB = NAND(word 1, ADDR)</c>, <c>OUT = NAND(MA, MB)</c>. Fan-outs of
+/// select/enable levels are served by copy cascades (the register's CPNL pattern) —
+/// every waveguide carries exactly one signal; the persisted signal names (issue
+/// #1025) merge the unconnected pins into the four toggles <c>ADDR</c>,
+/// <c>LOAD</c>, <c>D0</c>, <c>D1</c>. Because every register samples the same settled
+/// pre-step state and commits simultaneously (D-semantics), each
+/// <see cref="LogicNetworkEvaluator.Step"/> is one full clock tick: ADDR selects which
+/// word stores under LOAD and which word answers on the read bus R.
+/// </summary>
+public class LogicGateRam2x2ExampleTests
+    : IClassFixture<LogicGateRam2x2ExampleTests.RamFixture>
+{
+    private const double NotThreshold = 0.375;
+    private const double NandThreshold = 0.125;
+
+    private const string AddressSignal = "ADDR";
+    private const string LoadSignal = "LOAD";
+    private const string LowDataSignal = "D0";
+    private const string HighDataSignal = "D1";
+    private const string LowReadTap = "R0";
+    private const string HighReadTap = "R1";
+
+    private static readonly string[] GateNames =
+    {
+        "CPAX", "CPA", "NOTA", "CPNX", "CPN",
+        "EN0", "CPEA0", "CPEB0", "IW0", "CPI0",
+        "EN1", "CPEA1", "CPEB1", "IW1", "CPI1",
+        "H00", "LE00", "REG00", "CP00",
+        "H01", "LE01", "REG01", "CP01",
+        "H10", "LE10", "REG10", "CP10",
+        "H11", "LE11", "REG11", "CP11",
+        "MA0", "MB0", "OUT0", "MA1", "MB1", "OUT1",
+    };
+    private static readonly string[] RegisterNames = { "REG00", "REG01", "REG10", "REG11" };
+    private static readonly string[] CopyNames =
+    {
+        "CPAX", "CPA", "CPNX", "CPN",
+        "CPEA0", "CPEB0", "CPI0", "CPEA1", "CPEB1", "CPI1",
+        "CP00", "CP01", "CP10", "CP11",
+    };
+    private static readonly string[] NotNames = { "NOTA", "IW0", "IW1" };
+
+    /// <summary>The persisted input signal names of the groups with named unconnected pins (issue #1025).</summary>
+    private static readonly Dictionary<string, Dictionary<string, string>?> ExpectedInputSignalNames = new()
+    {
+        ["CPAX"] = new() { ["A"] = AddressSignal },
+        ["NOTA"] = new() { ["A"] = AddressSignal },
+        ["EN0"] = new() { ["A"] = LoadSignal },
+        ["EN1"] = new() { ["A"] = LoadSignal },
+        ["LE00"] = new() { ["A"] = LowDataSignal },
+        ["LE01"] = new() { ["A"] = HighDataSignal },
+        ["LE10"] = new() { ["A"] = LowDataSignal },
+        ["LE11"] = new() { ["A"] = HighDataSignal },
+    };
+
+    /// <summary>The persisted output signal names per gate group — the read taps R and the stored-word taps W.</summary>
+    private static readonly Dictionary<string, Dictionary<string, string>?> ExpectedOutputSignalNames = new()
+    {
+        ["OUT0"] = new() { ["Y"] = LowReadTap },
+        ["OUT1"] = new() { ["Y"] = HighReadTap },
+        ["CP00"] = new() { ["Y2"] = "W0D0" },
+        ["CP01"] = new() { ["Y2"] = "W0D1" },
+        ["CP10"] = new() { ["Y2"] = "W1D0" },
+        ["CP11"] = new() { ["Y2"] = "W1D1" },
+    };
+
+    private readonly RamFixture _fixture;
+
+    /// <summary>Attaches the shared RAM fixture.</summary>
+    public LogicGateRam2x2ExampleTests(RamFixture fixture) => _fixture = fixture;
+
+    /// <summary>The resting input bits: LOAD low (hold), the address and data inputs low.</summary>
+    private static Dictionary<string, bool> HoldingInputBits() =>
+        Bits(addr: false, load: false, d0: false, d1: false);
+
+    [Fact]
+    public void Example_LoadsOnlyTopLevelGateGroups_WithPersistedRolesAndRegisterDesignations()
+    {
+        _fixture.Canvas.Components.ShouldAllBe(
+            c => c.Component is ComponentGroup,
+            "the RAM contains only top-level gate groups");
+        _fixture.Canvas.Connections.Count.ShouldBe(49,
+            "49 wires join the 37 gates: the address/NA trees, the per-word enable "
+            + "cascades, the register feedbacks, the read taps and the read MUX — every "
+            + "waveguide keeps one driver and one load");
+
+        var groups = _fixture.Groups;
+        groups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+        foreach (var group in groups)
+        {
+            var roles = group.TruthTablePinAssignment.ShouldNotBeNull(
+                $"group '{group.GroupName}' must ship its persisted pin roles");
+            if (CopyNames.Contains(group.GroupName))
+            {
+                roles.InputPinNames.ShouldBe(new[] { "A" });
+                roles.OutputPinNames.ShouldBe(new[] { "Y1", "Y2" });
+                roles.BiasPinNames.ShouldBeEmpty();
+                roles.Threshold.ShouldBe(NotThreshold);
+                roles.IsRegister.ShouldBeFalse("a copy gate is combinational");
+            }
+            else if (NotNames.Contains(group.GroupName))
+            {
+                roles.InputPinNames.ShouldBe(new[] { "A" });
+                roles.OutputPinNames.ShouldBe(new[] { "Y" });
+                roles.BiasPinNames.ShouldBe(new[] { "BIAS" });
+                roles.Threshold.ShouldBe(NotThreshold);
+                roles.IsRegister.ShouldBeFalse($"the inverter '{group.GroupName}' is combinational");
+            }
+            else
+            {
+                roles.InputPinNames.ShouldBe(new[] { "A", "B" });
+                roles.OutputPinNames.ShouldBe(new[] { "Y" });
+                roles.BiasPinNames.ShouldBe(new[] { "BIAS" });
+                roles.Threshold.ShouldBe(NandThreshold);
+                roles.IsRegister.ShouldBe(RegisterNames.Contains(group.GroupName),
+                    $"the register designation of '{group.GroupName}' (issue #1098)");
+            }
+            roles.InputSignalNames.ShouldBe(ExpectedInputSignalNames.GetValueOrDefault(group.GroupName),
+                $"group '{group.GroupName}' ships its network-signal identity (issue #1025)");
+            var expectedOutputs = ExpectedOutputSignalNames.GetValueOrDefault(group.GroupName);
+            roles.OutputSignalNames.ShouldBe(expectedOutputs,
+                $"group '{group.GroupName}' ships its output tap identity (issue #1025)");
+            group.Description.ShouldContain("logic layer", Case.Sensitive,
+                "every gate carries the education note about logic-layer composition");
+            group.Description.ShouldContain(
+                CopyNames.Contains(group.GroupName) || NotNames.Contains(group.GroupName)
+                    ? "0.375" : "0.125");
+        }
+
+        foreach (var register in RegisterNames)
+        {
+            _fixture.Groups.Single(g => g.GroupName == register).Description
+                .ShouldContain("register", Case.Sensitive,
+                    "every register carries the designation note");
+        }
+    }
+
+    [Fact]
+    public void AssembledNetwork_ExposesAddrLoadDataTogglesTheNamedTapsAndFourRegisters()
+    {
+        _fixture.Network.InputPinNames.ShouldBe(
+            new[] { AddressSignal, LoadSignal, LowDataSignal, HighDataSignal },
+            ignoreOrder: true,
+            customMessage: "the signal names merge the unconnected pins into exactly four "
+                + "network inputs (issue #1025) — ADDR drives NOTA and CPAX, LOAD drives "
+                + "EN0/EN1, D0/D1 drive their load arms — without a wire");
+        _fixture.Network.OutputPinNames.ShouldContain(LowReadTap);
+        _fixture.Network.OutputPinNames.ShouldContain(HighReadTap);
+        _fixture.Network.RegisterState.Keys.ShouldBe(
+            RegisterNames.Select(name => new LogicPinRef(name, "Y")).ToArray(),
+            ignoreOrder: true,
+            customMessage: "all four word bits power up as state elements, committed "
+                + "outputs cleared");
+    }
+
+    [Fact]
+    public async Task BusView_GroupsDataAndReadBitsIntoDecimalRows_StartingAtZero()
+    {
+        var vm = new LogicPanelViewModel();
+        vm.Configure(_fixture.Canvas);
+        await vm.BuildNetworkCommand.ExecuteAsync(null);
+        vm.HasNetwork.ShouldBeTrue(vm.StatusText);
+
+        var inputBuses = vm.InputRows.OfType<LogicSignalBusInputViewModel>().ToList();
+        inputBuses.Select(b => b.Prefix).ShouldBe(new[] { "D" },
+            "D0 and D1 group into the data bus shown as one decimal row (issue #1068)");
+        inputBuses.Single().Members.Select(m => m.PinName).ShouldBe(new[] { "D0", "D1" });
+        vm.InputRows.OfType<LogicNetworkInputViewModel>().Select(i => i.PinName)
+            .ShouldBe(new[] { AddressSignal, LoadSignal }, ignoreOrder: true,
+                "ADDR and LOAD have no indexed family and stay plain toggles");
+
+        var outputBuses = vm.OutputRows.OfType<LogicSignalBusOutputViewModel>().ToList();
+        outputBuses.Select(b => b.Prefix).ShouldBe(new[] { "W0D", "W1D", "R" },
+            "the two stored-word tap pairs group into their own decimal rows and R0/R1 "
+            + "into the read bus row (issue #1068)");
+        var busR = outputBuses.Single(b => b.Prefix == "R");
+        busR.Members.Select(m => m.PinName).ShouldBe(new[] { "R0", "R1" });
+        busR.DecimalValue.ShouldBe(0, "the RAM powers up cleared: the read bus R reads 0");
+    }
+
+    [Fact]
+    public void StepSequence_StoreWord0ThenWord1_IsolatesTheAddressedWord()
+    {
+        AssertStoreIsolation(_fixture.Network);
+    }
+
+    [Fact]
+    public void StepSequence_LoadLow_HoldsBothWordsAcrossSteps()
+    {
+        AssertHoldAcrossSteps(_fixture.Network);
+    }
+
+    /// <summary>
+    /// Drives the RAM back into the powered-up-cleared state: LOAD=1 with D=0 commits
+    /// 0 into the currently addressed word, and the same for the other address. Fact
+    /// execution order is unspecified, so every sequence pins its own starting state.
+    /// </summary>
+    private static void ResetToZero(LogicNetworkEvaluator network)
+    {
+        foreach (var addr in new[] { false, true })
+        {
+            network.Evaluate(Bits(addr, load: true, d0: false, d1: false));
+            network.Step();
+        }
+        ReadWord(network, addr: false).ShouldBe(0, "word 0 cleared");
+        ReadWord(network, addr: true).ShouldBe(0, "word 1 cleared");
+    }
+
+    /// <summary>Reads the 2-bit word at the address: LOAD low, one evaluate, R as a decimal.</summary>
+    private static int ReadWord(LogicNetworkEvaluator network, bool addr)
+    {
+        var read = network.Evaluate(Bits(addr, load: false, d0: false, d1: false));
+        return (read[HighReadTap] ? 2 : 0) + (read[LowReadTap] ? 1 : 0);
+    }
+
+    /// <summary>Stores one 2-bit word at the address: ADDR + LOAD + D, one clock commit.</summary>
+    private static void StoreWord(LogicNetworkEvaluator network, bool addr, int d)
+    {
+        network.Evaluate(Bits(addr, load: true, d0: (d & 1) != 0, d1: (d & 2) != 0));
+        network.Step();
+    }
+
+    /// <summary>
+    /// Asserts the pinned store sequence (acceptance criteria 2 + 3): store D=2 at
+    /// ADDR=0, store D=1 at ADDR=1 — reading ADDR=1 then answers R=1 while ADDR=0
+    /// still answers R=2: the addressed word alone commits.
+    /// </summary>
+    private static void AssertStoreIsolation(LogicNetworkEvaluator network)
+    {
+        ResetToZero(network);
+
+        StoreWord(network, addr: false, d: 2);
+        ReadWord(network, addr: false).ShouldBe(2,
+            "ADDR=0, LOAD=1, D=2 + clock: reading ADDR=0 shows R=2");
+        ReadWord(network, addr: true).ShouldBe(0,
+            "word 1 is untouched: reading ADDR=1 still shows the cleared 0");
+
+        StoreWord(network, addr: true, d: 1);
+        ReadWord(network, addr: true).ShouldBe(1,
+            "ADDR=1, LOAD=1, D=1 + clock: reading ADDR=1 shows R=1");
+        ReadWord(network, addr: false).ShouldBe(2,
+            "isolation: reading ADDR=0 still shows R=2 — the addressed word alone commits");
+    }
+
+    /// <summary>
+    /// Asserts the pinned hold sequence (acceptance criterion 4): after the two stores,
+    /// LOAD=0 holds both words across further clock steps while the data inputs rest.
+    /// </summary>
+    private static void AssertHoldAcrossSteps(LogicNetworkEvaluator network)
+    {
+        AssertStoreIsolation(network);
+
+        network.Evaluate(HoldingInputBits());
+        network.Step();
+        network.Step();
+        ReadWord(network, addr: false).ShouldBe(2,
+            "LOAD=0: word 0 holds R=2 across two steps");
+        ReadWord(network, addr: true).ShouldBe(1,
+            "LOAD=0: word 1 holds R=1 across two steps");
+    }
+
+    [Fact]
+    public async Task SaveLoadRoundTrip_ReAssembledNetwork_YieldsTheSameRam()
+    {
+        var savedPath = await _fixture.SaveToTempFile();
+        try
+        {
+            var reloadedCanvas = await LogicGateHalfAdderExampleTests.LoadCanvas(savedPath);
+
+            var reloadedGroups = LogicGateHalfAdderExampleTests.GroupsOf(reloadedCanvas);
+            reloadedGroups.Select(g => g.GroupName).ShouldBe(GateNames, ignoreOrder: true);
+            reloadedGroups.ShouldAllBe(g => g.TruthTablePinAssignment != null,
+                "the persisted pin roles must survive the save → load round trip");
+            foreach (var group in reloadedGroups)
+            {
+                var roles = group.TruthTablePinAssignment!;
+                roles.IsRegister.ShouldBe(RegisterNames.Contains(group.GroupName),
+                    $"the register designation of '{group.GroupName}' must survive the save → load round trip");
+                var expectedInputs = CopyNames.Contains(group.GroupName) || NotNames.Contains(group.GroupName)
+                    ? new[] { "A" } : new[] { "A", "B" };
+                roles.InputPinNames.ToArray().ShouldBe(expectedInputs,
+                    customMessage: $"the input roles of '{group.GroupName}' must survive the save → load round trip");
+                roles.InputSignalNames.ShouldBe(ExpectedInputSignalNames.GetValueOrDefault(group.GroupName),
+                    $"the input signal names of '{group.GroupName}' must survive the save → load round trip (#1025)");
+                roles.OutputSignalNames.ShouldBe(ExpectedOutputSignalNames.GetValueOrDefault(group.GroupName),
+                    $"the output signal names of '{group.GroupName}' must survive the save → load round trip (#1025)");
+            }
+            reloadedCanvas.Connections.Count.ShouldBe(49,
+                "every RAM wire — the register feedbacks and read taps included — must "
+                + "survive the save → load round trip");
+
+            var reloaded = await LogicGateMuxExampleTests.AssembleNetwork(reloadedCanvas);
+            reloaded.InputPinNames.ShouldBe(_fixture.Network.InputPinNames);
+            reloaded.OutputPinNames.ShouldBe(_fixture.Network.OutputPinNames);
+            reloaded.RegisterState.Keys.ShouldBe(_fixture.Network.RegisterState.Keys, ignoreOrder: true,
+                customMessage: "the re-assembled network must carry the same register state elements");
+
+            AssertStoreIsolation(reloaded);
+            AssertHoldAcrossSteps(reloaded);
+        }
+        finally
+        {
+            if (File.Exists(savedPath)) File.Delete(savedPath);
+        }
+    }
+
+    /// <summary>The network input bits for one ADDR/LOAD/D0/D1 quadruple — one bit per signal (issue #1025).</summary>
+    private static Dictionary<string, bool> Bits(bool addr, bool load, bool d0, bool d1) =>
+        new()
+        {
+            [AddressSignal] = addr,
+            [LoadSignal] = load,
+            [LowDataSignal] = d0,
+            [HighDataSignal] = d1,
+        };
+
+    /// <summary>
+    /// Shared fixture: loads the shipped example once and assembles its logic network
+    /// (each extraction is a real simulation run), so every fact asserts against the
+    /// same loaded design and assembled network.
+    /// </summary>
+    public class RamFixture : IAsyncLifetime
+    {
+        private const string ExampleFileName = "Logic Gate RAM 2x2.lun";
+
+        /// <summary>Laser wavelength the persisted roles were extracted at.</summary>
+        public const int WavelengthNm = 1550;
+
+        /// <summary>The canvas the shipped example loaded onto.</summary>
+        public DesignCanvasViewModel Canvas { get; private set; } = null!;
+
+        /// <summary>The loaded top-level gate groups, in file order.</summary>
+        public List<ComponentGroup> Groups { get; private set; } = null!;
+
+        /// <summary>The logic network assembled from the loaded design.</summary>
+        public LogicNetworkEvaluator Network { get; private set; } = null!;
+
+        /// <summary>Loads the shipped example and assembles its logic network.</summary>
+        public async Task InitializeAsync()
+        {
+            var path = Path.Combine(ExampleDesignFilesTests.ExamplesDirectory(), ExampleFileName);
+            Canvas = await LogicGateHalfAdderExampleTests.LoadCanvas(path);
+            Groups = LogicGateHalfAdderExampleTests.GroupsOf(Canvas);
+            Network = await LogicGateMuxExampleTests.AssembleNetwork(Canvas);
+        }
+
+        /// <summary>No shared state to release.</summary>
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        /// <summary>Saves the loaded design through the real save path and returns the file path.</summary>
+        public async Task<string> SaveToTempFile()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"ram-2x2-{Guid.NewGuid():N}.lun");
+            var saveVm = LogicGateHalfAdderExampleTests.CreateFileOperations(Canvas);
+            var dialog = new Mock<IFileDialogService>();
+            dialog.Setup(f => f.ShowSaveFileDialogAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(path);
+            saveVm.FileDialogService = dialog.Object;
+            await saveVm.SaveDesignAsCommand.ExecuteAsync(null);
+            File.Exists(path).ShouldBeTrue("the real save path must write the temp .lun");
+            return path;
+        }
+    }
+}

--- a/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
+++ b/UnitTests/Services/Localization/ExamplesManifestLocalizationTests.cs
@@ -111,6 +111,27 @@ public class ExamplesManifestLocalizationTests
     }
 
     [Fact]
+    public void CuratedLadder_ListsTheRam2x2_BetweenTheRegisterAndTheCounter()
+    {
+        var ladder = new CAP.Avalonia.Services.ExampleDesignsService().GetExamples()
+            .Where(example => example.DescriptionKey != null)
+            .ToList();
+
+        var registerIndex = ladder.FindIndex(example => example.Name == "Logic Gate Register 2-bit");
+        registerIndex.ShouldBeGreaterThanOrEqualTo(0, "the 2-bit register rung must stay curated");
+
+        var ramIndex = ladder.FindIndex(example => example.Name == "Logic Gate RAM 2x2");
+        ramIndex.ShouldBeGreaterThan(registerIndex,
+            "the 2x2 RAM is the NAND2TETRIS RAM slice — it slots between the Register and the counter");
+        ladder[ramIndex].Level.ShouldBe("Sequential");
+        ladder[ramIndex].DescriptionKey.ShouldBe("Examples.Ram2x2.Description");
+
+        var counterIndex = ladder.FindIndex(example => example.Name == "Logic Gate Counter 2-bit");
+        counterIndex.ShouldBeGreaterThan(ramIndex,
+            "the 2-bit counter builds on addressable memory — it stays the rung after the RAM");
+    }
+
+    [Fact]
     public void CuratedLadder_ListsTheCounter2Bit_AfterTheSrLatch()
     {
         var ladder = new CAP.Avalonia.Services.ExampleDesignsService().GetExamples()

--- a/examples/Logic Gate RAM 2x2.lun
+++ b/examples/Logic Gate RAM 2x2.lun
@@ -1,0 +1,11092 @@
+{
+  "FormatVersion": "2.0",
+  "Components": [],
+  "Connections": [
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_a39fcf29ce034d6ea297850aba376d2f",
+      "EndComponentId": "group_6f44ebebf9d143d8a71376c3a7600fa0",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_a39fcf29ce034d6ea297850aba376d2f",
+      "EndComponentId": "group_3b90f0b3893642c198ba138b7d2066f6",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_3b90f0b3893642c198ba138b7d2066f6",
+      "EndComponentId": "group_0b036a72c40843abbd47d704c2b3ca1f",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_3b90f0b3893642c198ba138b7d2066f6",
+      "EndComponentId": "group_68b6d049dc8547f9a97cc2e99d93bb61",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_a08d2e3780f044e5ab899c3ac4f776db",
+      "EndComponentId": "group_5ab7815a82274ca99fe30b81567b4a7d",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_5ab7815a82274ca99fe30b81567b4a7d",
+      "EndComponentId": "group_342f1d021adc45b489445d55d9278cc1",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_5ab7815a82274ca99fe30b81567b4a7d",
+      "EndComponentId": "group_648c3c2b72964e979cfbff4ec0fde679",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_648c3c2b72964e979cfbff4ec0fde679",
+      "EndComponentId": "group_28cc6da51e7a4e2f82e39c86554b04da",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_648c3c2b72964e979cfbff4ec0fde679",
+      "EndComponentId": "group_dafb5168f8614308975195ad45ec9802",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_342f1d021adc45b489445d55d9278cc1",
+      "EndComponentId": "group_5d5e3f59430d491c92f8b56eafe09506",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_5d5e3f59430d491c92f8b56eafe09506",
+      "EndComponentId": "group_19b64a6f323f4233a7e158a96162c69a",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_5d5e3f59430d491c92f8b56eafe09506",
+      "EndComponentId": "group_e42b729df90f43a4b16556ffcac6e2aa",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_19b64a6f323f4233a7e158a96162c69a",
+      "EndComponentId": "group_29174244f9f64613b84026019db8f808",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_e42b729df90f43a4b16556ffcac6e2aa",
+      "EndComponentId": "group_de561681602e438c99c37cc519200906",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_29174244f9f64613b84026019db8f808",
+      "EndComponentId": "group_2a9bc650f1704bacae20fd02d2b18f65",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_de561681602e438c99c37cc519200906",
+      "EndComponentId": "group_0bde9dbf7e1348b298106bbe3dd1eaa1",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_2a9bc650f1704bacae20fd02d2b18f65",
+      "EndComponentId": "group_0bde9dbf7e1348b298106bbe3dd1eaa1",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_0bde9dbf7e1348b298106bbe3dd1eaa1",
+      "EndComponentId": "group_1c0833e27a0040c9a833a0f3933d40e7",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_1c0833e27a0040c9a833a0f3933d40e7",
+      "EndComponentId": "group_de561681602e438c99c37cc519200906",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_e42b729df90f43a4b16556ffcac6e2aa",
+      "EndComponentId": "group_5c44bbeaddf64b08a7dfaa36e9d0784d",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_29174244f9f64613b84026019db8f808",
+      "EndComponentId": "group_9ef9805feaf243429c345d2e488d3ebf",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_5c44bbeaddf64b08a7dfaa36e9d0784d",
+      "EndComponentId": "group_c698ad13f5f24a6694f4a642558da22f",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_9ef9805feaf243429c345d2e488d3ebf",
+      "EndComponentId": "group_c698ad13f5f24a6694f4a642558da22f",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_c698ad13f5f24a6694f4a642558da22f",
+      "EndComponentId": "group_dd56738cac2e48fe9361cb83e5eda1fc",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_dd56738cac2e48fe9361cb83e5eda1fc",
+      "EndComponentId": "group_5c44bbeaddf64b08a7dfaa36e9d0784d",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_6f44ebebf9d143d8a71376c3a7600fa0",
+      "EndComponentId": "group_614c4c27f6e74ee6aab949229948a74c",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_614c4c27f6e74ee6aab949229948a74c",
+      "EndComponentId": "group_ffd49fe698474c2f9b5f1e3009c62ba1",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_614c4c27f6e74ee6aab949229948a74c",
+      "EndComponentId": "group_54783bfafc2d455395e17fc1734df1eb",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_ffd49fe698474c2f9b5f1e3009c62ba1",
+      "EndComponentId": "group_ee7243fb3c414305a49b9b01d4d8efd9",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_54783bfafc2d455395e17fc1734df1eb",
+      "EndComponentId": "group_c109526fb6dc4b47b7dadfcbb1f22343",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_ee7243fb3c414305a49b9b01d4d8efd9",
+      "EndComponentId": "group_bca1fc22589246b1bba37329e7d24204",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_c109526fb6dc4b47b7dadfcbb1f22343",
+      "EndComponentId": "group_c17f1717c6994ad391c2cd3638e86ca0",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_bca1fc22589246b1bba37329e7d24204",
+      "EndComponentId": "group_c17f1717c6994ad391c2cd3638e86ca0",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_c17f1717c6994ad391c2cd3638e86ca0",
+      "EndComponentId": "group_b08a4f4ea9b44dec8c912dec31f4068f",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_b08a4f4ea9b44dec8c912dec31f4068f",
+      "EndComponentId": "group_c109526fb6dc4b47b7dadfcbb1f22343",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_54783bfafc2d455395e17fc1734df1eb",
+      "EndComponentId": "group_b0d1e63742d6401fa7ffd0162f90c8a6",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_ee7243fb3c414305a49b9b01d4d8efd9",
+      "EndComponentId": "group_e75640cb30fa40209cf460f63d4d8486",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_b0d1e63742d6401fa7ffd0162f90c8a6",
+      "EndComponentId": "group_d50e95dac9df4689b5600d69b1508e00",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_e75640cb30fa40209cf460f63d4d8486",
+      "EndComponentId": "group_d50e95dac9df4689b5600d69b1508e00",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_d50e95dac9df4689b5600d69b1508e00",
+      "EndComponentId": "group_6d15fbdfb4c4494f9bce07223781029c",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y1",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_6d15fbdfb4c4494f9bce07223781029c",
+      "EndComponentId": "group_b0d1e63742d6401fa7ffd0162f90c8a6",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_1c0833e27a0040c9a833a0f3933d40e7",
+      "EndComponentId": "group_28cc6da51e7a4e2f82e39c86554b04da",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_b08a4f4ea9b44dec8c912dec31f4068f",
+      "EndComponentId": "group_0b036a72c40843abbd47d704c2b3ca1f",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_28cc6da51e7a4e2f82e39c86554b04da",
+      "EndComponentId": "group_473a6695141b46bb89200532a7f1d25e",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_0b036a72c40843abbd47d704c2b3ca1f",
+      "EndComponentId": "group_473a6695141b46bb89200532a7f1d25e",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_dd56738cac2e48fe9361cb83e5eda1fc",
+      "EndComponentId": "group_dafb5168f8614308975195ad45ec9802",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y2",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_6d15fbdfb4c4494f9bce07223781029c",
+      "EndComponentId": "group_68b6d049dc8547f9a97cc2e99d93bb61",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "A",
+      "StartComponentId": "group_dafb5168f8614308975195ad45ec9802",
+      "EndComponentId": "group_8c174034a9ea478b88aefe5c8fb572cf",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    },
+    {
+      "StartComponentIndex": 0,
+      "StartPinName": "Y",
+      "EndComponentIndex": 0,
+      "EndPinName": "B",
+      "StartComponentId": "group_68b6d049dc8547f9a97cc2e99d93bb61",
+      "EndComponentId": "group_8c174034a9ea478b88aefe5c8fb572cf",
+      "WidthMicrometers": 0.5,
+      "BendRadiusMicrometers": 10
+    }
+  ],
+  "Groups": [
+    {
+      "GroupDto": {
+        "GroupName": "CPAX",
+        "Description": "copy gate (input A, threshold 0.375): ADDR fan-out onto the word-1 DMUX enable EN1 and the read-path selection cascade CPA — one waveguide per signal (#1128/#1138). The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_a39fcf29ce034d6ea297850aba376d2f",
+        "IdGuid": "90e1b43d-2c70-45d5-a0d2-7303b3980431",
+        "ChildComponentGuids": [
+          "aef70c43-ca06-459f-bc3e-45248ee8e30c",
+          "b60c97e3-a773-45c8-ad1d-f118d703edc0",
+          "a17cb387-ef2e-48d0-aaa2-6674d38c7c34",
+          "6114c4d4-1c09-4977-b8b3-60afee50a0e6"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_8256b5325b674b069e86f075abd0b683",
+          "split_a7665551b85f4607bc3ae0db78bcaef7",
+          "output_caf1d913a07d4062ab49a0a2e6c2cae9",
+          "output_aeb780b7847744c284fdf3d34f243553"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "34649a98-953c-4d29-84a6-78414b2abccc",
+            "StartComponentId": "input_8256b5325b674b069e86f075abd0b683",
+            "StartComponentGuid": "aef70c43-ca06-459f-bc3e-45248ee8e30c",
+            "StartPinName": "b0",
+            "EndComponentId": "split_a7665551b85f4607bc3ae0db78bcaef7",
+            "EndComponentGuid": "b60c97e3-a773-45c8-ad1d-f118d703edc0",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "b7a6ff35-749c-443f-a203-9ee37c22f708",
+            "StartComponentId": "split_a7665551b85f4607bc3ae0db78bcaef7",
+            "StartComponentGuid": "b60c97e3-a773-45c8-ad1d-f118d703edc0",
+            "StartPinName": "out1",
+            "EndComponentId": "output_caf1d913a07d4062ab49a0a2e6c2cae9",
+            "EndComponentGuid": "a17cb387-ef2e-48d0-aaa2-6674d38c7c34",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "90c44aa9-5a7a-4283-b4b3-2f442b8cafbf",
+            "StartComponentId": "split_a7665551b85f4607bc3ae0db78bcaef7",
+            "StartComponentGuid": "b60c97e3-a773-45c8-ad1d-f118d703edc0",
+            "StartPinName": "out2",
+            "EndComponentId": "output_aeb780b7847744c284fdf3d34f243553",
+            "EndComponentGuid": "6114c4d4-1c09-4977-b8b3-60afee50a0e6",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "b1e6f16b-5226-46de-9453-ea2123d7292f",
+            "Name": "A",
+            "InternalComponentId": "input_8256b5325b674b069e86f075abd0b683",
+            "InternalComponentGuid": "aef70c43-ca06-459f-bc3e-45248ee8e30c",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "dd64ccdd-e5b9-46f2-8080-d4dfa4dbeca1",
+            "Name": "Y1",
+            "InternalComponentId": "output_caf1d913a07d4062ab49a0a2e6c2cae9",
+            "InternalComponentGuid": "a17cb387-ef2e-48d0-aaa2-6674d38c7c34",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "b7100444-a2f8-4955-ac3e-a13cf2b6493e",
+            "Name": "Y2",
+            "InternalComponentId": "output_aeb780b7847744c284fdf3d34f243553",
+            "InternalComponentGuid": "6114c4d4-1c09-4977-b8b3-60afee50a0e6",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_8256b5325b674b069e86f075abd0b683",
+          "ComponentGuid": "aef70c43-ca06-459f-bc3e-45248ee8e30c",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_a7665551b85f4607bc3ae0db78bcaef7",
+          "ComponentGuid": "b60c97e3-a773-45c8-ad1d-f118d703edc0",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_caf1d913a07d4062ab49a0a2e6c2cae9",
+          "ComponentGuid": "a17cb387-ef2e-48d0-aaa2-6674d38c7c34",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_aeb780b7847744c284fdf3d34f243553",
+          "ComponentGuid": "6114c4d4-1c09-4977-b8b3-60afee50a0e6",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "InputSignalNames": {
+          "A": "ADDR"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPA",
+        "Description": "copy gate (input A, threshold 0.375): the second ADDR arm onto the two read-path word-1 select gates MB0/MB1. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_3b90f0b3893642c198ba138b7d2066f6",
+        "IdGuid": "a5bf85df-e1aa-4f1c-977a-c958191e5162",
+        "ChildComponentGuids": [
+          "a2bed6b5-0c52-4eac-b560-e7529c3f1312",
+          "13850941-6a33-4bc7-9cf0-c3012b12b87a",
+          "47bc22be-f009-4fc2-ae49-1d2f118a54ff",
+          "a08b9a2c-158c-4a07-a26c-2ea92756c9f6"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_1d9de15c3bbe457090c4628c7c80ddfb",
+          "split_376a068a7f5341ee9daa3369b5863c69",
+          "output_704c7f28bb54497693205eeb6a200530",
+          "output_b2bf12bb7c36490082febb1392b32336"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "137f3057-b510-4802-8442-d9a7d7aca269",
+            "StartComponentId": "input_1d9de15c3bbe457090c4628c7c80ddfb",
+            "StartComponentGuid": "a2bed6b5-0c52-4eac-b560-e7529c3f1312",
+            "StartPinName": "b0",
+            "EndComponentId": "split_376a068a7f5341ee9daa3369b5863c69",
+            "EndComponentGuid": "13850941-6a33-4bc7-9cf0-c3012b12b87a",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "cf4f182c-923d-4f69-aef5-0296042f3e05",
+            "StartComponentId": "split_376a068a7f5341ee9daa3369b5863c69",
+            "StartComponentGuid": "13850941-6a33-4bc7-9cf0-c3012b12b87a",
+            "StartPinName": "out1",
+            "EndComponentId": "output_704c7f28bb54497693205eeb6a200530",
+            "EndComponentGuid": "47bc22be-f009-4fc2-ae49-1d2f118a54ff",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "4a1202a1-fea3-41ee-a5ba-929cdca2b360",
+            "StartComponentId": "split_376a068a7f5341ee9daa3369b5863c69",
+            "StartComponentGuid": "13850941-6a33-4bc7-9cf0-c3012b12b87a",
+            "StartPinName": "out2",
+            "EndComponentId": "output_b2bf12bb7c36490082febb1392b32336",
+            "EndComponentGuid": "a08b9a2c-158c-4a07-a26c-2ea92756c9f6",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "90720125-a7a1-48a4-81bd-7110bab57c0f",
+            "Name": "A",
+            "InternalComponentId": "input_1d9de15c3bbe457090c4628c7c80ddfb",
+            "InternalComponentGuid": "a2bed6b5-0c52-4eac-b560-e7529c3f1312",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8df45781-2ca6-4bbe-bf32-77397a07ed69",
+            "Name": "Y1",
+            "InternalComponentId": "output_704c7f28bb54497693205eeb6a200530",
+            "InternalComponentGuid": "47bc22be-f009-4fc2-ae49-1d2f118a54ff",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "70f8051c-3f37-4d23-b207-8e2c1ba585eb",
+            "Name": "Y2",
+            "InternalComponentId": "output_b2bf12bb7c36490082febb1392b32336",
+            "InternalComponentGuid": "a08b9a2c-158c-4a07-a26c-2ea92756c9f6",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_1d9de15c3bbe457090c4628c7c80ddfb",
+          "ComponentGuid": "a2bed6b5-0c52-4eac-b560-e7529c3f1312",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_376a068a7f5341ee9daa3369b5863c69",
+          "ComponentGuid": "13850941-6a33-4bc7-9cf0-c3012b12b87a",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_704c7f28bb54497693205eeb6a200530",
+          "ComponentGuid": "47bc22be-f009-4fc2-ae49-1d2f118a54ff",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_b2bf12bb7c36490082febb1392b32336",
+          "ComponentGuid": "a08b9a2c-158c-4a07-a26c-2ea92756c9f6",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 500,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "NOTA",
+        "Description": "NOT reading (input A, BIAS constantly on, threshold 0.375) of the shipped 'Logic Gate NOT-NAND' gate. Role in the RAM: ADDR inversion, NA = NOT(ADDR), feeding the word-0 DMUX enable EN0 and the read-path word-0 select cascade CPN. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_a08d2e3780f044e5ab899c3ac4f776db",
+        "IdGuid": "ec06780e-4b5d-4196-a831-2a96cb7d67dd",
+        "ChildComponentGuids": [
+          "63520ed7-c2c4-4335-9e70-31b4852ba499",
+          "eaecd1b2-c7be-4431-a5a5-d2ce64f05fa3",
+          "c6c8586d-f442-4507-b8c3-50d64915470a",
+          "a8c58d84-e7f3-480c-ab52-173c9dc0ade2",
+          "b8f7f889-85c8-4116-b594-77360cc00479",
+          "5c4f100e-34e9-482a-a63d-5833ab044384"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_10eaffb7bbb84a48b9e8fc1c0da1d2f6",
+          "input_a1a187a669b14421b03ad4bc3484bb2b",
+          "combine_4441b6aab8984a8d9f1278e2f38cc531",
+          "phase_ee82dcf04523477398c0a00a3a586979",
+          "recombine_6cc59509987a4d9a8414bed807a3109f",
+          "output_21d995f2ee6a4b9497312fd49b788090"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "c993fc37-859c-4925-9251-7086bea4408c",
+            "StartComponentId": "input_10eaffb7bbb84a48b9e8fc1c0da1d2f6",
+            "StartComponentGuid": "63520ed7-c2c4-4335-9e70-31b4852ba499",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_4441b6aab8984a8d9f1278e2f38cc531",
+            "EndComponentGuid": "c6c8586d-f442-4507-b8c3-50d64915470a",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "a8c06ac0-cdc6-46fc-90bb-84f6700724ce",
+            "StartComponentId": "input_a1a187a669b14421b03ad4bc3484bb2b",
+            "StartComponentGuid": "eaecd1b2-c7be-4431-a5a5-d2ce64f05fa3",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_4441b6aab8984a8d9f1278e2f38cc531",
+            "EndComponentGuid": "c6c8586d-f442-4507-b8c3-50d64915470a",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "26c447ae-2a64-4f37-9b67-7c0e28fb7d1d",
+            "StartComponentId": "combine_4441b6aab8984a8d9f1278e2f38cc531",
+            "StartComponentGuid": "c6c8586d-f442-4507-b8c3-50d64915470a",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_6cc59509987a4d9a8414bed807a3109f",
+            "EndComponentGuid": "b8f7f889-85c8-4116-b594-77360cc00479",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "ae0a9ce8-0665-40b2-862b-449506c36f20",
+            "StartComponentId": "phase_ee82dcf04523477398c0a00a3a586979",
+            "StartComponentGuid": "a8c58d84-e7f3-480c-ab52-173c9dc0ade2",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_6cc59509987a4d9a8414bed807a3109f",
+            "EndComponentGuid": "b8f7f889-85c8-4116-b594-77360cc00479",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "5d2f212d-2a88-4411-8fc1-77fd4b47038c",
+            "StartComponentId": "recombine_6cc59509987a4d9a8414bed807a3109f",
+            "StartComponentGuid": "b8f7f889-85c8-4116-b594-77360cc00479",
+            "StartPinName": "out1",
+            "EndComponentId": "output_21d995f2ee6a4b9497312fd49b788090",
+            "EndComponentGuid": "5c4f100e-34e9-482a-a63d-5833ab044384",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "9df71984-fc9b-4d34-83e5-da840710588d",
+            "Name": "A",
+            "InternalComponentId": "input_10eaffb7bbb84a48b9e8fc1c0da1d2f6",
+            "InternalComponentGuid": "63520ed7-c2c4-4335-9e70-31b4852ba499",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "812d2d22-6073-4401-aea4-92443213937a",
+            "Name": "B",
+            "InternalComponentId": "input_a1a187a669b14421b03ad4bc3484bb2b",
+            "InternalComponentGuid": "eaecd1b2-c7be-4431-a5a5-d2ce64f05fa3",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "869da09c-d097-4db4-88ab-02160e3227ea",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_ee82dcf04523477398c0a00a3a586979",
+            "InternalComponentGuid": "a8c58d84-e7f3-480c-ab52-173c9dc0ade2",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "d68deb34-60e5-4aee-9ba2-90734f51e82f",
+            "Name": "Y",
+            "InternalComponentId": "output_21d995f2ee6a4b9497312fd49b788090",
+            "InternalComponentGuid": "5c4f100e-34e9-482a-a63d-5833ab044384",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_10eaffb7bbb84a48b9e8fc1c0da1d2f6",
+          "ComponentGuid": "63520ed7-c2c4-4335-9e70-31b4852ba499",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_a1a187a669b14421b03ad4bc3484bb2b",
+          "ComponentGuid": "eaecd1b2-c7be-4431-a5a5-d2ce64f05fa3",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_4441b6aab8984a8d9f1278e2f38cc531",
+          "ComponentGuid": "c6c8586d-f442-4507-b8c3-50d64915470a",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_ee82dcf04523477398c0a00a3a586979",
+          "ComponentGuid": "a8c58d84-e7f3-480c-ab52-173c9dc0ade2",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_6cc59509987a4d9a8414bed807a3109f",
+          "ComponentGuid": "b8f7f889-85c8-4116-b594-77360cc00479",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_21d995f2ee6a4b9497312fd49b788090",
+          "ComponentGuid": "5c4f100e-34e9-482a-a63d-5833ab044384",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 100,
+      "CanvasY": 300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.375,
+        "InputSignalNames": {
+          "A": "ADDR"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPNX",
+        "Description": "copy gate (input A, threshold 0.375): the inverted-address fan-out onto the word-0 enable EN0 and the word-0 read cascade CPN. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_5ab7815a82274ca99fe30b81567b4a7d",
+        "IdGuid": "8692727b-d6e2-463d-8353-10988e37cccc",
+        "ChildComponentGuids": [
+          "15f2778c-a544-410f-91ea-e250132293ef",
+          "d2372385-c162-45f3-a3b0-fa7c1e5504c7",
+          "b262742b-243f-4427-b317-a44267e002b0",
+          "05895ecc-5fb6-414e-85bc-65dcdb413841"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_cfb0fbd5e8fe475c8692bb1772349fdf",
+          "split_26baae88f2d0472e8395ab8904f09ceb",
+          "output_49a0550e00584c2691edf60d55018384",
+          "output_7ca59ad7c2a44096bbd58dec34b233fa"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "fcba39a7-d664-47ff-a3ad-e44c8361294d",
+            "StartComponentId": "input_cfb0fbd5e8fe475c8692bb1772349fdf",
+            "StartComponentGuid": "15f2778c-a544-410f-91ea-e250132293ef",
+            "StartPinName": "b0",
+            "EndComponentId": "split_26baae88f2d0472e8395ab8904f09ceb",
+            "EndComponentGuid": "d2372385-c162-45f3-a3b0-fa7c1e5504c7",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "5dfe73da-56bb-4427-a65e-5962a6a12af5",
+            "StartComponentId": "split_26baae88f2d0472e8395ab8904f09ceb",
+            "StartComponentGuid": "d2372385-c162-45f3-a3b0-fa7c1e5504c7",
+            "StartPinName": "out1",
+            "EndComponentId": "output_49a0550e00584c2691edf60d55018384",
+            "EndComponentGuid": "b262742b-243f-4427-b317-a44267e002b0",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "a8a8e407-74e5-47f5-898a-0524035250dd",
+            "StartComponentId": "split_26baae88f2d0472e8395ab8904f09ceb",
+            "StartComponentGuid": "d2372385-c162-45f3-a3b0-fa7c1e5504c7",
+            "StartPinName": "out2",
+            "EndComponentId": "output_7ca59ad7c2a44096bbd58dec34b233fa",
+            "EndComponentGuid": "05895ecc-5fb6-414e-85bc-65dcdb413841",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "e296b443-2575-4225-b33f-f6f8bbbbbe4e",
+            "Name": "A",
+            "InternalComponentId": "input_cfb0fbd5e8fe475c8692bb1772349fdf",
+            "InternalComponentGuid": "15f2778c-a544-410f-91ea-e250132293ef",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "57f3e06b-b662-48c1-80e0-8889d87cf998",
+            "Name": "Y1",
+            "InternalComponentId": "output_49a0550e00584c2691edf60d55018384",
+            "InternalComponentGuid": "b262742b-243f-4427-b317-a44267e002b0",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "d6f6eef6-14a2-4b9d-9179-d09690ab15c9",
+            "Name": "Y2",
+            "InternalComponentId": "output_7ca59ad7c2a44096bbd58dec34b233fa",
+            "InternalComponentGuid": "05895ecc-5fb6-414e-85bc-65dcdb413841",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_cfb0fbd5e8fe475c8692bb1772349fdf",
+          "ComponentGuid": "15f2778c-a544-410f-91ea-e250132293ef",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_26baae88f2d0472e8395ab8904f09ceb",
+          "ComponentGuid": "d2372385-c162-45f3-a3b0-fa7c1e5504c7",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_49a0550e00584c2691edf60d55018384",
+          "ComponentGuid": "b262742b-243f-4427-b317-a44267e002b0",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_7ca59ad7c2a44096bbd58dec34b233fa",
+          "ComponentGuid": "05895ecc-5fb6-414e-85bc-65dcdb413841",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 500,
+      "CanvasY": 300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPN",
+        "Description": "copy gate (input A, threshold 0.375): the second NA arm onto the two read-path word-0 select gates MA0/MA1. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_648c3c2b72964e979cfbff4ec0fde679",
+        "IdGuid": "de0cab05-8e7c-47af-8f67-331cb7509ee6",
+        "ChildComponentGuids": [
+          "ad4bc0ce-9b70-4fbc-9400-59eacfb7869c",
+          "5b093232-6c7a-4e11-8a65-f31bcc897317",
+          "1eeea093-8725-4bad-946b-6b942d139c30",
+          "9a010eab-92a4-4f85-8d51-b375923dfa89"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_3aeae3216de1405fbfbf6ac1044f75bc",
+          "split_11b2eb2494f0422d9d9eebc72b325c2d",
+          "output_d88d09139b7b410ab0624b1e967acced",
+          "output_e7a303d4f0f246e9b782872d8db596c4"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "b9085f35-fce0-4b5d-a5f1-2c8693480d21",
+            "StartComponentId": "input_3aeae3216de1405fbfbf6ac1044f75bc",
+            "StartComponentGuid": "ad4bc0ce-9b70-4fbc-9400-59eacfb7869c",
+            "StartPinName": "b0",
+            "EndComponentId": "split_11b2eb2494f0422d9d9eebc72b325c2d",
+            "EndComponentGuid": "5b093232-6c7a-4e11-8a65-f31bcc897317",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "8965e10c-0807-482f-9488-77765e50cfc4",
+            "StartComponentId": "split_11b2eb2494f0422d9d9eebc72b325c2d",
+            "StartComponentGuid": "5b093232-6c7a-4e11-8a65-f31bcc897317",
+            "StartPinName": "out1",
+            "EndComponentId": "output_d88d09139b7b410ab0624b1e967acced",
+            "EndComponentGuid": "1eeea093-8725-4bad-946b-6b942d139c30",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "9a60319b-abd0-446b-8d9e-a72f82aa5c54",
+            "StartComponentId": "split_11b2eb2494f0422d9d9eebc72b325c2d",
+            "StartComponentGuid": "5b093232-6c7a-4e11-8a65-f31bcc897317",
+            "StartPinName": "out2",
+            "EndComponentId": "output_e7a303d4f0f246e9b782872d8db596c4",
+            "EndComponentGuid": "9a010eab-92a4-4f85-8d51-b375923dfa89",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "6718c694-62a2-44aa-8e49-bf23f6ce7514",
+            "Name": "A",
+            "InternalComponentId": "input_3aeae3216de1405fbfbf6ac1044f75bc",
+            "InternalComponentGuid": "ad4bc0ce-9b70-4fbc-9400-59eacfb7869c",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "119851fd-0f6a-439e-a28e-7625eda1ebef",
+            "Name": "Y1",
+            "InternalComponentId": "output_d88d09139b7b410ab0624b1e967acced",
+            "InternalComponentGuid": "1eeea093-8725-4bad-946b-6b942d139c30",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "47345e4d-10e5-441b-8189-cb3a39b6500a",
+            "Name": "Y2",
+            "InternalComponentId": "output_e7a303d4f0f246e9b782872d8db596c4",
+            "InternalComponentGuid": "9a010eab-92a4-4f85-8d51-b375923dfa89",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_3aeae3216de1405fbfbf6ac1044f75bc",
+          "ComponentGuid": "ad4bc0ce-9b70-4fbc-9400-59eacfb7869c",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_11b2eb2494f0422d9d9eebc72b325c2d",
+          "ComponentGuid": "5b093232-6c7a-4e11-8a65-f31bcc897317",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_d88d09139b7b410ab0624b1e967acced",
+          "ComponentGuid": "1eeea093-8725-4bad-946b-6b942d139c30",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_e7a303d4f0f246e9b782872d8db596c4",
+          "ComponentGuid": "9a010eab-92a4-4f85-8d51-b375923dfa89",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 900,
+      "CanvasY": 300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "EN0",
+        "Description": "DMUX gate of word 0 (inputs A/B, threshold 0.125 — the AND/NOT pattern behind the MUX example #1059): EN = NAND(NA = NOT(ADDR), LOAD), the inverted word-0 load enable. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_342f1d021adc45b489445d55d9278cc1",
+        "IdGuid": "a272dd2a-043d-4e36-8b9b-52c28aa78ce6",
+        "ChildComponentGuids": [
+          "39b564b2-8f19-418c-8111-58454f81ea89",
+          "f2519a5f-dd2d-408e-b854-c80f594ba0e2",
+          "03291c0d-929e-47c8-b3d8-6b58268ddd02",
+          "b9daab97-4925-4aa9-8162-8693e5074ba2",
+          "d449d99e-993d-4c91-bb55-57471245582b",
+          "c68419de-b4ae-4084-a48b-c600511f18ff"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_144126a5850345f59c8be52e69af54c6",
+          "input_837f22be87c94039a3ed3bad81e26383",
+          "combine_4e31f35a3c56485189f15541471558f4",
+          "phase_7190f6332bad4982850696b67de55f41",
+          "recombine_4b841131bd8c43ba9f240e49136e0d1c",
+          "output_8cf1581fdb0d4ae18ec05132c93b7db5"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "b5032033-c761-456e-9e41-99b0a2d82d81",
+            "StartComponentId": "input_144126a5850345f59c8be52e69af54c6",
+            "StartComponentGuid": "39b564b2-8f19-418c-8111-58454f81ea89",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_4e31f35a3c56485189f15541471558f4",
+            "EndComponentGuid": "03291c0d-929e-47c8-b3d8-6b58268ddd02",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "3721db17-d52c-4a29-a668-8b93ddda1b38",
+            "StartComponentId": "input_837f22be87c94039a3ed3bad81e26383",
+            "StartComponentGuid": "f2519a5f-dd2d-408e-b854-c80f594ba0e2",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_4e31f35a3c56485189f15541471558f4",
+            "EndComponentGuid": "03291c0d-929e-47c8-b3d8-6b58268ddd02",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "4a8a50b5-7ee5-4cd7-b6f5-3cecc674dce9",
+            "StartComponentId": "combine_4e31f35a3c56485189f15541471558f4",
+            "StartComponentGuid": "03291c0d-929e-47c8-b3d8-6b58268ddd02",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_4b841131bd8c43ba9f240e49136e0d1c",
+            "EndComponentGuid": "d449d99e-993d-4c91-bb55-57471245582b",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "fa54f441-c69a-47e2-ae81-11e0709a03c7",
+            "StartComponentId": "phase_7190f6332bad4982850696b67de55f41",
+            "StartComponentGuid": "b9daab97-4925-4aa9-8162-8693e5074ba2",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_4b841131bd8c43ba9f240e49136e0d1c",
+            "EndComponentGuid": "d449d99e-993d-4c91-bb55-57471245582b",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "7c2adfb3-1e76-4cf2-bc20-fa12cdeddeb7",
+            "StartComponentId": "recombine_4b841131bd8c43ba9f240e49136e0d1c",
+            "StartComponentGuid": "d449d99e-993d-4c91-bb55-57471245582b",
+            "StartPinName": "out1",
+            "EndComponentId": "output_8cf1581fdb0d4ae18ec05132c93b7db5",
+            "EndComponentGuid": "c68419de-b4ae-4084-a48b-c600511f18ff",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "9288fe1e-6e17-463b-91ee-2fa669e972af",
+            "Name": "A",
+            "InternalComponentId": "input_144126a5850345f59c8be52e69af54c6",
+            "InternalComponentGuid": "39b564b2-8f19-418c-8111-58454f81ea89",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "333e0732-92f2-409a-90e0-259976b06d6d",
+            "Name": "B",
+            "InternalComponentId": "input_837f22be87c94039a3ed3bad81e26383",
+            "InternalComponentGuid": "f2519a5f-dd2d-408e-b854-c80f594ba0e2",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "38139163-282b-409f-afc1-79cd5a3deb97",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_7190f6332bad4982850696b67de55f41",
+            "InternalComponentGuid": "b9daab97-4925-4aa9-8162-8693e5074ba2",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "ea019b48-0369-488d-85b3-c6ff9988f91e",
+            "Name": "Y",
+            "InternalComponentId": "output_8cf1581fdb0d4ae18ec05132c93b7db5",
+            "InternalComponentGuid": "c68419de-b4ae-4084-a48b-c600511f18ff",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_144126a5850345f59c8be52e69af54c6",
+          "ComponentGuid": "39b564b2-8f19-418c-8111-58454f81ea89",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_837f22be87c94039a3ed3bad81e26383",
+          "ComponentGuid": "f2519a5f-dd2d-408e-b854-c80f594ba0e2",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_4e31f35a3c56485189f15541471558f4",
+          "ComponentGuid": "03291c0d-929e-47c8-b3d8-6b58268ddd02",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_7190f6332bad4982850696b67de55f41",
+          "ComponentGuid": "b9daab97-4925-4aa9-8162-8693e5074ba2",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_4b841131bd8c43ba9f240e49136e0d1c",
+          "ComponentGuid": "d449d99e-993d-4c91-bb55-57471245582b",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_8cf1581fdb0d4ae18ec05132c93b7db5",
+          "ComponentGuid": "c68419de-b4ae-4084-a48b-c600511f18ff",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 900,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false,
+        "InputSignalNames": {
+          "A": "LOAD"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPEA0",
+        "Description": "copy gate (input A, threshold 0.375): the inverted-enable fan-out onto the inverter IW and the hold-arm chain CPEB. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_5d5e3f59430d491c92f8b56eafe09506",
+        "IdGuid": "739e485e-921f-445a-9dda-93c3ab4a5623",
+        "ChildComponentGuids": [
+          "ad942223-5c07-44a2-82cd-77cea0686d6e",
+          "0bc34c67-f5ce-4440-910b-395cc1c790e0",
+          "53ad089b-6f87-4196-ba34-e5fd4aab683d",
+          "f41e1dc7-8e4d-4e75-aebb-bb4dffe54fca"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_3d9acfaa37174addbeb04d858581edab",
+          "split_ae94d249c6624e1594eb0bcd0df5f4ae",
+          "output_3a531378ae5a4c48bee7aa40d3a38899",
+          "output_819cda1a9b2e49a7a9148284a94208dc"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "cd5baadd-c847-4118-a991-756f3fad0081",
+            "StartComponentId": "input_3d9acfaa37174addbeb04d858581edab",
+            "StartComponentGuid": "ad942223-5c07-44a2-82cd-77cea0686d6e",
+            "StartPinName": "b0",
+            "EndComponentId": "split_ae94d249c6624e1594eb0bcd0df5f4ae",
+            "EndComponentGuid": "0bc34c67-f5ce-4440-910b-395cc1c790e0",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "db8d8eb0-f7a5-4191-8c47-606e76b0f921",
+            "StartComponentId": "split_ae94d249c6624e1594eb0bcd0df5f4ae",
+            "StartComponentGuid": "0bc34c67-f5ce-4440-910b-395cc1c790e0",
+            "StartPinName": "out1",
+            "EndComponentId": "output_3a531378ae5a4c48bee7aa40d3a38899",
+            "EndComponentGuid": "53ad089b-6f87-4196-ba34-e5fd4aab683d",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1e82376a-18b8-4b0b-a9fa-72a181ab9338",
+            "StartComponentId": "split_ae94d249c6624e1594eb0bcd0df5f4ae",
+            "StartComponentGuid": "0bc34c67-f5ce-4440-910b-395cc1c790e0",
+            "StartPinName": "out2",
+            "EndComponentId": "output_819cda1a9b2e49a7a9148284a94208dc",
+            "EndComponentGuid": "f41e1dc7-8e4d-4e75-aebb-bb4dffe54fca",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "45f0a22f-d98f-409a-a0e2-e50d1ea96fba",
+            "Name": "A",
+            "InternalComponentId": "input_3d9acfaa37174addbeb04d858581edab",
+            "InternalComponentGuid": "ad942223-5c07-44a2-82cd-77cea0686d6e",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "4998b30a-05a6-4134-aace-a6873d3dacf6",
+            "Name": "Y1",
+            "InternalComponentId": "output_3a531378ae5a4c48bee7aa40d3a38899",
+            "InternalComponentGuid": "53ad089b-6f87-4196-ba34-e5fd4aab683d",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "b641cfd7-4c99-4c64-8ff8-2088799ea0a4",
+            "Name": "Y2",
+            "InternalComponentId": "output_819cda1a9b2e49a7a9148284a94208dc",
+            "InternalComponentGuid": "f41e1dc7-8e4d-4e75-aebb-bb4dffe54fca",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_3d9acfaa37174addbeb04d858581edab",
+          "ComponentGuid": "ad942223-5c07-44a2-82cd-77cea0686d6e",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_ae94d249c6624e1594eb0bcd0df5f4ae",
+          "ComponentGuid": "0bc34c67-f5ce-4440-910b-395cc1c790e0",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_3a531378ae5a4c48bee7aa40d3a38899",
+          "ComponentGuid": "53ad089b-6f87-4196-ba34-e5fd4aab683d",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_819cda1a9b2e49a7a9148284a94208dc",
+          "ComponentGuid": "f41e1dc7-8e4d-4e75-aebb-bb4dffe54fca",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1300,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPEB0",
+        "Description": "copy gate (input A, threshold 0.375): the inverted enable onto the two hold arms H{w}0/H{w}1. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_e42b729df90f43a4b16556ffcac6e2aa",
+        "IdGuid": "5ddbb7e5-a2e2-4430-a9ac-3a256f8b965c",
+        "ChildComponentGuids": [
+          "2c654b03-c4a2-4681-9162-af7295a75452",
+          "0874edb0-fbf9-42d7-b9d7-2af59f658385",
+          "8a072702-15b8-49de-927d-7f36cdd6d4cc",
+          "9e45c953-ad09-4850-b51e-2aa9a44090b2"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_d9364fe5364f4946bf308c66629091e1",
+          "split_5e84d94de0be46cfb790dd12d5d23fc2",
+          "output_08b62195956f4bda8c526d2037cdd22f",
+          "output_f7067f226855402caa560f82ed0864e1"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "d2a0c52e-f25d-440f-a99a-2a794882d645",
+            "StartComponentId": "input_d9364fe5364f4946bf308c66629091e1",
+            "StartComponentGuid": "2c654b03-c4a2-4681-9162-af7295a75452",
+            "StartPinName": "b0",
+            "EndComponentId": "split_5e84d94de0be46cfb790dd12d5d23fc2",
+            "EndComponentGuid": "0874edb0-fbf9-42d7-b9d7-2af59f658385",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "eb95cf6c-e142-4200-81b5-268ca645a5ea",
+            "StartComponentId": "split_5e84d94de0be46cfb790dd12d5d23fc2",
+            "StartComponentGuid": "0874edb0-fbf9-42d7-b9d7-2af59f658385",
+            "StartPinName": "out1",
+            "EndComponentId": "output_08b62195956f4bda8c526d2037cdd22f",
+            "EndComponentGuid": "8a072702-15b8-49de-927d-7f36cdd6d4cc",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "9a0cbeea-b025-44f4-ad84-71fb01d5f3f6",
+            "StartComponentId": "split_5e84d94de0be46cfb790dd12d5d23fc2",
+            "StartComponentGuid": "0874edb0-fbf9-42d7-b9d7-2af59f658385",
+            "StartPinName": "out2",
+            "EndComponentId": "output_f7067f226855402caa560f82ed0864e1",
+            "EndComponentGuid": "9e45c953-ad09-4850-b51e-2aa9a44090b2",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "a2467478-c504-44b4-863a-8dd354f54335",
+            "Name": "A",
+            "InternalComponentId": "input_d9364fe5364f4946bf308c66629091e1",
+            "InternalComponentGuid": "2c654b03-c4a2-4681-9162-af7295a75452",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "3a1d60cd-797d-4a6f-a4e4-248248ffd54d",
+            "Name": "Y1",
+            "InternalComponentId": "output_08b62195956f4bda8c526d2037cdd22f",
+            "InternalComponentGuid": "8a072702-15b8-49de-927d-7f36cdd6d4cc",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "38a1534e-6b4f-4f58-bcaa-f5430503f134",
+            "Name": "Y2",
+            "InternalComponentId": "output_f7067f226855402caa560f82ed0864e1",
+            "InternalComponentGuid": "9e45c953-ad09-4850-b51e-2aa9a44090b2",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_d9364fe5364f4946bf308c66629091e1",
+          "ComponentGuid": "2c654b03-c4a2-4681-9162-af7295a75452",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_5e84d94de0be46cfb790dd12d5d23fc2",
+          "ComponentGuid": "0874edb0-fbf9-42d7-b9d7-2af59f658385",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_08b62195956f4bda8c526d2037cdd22f",
+          "ComponentGuid": "8a072702-15b8-49de-927d-7f36cdd6d4cc",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_f7067f226855402caa560f82ed0864e1",
+          "ComponentGuid": "9e45c953-ad09-4850-b51e-2aa9a44090b2",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1700,
+      "CanvasY": 100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "IW0",
+        "Description": "inverter (input A, threshold 0.375): the true word load enable feeding the load arms through CPI. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_19b64a6f323f4233a7e158a96162c69a",
+        "IdGuid": "a96c6ebc-ef9b-44d4-aa20-afe849358ef7",
+        "ChildComponentGuids": [
+          "250a46ab-9dd7-4843-8a80-7969a1742d5e",
+          "6bc021fa-3f24-409a-b480-f6d369367dfa",
+          "499b3d00-70db-46bf-b8dc-dfd721f3f2c1",
+          "7dc15441-552c-4546-8881-18bfb6da1957",
+          "cd2f0fcc-caa7-4b2b-a7ee-ea5e86d1fe7c",
+          "9b2da6a8-0e19-43f8-b935-8caab14fdddb"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_91d1446dd9f5474f95d39ee58b1cba54",
+          "input_b601a08b95aa4bffb479b65b82c85a88",
+          "combine_082d3aa8f8dc415aa8f4573b010b59ae",
+          "phase_9118dee98d57429bb7372fb18dae1565",
+          "recombine_78cd245cbc7142da9458205ba2814584",
+          "output_067ed41fb9934eeea193adceef127162"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "480a1865-79be-42f6-8e89-8d41c7b22c84",
+            "StartComponentId": "input_91d1446dd9f5474f95d39ee58b1cba54",
+            "StartComponentGuid": "250a46ab-9dd7-4843-8a80-7969a1742d5e",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_082d3aa8f8dc415aa8f4573b010b59ae",
+            "EndComponentGuid": "499b3d00-70db-46bf-b8dc-dfd721f3f2c1",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "e676cbff-20c5-47b1-9f4a-6456970ec919",
+            "StartComponentId": "input_b601a08b95aa4bffb479b65b82c85a88",
+            "StartComponentGuid": "6bc021fa-3f24-409a-b480-f6d369367dfa",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_082d3aa8f8dc415aa8f4573b010b59ae",
+            "EndComponentGuid": "499b3d00-70db-46bf-b8dc-dfd721f3f2c1",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "79f28d8c-5a68-45f0-9732-6d61780bb822",
+            "StartComponentId": "combine_082d3aa8f8dc415aa8f4573b010b59ae",
+            "StartComponentGuid": "499b3d00-70db-46bf-b8dc-dfd721f3f2c1",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_78cd245cbc7142da9458205ba2814584",
+            "EndComponentGuid": "cd2f0fcc-caa7-4b2b-a7ee-ea5e86d1fe7c",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "0a488e32-00de-483d-b5a7-43bd91253463",
+            "StartComponentId": "phase_9118dee98d57429bb7372fb18dae1565",
+            "StartComponentGuid": "7dc15441-552c-4546-8881-18bfb6da1957",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_78cd245cbc7142da9458205ba2814584",
+            "EndComponentGuid": "cd2f0fcc-caa7-4b2b-a7ee-ea5e86d1fe7c",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "2767b976-9c2c-4bdc-8d1c-b0d79c75a204",
+            "StartComponentId": "recombine_78cd245cbc7142da9458205ba2814584",
+            "StartComponentGuid": "cd2f0fcc-caa7-4b2b-a7ee-ea5e86d1fe7c",
+            "StartPinName": "out1",
+            "EndComponentId": "output_067ed41fb9934eeea193adceef127162",
+            "EndComponentGuid": "9b2da6a8-0e19-43f8-b935-8caab14fdddb",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "0ba51b48-9b93-4d04-8cfd-2e120125c4ba",
+            "Name": "A",
+            "InternalComponentId": "input_91d1446dd9f5474f95d39ee58b1cba54",
+            "InternalComponentGuid": "250a46ab-9dd7-4843-8a80-7969a1742d5e",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "360506a5-aee0-4b03-ab82-030852f527c2",
+            "Name": "B",
+            "InternalComponentId": "input_b601a08b95aa4bffb479b65b82c85a88",
+            "InternalComponentGuid": "6bc021fa-3f24-409a-b480-f6d369367dfa",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a832cff3-5712-46f8-bef3-2cde89aed9a7",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_9118dee98d57429bb7372fb18dae1565",
+            "InternalComponentGuid": "7dc15441-552c-4546-8881-18bfb6da1957",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "168536ea-0788-41c7-ab92-4151cea25554",
+            "Name": "Y",
+            "InternalComponentId": "output_067ed41fb9934eeea193adceef127162",
+            "InternalComponentGuid": "9b2da6a8-0e19-43f8-b935-8caab14fdddb",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_91d1446dd9f5474f95d39ee58b1cba54",
+          "ComponentGuid": "250a46ab-9dd7-4843-8a80-7969a1742d5e",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_b601a08b95aa4bffb479b65b82c85a88",
+          "ComponentGuid": "6bc021fa-3f24-409a-b480-f6d369367dfa",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_082d3aa8f8dc415aa8f4573b010b59ae",
+          "ComponentGuid": "499b3d00-70db-46bf-b8dc-dfd721f3f2c1",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_9118dee98d57429bb7372fb18dae1565",
+          "ComponentGuid": "7dc15441-552c-4546-8881-18bfb6da1957",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_78cd245cbc7142da9458205ba2814584",
+          "ComponentGuid": "cd2f0fcc-caa7-4b2b-a7ee-ea5e86d1fe7c",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_067ed41fb9934eeea193adceef127162",
+          "ComponentGuid": "9b2da6a8-0e19-43f8-b935-8caab14fdddb",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1300,
+      "CanvasY": 300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPI0",
+        "Description": "copy gate (input A, threshold 0.375): the true load enable onto the two load arms LE{w}0/LE{w}1. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_29174244f9f64613b84026019db8f808",
+        "IdGuid": "f5a956be-55fa-49c0-882b-326f7b8b1baa",
+        "ChildComponentGuids": [
+          "5b065834-e194-45cf-b5ee-34dd657faf17",
+          "a10784a8-2acd-4ee6-8319-fc9bc1c09b12",
+          "63dfbe10-8cf8-4c4d-8f11-6822f9060507",
+          "0a46c2cb-0552-48ae-9984-07ea1bb4dc00"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_0099b700270f43bea77b3f567e0cace8",
+          "split_bb02a1cdbe6245d68e618623f318ea98",
+          "output_3d4c396a8e944a5188d123bcf523b797",
+          "output_23b62d92f6ef40af9760cca66a0157d7"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "ed112d0d-7f94-4e14-8d75-545d8fbde278",
+            "StartComponentId": "input_0099b700270f43bea77b3f567e0cace8",
+            "StartComponentGuid": "5b065834-e194-45cf-b5ee-34dd657faf17",
+            "StartPinName": "b0",
+            "EndComponentId": "split_bb02a1cdbe6245d68e618623f318ea98",
+            "EndComponentGuid": "a10784a8-2acd-4ee6-8319-fc9bc1c09b12",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "cbc34e78-3436-4246-9054-0d544d1f61b5",
+            "StartComponentId": "split_bb02a1cdbe6245d68e618623f318ea98",
+            "StartComponentGuid": "a10784a8-2acd-4ee6-8319-fc9bc1c09b12",
+            "StartPinName": "out1",
+            "EndComponentId": "output_3d4c396a8e944a5188d123bcf523b797",
+            "EndComponentGuid": "63dfbe10-8cf8-4c4d-8f11-6822f9060507",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f8249275-b78c-489f-95c8-f8b185e93f05",
+            "StartComponentId": "split_bb02a1cdbe6245d68e618623f318ea98",
+            "StartComponentGuid": "a10784a8-2acd-4ee6-8319-fc9bc1c09b12",
+            "StartPinName": "out2",
+            "EndComponentId": "output_23b62d92f6ef40af9760cca66a0157d7",
+            "EndComponentGuid": "0a46c2cb-0552-48ae-9984-07ea1bb4dc00",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "6aea9f72-126b-4225-a9ac-c0ff90440a92",
+            "Name": "A",
+            "InternalComponentId": "input_0099b700270f43bea77b3f567e0cace8",
+            "InternalComponentGuid": "5b065834-e194-45cf-b5ee-34dd657faf17",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "9c2b7766-8301-4c6b-b975-6c9792d6f48e",
+            "Name": "Y1",
+            "InternalComponentId": "output_3d4c396a8e944a5188d123bcf523b797",
+            "InternalComponentGuid": "63dfbe10-8cf8-4c4d-8f11-6822f9060507",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "699b1af2-cadf-470c-98ef-4377360d9b91",
+            "Name": "Y2",
+            "InternalComponentId": "output_23b62d92f6ef40af9760cca66a0157d7",
+            "InternalComponentGuid": "0a46c2cb-0552-48ae-9984-07ea1bb4dc00",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_0099b700270f43bea77b3f567e0cace8",
+          "ComponentGuid": "5b065834-e194-45cf-b5ee-34dd657faf17",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_bb02a1cdbe6245d68e618623f318ea98",
+          "ComponentGuid": "a10784a8-2acd-4ee6-8319-fc9bc1c09b12",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_3d4c396a8e944a5188d123bcf523b797",
+          "ComponentGuid": "63dfbe10-8cf8-4c4d-8f11-6822f9060507",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_23b62d92f6ef40af9760cca66a0157d7",
+          "ComponentGuid": "0a46c2cb-0552-48ae-9984-07ea1bb4dc00",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1700,
+      "CanvasY": 300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "H00",
+        "Description": "hold arm of bit D0, word 0 (inputs A/B, threshold 0.125): H = NAND(R0, EN0) — the shipped register's hold pattern (#1138), blocked while this word loads. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_de561681602e438c99c37cc519200906",
+        "IdGuid": "9dfad36b-8948-4e3c-904d-2c5c8889790f",
+        "ChildComponentGuids": [
+          "6082adb2-dc0c-4173-80c2-f2c1f6d529bf",
+          "2c0db6d3-7536-4598-a0bf-a80cf8891e97",
+          "4871f54d-40e5-4b51-a242-ced6414d1135",
+          "6e58b376-48e0-4a13-b3e4-21afa3a654a1",
+          "16716040-0f7d-4176-9beb-2d2fff9ce662",
+          "2b07b2c4-130c-4c9a-aa8f-e17dba6e5679"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_021ad6c4f3ae451cb1550557c8543709",
+          "input_74fd0656d8b64306826c2bc8f1a70ded",
+          "combine_852aed341bac4eb995c5dbf23bdfa472",
+          "phase_ad784d483d0147109b3e147e75ff4737",
+          "recombine_27a44e3e1e4047b29d007176882dd031",
+          "output_47162fc8e22948ec86847837c4d2b576"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "08ca8e62-130c-4b63-afaf-44d3bf701bfe",
+            "StartComponentId": "input_021ad6c4f3ae451cb1550557c8543709",
+            "StartComponentGuid": "6082adb2-dc0c-4173-80c2-f2c1f6d529bf",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_852aed341bac4eb995c5dbf23bdfa472",
+            "EndComponentGuid": "4871f54d-40e5-4b51-a242-ced6414d1135",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6d898ac4-b838-4f84-9c25-c759026a3515",
+            "StartComponentId": "input_74fd0656d8b64306826c2bc8f1a70ded",
+            "StartComponentGuid": "2c0db6d3-7536-4598-a0bf-a80cf8891e97",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_852aed341bac4eb995c5dbf23bdfa472",
+            "EndComponentGuid": "4871f54d-40e5-4b51-a242-ced6414d1135",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "67f2e34e-1cc7-4657-aafa-9d20d4af7c00",
+            "StartComponentId": "combine_852aed341bac4eb995c5dbf23bdfa472",
+            "StartComponentGuid": "4871f54d-40e5-4b51-a242-ced6414d1135",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_27a44e3e1e4047b29d007176882dd031",
+            "EndComponentGuid": "16716040-0f7d-4176-9beb-2d2fff9ce662",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "bd811262-13e5-4870-a60c-b3aedd52594e",
+            "StartComponentId": "phase_ad784d483d0147109b3e147e75ff4737",
+            "StartComponentGuid": "6e58b376-48e0-4a13-b3e4-21afa3a654a1",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_27a44e3e1e4047b29d007176882dd031",
+            "EndComponentGuid": "16716040-0f7d-4176-9beb-2d2fff9ce662",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1e7b71e3-9b5e-4581-8ba4-fc87f46d9cb0",
+            "StartComponentId": "recombine_27a44e3e1e4047b29d007176882dd031",
+            "StartComponentGuid": "16716040-0f7d-4176-9beb-2d2fff9ce662",
+            "StartPinName": "out1",
+            "EndComponentId": "output_47162fc8e22948ec86847837c4d2b576",
+            "EndComponentGuid": "2b07b2c4-130c-4c9a-aa8f-e17dba6e5679",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "9966bb07-6834-47a9-9f6c-9b2fe35dc787",
+            "Name": "A",
+            "InternalComponentId": "input_021ad6c4f3ae451cb1550557c8543709",
+            "InternalComponentGuid": "6082adb2-dc0c-4173-80c2-f2c1f6d529bf",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "3c87f112-4e87-431c-8d55-610710e3a9db",
+            "Name": "B",
+            "InternalComponentId": "input_74fd0656d8b64306826c2bc8f1a70ded",
+            "InternalComponentGuid": "2c0db6d3-7536-4598-a0bf-a80cf8891e97",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "b36147f4-6926-4d03-b045-f0386d86122a",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_ad784d483d0147109b3e147e75ff4737",
+            "InternalComponentGuid": "6e58b376-48e0-4a13-b3e4-21afa3a654a1",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "e761364a-a041-474c-b999-4e4cb8f6add4",
+            "Name": "Y",
+            "InternalComponentId": "output_47162fc8e22948ec86847837c4d2b576",
+            "InternalComponentGuid": "2b07b2c4-130c-4c9a-aa8f-e17dba6e5679",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_021ad6c4f3ae451cb1550557c8543709",
+          "ComponentGuid": "6082adb2-dc0c-4173-80c2-f2c1f6d529bf",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_74fd0656d8b64306826c2bc8f1a70ded",
+          "ComponentGuid": "2c0db6d3-7536-4598-a0bf-a80cf8891e97",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_852aed341bac4eb995c5dbf23bdfa472",
+          "ComponentGuid": "4871f54d-40e5-4b51-a242-ced6414d1135",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_ad784d483d0147109b3e147e75ff4737",
+          "ComponentGuid": "6e58b376-48e0-4a13-b3e4-21afa3a654a1",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_27a44e3e1e4047b29d007176882dd031",
+          "ComponentGuid": "16716040-0f7d-4176-9beb-2d2fff9ce662",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_47162fc8e22948ec86847837c4d2b576",
+          "ComponentGuid": "2b07b2c4-130c-4c9a-aa8f-e17dba6e5679",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1100,
+      "CanvasY": 500,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "LE00",
+        "Description": "load arm of bit D0, word 0 (inputs A/B, threshold 0.125): LE = NAND(D0, IW0) — passes D0 while this word is addressed under LOAD. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_2a9bc650f1704bacae20fd02d2b18f65",
+        "IdGuid": "b654ff5f-10f0-4e92-aa1f-0692cd27836d",
+        "ChildComponentGuids": [
+          "419f25b0-d506-400a-9f54-9641a3f73e74",
+          "5ab623d8-e2da-4b04-b2c5-e7cc2f7756af",
+          "303f706d-9a3e-49e0-9e9a-ac89a1247b81",
+          "57575a20-2976-4036-9053-48744027e164",
+          "89fbe112-43f8-45f6-9f6a-29cda40fc24a",
+          "c63c0464-3a97-4a2e-8fcd-fb47a3e9da45"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_8e5374f48c1b4a46a898df6b1c0c498c",
+          "input_ccd9746336b3403c95589ed9ba7ab521",
+          "combine_eae74a06457e4f189eae0978095fccb2",
+          "phase_c0140b6f0e2445989764ddec1e2d12d0",
+          "recombine_23bcf4ee013b40848d856211602ed0b5",
+          "output_0387f2adf2da48bd98f5c6873ec9a321"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "b543b5d0-5751-41d2-8e03-09e755f3f72d",
+            "StartComponentId": "input_8e5374f48c1b4a46a898df6b1c0c498c",
+            "StartComponentGuid": "419f25b0-d506-400a-9f54-9641a3f73e74",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_eae74a06457e4f189eae0978095fccb2",
+            "EndComponentGuid": "303f706d-9a3e-49e0-9e9a-ac89a1247b81",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "d0c92e93-7756-43f4-8f90-d7fed0906733",
+            "StartComponentId": "input_ccd9746336b3403c95589ed9ba7ab521",
+            "StartComponentGuid": "5ab623d8-e2da-4b04-b2c5-e7cc2f7756af",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_eae74a06457e4f189eae0978095fccb2",
+            "EndComponentGuid": "303f706d-9a3e-49e0-9e9a-ac89a1247b81",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "bfbd6732-93ca-4931-b4e9-ecf14ff27ce8",
+            "StartComponentId": "combine_eae74a06457e4f189eae0978095fccb2",
+            "StartComponentGuid": "303f706d-9a3e-49e0-9e9a-ac89a1247b81",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_23bcf4ee013b40848d856211602ed0b5",
+            "EndComponentGuid": "89fbe112-43f8-45f6-9f6a-29cda40fc24a",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "5c41a6e3-a061-4904-b5f5-3a2b9892c46a",
+            "StartComponentId": "phase_c0140b6f0e2445989764ddec1e2d12d0",
+            "StartComponentGuid": "57575a20-2976-4036-9053-48744027e164",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_23bcf4ee013b40848d856211602ed0b5",
+            "EndComponentGuid": "89fbe112-43f8-45f6-9f6a-29cda40fc24a",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "33057741-7e94-4863-b66f-4e057b213658",
+            "StartComponentId": "recombine_23bcf4ee013b40848d856211602ed0b5",
+            "StartComponentGuid": "89fbe112-43f8-45f6-9f6a-29cda40fc24a",
+            "StartPinName": "out1",
+            "EndComponentId": "output_0387f2adf2da48bd98f5c6873ec9a321",
+            "EndComponentGuid": "c63c0464-3a97-4a2e-8fcd-fb47a3e9da45",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "9769a478-fa42-416a-be50-bcfd463af118",
+            "Name": "A",
+            "InternalComponentId": "input_8e5374f48c1b4a46a898df6b1c0c498c",
+            "InternalComponentGuid": "419f25b0-d506-400a-9f54-9641a3f73e74",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "67c4bbc9-1029-4c6e-a2d1-ce49bd830656",
+            "Name": "B",
+            "InternalComponentId": "input_ccd9746336b3403c95589ed9ba7ab521",
+            "InternalComponentGuid": "5ab623d8-e2da-4b04-b2c5-e7cc2f7756af",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "88782699-4afa-4502-a473-e15b8393a239",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_c0140b6f0e2445989764ddec1e2d12d0",
+            "InternalComponentGuid": "57575a20-2976-4036-9053-48744027e164",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "f58a8b44-9be2-4fe0-adfb-ab54da9fb1a5",
+            "Name": "Y",
+            "InternalComponentId": "output_0387f2adf2da48bd98f5c6873ec9a321",
+            "InternalComponentGuid": "c63c0464-3a97-4a2e-8fcd-fb47a3e9da45",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_8e5374f48c1b4a46a898df6b1c0c498c",
+          "ComponentGuid": "419f25b0-d506-400a-9f54-9641a3f73e74",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_ccd9746336b3403c95589ed9ba7ab521",
+          "ComponentGuid": "5ab623d8-e2da-4b04-b2c5-e7cc2f7756af",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_eae74a06457e4f189eae0978095fccb2",
+          "ComponentGuid": "303f706d-9a3e-49e0-9e9a-ac89a1247b81",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_c0140b6f0e2445989764ddec1e2d12d0",
+          "ComponentGuid": "57575a20-2976-4036-9053-48744027e164",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_23bcf4ee013b40848d856211602ed0b5",
+          "ComponentGuid": "89fbe112-43f8-45f6-9f6a-29cda40fc24a",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_0387f2adf2da48bd98f5c6873ec9a321",
+          "ComponentGuid": "c63c0464-3a97-4a2e-8fcd-fb47a3e9da45",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 700,
+      "CanvasY": 500,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false,
+        "InputSignalNames": {
+          "A": "D0"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "REG00",
+        "Description": "register of bit D0, word 0 (inputs A/B, threshold 0.125): REG = NAND(H, LE) closing the bit multiplexer; register designation as in the shipped register (#1098). The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_0bde9dbf7e1348b298106bbe3dd1eaa1",
+        "IdGuid": "4168de65-bd81-441b-af43-3b1d42e61c93",
+        "ChildComponentGuids": [
+          "8c6c051d-bdf7-45d6-bba4-d2e58f343540",
+          "b682b3f4-98e8-4eaa-8109-228bb0853181",
+          "b6b4e74f-1030-4927-8b19-8322b4f27142",
+          "ce84fa4a-b98d-447b-a413-3b67843c0a63",
+          "661ee9cf-3f1a-4bd3-9e23-9a2104a4c920",
+          "eac035de-9598-41ba-9f0b-699bedb4bfec"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_a58ac2f69d344146ad68eef5809d408c",
+          "input_f686f77b07ff46d98d5cf43e1df20532",
+          "combine_de6ef27935b749f79661f14a93ce50ce",
+          "phase_fc33d76643c64b9c891dd3c6267fa212",
+          "recombine_fb5c2972725543418051f0315dbb57af",
+          "output_deb49d1f74b14e099fd9d48798cc9ebb"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "0da8aab9-70a4-4742-9ab8-94d7dbc4a42c",
+            "StartComponentId": "input_a58ac2f69d344146ad68eef5809d408c",
+            "StartComponentGuid": "8c6c051d-bdf7-45d6-bba4-d2e58f343540",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_de6ef27935b749f79661f14a93ce50ce",
+            "EndComponentGuid": "b6b4e74f-1030-4927-8b19-8322b4f27142",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "e3b12fd2-a1ea-4ccf-911f-c78aa28f4e62",
+            "StartComponentId": "input_f686f77b07ff46d98d5cf43e1df20532",
+            "StartComponentGuid": "b682b3f4-98e8-4eaa-8109-228bb0853181",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_de6ef27935b749f79661f14a93ce50ce",
+            "EndComponentGuid": "b6b4e74f-1030-4927-8b19-8322b4f27142",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "ceebc590-e2e1-4898-be64-e1388cadb425",
+            "StartComponentId": "combine_de6ef27935b749f79661f14a93ce50ce",
+            "StartComponentGuid": "b6b4e74f-1030-4927-8b19-8322b4f27142",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_fb5c2972725543418051f0315dbb57af",
+            "EndComponentGuid": "661ee9cf-3f1a-4bd3-9e23-9a2104a4c920",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "ebe17df3-76d9-40fe-b403-4f2fbc252bf4",
+            "StartComponentId": "phase_fc33d76643c64b9c891dd3c6267fa212",
+            "StartComponentGuid": "ce84fa4a-b98d-447b-a413-3b67843c0a63",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_fb5c2972725543418051f0315dbb57af",
+            "EndComponentGuid": "661ee9cf-3f1a-4bd3-9e23-9a2104a4c920",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f0e671dc-a93d-4305-8891-dd7739503a0e",
+            "StartComponentId": "recombine_fb5c2972725543418051f0315dbb57af",
+            "StartComponentGuid": "661ee9cf-3f1a-4bd3-9e23-9a2104a4c920",
+            "StartPinName": "out1",
+            "EndComponentId": "output_deb49d1f74b14e099fd9d48798cc9ebb",
+            "EndComponentGuid": "eac035de-9598-41ba-9f0b-699bedb4bfec",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "f4c065a5-6046-4f01-b035-93ba77394239",
+            "Name": "A",
+            "InternalComponentId": "input_a58ac2f69d344146ad68eef5809d408c",
+            "InternalComponentGuid": "8c6c051d-bdf7-45d6-bba4-d2e58f343540",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "597c4eb1-fe97-4a6d-b8d5-3a2a75e7686d",
+            "Name": "B",
+            "InternalComponentId": "input_f686f77b07ff46d98d5cf43e1df20532",
+            "InternalComponentGuid": "b682b3f4-98e8-4eaa-8109-228bb0853181",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "ea2547a3-f804-4cd7-9561-837bc638e651",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_fc33d76643c64b9c891dd3c6267fa212",
+            "InternalComponentGuid": "ce84fa4a-b98d-447b-a413-3b67843c0a63",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "11617295-94dc-44e0-aece-3f4d70749edd",
+            "Name": "Y",
+            "InternalComponentId": "output_deb49d1f74b14e099fd9d48798cc9ebb",
+            "InternalComponentGuid": "eac035de-9598-41ba-9f0b-699bedb4bfec",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_a58ac2f69d344146ad68eef5809d408c",
+          "ComponentGuid": "8c6c051d-bdf7-45d6-bba4-d2e58f343540",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_f686f77b07ff46d98d5cf43e1df20532",
+          "ComponentGuid": "b682b3f4-98e8-4eaa-8109-228bb0853181",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_de6ef27935b749f79661f14a93ce50ce",
+          "ComponentGuid": "b6b4e74f-1030-4927-8b19-8322b4f27142",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_fc33d76643c64b9c891dd3c6267fa212",
+          "ComponentGuid": "ce84fa4a-b98d-447b-a413-3b67843c0a63",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_fb5c2972725543418051f0315dbb57af",
+          "ComponentGuid": "661ee9cf-3f1a-4bd3-9e23-9a2104a4c920",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_deb49d1f74b14e099fd9d48798cc9ebb",
+          "ComponentGuid": "eac035de-9598-41ba-9f0b-699bedb4bfec",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1500,
+      "CanvasY": 500,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": true
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CP00",
+        "Description": "read tap of stored word 0 bit D0 (input A, threshold 0.375): one arm feeds the register's own hold feedback, the other the read MUX arm — one waveguide per signal; the word-0 bit tap W0D0 is renamed on the read arm. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_1c0833e27a0040c9a833a0f3933d40e7",
+        "IdGuid": "59a1ff17-b317-4da9-b027-c6d891c80fe9",
+        "ChildComponentGuids": [
+          "61319972-6c86-4453-895e-1083c3512d57",
+          "08e5c815-be5c-4b5e-8909-e67afcf9bd7b",
+          "9399da48-86eb-4363-95e3-606d188e0976",
+          "9b6c8ac5-22a1-4afe-a71b-f4e84b8fc679"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_ea78af40e5b7484bbc5db4b3a036651e",
+          "split_ecb58245b9ec4c2e8884852f87c95925",
+          "output_15c293000cf34cd6be620e73968d193d",
+          "output_89f963301e0f426aa395ab78251869fb"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "9a997517-84ce-4570-969f-89e374125310",
+            "StartComponentId": "input_ea78af40e5b7484bbc5db4b3a036651e",
+            "StartComponentGuid": "61319972-6c86-4453-895e-1083c3512d57",
+            "StartPinName": "b0",
+            "EndComponentId": "split_ecb58245b9ec4c2e8884852f87c95925",
+            "EndComponentGuid": "08e5c815-be5c-4b5e-8909-e67afcf9bd7b",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "57a54b5d-0019-4d60-9a9a-5dbde0c4bd42",
+            "StartComponentId": "split_ecb58245b9ec4c2e8884852f87c95925",
+            "StartComponentGuid": "08e5c815-be5c-4b5e-8909-e67afcf9bd7b",
+            "StartPinName": "out1",
+            "EndComponentId": "output_15c293000cf34cd6be620e73968d193d",
+            "EndComponentGuid": "9399da48-86eb-4363-95e3-606d188e0976",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "057b0120-2ebf-4c66-9c5c-ed918d043b73",
+            "StartComponentId": "split_ecb58245b9ec4c2e8884852f87c95925",
+            "StartComponentGuid": "08e5c815-be5c-4b5e-8909-e67afcf9bd7b",
+            "StartPinName": "out2",
+            "EndComponentId": "output_89f963301e0f426aa395ab78251869fb",
+            "EndComponentGuid": "9b6c8ac5-22a1-4afe-a71b-f4e84b8fc679",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "12b89eb3-c556-4c41-ae07-1db3ab043974",
+            "Name": "A",
+            "InternalComponentId": "input_ea78af40e5b7484bbc5db4b3a036651e",
+            "InternalComponentGuid": "61319972-6c86-4453-895e-1083c3512d57",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8e6996aa-2aca-4e27-a885-d40e5f08f769",
+            "Name": "Y1",
+            "InternalComponentId": "output_15c293000cf34cd6be620e73968d193d",
+            "InternalComponentGuid": "9399da48-86eb-4363-95e3-606d188e0976",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "86ac4113-7433-4b4b-bbea-331390fb6f3f",
+            "Name": "Y2",
+            "InternalComponentId": "output_89f963301e0f426aa395ab78251869fb",
+            "InternalComponentGuid": "9b6c8ac5-22a1-4afe-a71b-f4e84b8fc679",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_ea78af40e5b7484bbc5db4b3a036651e",
+          "ComponentGuid": "61319972-6c86-4453-895e-1083c3512d57",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_ecb58245b9ec4c2e8884852f87c95925",
+          "ComponentGuid": "08e5c815-be5c-4b5e-8909-e67afcf9bd7b",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_15c293000cf34cd6be620e73968d193d",
+          "ComponentGuid": "9399da48-86eb-4363-95e3-606d188e0976",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_89f963301e0f426aa395ab78251869fb",
+          "ComponentGuid": "9b6c8ac5-22a1-4afe-a71b-f4e84b8fc679",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1900,
+      "CanvasY": 500,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "OutputSignalNames": {
+          "Y2": "W0D0"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "H01",
+        "Description": "hold arm of bit D1, word 0 (inputs A/B, threshold 0.125): H = NAND(R1, EN0) — the shipped register's hold pattern (#1138), blocked while this word loads. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_5c44bbeaddf64b08a7dfaa36e9d0784d",
+        "IdGuid": "083f8ce6-f589-4405-acf7-6ec41b1ed392",
+        "ChildComponentGuids": [
+          "8414b050-47e8-46c4-ba45-9de0fe837b11",
+          "ff0d55cf-2aec-495b-bdf8-b8f3b5c1801b",
+          "05a54e79-efd3-4da8-99c9-83309c300710",
+          "0d4b74d7-7e9f-4be8-8e3b-a7c74b6b4c71",
+          "0d082dd3-504f-4d6d-9013-b7a7ed448ffe",
+          "1768ebd2-206f-42b8-8b38-7a2c85515f95"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_5d3c659f4fc6412c84a7df458d64307a",
+          "input_0d2bb88751c34630b0544fdf9bcafdab",
+          "combine_458d2477e6b74738bba26453edb51ce5",
+          "phase_c02d2ad4a5a14dc7861a5eed2ef38ddd",
+          "recombine_a6d98b9c9e9e431b967a240cec2bb220",
+          "output_81dba2f73b5943209a779a04d9a3ecb8"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "d7cdcd52-6a67-4504-8b3d-6210e49c2e8d",
+            "StartComponentId": "input_5d3c659f4fc6412c84a7df458d64307a",
+            "StartComponentGuid": "8414b050-47e8-46c4-ba45-9de0fe837b11",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_458d2477e6b74738bba26453edb51ce5",
+            "EndComponentGuid": "05a54e79-efd3-4da8-99c9-83309c300710",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "bc6f724f-28a4-4b8f-8c21-c41fa0c62517",
+            "StartComponentId": "input_0d2bb88751c34630b0544fdf9bcafdab",
+            "StartComponentGuid": "ff0d55cf-2aec-495b-bdf8-b8f3b5c1801b",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_458d2477e6b74738bba26453edb51ce5",
+            "EndComponentGuid": "05a54e79-efd3-4da8-99c9-83309c300710",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f5e7c5ab-2475-4204-ba90-d23a8baf3b69",
+            "StartComponentId": "combine_458d2477e6b74738bba26453edb51ce5",
+            "StartComponentGuid": "05a54e79-efd3-4da8-99c9-83309c300710",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_a6d98b9c9e9e431b967a240cec2bb220",
+            "EndComponentGuid": "0d082dd3-504f-4d6d-9013-b7a7ed448ffe",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "b34ccd56-f88c-40fa-91e1-06202010fee4",
+            "StartComponentId": "phase_c02d2ad4a5a14dc7861a5eed2ef38ddd",
+            "StartComponentGuid": "0d4b74d7-7e9f-4be8-8e3b-a7c74b6b4c71",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_a6d98b9c9e9e431b967a240cec2bb220",
+            "EndComponentGuid": "0d082dd3-504f-4d6d-9013-b7a7ed448ffe",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "46d36785-dbbe-4221-ad7e-a6121d78dc8e",
+            "StartComponentId": "recombine_a6d98b9c9e9e431b967a240cec2bb220",
+            "StartComponentGuid": "0d082dd3-504f-4d6d-9013-b7a7ed448ffe",
+            "StartPinName": "out1",
+            "EndComponentId": "output_81dba2f73b5943209a779a04d9a3ecb8",
+            "EndComponentGuid": "1768ebd2-206f-42b8-8b38-7a2c85515f95",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "b8ff98dd-d782-4fcb-9b56-b064c2956fae",
+            "Name": "A",
+            "InternalComponentId": "input_5d3c659f4fc6412c84a7df458d64307a",
+            "InternalComponentGuid": "8414b050-47e8-46c4-ba45-9de0fe837b11",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "c42b1af2-927d-4af0-b0e8-c6e1111e808f",
+            "Name": "B",
+            "InternalComponentId": "input_0d2bb88751c34630b0544fdf9bcafdab",
+            "InternalComponentGuid": "ff0d55cf-2aec-495b-bdf8-b8f3b5c1801b",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "9b14363e-240f-4c8e-8b92-e8e68dae5bb6",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_c02d2ad4a5a14dc7861a5eed2ef38ddd",
+            "InternalComponentGuid": "0d4b74d7-7e9f-4be8-8e3b-a7c74b6b4c71",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "6d43ed6f-4855-4ad1-8c66-e3cde6698272",
+            "Name": "Y",
+            "InternalComponentId": "output_81dba2f73b5943209a779a04d9a3ecb8",
+            "InternalComponentGuid": "1768ebd2-206f-42b8-8b38-7a2c85515f95",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_5d3c659f4fc6412c84a7df458d64307a",
+          "ComponentGuid": "8414b050-47e8-46c4-ba45-9de0fe837b11",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_0d2bb88751c34630b0544fdf9bcafdab",
+          "ComponentGuid": "ff0d55cf-2aec-495b-bdf8-b8f3b5c1801b",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_458d2477e6b74738bba26453edb51ce5",
+          "ComponentGuid": "05a54e79-efd3-4da8-99c9-83309c300710",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_c02d2ad4a5a14dc7861a5eed2ef38ddd",
+          "ComponentGuid": "0d4b74d7-7e9f-4be8-8e3b-a7c74b6b4c71",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_a6d98b9c9e9e431b967a240cec2bb220",
+          "ComponentGuid": "0d082dd3-504f-4d6d-9013-b7a7ed448ffe",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_81dba2f73b5943209a779a04d9a3ecb8",
+          "ComponentGuid": "1768ebd2-206f-42b8-8b38-7a2c85515f95",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1100,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "LE01",
+        "Description": "load arm of bit D1, word 0 (inputs A/B, threshold 0.125): LE = NAND(D1, IW0) — passes D1 while this word is addressed under LOAD. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_9ef9805feaf243429c345d2e488d3ebf",
+        "IdGuid": "01cd3f04-2fd2-4482-a03b-c56c9b1e48a9",
+        "ChildComponentGuids": [
+          "dbf41bea-6175-4503-a9c2-d8912217b9c7",
+          "e75db7a8-4298-4a23-83e2-cf687a9288d8",
+          "edcf8a39-7d99-4b93-b44a-2311a91f4923",
+          "baf7e8ea-e9f9-410f-b559-2de5b1c6f337",
+          "6d1661f7-1a8e-4b40-994b-685c149aa705",
+          "b992cd9e-6dfe-49f8-a48a-92fce19407f8"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_04cdd546e8544166bb5d971ee40dffd6",
+          "input_c54c05655570476996dda1d455099d71",
+          "combine_2e37b47fbcac4ba6844d57bc2cc5ddd1",
+          "phase_1d64c626ac4c406ba3b57e2eb83896e7",
+          "recombine_ed9bed5d4c0043ddb1370e99fe504d57",
+          "output_036e9debdcb545aa8a0f212666275e35"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "81fc9840-766b-44ce-bec7-99d0c1d0ca1f",
+            "StartComponentId": "input_04cdd546e8544166bb5d971ee40dffd6",
+            "StartComponentGuid": "dbf41bea-6175-4503-a9c2-d8912217b9c7",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_2e37b47fbcac4ba6844d57bc2cc5ddd1",
+            "EndComponentGuid": "edcf8a39-7d99-4b93-b44a-2311a91f4923",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "509ac021-88b1-4ec7-9c94-baf58a94810e",
+            "StartComponentId": "input_c54c05655570476996dda1d455099d71",
+            "StartComponentGuid": "e75db7a8-4298-4a23-83e2-cf687a9288d8",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_2e37b47fbcac4ba6844d57bc2cc5ddd1",
+            "EndComponentGuid": "edcf8a39-7d99-4b93-b44a-2311a91f4923",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "773e32c6-a7c3-4097-9edf-c8255652c849",
+            "StartComponentId": "combine_2e37b47fbcac4ba6844d57bc2cc5ddd1",
+            "StartComponentGuid": "edcf8a39-7d99-4b93-b44a-2311a91f4923",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_ed9bed5d4c0043ddb1370e99fe504d57",
+            "EndComponentGuid": "6d1661f7-1a8e-4b40-994b-685c149aa705",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "280b4f68-e5c0-4a5c-bd78-9c0ed00ccdb9",
+            "StartComponentId": "phase_1d64c626ac4c406ba3b57e2eb83896e7",
+            "StartComponentGuid": "baf7e8ea-e9f9-410f-b559-2de5b1c6f337",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_ed9bed5d4c0043ddb1370e99fe504d57",
+            "EndComponentGuid": "6d1661f7-1a8e-4b40-994b-685c149aa705",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1edfd611-36a5-497f-acda-3287be4bc433",
+            "StartComponentId": "recombine_ed9bed5d4c0043ddb1370e99fe504d57",
+            "StartComponentGuid": "6d1661f7-1a8e-4b40-994b-685c149aa705",
+            "StartPinName": "out1",
+            "EndComponentId": "output_036e9debdcb545aa8a0f212666275e35",
+            "EndComponentGuid": "b992cd9e-6dfe-49f8-a48a-92fce19407f8",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "968332b9-aaf2-47a7-98f4-ad2a27370f07",
+            "Name": "A",
+            "InternalComponentId": "input_04cdd546e8544166bb5d971ee40dffd6",
+            "InternalComponentGuid": "dbf41bea-6175-4503-a9c2-d8912217b9c7",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "81db1bd5-8800-4f56-8517-b6eb0fbb9603",
+            "Name": "B",
+            "InternalComponentId": "input_c54c05655570476996dda1d455099d71",
+            "InternalComponentGuid": "e75db7a8-4298-4a23-83e2-cf687a9288d8",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a21818bf-3882-4ca0-827a-1b9ffb4f7edf",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_1d64c626ac4c406ba3b57e2eb83896e7",
+            "InternalComponentGuid": "baf7e8ea-e9f9-410f-b559-2de5b1c6f337",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "f32d0720-4035-44e9-b021-99b2c8fc6b87",
+            "Name": "Y",
+            "InternalComponentId": "output_036e9debdcb545aa8a0f212666275e35",
+            "InternalComponentGuid": "b992cd9e-6dfe-49f8-a48a-92fce19407f8",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_04cdd546e8544166bb5d971ee40dffd6",
+          "ComponentGuid": "dbf41bea-6175-4503-a9c2-d8912217b9c7",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_c54c05655570476996dda1d455099d71",
+          "ComponentGuid": "e75db7a8-4298-4a23-83e2-cf687a9288d8",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_2e37b47fbcac4ba6844d57bc2cc5ddd1",
+          "ComponentGuid": "edcf8a39-7d99-4b93-b44a-2311a91f4923",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_1d64c626ac4c406ba3b57e2eb83896e7",
+          "ComponentGuid": "baf7e8ea-e9f9-410f-b559-2de5b1c6f337",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_ed9bed5d4c0043ddb1370e99fe504d57",
+          "ComponentGuid": "6d1661f7-1a8e-4b40-994b-685c149aa705",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_036e9debdcb545aa8a0f212666275e35",
+          "ComponentGuid": "b992cd9e-6dfe-49f8-a48a-92fce19407f8",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 700,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false,
+        "InputSignalNames": {
+          "A": "D1"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "REG01",
+        "Description": "register of bit D1, word 0 (inputs A/B, threshold 0.125): REG = NAND(H, LE) closing the bit multiplexer; register designation as in the shipped register (#1098). The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_c698ad13f5f24a6694f4a642558da22f",
+        "IdGuid": "de6848c1-b5f6-43f1-b35e-7fa11103238b",
+        "ChildComponentGuids": [
+          "b0ec6722-f696-4ebd-95d4-23cf5a24cc98",
+          "785385c8-c188-405a-97ae-e7190346c6ec",
+          "d0cb97db-907e-4bd6-9dee-93dfd3f59ad4",
+          "6915e43f-594d-4980-ba49-c06c39c22a1c",
+          "84733503-d530-4433-9880-7da2683bda1f",
+          "6f6ccbc1-bc69-496c-bf83-b2833d99bc62"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_27dbbd810739430c901abafeb8828d11",
+          "input_8f4eab2b5dce4622bbc28203e4576937",
+          "combine_e2170d45d14d4fa2a7ab3c3a6d3ace55",
+          "phase_6eb34c7e0b2242ef9e234217afb5da75",
+          "recombine_d760d90303bc4a558f26f248df82d2d7",
+          "output_04eb2a31f5924c27a210b7944a001786"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "2e8b198a-3830-4228-86d7-e9d64b91d751",
+            "StartComponentId": "input_27dbbd810739430c901abafeb8828d11",
+            "StartComponentGuid": "b0ec6722-f696-4ebd-95d4-23cf5a24cc98",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_e2170d45d14d4fa2a7ab3c3a6d3ace55",
+            "EndComponentGuid": "d0cb97db-907e-4bd6-9dee-93dfd3f59ad4",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "df5577be-5e97-4106-8ff9-dbcc16be8523",
+            "StartComponentId": "input_8f4eab2b5dce4622bbc28203e4576937",
+            "StartComponentGuid": "785385c8-c188-405a-97ae-e7190346c6ec",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_e2170d45d14d4fa2a7ab3c3a6d3ace55",
+            "EndComponentGuid": "d0cb97db-907e-4bd6-9dee-93dfd3f59ad4",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "9ee7cdce-b16a-4e5e-9292-da4dcdd974a2",
+            "StartComponentId": "combine_e2170d45d14d4fa2a7ab3c3a6d3ace55",
+            "StartComponentGuid": "d0cb97db-907e-4bd6-9dee-93dfd3f59ad4",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_d760d90303bc4a558f26f248df82d2d7",
+            "EndComponentGuid": "84733503-d530-4433-9880-7da2683bda1f",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6269f3c6-c34c-4369-9c31-70dc19ae8d40",
+            "StartComponentId": "phase_6eb34c7e0b2242ef9e234217afb5da75",
+            "StartComponentGuid": "6915e43f-594d-4980-ba49-c06c39c22a1c",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_d760d90303bc4a558f26f248df82d2d7",
+            "EndComponentGuid": "84733503-d530-4433-9880-7da2683bda1f",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "58eb75bb-c722-4a27-a0d1-40a9b323ea1c",
+            "StartComponentId": "recombine_d760d90303bc4a558f26f248df82d2d7",
+            "StartComponentGuid": "84733503-d530-4433-9880-7da2683bda1f",
+            "StartPinName": "out1",
+            "EndComponentId": "output_04eb2a31f5924c27a210b7944a001786",
+            "EndComponentGuid": "6f6ccbc1-bc69-496c-bf83-b2833d99bc62",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "f932fab9-4f44-4955-8f3f-8d5efda04ed1",
+            "Name": "A",
+            "InternalComponentId": "input_27dbbd810739430c901abafeb8828d11",
+            "InternalComponentGuid": "b0ec6722-f696-4ebd-95d4-23cf5a24cc98",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "5d66c2f7-d32d-43e0-a35c-65ccf278172f",
+            "Name": "B",
+            "InternalComponentId": "input_8f4eab2b5dce4622bbc28203e4576937",
+            "InternalComponentGuid": "785385c8-c188-405a-97ae-e7190346c6ec",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "d65748a4-7c2b-4f8e-83c1-66fc25de8690",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_6eb34c7e0b2242ef9e234217afb5da75",
+            "InternalComponentGuid": "6915e43f-594d-4980-ba49-c06c39c22a1c",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "b425e413-413d-4130-9dc5-c9a0a772e2df",
+            "Name": "Y",
+            "InternalComponentId": "output_04eb2a31f5924c27a210b7944a001786",
+            "InternalComponentGuid": "6f6ccbc1-bc69-496c-bf83-b2833d99bc62",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_27dbbd810739430c901abafeb8828d11",
+          "ComponentGuid": "b0ec6722-f696-4ebd-95d4-23cf5a24cc98",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_8f4eab2b5dce4622bbc28203e4576937",
+          "ComponentGuid": "785385c8-c188-405a-97ae-e7190346c6ec",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_e2170d45d14d4fa2a7ab3c3a6d3ace55",
+          "ComponentGuid": "d0cb97db-907e-4bd6-9dee-93dfd3f59ad4",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_6eb34c7e0b2242ef9e234217afb5da75",
+          "ComponentGuid": "6915e43f-594d-4980-ba49-c06c39c22a1c",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_d760d90303bc4a558f26f248df82d2d7",
+          "ComponentGuid": "84733503-d530-4433-9880-7da2683bda1f",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_04eb2a31f5924c27a210b7944a001786",
+          "ComponentGuid": "6f6ccbc1-bc69-496c-bf83-b2833d99bc62",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1500,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": true
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CP01",
+        "Description": "read tap of stored word 0 bit D1 (input A, threshold 0.375): one arm feeds the register's own hold feedback, the other the read MUX arm — one waveguide per signal; the word-0 bit tap W0D1 is renamed on the read arm. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_dd56738cac2e48fe9361cb83e5eda1fc",
+        "IdGuid": "7b98bb10-4b48-4613-8325-83d34587bfa3",
+        "ChildComponentGuids": [
+          "a181d7a6-7116-4bdf-837e-7e73cb04b72a",
+          "80092edf-5d96-4c1e-ac4e-26f078b7fef4",
+          "333d77ec-8e59-49ba-b69b-c763d2466927",
+          "baf32378-1907-4854-be8a-278bfc39955a"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_90dd351a0b43414b865bc5747344a17d",
+          "split_95ed6c9a71fb43dcbb60ec3d20696548",
+          "output_e6160d9f404b4a2aaf8c2ec2aae43223",
+          "output_25805f2a748248b18a54d0012a0efd24"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "e34166a4-e7e6-4bc7-a54f-9b1ab34fecc0",
+            "StartComponentId": "input_90dd351a0b43414b865bc5747344a17d",
+            "StartComponentGuid": "a181d7a6-7116-4bdf-837e-7e73cb04b72a",
+            "StartPinName": "b0",
+            "EndComponentId": "split_95ed6c9a71fb43dcbb60ec3d20696548",
+            "EndComponentGuid": "80092edf-5d96-4c1e-ac4e-26f078b7fef4",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6a171329-a2e7-47c2-9f97-d5ce74b502c9",
+            "StartComponentId": "split_95ed6c9a71fb43dcbb60ec3d20696548",
+            "StartComponentGuid": "80092edf-5d96-4c1e-ac4e-26f078b7fef4",
+            "StartPinName": "out1",
+            "EndComponentId": "output_e6160d9f404b4a2aaf8c2ec2aae43223",
+            "EndComponentGuid": "333d77ec-8e59-49ba-b69b-c763d2466927",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "c028305c-0a59-47a2-9898-c62d848bc8d6",
+            "StartComponentId": "split_95ed6c9a71fb43dcbb60ec3d20696548",
+            "StartComponentGuid": "80092edf-5d96-4c1e-ac4e-26f078b7fef4",
+            "StartPinName": "out2",
+            "EndComponentId": "output_25805f2a748248b18a54d0012a0efd24",
+            "EndComponentGuid": "baf32378-1907-4854-be8a-278bfc39955a",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "34953f0c-5381-4125-a70b-aaac4217ff3c",
+            "Name": "A",
+            "InternalComponentId": "input_90dd351a0b43414b865bc5747344a17d",
+            "InternalComponentGuid": "a181d7a6-7116-4bdf-837e-7e73cb04b72a",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a3fc0880-fff9-47cd-af2d-531bbc48bfb6",
+            "Name": "Y1",
+            "InternalComponentId": "output_e6160d9f404b4a2aaf8c2ec2aae43223",
+            "InternalComponentGuid": "333d77ec-8e59-49ba-b69b-c763d2466927",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "4a4aa116-7da0-4726-977e-af9794982a64",
+            "Name": "Y2",
+            "InternalComponentId": "output_25805f2a748248b18a54d0012a0efd24",
+            "InternalComponentGuid": "baf32378-1907-4854-be8a-278bfc39955a",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_90dd351a0b43414b865bc5747344a17d",
+          "ComponentGuid": "a181d7a6-7116-4bdf-837e-7e73cb04b72a",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_95ed6c9a71fb43dcbb60ec3d20696548",
+          "ComponentGuid": "80092edf-5d96-4c1e-ac4e-26f078b7fef4",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_e6160d9f404b4a2aaf8c2ec2aae43223",
+          "ComponentGuid": "333d77ec-8e59-49ba-b69b-c763d2466927",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_25805f2a748248b18a54d0012a0efd24",
+          "ComponentGuid": "baf32378-1907-4854-be8a-278bfc39955a",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1900,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "OutputSignalNames": {
+          "Y2": "W0D1"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "EN1",
+        "Description": "DMUX gate of word 1 (inputs A/B, threshold 0.125 — the AND/NOT pattern behind the MUX example #1059): EN = NAND(ADDR, LOAD), the inverted word-1 load enable. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_6f44ebebf9d143d8a71376c3a7600fa0",
+        "IdGuid": "44e8fbfa-bb7d-4bc5-a932-9c071f9e275b",
+        "ChildComponentGuids": [
+          "ff830f1c-3983-429c-a1d1-1747a425f7fa",
+          "b415ba63-49da-4bff-9f47-ff720cdee43b",
+          "1427be68-6ce4-4f5f-a845-87a655e66664",
+          "7602aead-25c2-4617-8f74-3a75ec17500e",
+          "984ae71a-eaf7-4cb6-b384-e7262a1498f0",
+          "09bc68a2-f990-4db8-b75c-6a2cde492ca8"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_1013beff6085460e8e2c2ec29a66f357",
+          "input_c7aad84638f4468ebe84d4a6e7d87ce2",
+          "combine_95059e47c30d414eb1ef6ffb7274636b",
+          "phase_153cda58628e4fda84cc700ca2a6c927",
+          "recombine_226b41531fd74a30ab545f085d7862a5",
+          "output_7afcccb5fd2642f684a95ac365fc7281"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "ab0265cc-1681-49c3-ae24-5dac8ef0d625",
+            "StartComponentId": "input_1013beff6085460e8e2c2ec29a66f357",
+            "StartComponentGuid": "ff830f1c-3983-429c-a1d1-1747a425f7fa",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_95059e47c30d414eb1ef6ffb7274636b",
+            "EndComponentGuid": "1427be68-6ce4-4f5f-a845-87a655e66664",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "2a3163ab-fc8a-4c15-9def-f273bf3d27cd",
+            "StartComponentId": "input_c7aad84638f4468ebe84d4a6e7d87ce2",
+            "StartComponentGuid": "b415ba63-49da-4bff-9f47-ff720cdee43b",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_95059e47c30d414eb1ef6ffb7274636b",
+            "EndComponentGuid": "1427be68-6ce4-4f5f-a845-87a655e66664",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1ca38829-0e30-4716-9941-9a86dc3a11db",
+            "StartComponentId": "combine_95059e47c30d414eb1ef6ffb7274636b",
+            "StartComponentGuid": "1427be68-6ce4-4f5f-a845-87a655e66664",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_226b41531fd74a30ab545f085d7862a5",
+            "EndComponentGuid": "984ae71a-eaf7-4cb6-b384-e7262a1498f0",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "c9ef8d27-ec29-4a49-a65f-697ff3461db2",
+            "StartComponentId": "phase_153cda58628e4fda84cc700ca2a6c927",
+            "StartComponentGuid": "7602aead-25c2-4617-8f74-3a75ec17500e",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_226b41531fd74a30ab545f085d7862a5",
+            "EndComponentGuid": "984ae71a-eaf7-4cb6-b384-e7262a1498f0",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "53ec17bb-ada7-4163-b618-592273a62ea5",
+            "StartComponentId": "recombine_226b41531fd74a30ab545f085d7862a5",
+            "StartComponentGuid": "984ae71a-eaf7-4cb6-b384-e7262a1498f0",
+            "StartPinName": "out1",
+            "EndComponentId": "output_7afcccb5fd2642f684a95ac365fc7281",
+            "EndComponentGuid": "09bc68a2-f990-4db8-b75c-6a2cde492ca8",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "78831c86-1c83-421f-89d8-6ce0de1a346c",
+            "Name": "A",
+            "InternalComponentId": "input_1013beff6085460e8e2c2ec29a66f357",
+            "InternalComponentGuid": "ff830f1c-3983-429c-a1d1-1747a425f7fa",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "f10124ef-613e-4b15-9fbe-276fb7f8a249",
+            "Name": "B",
+            "InternalComponentId": "input_c7aad84638f4468ebe84d4a6e7d87ce2",
+            "InternalComponentGuid": "b415ba63-49da-4bff-9f47-ff720cdee43b",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "84912563-e07f-4244-b6ac-9f8cd4f20d05",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_153cda58628e4fda84cc700ca2a6c927",
+            "InternalComponentGuid": "7602aead-25c2-4617-8f74-3a75ec17500e",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "4d926be9-6385-4b0d-a1f8-78b372590559",
+            "Name": "Y",
+            "InternalComponentId": "output_7afcccb5fd2642f684a95ac365fc7281",
+            "InternalComponentGuid": "09bc68a2-f990-4db8-b75c-6a2cde492ca8",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_1013beff6085460e8e2c2ec29a66f357",
+          "ComponentGuid": "ff830f1c-3983-429c-a1d1-1747a425f7fa",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_c7aad84638f4468ebe84d4a6e7d87ce2",
+          "ComponentGuid": "b415ba63-49da-4bff-9f47-ff720cdee43b",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_95059e47c30d414eb1ef6ffb7274636b",
+          "ComponentGuid": "1427be68-6ce4-4f5f-a845-87a655e66664",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_153cda58628e4fda84cc700ca2a6c927",
+          "ComponentGuid": "7602aead-25c2-4617-8f74-3a75ec17500e",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_226b41531fd74a30ab545f085d7862a5",
+          "ComponentGuid": "984ae71a-eaf7-4cb6-b384-e7262a1498f0",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_7afcccb5fd2642f684a95ac365fc7281",
+          "ComponentGuid": "09bc68a2-f990-4db8-b75c-6a2cde492ca8",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 900,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false,
+        "InputSignalNames": {
+          "A": "LOAD"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPEA1",
+        "Description": "copy gate (input A, threshold 0.375): the inverted-enable fan-out onto the inverter IW and the hold-arm chain CPEB. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_614c4c27f6e74ee6aab949229948a74c",
+        "IdGuid": "c78b9e12-e1f0-4376-aea0-734bf7c1a834",
+        "ChildComponentGuids": [
+          "977190c5-628b-4dad-9c18-0f8fc8c12b06",
+          "999e1409-8b2e-47f9-89fb-063286489d5c",
+          "da089ea3-7714-4b10-b19c-2bab7b5ef890",
+          "9b918db3-0963-4c19-b87a-d2454e33dc7d"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_51f14b3c5c0c459abd5d535b0e21fb2c",
+          "split_ab8a69581e414c4fbe3ee455c0351981",
+          "output_e1f3baf68611481ea8ac296307c1e88e",
+          "output_776b04df86ce4dcf8e6497a0ebfe4696"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "71effce3-3f19-4c9f-af48-32a991fd3511",
+            "StartComponentId": "input_51f14b3c5c0c459abd5d535b0e21fb2c",
+            "StartComponentGuid": "977190c5-628b-4dad-9c18-0f8fc8c12b06",
+            "StartPinName": "b0",
+            "EndComponentId": "split_ab8a69581e414c4fbe3ee455c0351981",
+            "EndComponentGuid": "999e1409-8b2e-47f9-89fb-063286489d5c",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "cc43248b-153d-4acf-80d1-a5988da424e6",
+            "StartComponentId": "split_ab8a69581e414c4fbe3ee455c0351981",
+            "StartComponentGuid": "999e1409-8b2e-47f9-89fb-063286489d5c",
+            "StartPinName": "out1",
+            "EndComponentId": "output_e1f3baf68611481ea8ac296307c1e88e",
+            "EndComponentGuid": "da089ea3-7714-4b10-b19c-2bab7b5ef890",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "35df763f-7db7-4ed9-87ec-a25e762a93d1",
+            "StartComponentId": "split_ab8a69581e414c4fbe3ee455c0351981",
+            "StartComponentGuid": "999e1409-8b2e-47f9-89fb-063286489d5c",
+            "StartPinName": "out2",
+            "EndComponentId": "output_776b04df86ce4dcf8e6497a0ebfe4696",
+            "EndComponentGuid": "9b918db3-0963-4c19-b87a-d2454e33dc7d",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "6b7a324b-adb9-4e73-bb93-015e1859c626",
+            "Name": "A",
+            "InternalComponentId": "input_51f14b3c5c0c459abd5d535b0e21fb2c",
+            "InternalComponentGuid": "977190c5-628b-4dad-9c18-0f8fc8c12b06",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "52f0de6a-f8eb-46c3-a103-7fb991f8287a",
+            "Name": "Y1",
+            "InternalComponentId": "output_e1f3baf68611481ea8ac296307c1e88e",
+            "InternalComponentGuid": "da089ea3-7714-4b10-b19c-2bab7b5ef890",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "9d360494-b1b9-4373-91d2-7ac36491bfc0",
+            "Name": "Y2",
+            "InternalComponentId": "output_776b04df86ce4dcf8e6497a0ebfe4696",
+            "InternalComponentGuid": "9b918db3-0963-4c19-b87a-d2454e33dc7d",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_51f14b3c5c0c459abd5d535b0e21fb2c",
+          "ComponentGuid": "977190c5-628b-4dad-9c18-0f8fc8c12b06",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_ab8a69581e414c4fbe3ee455c0351981",
+          "ComponentGuid": "999e1409-8b2e-47f9-89fb-063286489d5c",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_e1f3baf68611481ea8ac296307c1e88e",
+          "ComponentGuid": "da089ea3-7714-4b10-b19c-2bab7b5ef890",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_776b04df86ce4dcf8e6497a0ebfe4696",
+          "ComponentGuid": "9b918db3-0963-4c19-b87a-d2454e33dc7d",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1300,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPEB1",
+        "Description": "copy gate (input A, threshold 0.375): the inverted enable onto the two hold arms H{w}0/H{w}1. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_54783bfafc2d455395e17fc1734df1eb",
+        "IdGuid": "a59030d1-d0d3-467c-920a-0791dfc018fc",
+        "ChildComponentGuids": [
+          "a9f93e44-c8ad-4369-b840-fb239fa92d6d",
+          "d12545e6-2455-449c-bba1-766935f938e4",
+          "7cbf0408-0647-4907-9749-e312c68ccb74",
+          "2020a16d-8861-4d5d-9fd8-989e9e6bdec5"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_8a808f5238984984aa773b067c8eb615",
+          "split_393e3cbec5d24f4691395a29be89f865",
+          "output_178f70159f664f9eb0ff6bdfbc7f4fb9",
+          "output_dbd24b7dbce1488793c9c99ffd186742"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "e221d797-246e-4cbb-8bd5-ac41d4ea6a3f",
+            "StartComponentId": "input_8a808f5238984984aa773b067c8eb615",
+            "StartComponentGuid": "a9f93e44-c8ad-4369-b840-fb239fa92d6d",
+            "StartPinName": "b0",
+            "EndComponentId": "split_393e3cbec5d24f4691395a29be89f865",
+            "EndComponentGuid": "d12545e6-2455-449c-bba1-766935f938e4",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "40bbc12c-ec9f-441b-b4d5-d4f3a8fd5fba",
+            "StartComponentId": "split_393e3cbec5d24f4691395a29be89f865",
+            "StartComponentGuid": "d12545e6-2455-449c-bba1-766935f938e4",
+            "StartPinName": "out1",
+            "EndComponentId": "output_178f70159f664f9eb0ff6bdfbc7f4fb9",
+            "EndComponentGuid": "7cbf0408-0647-4907-9749-e312c68ccb74",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "017242ac-74e1-4490-b4cb-a816ac6afc8c",
+            "StartComponentId": "split_393e3cbec5d24f4691395a29be89f865",
+            "StartComponentGuid": "d12545e6-2455-449c-bba1-766935f938e4",
+            "StartPinName": "out2",
+            "EndComponentId": "output_dbd24b7dbce1488793c9c99ffd186742",
+            "EndComponentGuid": "2020a16d-8861-4d5d-9fd8-989e9e6bdec5",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "e87b84d1-c81c-4bde-804b-8a25e579f161",
+            "Name": "A",
+            "InternalComponentId": "input_8a808f5238984984aa773b067c8eb615",
+            "InternalComponentGuid": "a9f93e44-c8ad-4369-b840-fb239fa92d6d",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "4b6d89b5-3af5-4007-9f4b-805ec49b8aff",
+            "Name": "Y1",
+            "InternalComponentId": "output_178f70159f664f9eb0ff6bdfbc7f4fb9",
+            "InternalComponentGuid": "7cbf0408-0647-4907-9749-e312c68ccb74",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "01a7d7e2-2fb6-4bef-9ffa-efd4a4571799",
+            "Name": "Y2",
+            "InternalComponentId": "output_dbd24b7dbce1488793c9c99ffd186742",
+            "InternalComponentGuid": "2020a16d-8861-4d5d-9fd8-989e9e6bdec5",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_8a808f5238984984aa773b067c8eb615",
+          "ComponentGuid": "a9f93e44-c8ad-4369-b840-fb239fa92d6d",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_393e3cbec5d24f4691395a29be89f865",
+          "ComponentGuid": "d12545e6-2455-449c-bba1-766935f938e4",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_178f70159f664f9eb0ff6bdfbc7f4fb9",
+          "ComponentGuid": "7cbf0408-0647-4907-9749-e312c68ccb74",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_dbd24b7dbce1488793c9c99ffd186742",
+          "ComponentGuid": "2020a16d-8861-4d5d-9fd8-989e9e6bdec5",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1700,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "IW1",
+        "Description": "inverter (input A, threshold 0.375): the true word load enable feeding the load arms through CPI. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_ffd49fe698474c2f9b5f1e3009c62ba1",
+        "IdGuid": "5976f2ca-4c6b-4049-9c6e-52857ebb06da",
+        "ChildComponentGuids": [
+          "993dab9d-daf9-495f-91a6-b588c131a5ba",
+          "1c3edd96-1bf5-4868-a664-13c6952eda8a",
+          "daa6389e-1c63-401b-86d8-b9d232da7670",
+          "1929a6fc-3428-4ce7-bd94-c9b6708d85b7",
+          "e0651680-0652-4b8c-af2d-97d0056f41dd",
+          "b81a13ce-b243-4d6f-a601-5d1854cdd48a"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 100,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_355ef96044db404a98ec3b919da0ad89",
+          "input_033f82e6d9ae4315b933ad6ccf34aeed",
+          "combine_0429c1345b644316afaa1a960b39496a",
+          "phase_414bdf594d724abe8cfab11f6dca476d",
+          "recombine_2203a1b2d6094f19b74ab86df896fb18",
+          "output_a9f774661dd5477a8e7318d323332c2b"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "eaffcd0c-9849-47b6-868e-7fa481750d23",
+            "StartComponentId": "input_355ef96044db404a98ec3b919da0ad89",
+            "StartComponentGuid": "993dab9d-daf9-495f-91a6-b588c131a5ba",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_0429c1345b644316afaa1a960b39496a",
+            "EndComponentGuid": "daa6389e-1c63-401b-86d8-b9d232da7670",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "98dc12d8-7f33-4d41-8964-313668a63b7d",
+            "StartComponentId": "input_033f82e6d9ae4315b933ad6ccf34aeed",
+            "StartComponentGuid": "1c3edd96-1bf5-4868-a664-13c6952eda8a",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_0429c1345b644316afaa1a960b39496a",
+            "EndComponentGuid": "daa6389e-1c63-401b-86d8-b9d232da7670",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "c02a5b71-a3bf-4daa-9ef2-63886015ebda",
+            "StartComponentId": "combine_0429c1345b644316afaa1a960b39496a",
+            "StartComponentGuid": "daa6389e-1c63-401b-86d8-b9d232da7670",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_2203a1b2d6094f19b74ab86df896fb18",
+            "EndComponentGuid": "e0651680-0652-4b8c-af2d-97d0056f41dd",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "5857ec98-398f-4040-8ccf-2c4eb738d35a",
+            "StartComponentId": "phase_414bdf594d724abe8cfab11f6dca476d",
+            "StartComponentGuid": "1929a6fc-3428-4ce7-bd94-c9b6708d85b7",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_2203a1b2d6094f19b74ab86df896fb18",
+            "EndComponentGuid": "e0651680-0652-4b8c-af2d-97d0056f41dd",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "0c5c10bd-3679-4391-9986-c9894dccf14e",
+            "StartComponentId": "recombine_2203a1b2d6094f19b74ab86df896fb18",
+            "StartComponentGuid": "e0651680-0652-4b8c-af2d-97d0056f41dd",
+            "StartPinName": "out1",
+            "EndComponentId": "output_a9f774661dd5477a8e7318d323332c2b",
+            "EndComponentGuid": "b81a13ce-b243-4d6f-a601-5d1854cdd48a",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "7db4ffbc-981c-48bf-934f-96cc0434ee8b",
+            "Name": "A",
+            "InternalComponentId": "input_355ef96044db404a98ec3b919da0ad89",
+            "InternalComponentGuid": "993dab9d-daf9-495f-91a6-b588c131a5ba",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "cbe63b79-4df2-4c51-b2e7-12699f24db4a",
+            "Name": "B",
+            "InternalComponentId": "input_033f82e6d9ae4315b933ad6ccf34aeed",
+            "InternalComponentGuid": "1c3edd96-1bf5-4868-a664-13c6952eda8a",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "e9a5804d-f61f-4d24-851b-66ad02cfb1f8",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_414bdf594d724abe8cfab11f6dca476d",
+            "InternalComponentGuid": "1929a6fc-3428-4ce7-bd94-c9b6708d85b7",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "5b4ea5ce-e1ba-430a-aa85-a223f368d2fd",
+            "Name": "Y",
+            "InternalComponentId": "output_a9f774661dd5477a8e7318d323332c2b",
+            "InternalComponentGuid": "b81a13ce-b243-4d6f-a601-5d1854cdd48a",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_355ef96044db404a98ec3b919da0ad89",
+          "ComponentGuid": "993dab9d-daf9-495f-91a6-b588c131a5ba",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_033f82e6d9ae4315b933ad6ccf34aeed",
+          "ComponentGuid": "1c3edd96-1bf5-4868-a664-13c6952eda8a",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_0429c1345b644316afaa1a960b39496a",
+          "ComponentGuid": "daa6389e-1c63-401b-86d8-b9d232da7670",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_414bdf594d724abe8cfab11f6dca476d",
+          "ComponentGuid": "1929a6fc-3428-4ce7-bd94-c9b6708d85b7",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_2203a1b2d6094f19b74ab86df896fb18",
+          "ComponentGuid": "e0651680-0652-4b8c-af2d-97d0056f41dd",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_a9f774661dd5477a8e7318d323332c2b",
+          "ComponentGuid": "b81a13ce-b243-4d6f-a601-5d1854cdd48a",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1300,
+      "CanvasY": 1100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CPI1",
+        "Description": "copy gate (input A, threshold 0.375): the true load enable onto the two load arms LE{w}0/LE{w}1. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_ee7243fb3c414305a49b9b01d4d8efd9",
+        "IdGuid": "0837ea13-11ad-42a6-8ec4-b04f086ded8d",
+        "ChildComponentGuids": [
+          "7d4b1de2-d25c-4dc8-a803-b50cb104d99e",
+          "2c17d073-95bf-4cdb-911d-11264f22acf1",
+          "cc64f794-2fec-4dcf-849d-08f3d94fa798",
+          "6c9871cd-2e7d-4f43-af5d-1f26eff6d50e"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_c876813f87a14a6fb4713d861af51441",
+          "split_f6ac64da9db242bb8d2669dae9ab818a",
+          "output_fef9bf9de17b43f6a181d6372c27f86f",
+          "output_78b9ffd4693845f99238aa86f892fa0e"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "65f41400-47db-4d30-ac38-ec3c2dfa7999",
+            "StartComponentId": "input_c876813f87a14a6fb4713d861af51441",
+            "StartComponentGuid": "7d4b1de2-d25c-4dc8-a803-b50cb104d99e",
+            "StartPinName": "b0",
+            "EndComponentId": "split_f6ac64da9db242bb8d2669dae9ab818a",
+            "EndComponentGuid": "2c17d073-95bf-4cdb-911d-11264f22acf1",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "dca6b54d-bcc1-4299-ad0d-0020f0dcdef0",
+            "StartComponentId": "split_f6ac64da9db242bb8d2669dae9ab818a",
+            "StartComponentGuid": "2c17d073-95bf-4cdb-911d-11264f22acf1",
+            "StartPinName": "out1",
+            "EndComponentId": "output_fef9bf9de17b43f6a181d6372c27f86f",
+            "EndComponentGuid": "cc64f794-2fec-4dcf-849d-08f3d94fa798",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "02d36491-110c-4a52-9b96-1e25113d14ae",
+            "StartComponentId": "split_f6ac64da9db242bb8d2669dae9ab818a",
+            "StartComponentGuid": "2c17d073-95bf-4cdb-911d-11264f22acf1",
+            "StartPinName": "out2",
+            "EndComponentId": "output_78b9ffd4693845f99238aa86f892fa0e",
+            "EndComponentGuid": "6c9871cd-2e7d-4f43-af5d-1f26eff6d50e",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "1fd2216d-ffaa-4de7-8c44-239a7e1beb62",
+            "Name": "A",
+            "InternalComponentId": "input_c876813f87a14a6fb4713d861af51441",
+            "InternalComponentGuid": "7d4b1de2-d25c-4dc8-a803-b50cb104d99e",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "e4cc5890-a123-43b7-a83c-3a58a2dc4003",
+            "Name": "Y1",
+            "InternalComponentId": "output_fef9bf9de17b43f6a181d6372c27f86f",
+            "InternalComponentGuid": "cc64f794-2fec-4dcf-849d-08f3d94fa798",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "48fc324c-67cf-4d2a-a2ad-e8e66aea64de",
+            "Name": "Y2",
+            "InternalComponentId": "output_78b9ffd4693845f99238aa86f892fa0e",
+            "InternalComponentGuid": "6c9871cd-2e7d-4f43-af5d-1f26eff6d50e",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_c876813f87a14a6fb4713d861af51441",
+          "ComponentGuid": "7d4b1de2-d25c-4dc8-a803-b50cb104d99e",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_f6ac64da9db242bb8d2669dae9ab818a",
+          "ComponentGuid": "2c17d073-95bf-4cdb-911d-11264f22acf1",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_fef9bf9de17b43f6a181d6372c27f86f",
+          "ComponentGuid": "cc64f794-2fec-4dcf-849d-08f3d94fa798",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_78b9ffd4693845f99238aa86f892fa0e",
+          "ComponentGuid": "6c9871cd-2e7d-4f43-af5d-1f26eff6d50e",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1700,
+      "CanvasY": 1100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "H10",
+        "Description": "hold arm of bit D0, word 1 (inputs A/B, threshold 0.125): H = NAND(R0, EN1) — the shipped register's hold pattern (#1138), blocked while this word loads. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_c109526fb6dc4b47b7dadfcbb1f22343",
+        "IdGuid": "6c048e1d-941a-4c37-9499-0a8e12541090",
+        "ChildComponentGuids": [
+          "36b99705-c44b-4f56-8d29-6a73217d8574",
+          "47dc4c4f-3e45-4afc-b969-14de7eeedf6b",
+          "118fb796-d4ad-413e-8721-71074e1a4769",
+          "1dff3eb9-1f28-43a2-8547-7bd2c90820f7",
+          "00a4113a-941e-440a-983b-f622c7ca11af",
+          "83832457-09cc-4d28-bbe1-d9aaa124a83b"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_6aa1c56cc3f6463cb610ad33c1ef1225",
+          "input_95b6439cee74464fbcd25e27f0ba68d9",
+          "combine_6c408a32d06647e5ba8ecef9d12f2440",
+          "phase_71f315954d9948de9474fd86ca0e8eb5",
+          "recombine_ea6ae33240194c7f95a82425d3c2ae69",
+          "output_72e9a012cdec498092c63eb8242f96f6"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "5e541a6c-51eb-4c10-9cfa-59971706f192",
+            "StartComponentId": "input_6aa1c56cc3f6463cb610ad33c1ef1225",
+            "StartComponentGuid": "36b99705-c44b-4f56-8d29-6a73217d8574",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_6c408a32d06647e5ba8ecef9d12f2440",
+            "EndComponentGuid": "118fb796-d4ad-413e-8721-71074e1a4769",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "0e2b170f-90b7-455d-aa05-ca40c63db8b7",
+            "StartComponentId": "input_95b6439cee74464fbcd25e27f0ba68d9",
+            "StartComponentGuid": "47dc4c4f-3e45-4afc-b969-14de7eeedf6b",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_6c408a32d06647e5ba8ecef9d12f2440",
+            "EndComponentGuid": "118fb796-d4ad-413e-8721-71074e1a4769",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "fa66abe0-8962-404b-8394-e2171f78bb3f",
+            "StartComponentId": "combine_6c408a32d06647e5ba8ecef9d12f2440",
+            "StartComponentGuid": "118fb796-d4ad-413e-8721-71074e1a4769",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_ea6ae33240194c7f95a82425d3c2ae69",
+            "EndComponentGuid": "00a4113a-941e-440a-983b-f622c7ca11af",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "7f7239e0-6203-4e5d-8e28-939424514da7",
+            "StartComponentId": "phase_71f315954d9948de9474fd86ca0e8eb5",
+            "StartComponentGuid": "1dff3eb9-1f28-43a2-8547-7bd2c90820f7",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_ea6ae33240194c7f95a82425d3c2ae69",
+            "EndComponentGuid": "00a4113a-941e-440a-983b-f622c7ca11af",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "efc5daa2-7e36-43c2-9ffc-ec0b2b7ee613",
+            "StartComponentId": "recombine_ea6ae33240194c7f95a82425d3c2ae69",
+            "StartComponentGuid": "00a4113a-941e-440a-983b-f622c7ca11af",
+            "StartPinName": "out1",
+            "EndComponentId": "output_72e9a012cdec498092c63eb8242f96f6",
+            "EndComponentGuid": "83832457-09cc-4d28-bbe1-d9aaa124a83b",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "a3f29983-1f84-403b-a407-b2f51b461642",
+            "Name": "A",
+            "InternalComponentId": "input_6aa1c56cc3f6463cb610ad33c1ef1225",
+            "InternalComponentGuid": "36b99705-c44b-4f56-8d29-6a73217d8574",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "4d4bb59e-c9c5-41ae-ab5f-978f681292c4",
+            "Name": "B",
+            "InternalComponentId": "input_95b6439cee74464fbcd25e27f0ba68d9",
+            "InternalComponentGuid": "47dc4c4f-3e45-4afc-b969-14de7eeedf6b",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "3d2f6479-d2ee-4e92-80bc-6bfbe72b4154",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_71f315954d9948de9474fd86ca0e8eb5",
+            "InternalComponentGuid": "1dff3eb9-1f28-43a2-8547-7bd2c90820f7",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "d9651062-913d-49ab-895e-3dd9e92d6dd6",
+            "Name": "Y",
+            "InternalComponentId": "output_72e9a012cdec498092c63eb8242f96f6",
+            "InternalComponentGuid": "83832457-09cc-4d28-bbe1-d9aaa124a83b",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_6aa1c56cc3f6463cb610ad33c1ef1225",
+          "ComponentGuid": "36b99705-c44b-4f56-8d29-6a73217d8574",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_95b6439cee74464fbcd25e27f0ba68d9",
+          "ComponentGuid": "47dc4c4f-3e45-4afc-b969-14de7eeedf6b",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_6c408a32d06647e5ba8ecef9d12f2440",
+          "ComponentGuid": "118fb796-d4ad-413e-8721-71074e1a4769",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_71f315954d9948de9474fd86ca0e8eb5",
+          "ComponentGuid": "1dff3eb9-1f28-43a2-8547-7bd2c90820f7",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_ea6ae33240194c7f95a82425d3c2ae69",
+          "ComponentGuid": "00a4113a-941e-440a-983b-f622c7ca11af",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_72e9a012cdec498092c63eb8242f96f6",
+          "ComponentGuid": "83832457-09cc-4d28-bbe1-d9aaa124a83b",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1100,
+      "CanvasY": 1300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "LE10",
+        "Description": "load arm of bit D0, word 1 (inputs A/B, threshold 0.125): LE = NAND(D0, IW1) — passes D0 while this word is addressed under LOAD. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_bca1fc22589246b1bba37329e7d24204",
+        "IdGuid": "9dd98fb7-a82e-4330-b47f-37f424b6298d",
+        "ChildComponentGuids": [
+          "75122ff2-3f77-46a6-8f3a-f599807d1e6f",
+          "b3580b16-a71e-4f52-ad1c-d6b0f605faf9",
+          "b76ae4cc-4508-4101-9a5d-729bf458d172",
+          "7a8fe18c-af48-4774-8bff-8d5db51734fb",
+          "7ef92f95-ee49-4665-9a28-37d8ddb9ecee",
+          "3327f872-8ccf-4fb8-911d-fc11000bcd8e"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_99d4acf75b284a7282ae90df528a317d",
+          "input_de2b66c8e512443584f18d8fc1b37ae1",
+          "combine_46178aad2d8e4f3994ab0948a6c439a3",
+          "phase_f421de0c953e4cea94a6f029b48c5def",
+          "recombine_4b370e707bca4a21845efc78b0734a17",
+          "output_54680984c39040f2853184e874457b1f"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "32c6a9f0-b2db-48c3-ae7c-120e16867cf3",
+            "StartComponentId": "input_99d4acf75b284a7282ae90df528a317d",
+            "StartComponentGuid": "75122ff2-3f77-46a6-8f3a-f599807d1e6f",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_46178aad2d8e4f3994ab0948a6c439a3",
+            "EndComponentGuid": "b76ae4cc-4508-4101-9a5d-729bf458d172",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "a246ea80-4441-48cb-9cf8-322233e6d7ac",
+            "StartComponentId": "input_de2b66c8e512443584f18d8fc1b37ae1",
+            "StartComponentGuid": "b3580b16-a71e-4f52-ad1c-d6b0f605faf9",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_46178aad2d8e4f3994ab0948a6c439a3",
+            "EndComponentGuid": "b76ae4cc-4508-4101-9a5d-729bf458d172",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "b229e568-7675-4d76-8394-18800c1e5953",
+            "StartComponentId": "combine_46178aad2d8e4f3994ab0948a6c439a3",
+            "StartComponentGuid": "b76ae4cc-4508-4101-9a5d-729bf458d172",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_4b370e707bca4a21845efc78b0734a17",
+            "EndComponentGuid": "7ef92f95-ee49-4665-9a28-37d8ddb9ecee",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "aabb0630-3ef0-4389-82b8-17e866e274a0",
+            "StartComponentId": "phase_f421de0c953e4cea94a6f029b48c5def",
+            "StartComponentGuid": "7a8fe18c-af48-4774-8bff-8d5db51734fb",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_4b370e707bca4a21845efc78b0734a17",
+            "EndComponentGuid": "7ef92f95-ee49-4665-9a28-37d8ddb9ecee",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "6ff9a427-decf-4608-8990-15f90d180797",
+            "StartComponentId": "recombine_4b370e707bca4a21845efc78b0734a17",
+            "StartComponentGuid": "7ef92f95-ee49-4665-9a28-37d8ddb9ecee",
+            "StartPinName": "out1",
+            "EndComponentId": "output_54680984c39040f2853184e874457b1f",
+            "EndComponentGuid": "3327f872-8ccf-4fb8-911d-fc11000bcd8e",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "eb7f8183-ae30-4258-895c-84f6698011e2",
+            "Name": "A",
+            "InternalComponentId": "input_99d4acf75b284a7282ae90df528a317d",
+            "InternalComponentGuid": "75122ff2-3f77-46a6-8f3a-f599807d1e6f",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "07c7cc36-da3c-4aac-80e2-cf736bdc8236",
+            "Name": "B",
+            "InternalComponentId": "input_de2b66c8e512443584f18d8fc1b37ae1",
+            "InternalComponentGuid": "b3580b16-a71e-4f52-ad1c-d6b0f605faf9",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "ece5b252-c914-4d26-9c42-8706465a4742",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_f421de0c953e4cea94a6f029b48c5def",
+            "InternalComponentGuid": "7a8fe18c-af48-4774-8bff-8d5db51734fb",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "cf231172-5adb-409f-8afd-622ab9228bb4",
+            "Name": "Y",
+            "InternalComponentId": "output_54680984c39040f2853184e874457b1f",
+            "InternalComponentGuid": "3327f872-8ccf-4fb8-911d-fc11000bcd8e",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_99d4acf75b284a7282ae90df528a317d",
+          "ComponentGuid": "75122ff2-3f77-46a6-8f3a-f599807d1e6f",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_de2b66c8e512443584f18d8fc1b37ae1",
+          "ComponentGuid": "b3580b16-a71e-4f52-ad1c-d6b0f605faf9",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_46178aad2d8e4f3994ab0948a6c439a3",
+          "ComponentGuid": "b76ae4cc-4508-4101-9a5d-729bf458d172",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_f421de0c953e4cea94a6f029b48c5def",
+          "ComponentGuid": "7a8fe18c-af48-4774-8bff-8d5db51734fb",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_4b370e707bca4a21845efc78b0734a17",
+          "ComponentGuid": "7ef92f95-ee49-4665-9a28-37d8ddb9ecee",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_54680984c39040f2853184e874457b1f",
+          "ComponentGuid": "3327f872-8ccf-4fb8-911d-fc11000bcd8e",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 700,
+      "CanvasY": 1300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false,
+        "InputSignalNames": {
+          "A": "D0"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "REG10",
+        "Description": "register of bit D0, word 1 (inputs A/B, threshold 0.125): REG = NAND(H, LE) closing the bit multiplexer; register designation as in the shipped register (#1098). The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_c17f1717c6994ad391c2cd3638e86ca0",
+        "IdGuid": "5853e3ef-e331-4f1a-933d-d1d1bbbe1c32",
+        "ChildComponentGuids": [
+          "478247ba-757d-4ae9-b628-6f90490093f6",
+          "d309e1e9-95ad-4747-9406-14124daf3a36",
+          "5d0b5c24-9557-4a91-9580-3857fbd02299",
+          "a1b7d155-bad3-4783-a5da-b9aca2c3153c",
+          "dce74295-94a2-45af-bdcc-c8945bf01408",
+          "4d639b08-5d58-4219-9fd5-c7ebdb29fe85"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_905e0571314943aeb53f85467d90b410",
+          "input_ecc8c443061440aeb2a3333d1333e211",
+          "combine_0c8a1f430aa94692b272fc7c77514e60",
+          "phase_3326cb0ab1eb4c29931d50cbbdfd5431",
+          "recombine_3fdfee21fb5b45db85079c1fc4c9f492",
+          "output_32954f14dea54047acf6c29b99256d5b"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "29b2ce33-82fe-4791-af93-7ce388ebcaf7",
+            "StartComponentId": "input_905e0571314943aeb53f85467d90b410",
+            "StartComponentGuid": "478247ba-757d-4ae9-b628-6f90490093f6",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_0c8a1f430aa94692b272fc7c77514e60",
+            "EndComponentGuid": "5d0b5c24-9557-4a91-9580-3857fbd02299",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "9f7caae1-03bf-4cb5-974d-320c9710ab6e",
+            "StartComponentId": "input_ecc8c443061440aeb2a3333d1333e211",
+            "StartComponentGuid": "d309e1e9-95ad-4747-9406-14124daf3a36",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_0c8a1f430aa94692b272fc7c77514e60",
+            "EndComponentGuid": "5d0b5c24-9557-4a91-9580-3857fbd02299",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1a89afd6-73ea-491b-8014-a3d89827ac2c",
+            "StartComponentId": "combine_0c8a1f430aa94692b272fc7c77514e60",
+            "StartComponentGuid": "5d0b5c24-9557-4a91-9580-3857fbd02299",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_3fdfee21fb5b45db85079c1fc4c9f492",
+            "EndComponentGuid": "dce74295-94a2-45af-bdcc-c8945bf01408",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "fc59b24e-5391-4975-b38a-db9c643d7d6d",
+            "StartComponentId": "phase_3326cb0ab1eb4c29931d50cbbdfd5431",
+            "StartComponentGuid": "a1b7d155-bad3-4783-a5da-b9aca2c3153c",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_3fdfee21fb5b45db85079c1fc4c9f492",
+            "EndComponentGuid": "dce74295-94a2-45af-bdcc-c8945bf01408",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1c36cbb0-170e-4b47-b084-98c4c6fe050e",
+            "StartComponentId": "recombine_3fdfee21fb5b45db85079c1fc4c9f492",
+            "StartComponentGuid": "dce74295-94a2-45af-bdcc-c8945bf01408",
+            "StartPinName": "out1",
+            "EndComponentId": "output_32954f14dea54047acf6c29b99256d5b",
+            "EndComponentGuid": "4d639b08-5d58-4219-9fd5-c7ebdb29fe85",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "aa1d16dc-d9a5-4ddb-9512-8cf0d3301de0",
+            "Name": "A",
+            "InternalComponentId": "input_905e0571314943aeb53f85467d90b410",
+            "InternalComponentGuid": "478247ba-757d-4ae9-b628-6f90490093f6",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "5a3023be-9411-44c9-a3da-354cc23f4c5d",
+            "Name": "B",
+            "InternalComponentId": "input_ecc8c443061440aeb2a3333d1333e211",
+            "InternalComponentGuid": "d309e1e9-95ad-4747-9406-14124daf3a36",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8fc035c1-4005-460e-92ce-d29f6d7ad0fa",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_3326cb0ab1eb4c29931d50cbbdfd5431",
+            "InternalComponentGuid": "a1b7d155-bad3-4783-a5da-b9aca2c3153c",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "b323083a-e64a-46b0-b7e3-b9190749d9d6",
+            "Name": "Y",
+            "InternalComponentId": "output_32954f14dea54047acf6c29b99256d5b",
+            "InternalComponentGuid": "4d639b08-5d58-4219-9fd5-c7ebdb29fe85",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_905e0571314943aeb53f85467d90b410",
+          "ComponentGuid": "478247ba-757d-4ae9-b628-6f90490093f6",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_ecc8c443061440aeb2a3333d1333e211",
+          "ComponentGuid": "d309e1e9-95ad-4747-9406-14124daf3a36",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_0c8a1f430aa94692b272fc7c77514e60",
+          "ComponentGuid": "5d0b5c24-9557-4a91-9580-3857fbd02299",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_3326cb0ab1eb4c29931d50cbbdfd5431",
+          "ComponentGuid": "a1b7d155-bad3-4783-a5da-b9aca2c3153c",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_3fdfee21fb5b45db85079c1fc4c9f492",
+          "ComponentGuid": "dce74295-94a2-45af-bdcc-c8945bf01408",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_32954f14dea54047acf6c29b99256d5b",
+          "ComponentGuid": "4d639b08-5d58-4219-9fd5-c7ebdb29fe85",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1500,
+      "CanvasY": 1300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": true
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CP10",
+        "Description": "read tap of stored word 1 bit D0 (input A, threshold 0.375): one arm feeds the register's own hold feedback, the other the read MUX arm — one waveguide per signal; the word-1 bit tap W1D0 is renamed on the read arm. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_b08a4f4ea9b44dec8c912dec31f4068f",
+        "IdGuid": "e4c3e564-4108-4071-b2f7-aaadd60f7992",
+        "ChildComponentGuids": [
+          "4ef2fcd5-3adf-4be2-9a78-228efcee3ee9",
+          "a01b4bb1-6b53-444a-9107-53512c028425",
+          "17775ee7-dc7a-47c3-afea-5ba272cd0765",
+          "5876a18e-af5a-4c2f-8976-bcc6eb06a338"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_42ec77c56e274496917f8cc5d5a65a5e",
+          "split_357bcf711b284de98ec83fe33144c8ba",
+          "output_87a7fc3f9f9c48d6a104362db1548f07",
+          "output_ca4c1771007f49f9ac3be6de207cfe6c"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "3d09fb5d-d420-4909-9eb4-b91dd0d3ceab",
+            "StartComponentId": "input_42ec77c56e274496917f8cc5d5a65a5e",
+            "StartComponentGuid": "4ef2fcd5-3adf-4be2-9a78-228efcee3ee9",
+            "StartPinName": "b0",
+            "EndComponentId": "split_357bcf711b284de98ec83fe33144c8ba",
+            "EndComponentGuid": "a01b4bb1-6b53-444a-9107-53512c028425",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1b22c4ae-b3a6-451e-bf16-265e208d9617",
+            "StartComponentId": "split_357bcf711b284de98ec83fe33144c8ba",
+            "StartComponentGuid": "a01b4bb1-6b53-444a-9107-53512c028425",
+            "StartPinName": "out1",
+            "EndComponentId": "output_87a7fc3f9f9c48d6a104362db1548f07",
+            "EndComponentGuid": "17775ee7-dc7a-47c3-afea-5ba272cd0765",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "fe0124b4-1ff9-4782-b70f-c5d709902f84",
+            "StartComponentId": "split_357bcf711b284de98ec83fe33144c8ba",
+            "StartComponentGuid": "a01b4bb1-6b53-444a-9107-53512c028425",
+            "StartPinName": "out2",
+            "EndComponentId": "output_ca4c1771007f49f9ac3be6de207cfe6c",
+            "EndComponentGuid": "5876a18e-af5a-4c2f-8976-bcc6eb06a338",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "d6150197-702f-48a1-a5f0-774159dacc84",
+            "Name": "A",
+            "InternalComponentId": "input_42ec77c56e274496917f8cc5d5a65a5e",
+            "InternalComponentGuid": "4ef2fcd5-3adf-4be2-9a78-228efcee3ee9",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "69ad0cc1-6678-4ac7-a1e8-d898d0602530",
+            "Name": "Y1",
+            "InternalComponentId": "output_87a7fc3f9f9c48d6a104362db1548f07",
+            "InternalComponentGuid": "17775ee7-dc7a-47c3-afea-5ba272cd0765",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "a1133f57-8536-4d4d-9ab8-f689cb478255",
+            "Name": "Y2",
+            "InternalComponentId": "output_ca4c1771007f49f9ac3be6de207cfe6c",
+            "InternalComponentGuid": "5876a18e-af5a-4c2f-8976-bcc6eb06a338",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_42ec77c56e274496917f8cc5d5a65a5e",
+          "ComponentGuid": "4ef2fcd5-3adf-4be2-9a78-228efcee3ee9",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_357bcf711b284de98ec83fe33144c8ba",
+          "ComponentGuid": "a01b4bb1-6b53-444a-9107-53512c028425",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_87a7fc3f9f9c48d6a104362db1548f07",
+          "ComponentGuid": "17775ee7-dc7a-47c3-afea-5ba272cd0765",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_ca4c1771007f49f9ac3be6de207cfe6c",
+          "ComponentGuid": "5876a18e-af5a-4c2f-8976-bcc6eb06a338",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1900,
+      "CanvasY": 1300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "OutputSignalNames": {
+          "Y2": "W1D0"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "H11",
+        "Description": "hold arm of bit D1, word 1 (inputs A/B, threshold 0.125): H = NAND(R1, EN1) — the shipped register's hold pattern (#1138), blocked while this word loads. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_b0d1e63742d6401fa7ffd0162f90c8a6",
+        "IdGuid": "3d3ce3e7-6b3b-4a78-bfac-fc45952a9524",
+        "ChildComponentGuids": [
+          "25db77e9-171e-49c2-a179-34574d839203",
+          "18387e2d-2924-4622-af30-0648bbbf1c03",
+          "70054590-7060-498b-8a51-184f740e6fec",
+          "6d6756ef-8297-4840-9346-87883d5a6c7e",
+          "32e2eb5d-5c6e-4585-9da1-e8533cf6342b",
+          "4405c835-8e02-4e27-b4fd-cefb75fe0c58"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_9ca3e818ea6548f98cfed35bb560c7a4",
+          "input_5062c96cd6474d14938c6fcf787e2b8c",
+          "combine_68014aeaaf404d13a826b5bc871bd34a",
+          "phase_8fffd3b40f47435d95335dd27031a215",
+          "recombine_655a99f37bfc41bab7f06af315dccbe3",
+          "output_c053543cae2e4783a05196bc990d7b3b"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "daa95cbe-d90b-4f77-8951-ce3f8a7a95d9",
+            "StartComponentId": "input_9ca3e818ea6548f98cfed35bb560c7a4",
+            "StartComponentGuid": "25db77e9-171e-49c2-a179-34574d839203",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_68014aeaaf404d13a826b5bc871bd34a",
+            "EndComponentGuid": "70054590-7060-498b-8a51-184f740e6fec",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "8fb64bf6-c969-4313-af57-7fb4aa7c20db",
+            "StartComponentId": "input_5062c96cd6474d14938c6fcf787e2b8c",
+            "StartComponentGuid": "18387e2d-2924-4622-af30-0648bbbf1c03",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_68014aeaaf404d13a826b5bc871bd34a",
+            "EndComponentGuid": "70054590-7060-498b-8a51-184f740e6fec",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "07a80d42-d14a-4d4e-bed3-9a1e4ab36b36",
+            "StartComponentId": "combine_68014aeaaf404d13a826b5bc871bd34a",
+            "StartComponentGuid": "70054590-7060-498b-8a51-184f740e6fec",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_655a99f37bfc41bab7f06af315dccbe3",
+            "EndComponentGuid": "32e2eb5d-5c6e-4585-9da1-e8533cf6342b",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "b75c34b4-626e-4b3c-a2e6-1f31929b8e6e",
+            "StartComponentId": "phase_8fffd3b40f47435d95335dd27031a215",
+            "StartComponentGuid": "6d6756ef-8297-4840-9346-87883d5a6c7e",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_655a99f37bfc41bab7f06af315dccbe3",
+            "EndComponentGuid": "32e2eb5d-5c6e-4585-9da1-e8533cf6342b",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "863bfc62-cf3a-496c-a933-d5640c2e6852",
+            "StartComponentId": "recombine_655a99f37bfc41bab7f06af315dccbe3",
+            "StartComponentGuid": "32e2eb5d-5c6e-4585-9da1-e8533cf6342b",
+            "StartPinName": "out1",
+            "EndComponentId": "output_c053543cae2e4783a05196bc990d7b3b",
+            "EndComponentGuid": "4405c835-8e02-4e27-b4fd-cefb75fe0c58",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "4d0c99f4-064a-4c25-a760-71db86e9bcc6",
+            "Name": "A",
+            "InternalComponentId": "input_9ca3e818ea6548f98cfed35bb560c7a4",
+            "InternalComponentGuid": "25db77e9-171e-49c2-a179-34574d839203",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a38d6bad-9f37-42ad-a2aa-cc23e549829a",
+            "Name": "B",
+            "InternalComponentId": "input_5062c96cd6474d14938c6fcf787e2b8c",
+            "InternalComponentGuid": "18387e2d-2924-4622-af30-0648bbbf1c03",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "4185e837-d818-4ce2-b074-1ab391afea7a",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_8fffd3b40f47435d95335dd27031a215",
+            "InternalComponentGuid": "6d6756ef-8297-4840-9346-87883d5a6c7e",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "c97ee1e5-f6c8-435a-9d83-cccb3be44de2",
+            "Name": "Y",
+            "InternalComponentId": "output_c053543cae2e4783a05196bc990d7b3b",
+            "InternalComponentGuid": "4405c835-8e02-4e27-b4fd-cefb75fe0c58",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_9ca3e818ea6548f98cfed35bb560c7a4",
+          "ComponentGuid": "25db77e9-171e-49c2-a179-34574d839203",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_5062c96cd6474d14938c6fcf787e2b8c",
+          "ComponentGuid": "18387e2d-2924-4622-af30-0648bbbf1c03",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_68014aeaaf404d13a826b5bc871bd34a",
+          "ComponentGuid": "70054590-7060-498b-8a51-184f740e6fec",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_8fffd3b40f47435d95335dd27031a215",
+          "ComponentGuid": "6d6756ef-8297-4840-9346-87883d5a6c7e",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_655a99f37bfc41bab7f06af315dccbe3",
+          "ComponentGuid": "32e2eb5d-5c6e-4585-9da1-e8533cf6342b",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_c053543cae2e4783a05196bc990d7b3b",
+          "ComponentGuid": "4405c835-8e02-4e27-b4fd-cefb75fe0c58",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1100,
+      "CanvasY": 1700,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "LE11",
+        "Description": "load arm of bit D1, word 1 (inputs A/B, threshold 0.125): LE = NAND(D1, IW1) — passes D1 while this word is addressed under LOAD. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_e75640cb30fa40209cf460f63d4d8486",
+        "IdGuid": "8bfdbf2f-c4b6-41bc-bc7d-8f8fa5b05ec2",
+        "ChildComponentGuids": [
+          "8380d13c-52fc-4cb3-b345-613c34bf66b5",
+          "0332ea52-28d0-42b0-81b9-b1134f573603",
+          "a9d73f3f-b1ce-41cd-af1e-99d331005a4d",
+          "9da808eb-5a3c-4d45-8c9d-6f74f7e79b79",
+          "e1275e4c-8eac-42ae-ae68-a4589d647029",
+          "e9237999-b61f-4d64-8a70-1852e24bfd2a"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_d043e885b0734f338066ff3c85a922b2",
+          "input_85a3687c4ec04b6683df14b687f0c2a3",
+          "combine_b801d78cc8734115b87e43af021661a6",
+          "phase_c889a5e4e4e14413b62e31cacdae539f",
+          "recombine_c25cbfbae6fb440397d575f8c18bfd80",
+          "output_438a23f5de444f36bae57d450e99b949"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "af8a0ab8-94e2-4fdc-9818-a0e89941764b",
+            "StartComponentId": "input_d043e885b0734f338066ff3c85a922b2",
+            "StartComponentGuid": "8380d13c-52fc-4cb3-b345-613c34bf66b5",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_b801d78cc8734115b87e43af021661a6",
+            "EndComponentGuid": "a9d73f3f-b1ce-41cd-af1e-99d331005a4d",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "97de8a61-0736-40c5-8ac6-97d87f1553b4",
+            "StartComponentId": "input_85a3687c4ec04b6683df14b687f0c2a3",
+            "StartComponentGuid": "0332ea52-28d0-42b0-81b9-b1134f573603",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_b801d78cc8734115b87e43af021661a6",
+            "EndComponentGuid": "a9d73f3f-b1ce-41cd-af1e-99d331005a4d",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "9d60832f-9c9c-481f-971a-68e7fd4503e9",
+            "StartComponentId": "combine_b801d78cc8734115b87e43af021661a6",
+            "StartComponentGuid": "a9d73f3f-b1ce-41cd-af1e-99d331005a4d",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_c25cbfbae6fb440397d575f8c18bfd80",
+            "EndComponentGuid": "e1275e4c-8eac-42ae-ae68-a4589d647029",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "02882bc8-e409-4184-b805-20704ec25a4e",
+            "StartComponentId": "phase_c889a5e4e4e14413b62e31cacdae539f",
+            "StartComponentGuid": "9da808eb-5a3c-4d45-8c9d-6f74f7e79b79",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_c25cbfbae6fb440397d575f8c18bfd80",
+            "EndComponentGuid": "e1275e4c-8eac-42ae-ae68-a4589d647029",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "946f1925-15a4-4627-976a-29a82191a7b4",
+            "StartComponentId": "recombine_c25cbfbae6fb440397d575f8c18bfd80",
+            "StartComponentGuid": "e1275e4c-8eac-42ae-ae68-a4589d647029",
+            "StartPinName": "out1",
+            "EndComponentId": "output_438a23f5de444f36bae57d450e99b949",
+            "EndComponentGuid": "e9237999-b61f-4d64-8a70-1852e24bfd2a",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "81b8fe65-7a85-437a-91ff-e7566f5d2716",
+            "Name": "A",
+            "InternalComponentId": "input_d043e885b0734f338066ff3c85a922b2",
+            "InternalComponentGuid": "8380d13c-52fc-4cb3-b345-613c34bf66b5",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "510defe5-7ba2-4387-b455-fc7e4602f11e",
+            "Name": "B",
+            "InternalComponentId": "input_85a3687c4ec04b6683df14b687f0c2a3",
+            "InternalComponentGuid": "0332ea52-28d0-42b0-81b9-b1134f573603",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "18b88bb7-116b-4d4d-b472-304a3b8b2067",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_c889a5e4e4e14413b62e31cacdae539f",
+            "InternalComponentGuid": "9da808eb-5a3c-4d45-8c9d-6f74f7e79b79",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "5946ba4e-5dfc-4ff2-b438-4be992bd59b8",
+            "Name": "Y",
+            "InternalComponentId": "output_438a23f5de444f36bae57d450e99b949",
+            "InternalComponentGuid": "e9237999-b61f-4d64-8a70-1852e24bfd2a",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_d043e885b0734f338066ff3c85a922b2",
+          "ComponentGuid": "8380d13c-52fc-4cb3-b345-613c34bf66b5",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_85a3687c4ec04b6683df14b687f0c2a3",
+          "ComponentGuid": "0332ea52-28d0-42b0-81b9-b1134f573603",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_b801d78cc8734115b87e43af021661a6",
+          "ComponentGuid": "a9d73f3f-b1ce-41cd-af1e-99d331005a4d",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_c889a5e4e4e14413b62e31cacdae539f",
+          "ComponentGuid": "9da808eb-5a3c-4d45-8c9d-6f74f7e79b79",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_c25cbfbae6fb440397d575f8c18bfd80",
+          "ComponentGuid": "e1275e4c-8eac-42ae-ae68-a4589d647029",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_438a23f5de444f36bae57d450e99b949",
+          "ComponentGuid": "e9237999-b61f-4d64-8a70-1852e24bfd2a",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 700,
+      "CanvasY": 1700,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false,
+        "InputSignalNames": {
+          "A": "D1"
+        }
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "REG11",
+        "Description": "register of bit D1, word 1 (inputs A/B, threshold 0.125): REG = NAND(H, LE) closing the bit multiplexer; register designation as in the shipped register (#1098). The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_d50e95dac9df4689b5600d69b1508e00",
+        "IdGuid": "50885469-f6d6-4af3-833d-9dd563a4badb",
+        "ChildComponentGuids": [
+          "6fb428b6-d566-4689-b12b-756dafb570eb",
+          "9e65a4be-bef9-467f-a982-34c29b0fdd4c",
+          "f719ee12-0867-4697-98b1-54cd7eb2bacd",
+          "4549504b-c3f2-41f6-8dca-e3f0e3b9d927",
+          "cfc1caa1-83e9-4914-96ea-fee2fb80dbc6",
+          "4f14a0e2-2b6a-4797-9fb9-fdfbd2219320"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_b759df77fa394340bcc85f3b02a151b1",
+          "input_29786c8c24164e46b8da7bcf7064834d",
+          "combine_cf1b4d5adacb4bda80c22b87e6559318",
+          "phase_224b0811e4624f3691b0611cbf00c90d",
+          "recombine_858b11b99ed84275b467ecc590a8c183",
+          "output_e3dfefb4cf1d4ff19bbd22c5a99dae48"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "f6fd9297-f1d1-4a43-8fb9-3db171330741",
+            "StartComponentId": "input_b759df77fa394340bcc85f3b02a151b1",
+            "StartComponentGuid": "6fb428b6-d566-4689-b12b-756dafb570eb",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_cf1b4d5adacb4bda80c22b87e6559318",
+            "EndComponentGuid": "f719ee12-0867-4697-98b1-54cd7eb2bacd",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "991c59e3-e692-421f-906e-fca3f7d1068c",
+            "StartComponentId": "input_29786c8c24164e46b8da7bcf7064834d",
+            "StartComponentGuid": "9e65a4be-bef9-467f-a982-34c29b0fdd4c",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_cf1b4d5adacb4bda80c22b87e6559318",
+            "EndComponentGuid": "f719ee12-0867-4697-98b1-54cd7eb2bacd",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "45935bff-735b-4f3f-ab69-c4ece38a664e",
+            "StartComponentId": "combine_cf1b4d5adacb4bda80c22b87e6559318",
+            "StartComponentGuid": "f719ee12-0867-4697-98b1-54cd7eb2bacd",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_858b11b99ed84275b467ecc590a8c183",
+            "EndComponentGuid": "cfc1caa1-83e9-4914-96ea-fee2fb80dbc6",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "cc94fcff-1091-49ec-b0bf-4175217422de",
+            "StartComponentId": "phase_224b0811e4624f3691b0611cbf00c90d",
+            "StartComponentGuid": "4549504b-c3f2-41f6-8dca-e3f0e3b9d927",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_858b11b99ed84275b467ecc590a8c183",
+            "EndComponentGuid": "cfc1caa1-83e9-4914-96ea-fee2fb80dbc6",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "873e06bb-010b-4ada-b6b7-da235ed3fcda",
+            "StartComponentId": "recombine_858b11b99ed84275b467ecc590a8c183",
+            "StartComponentGuid": "cfc1caa1-83e9-4914-96ea-fee2fb80dbc6",
+            "StartPinName": "out1",
+            "EndComponentId": "output_e3dfefb4cf1d4ff19bbd22c5a99dae48",
+            "EndComponentGuid": "4f14a0e2-2b6a-4797-9fb9-fdfbd2219320",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "d560c347-c5bb-43a6-b487-553c4f8a3a42",
+            "Name": "A",
+            "InternalComponentId": "input_b759df77fa394340bcc85f3b02a151b1",
+            "InternalComponentGuid": "6fb428b6-d566-4689-b12b-756dafb570eb",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "95d8d77c-1ee0-44c4-be35-7e3edb069958",
+            "Name": "B",
+            "InternalComponentId": "input_29786c8c24164e46b8da7bcf7064834d",
+            "InternalComponentGuid": "9e65a4be-bef9-467f-a982-34c29b0fdd4c",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "c3fd4ee3-8e18-4d5c-b582-c3c17528bdea",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_224b0811e4624f3691b0611cbf00c90d",
+            "InternalComponentGuid": "4549504b-c3f2-41f6-8dca-e3f0e3b9d927",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a9c5955b-5e87-4b0c-bdba-56ba5a0218df",
+            "Name": "Y",
+            "InternalComponentId": "output_e3dfefb4cf1d4ff19bbd22c5a99dae48",
+            "InternalComponentGuid": "4f14a0e2-2b6a-4797-9fb9-fdfbd2219320",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_b759df77fa394340bcc85f3b02a151b1",
+          "ComponentGuid": "6fb428b6-d566-4689-b12b-756dafb570eb",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_29786c8c24164e46b8da7bcf7064834d",
+          "ComponentGuid": "9e65a4be-bef9-467f-a982-34c29b0fdd4c",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_cf1b4d5adacb4bda80c22b87e6559318",
+          "ComponentGuid": "f719ee12-0867-4697-98b1-54cd7eb2bacd",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_224b0811e4624f3691b0611cbf00c90d",
+          "ComponentGuid": "4549504b-c3f2-41f6-8dca-e3f0e3b9d927",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_858b11b99ed84275b467ecc590a8c183",
+          "ComponentGuid": "cfc1caa1-83e9-4914-96ea-fee2fb80dbc6",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_e3dfefb4cf1d4ff19bbd22c5a99dae48",
+          "ComponentGuid": "4f14a0e2-2b6a-4797-9fb9-fdfbd2219320",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1500,
+      "CanvasY": 1700,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": true
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "CP11",
+        "Description": "read tap of stored word 1 bit D1 (input A, threshold 0.375): one arm feeds the register's own hold feedback, the other the read MUX arm — one waveguide per signal; the word-1 bit tap W1D1 is renamed on the read arm. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_6d15fbdfb4c4494f9bce07223781029c",
+        "IdGuid": "a75b4042-6425-40a4-aed3-20cd4997a0a7",
+        "ChildComponentGuids": [
+          "fa1f0e1c-42fd-4b9c-ab96-bb05a7b25322",
+          "0eaf1325-7656-457a-bce6-9d9275451ee5",
+          "b3d855df-ffaa-4def-a2b1-236f44c0a727",
+          "fb24dcb6-f4c2-4507-847e-699cc18bec4e"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 500,
+        "PhysicalY": 100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_e966fe5aa60443d1be47c9ec730354ba",
+          "split_8014d4354f664d81993062e1d9b72ce7",
+          "output_5eaaba3e87e94ca78016befc92cd7d4d",
+          "output_a5b7b55152f040acbdc770de126956b2"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "4f1cc9dd-64f4-423c-bafb-2b49cbeccaed",
+            "StartComponentId": "input_e966fe5aa60443d1be47c9ec730354ba",
+            "StartComponentGuid": "fa1f0e1c-42fd-4b9c-ab96-bb05a7b25322",
+            "StartPinName": "b0",
+            "EndComponentId": "split_8014d4354f664d81993062e1d9b72ce7",
+            "EndComponentGuid": "0eaf1325-7656-457a-bce6-9d9275451ee5",
+            "EndPinName": "in",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "2f459169-4886-4de7-af55-6903d161bc9a",
+            "StartComponentId": "split_8014d4354f664d81993062e1d9b72ce7",
+            "StartComponentGuid": "0eaf1325-7656-457a-bce6-9d9275451ee5",
+            "StartPinName": "out1",
+            "EndComponentId": "output_5eaaba3e87e94ca78016befc92cd7d4d",
+            "EndComponentGuid": "b3d855df-ffaa-4def-a2b1-236f44c0a727",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 121.5,
+                "EndX": 1135,
+                "EndY": 121.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f6d63a0c-3f66-404a-a516-0b59efda3219",
+            "StartComponentId": "split_8014d4354f664d81993062e1d9b72ce7",
+            "StartComponentGuid": "0eaf1325-7656-457a-bce6-9d9275451ee5",
+            "StartPinName": "out2",
+            "EndComponentId": "output_a5b7b55152f040acbdc770de126956b2",
+            "EndComponentGuid": "fb24dcb6-f4c2-4507-847e-699cc18bec4e",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1035,
+                "StartY": 125.5,
+                "EndX": 1135,
+                "EndY": 125.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "635b88c3-6dea-4448-a804-5851218729e1",
+            "Name": "A",
+            "InternalComponentId": "input_e966fe5aa60443d1be47c9ec730354ba",
+            "InternalComponentGuid": "fa1f0e1c-42fd-4b9c-ab96-bb05a7b25322",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "c6102820-8d9c-45e9-a78f-08ac3cac47ac",
+            "Name": "Y1",
+            "InternalComponentId": "output_5eaaba3e87e94ca78016befc92cd7d4d",
+            "InternalComponentGuid": "b3d855df-ffaa-4def-a2b1-236f44c0a727",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 21.5,
+            "AngleDegrees": 0
+          },
+          {
+            "PinId": "8e800e2d-11ad-4761-99a2-6bde67f7d9e4",
+            "Name": "Y2",
+            "InternalComponentId": "output_a5b7b55152f040acbdc770de126956b2",
+            "InternalComponentGuid": "fb24dcb6-f4c2-4507-847e-699cc18bec4e",
+            "InternalPinName": "b0",
+            "RelativeX": 1235,
+            "RelativeY": 25.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_e966fe5aa60443d1be47c9ec730354ba",
+          "ComponentGuid": "fa1f0e1c-42fd-4b9c-ab96-bb05a7b25322",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "split_8014d4354f664d81993062e1d9b72ce7",
+          "ComponentGuid": "0eaf1325-7656-457a-bce6-9d9275451ee5",
+          "TemplateName": "1x2 MMI Splitter",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 96,
+          "Rotation": 0,
+          "HumanReadableName": "1x2 MMI Splitter"
+        },
+        {
+          "Identifier": "output_5eaaba3e87e94ca78016befc92cd7d4d",
+          "ComponentGuid": "b3d855df-ffaa-4def-a2b1-236f44c0a727",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 116.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "output_a5b7b55152f040acbdc770de126956b2",
+          "ComponentGuid": "fb24dcb6-f4c2-4507-847e-699cc18bec4e",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1135,
+          "Y": 120.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 1900,
+      "CanvasY": 1700,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A"
+        ],
+        "OutputPinNames": [
+          "Y1",
+          "Y2"
+        ],
+        "BiasPinNames": [],
+        "Threshold": 0.375,
+        "OutputSignalNames": {
+          "Y2": "W1D1"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "MA0",
+        "Description": "word-0 select arm of the read MUX, data bit 0 (inputs A/B, threshold 0.125): MA = NAND(W0D0, NA) — passes word 0 while ADDR reads low. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_28cc6da51e7a4e2f82e39c86554b04da",
+        "IdGuid": "9ad132fe-b677-4c8b-aa13-ff259f076e1e",
+        "ChildComponentGuids": [
+          "6ee2d418-3ead-4846-9afb-71bb61470577",
+          "7635addc-ecdd-46ae-ad44-ac471e14a481",
+          "379b6455-066c-47e5-ac45-a10c9924674b",
+          "9eced930-097a-45a3-a1fb-b395589b4cd1",
+          "2387ad0f-6eee-490c-b56e-256c364c12b6",
+          "903a7de2-1081-4df6-ae09-f713e446455c"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_218e5be6e59c44509e9a7041ac2a6c73",
+          "input_1320b895812c4e9c8dd6f347abc1ac56",
+          "combine_38754fde27894a19909f999cc8924a24",
+          "phase_62cb0ee434a842c2b249ae01e08c3b83",
+          "recombine_efe024c509024bb8ab9e96f88819b263",
+          "output_b018aabecae2406e86d530027fcccf15"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "74e9d55a-a078-4a8d-90d8-53a1e94ba7cd",
+            "StartComponentId": "input_218e5be6e59c44509e9a7041ac2a6c73",
+            "StartComponentGuid": "6ee2d418-3ead-4846-9afb-71bb61470577",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_38754fde27894a19909f999cc8924a24",
+            "EndComponentGuid": "379b6455-066c-47e5-ac45-a10c9924674b",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "86c82bf3-cbc6-42be-8971-ce40e07c5ad8",
+            "StartComponentId": "input_1320b895812c4e9c8dd6f347abc1ac56",
+            "StartComponentGuid": "7635addc-ecdd-46ae-ad44-ac471e14a481",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_38754fde27894a19909f999cc8924a24",
+            "EndComponentGuid": "379b6455-066c-47e5-ac45-a10c9924674b",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "19aba9bb-0e75-4a6b-a081-d0132af733b8",
+            "StartComponentId": "combine_38754fde27894a19909f999cc8924a24",
+            "StartComponentGuid": "379b6455-066c-47e5-ac45-a10c9924674b",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_efe024c509024bb8ab9e96f88819b263",
+            "EndComponentGuid": "2387ad0f-6eee-490c-b56e-256c364c12b6",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "e5c5478e-4ca6-43f1-98cf-47f54d0058d7",
+            "StartComponentId": "phase_62cb0ee434a842c2b249ae01e08c3b83",
+            "StartComponentGuid": "9eced930-097a-45a3-a1fb-b395589b4cd1",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_efe024c509024bb8ab9e96f88819b263",
+            "EndComponentGuid": "2387ad0f-6eee-490c-b56e-256c364c12b6",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "024e206c-4323-4cfb-a75e-d13958294d28",
+            "StartComponentId": "recombine_efe024c509024bb8ab9e96f88819b263",
+            "StartComponentGuid": "2387ad0f-6eee-490c-b56e-256c364c12b6",
+            "StartPinName": "out1",
+            "EndComponentId": "output_b018aabecae2406e86d530027fcccf15",
+            "EndComponentGuid": "903a7de2-1081-4df6-ae09-f713e446455c",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "1094976a-870c-4470-bd2d-f7545e3a3ad7",
+            "Name": "A",
+            "InternalComponentId": "input_218e5be6e59c44509e9a7041ac2a6c73",
+            "InternalComponentGuid": "6ee2d418-3ead-4846-9afb-71bb61470577",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "ed895b14-5e3a-4272-b5d1-2bd4f4f47e7b",
+            "Name": "B",
+            "InternalComponentId": "input_1320b895812c4e9c8dd6f347abc1ac56",
+            "InternalComponentGuid": "7635addc-ecdd-46ae-ad44-ac471e14a481",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "76b77991-ddd8-4415-8540-7cb11b2e9c31",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_62cb0ee434a842c2b249ae01e08c3b83",
+            "InternalComponentGuid": "9eced930-097a-45a3-a1fb-b395589b4cd1",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "a477912e-532f-4800-bf75-92b33ee9be1b",
+            "Name": "Y",
+            "InternalComponentId": "output_b018aabecae2406e86d530027fcccf15",
+            "InternalComponentGuid": "903a7de2-1081-4df6-ae09-f713e446455c",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_218e5be6e59c44509e9a7041ac2a6c73",
+          "ComponentGuid": "6ee2d418-3ead-4846-9afb-71bb61470577",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_1320b895812c4e9c8dd6f347abc1ac56",
+          "ComponentGuid": "7635addc-ecdd-46ae-ad44-ac471e14a481",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_38754fde27894a19909f999cc8924a24",
+          "ComponentGuid": "379b6455-066c-47e5-ac45-a10c9924674b",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_62cb0ee434a842c2b249ae01e08c3b83",
+          "ComponentGuid": "9eced930-097a-45a3-a1fb-b395589b4cd1",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_efe024c509024bb8ab9e96f88819b263",
+          "ComponentGuid": "2387ad0f-6eee-490c-b56e-256c364c12b6",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_b018aabecae2406e86d530027fcccf15",
+          "ComponentGuid": "903a7de2-1081-4df6-ae09-f713e446455c",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 2300,
+      "CanvasY": 500,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "MB0",
+        "Description": "word-1 select arm of the read MUX, data bit 0 (inputs A/B, threshold 0.125): MB = NAND(W1D0, ADDR) — passes word 1 while ADDR reads high. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_0b036a72c40843abbd47d704c2b3ca1f",
+        "IdGuid": "d0ae5b51-d82a-4fdf-b6a0-2d827e4d99f5",
+        "ChildComponentGuids": [
+          "2e97de7c-a05e-452f-8e43-ba4041401870",
+          "ac9cdf14-3f0d-4fd9-a2a6-854fe6210f83",
+          "4abcb929-2d08-4851-8630-57e26b70d90e",
+          "7ca2a0ee-8d6a-4563-8dcd-23038fb0cf63",
+          "d0b67f9f-5648-4970-a934-c07b786f8510",
+          "cabebbbd-0621-411c-939f-ea82848ed5d8"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_3a62fd1f3e57494aa81ce09f36d40924",
+          "input_fc3c353cee2a41e6898eed3dd2b6c100",
+          "combine_9e25b7fff76548ab8e21cef75a6e8126",
+          "phase_9eb15119a17a4763bcae1d81ee4c46d4",
+          "recombine_bbae1abc31d34f98b4dd840f624f0862",
+          "output_aa4c5b1ece714ff78410de9eb426c246"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "918aa037-44a2-4a8b-80a0-685fa412ad3f",
+            "StartComponentId": "input_3a62fd1f3e57494aa81ce09f36d40924",
+            "StartComponentGuid": "2e97de7c-a05e-452f-8e43-ba4041401870",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_9e25b7fff76548ab8e21cef75a6e8126",
+            "EndComponentGuid": "4abcb929-2d08-4851-8630-57e26b70d90e",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "9ef15168-b5dd-4612-9b70-c62aa1091588",
+            "StartComponentId": "input_fc3c353cee2a41e6898eed3dd2b6c100",
+            "StartComponentGuid": "ac9cdf14-3f0d-4fd9-a2a6-854fe6210f83",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_9e25b7fff76548ab8e21cef75a6e8126",
+            "EndComponentGuid": "4abcb929-2d08-4851-8630-57e26b70d90e",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "efd97b27-4e7c-427f-9d95-58487df10657",
+            "StartComponentId": "combine_9e25b7fff76548ab8e21cef75a6e8126",
+            "StartComponentGuid": "4abcb929-2d08-4851-8630-57e26b70d90e",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_bbae1abc31d34f98b4dd840f624f0862",
+            "EndComponentGuid": "d0b67f9f-5648-4970-a934-c07b786f8510",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "b0d7a5a7-feb6-4412-845b-77cb4fcb0ae4",
+            "StartComponentId": "phase_9eb15119a17a4763bcae1d81ee4c46d4",
+            "StartComponentGuid": "7ca2a0ee-8d6a-4563-8dcd-23038fb0cf63",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_bbae1abc31d34f98b4dd840f624f0862",
+            "EndComponentGuid": "d0b67f9f-5648-4970-a934-c07b786f8510",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "fd79cb38-3e9e-449a-9109-59c35df5fd47",
+            "StartComponentId": "recombine_bbae1abc31d34f98b4dd840f624f0862",
+            "StartComponentGuid": "d0b67f9f-5648-4970-a934-c07b786f8510",
+            "StartPinName": "out1",
+            "EndComponentId": "output_aa4c5b1ece714ff78410de9eb426c246",
+            "EndComponentGuid": "cabebbbd-0621-411c-939f-ea82848ed5d8",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "4d4f5023-0170-4c52-a841-344907bbfc3e",
+            "Name": "A",
+            "InternalComponentId": "input_3a62fd1f3e57494aa81ce09f36d40924",
+            "InternalComponentGuid": "2e97de7c-a05e-452f-8e43-ba4041401870",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "0b36c916-71dc-4b13-959e-95c4aa0778cc",
+            "Name": "B",
+            "InternalComponentId": "input_fc3c353cee2a41e6898eed3dd2b6c100",
+            "InternalComponentGuid": "ac9cdf14-3f0d-4fd9-a2a6-854fe6210f83",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "b2f180ed-c6db-4225-bb4c-0b4c37bd6b40",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_9eb15119a17a4763bcae1d81ee4c46d4",
+            "InternalComponentGuid": "7ca2a0ee-8d6a-4563-8dcd-23038fb0cf63",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "d5f3f13d-47d6-471f-8c40-a47197da9c45",
+            "Name": "Y",
+            "InternalComponentId": "output_aa4c5b1ece714ff78410de9eb426c246",
+            "InternalComponentGuid": "cabebbbd-0621-411c-939f-ea82848ed5d8",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_3a62fd1f3e57494aa81ce09f36d40924",
+          "ComponentGuid": "2e97de7c-a05e-452f-8e43-ba4041401870",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_fc3c353cee2a41e6898eed3dd2b6c100",
+          "ComponentGuid": "ac9cdf14-3f0d-4fd9-a2a6-854fe6210f83",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_9e25b7fff76548ab8e21cef75a6e8126",
+          "ComponentGuid": "4abcb929-2d08-4851-8630-57e26b70d90e",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_9eb15119a17a4763bcae1d81ee4c46d4",
+          "ComponentGuid": "7ca2a0ee-8d6a-4563-8dcd-23038fb0cf63",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_bbae1abc31d34f98b4dd840f624f0862",
+          "ComponentGuid": "d0b67f9f-5648-4970-a934-c07b786f8510",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_aa4c5b1ece714ff78410de9eb426c246",
+          "ComponentGuid": "cabebbbd-0621-411c-939f-ea82848ed5d8",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 2300,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "OUT0",
+        "Description": "read output of data bit 0 (inputs A/B, threshold 0.125): OUT = NAND(MA, MB), the 2-to-1 MUX of the shipped example (#1059); the tap R0 is renamed here. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_473a6695141b46bb89200532a7f1d25e",
+        "IdGuid": "b9d12229-1055-4475-a5b4-7b6388f579d3",
+        "ChildComponentGuids": [
+          "f65a0c62-a5d9-4cc4-b0a0-7e7223b2b424",
+          "c6286485-87ba-4a4c-9be8-41dbb9c67192",
+          "2ff5d64c-d593-4f29-a81b-0ee76b1da965",
+          "04dbec1e-0082-47d1-8d61-ca6952d0d5ce",
+          "b3f923d8-bab3-45c0-b1a9-75f669c16bfb",
+          "934e4e8c-2b02-41d2-984f-ca0181523120"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_3261ffa5d2504d0c9255939a8883aa63",
+          "input_76077903287a4404b207c6173a46f7a0",
+          "combine_b2ac3d780dd64265ac75e19f8ba97d25",
+          "phase_c04e030b3c974d8aaf6ef0bcc26be72f",
+          "recombine_b9b2953611184955971d6c478db86ed8",
+          "output_a3c9d83e9d0f4f0ca7786b64bed00077"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "e238739d-f813-4ba4-95f7-ccb010997f96",
+            "StartComponentId": "input_3261ffa5d2504d0c9255939a8883aa63",
+            "StartComponentGuid": "f65a0c62-a5d9-4cc4-b0a0-7e7223b2b424",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_b2ac3d780dd64265ac75e19f8ba97d25",
+            "EndComponentGuid": "2ff5d64c-d593-4f29-a81b-0ee76b1da965",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "1c4c318d-1189-4e18-9e9c-e82de2191810",
+            "StartComponentId": "input_76077903287a4404b207c6173a46f7a0",
+            "StartComponentGuid": "c6286485-87ba-4a4c-9be8-41dbb9c67192",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_b2ac3d780dd64265ac75e19f8ba97d25",
+            "EndComponentGuid": "2ff5d64c-d593-4f29-a81b-0ee76b1da965",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "01290f7c-31df-4ea9-959a-0cf853a2009b",
+            "StartComponentId": "combine_b2ac3d780dd64265ac75e19f8ba97d25",
+            "StartComponentGuid": "2ff5d64c-d593-4f29-a81b-0ee76b1da965",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_b9b2953611184955971d6c478db86ed8",
+            "EndComponentGuid": "b3f923d8-bab3-45c0-b1a9-75f669c16bfb",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "92ae6b2b-544b-4e4e-a6d9-a00557d0febf",
+            "StartComponentId": "phase_c04e030b3c974d8aaf6ef0bcc26be72f",
+            "StartComponentGuid": "04dbec1e-0082-47d1-8d61-ca6952d0d5ce",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_b9b2953611184955971d6c478db86ed8",
+            "EndComponentGuid": "b3f923d8-bab3-45c0-b1a9-75f669c16bfb",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f825b7d2-b830-483b-85b1-799172719107",
+            "StartComponentId": "recombine_b9b2953611184955971d6c478db86ed8",
+            "StartComponentGuid": "b3f923d8-bab3-45c0-b1a9-75f669c16bfb",
+            "StartPinName": "out1",
+            "EndComponentId": "output_a3c9d83e9d0f4f0ca7786b64bed00077",
+            "EndComponentGuid": "934e4e8c-2b02-41d2-984f-ca0181523120",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "6ef9bfeb-fb3e-4709-abdc-3f7b92af2843",
+            "Name": "A",
+            "InternalComponentId": "input_3261ffa5d2504d0c9255939a8883aa63",
+            "InternalComponentGuid": "f65a0c62-a5d9-4cc4-b0a0-7e7223b2b424",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "f5c7f8be-a5dd-4d86-b592-e9a6046012dc",
+            "Name": "B",
+            "InternalComponentId": "input_76077903287a4404b207c6173a46f7a0",
+            "InternalComponentGuid": "c6286485-87ba-4a4c-9be8-41dbb9c67192",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "7e95b159-4c6c-460b-8e0e-4e3abfc12bd8",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_c04e030b3c974d8aaf6ef0bcc26be72f",
+            "InternalComponentGuid": "04dbec1e-0082-47d1-8d61-ca6952d0d5ce",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "db5e1540-3642-4a76-9225-cd33f9693ae1",
+            "Name": "Y",
+            "InternalComponentId": "output_a3c9d83e9d0f4f0ca7786b64bed00077",
+            "InternalComponentGuid": "934e4e8c-2b02-41d2-984f-ca0181523120",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_3261ffa5d2504d0c9255939a8883aa63",
+          "ComponentGuid": "f65a0c62-a5d9-4cc4-b0a0-7e7223b2b424",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_76077903287a4404b207c6173a46f7a0",
+          "ComponentGuid": "c6286485-87ba-4a4c-9be8-41dbb9c67192",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_b2ac3d780dd64265ac75e19f8ba97d25",
+          "ComponentGuid": "2ff5d64c-d593-4f29-a81b-0ee76b1da965",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_c04e030b3c974d8aaf6ef0bcc26be72f",
+          "ComponentGuid": "04dbec1e-0082-47d1-8d61-ca6952d0d5ce",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_b9b2953611184955971d6c478db86ed8",
+          "ComponentGuid": "b3f923d8-bab3-45c0-b1a9-75f669c16bfb",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_a3c9d83e9d0f4f0ca7786b64bed00077",
+          "ComponentGuid": "934e4e8c-2b02-41d2-984f-ca0181523120",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 2700,
+      "CanvasY": 700,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "OutputSignalNames": {
+          "Y": "R0"
+        },
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "MA1",
+        "Description": "word-0 select arm of the read MUX, data bit 1 (inputs A/B, threshold 0.125): MA = NAND(W0D1, NA) — passes word 0 while ADDR reads low. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_dafb5168f8614308975195ad45ec9802",
+        "IdGuid": "5d6add8c-a98f-4d6e-ae70-dafd62f595ef",
+        "ChildComponentGuids": [
+          "385e4ef7-aac7-4feb-a98c-73ce35b5ccb2",
+          "69b61edf-cff9-43ae-b238-38bf79438e3e",
+          "b95f24b2-14f9-4e6f-abf8-ce02d75efa1c",
+          "d5f4c76b-bf6a-406e-931d-d98ee40a58f3",
+          "37996ab5-5888-4f6b-9f7d-3fe4e56d6d04",
+          "9f47c163-0a6c-494a-980c-1b8773ddb57f"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_5b879306d67c4dbdb1523d74f4839b19",
+          "input_212c56ebfb584f3e93318bdd31c9f979",
+          "combine_72afc8a2ec1c47419b50c01be07086cb",
+          "phase_15c8b93213994d2db4a7cf768b83e26b",
+          "recombine_35e3436525c94c29b26923ca20fe5376",
+          "output_5e07accfaeec4ed3a73023e3a5a4bd30"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "1b45ae76-2c84-47df-94d2-a6bbdd414bea",
+            "StartComponentId": "input_5b879306d67c4dbdb1523d74f4839b19",
+            "StartComponentGuid": "385e4ef7-aac7-4feb-a98c-73ce35b5ccb2",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_72afc8a2ec1c47419b50c01be07086cb",
+            "EndComponentGuid": "b95f24b2-14f9-4e6f-abf8-ce02d75efa1c",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "9621dcc9-d427-4420-85bb-5efbaac18920",
+            "StartComponentId": "input_212c56ebfb584f3e93318bdd31c9f979",
+            "StartComponentGuid": "69b61edf-cff9-43ae-b238-38bf79438e3e",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_72afc8a2ec1c47419b50c01be07086cb",
+            "EndComponentGuid": "b95f24b2-14f9-4e6f-abf8-ce02d75efa1c",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "e6f605d8-587b-41a7-ae5c-c67e79fc2f37",
+            "StartComponentId": "combine_72afc8a2ec1c47419b50c01be07086cb",
+            "StartComponentGuid": "b95f24b2-14f9-4e6f-abf8-ce02d75efa1c",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_35e3436525c94c29b26923ca20fe5376",
+            "EndComponentGuid": "37996ab5-5888-4f6b-9f7d-3fe4e56d6d04",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "018fa1c2-ff34-4000-bf33-97b56c31dca9",
+            "StartComponentId": "phase_15c8b93213994d2db4a7cf768b83e26b",
+            "StartComponentGuid": "d5f4c76b-bf6a-406e-931d-d98ee40a58f3",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_35e3436525c94c29b26923ca20fe5376",
+            "EndComponentGuid": "37996ab5-5888-4f6b-9f7d-3fe4e56d6d04",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "8217b4b3-93a3-45bf-9d1a-2561ee5156b2",
+            "StartComponentId": "recombine_35e3436525c94c29b26923ca20fe5376",
+            "StartComponentGuid": "37996ab5-5888-4f6b-9f7d-3fe4e56d6d04",
+            "StartPinName": "out1",
+            "EndComponentId": "output_5e07accfaeec4ed3a73023e3a5a4bd30",
+            "EndComponentGuid": "9f47c163-0a6c-494a-980c-1b8773ddb57f",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "434af198-f0de-4291-9d82-298dd61905d6",
+            "Name": "A",
+            "InternalComponentId": "input_5b879306d67c4dbdb1523d74f4839b19",
+            "InternalComponentGuid": "385e4ef7-aac7-4feb-a98c-73ce35b5ccb2",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "b0e7c04a-a974-4e55-906b-bfd8765afa4f",
+            "Name": "B",
+            "InternalComponentId": "input_212c56ebfb584f3e93318bdd31c9f979",
+            "InternalComponentGuid": "69b61edf-cff9-43ae-b238-38bf79438e3e",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "72642b87-473f-400f-996a-2bdcd574d003",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_15c8b93213994d2db4a7cf768b83e26b",
+            "InternalComponentGuid": "d5f4c76b-bf6a-406e-931d-d98ee40a58f3",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "3bf8ac9a-9e22-4eed-b386-a231b93efd88",
+            "Name": "Y",
+            "InternalComponentId": "output_5e07accfaeec4ed3a73023e3a5a4bd30",
+            "InternalComponentGuid": "9f47c163-0a6c-494a-980c-1b8773ddb57f",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_5b879306d67c4dbdb1523d74f4839b19",
+          "ComponentGuid": "385e4ef7-aac7-4feb-a98c-73ce35b5ccb2",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_212c56ebfb584f3e93318bdd31c9f979",
+          "ComponentGuid": "69b61edf-cff9-43ae-b238-38bf79438e3e",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_72afc8a2ec1c47419b50c01be07086cb",
+          "ComponentGuid": "b95f24b2-14f9-4e6f-abf8-ce02d75efa1c",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_15c8b93213994d2db4a7cf768b83e26b",
+          "ComponentGuid": "d5f4c76b-bf6a-406e-931d-d98ee40a58f3",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_35e3436525c94c29b26923ca20fe5376",
+          "ComponentGuid": "37996ab5-5888-4f6b-9f7d-3fe4e56d6d04",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_5e07accfaeec4ed3a73023e3a5a4bd30",
+          "ComponentGuid": "9f47c163-0a6c-494a-980c-1b8773ddb57f",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 2300,
+      "CanvasY": 900,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "MB1",
+        "Description": "word-1 select arm of the read MUX, data bit 1 (inputs A/B, threshold 0.125): MB = NAND(W1D1, ADDR) — passes word 1 while ADDR reads high. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_68b6d049dc8547f9a97cc2e99d93bb61",
+        "IdGuid": "042c7d16-a73d-457a-9ab2-f4f95c7ccb84",
+        "ChildComponentGuids": [
+          "19cfe29a-5311-404e-802a-668c53088995",
+          "341b83f9-d498-41b1-8c65-957d79a68b2c",
+          "ddab94d1-6e58-470c-9848-e9a03e995341",
+          "f8e17e22-10f9-4a50-8ef6-1e2763eb9845",
+          "f6125b36-2cd0-4891-854e-8d43f9e7f341",
+          "389ced18-e060-4d4e-bc30-6362ea1b9abe"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_518a63667af24c52a9f857333010cc86",
+          "input_b7f40af48ecb47a49363ba0840638b4c",
+          "combine_6680928e40574222b945a99566aedf22",
+          "phase_9121af57100f4f0d8ba89b7501956fab",
+          "recombine_9d1e3152702645329454f91454ea18e5",
+          "output_4ba7911aeb8a43639b708927ff7de578"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "a7b1114a-b70c-4ae8-a147-127ea33319d4",
+            "StartComponentId": "input_518a63667af24c52a9f857333010cc86",
+            "StartComponentGuid": "19cfe29a-5311-404e-802a-668c53088995",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_6680928e40574222b945a99566aedf22",
+            "EndComponentGuid": "ddab94d1-6e58-470c-9848-e9a03e995341",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "3fea8c56-d6f4-4028-b415-ce26b4438ca2",
+            "StartComponentId": "input_b7f40af48ecb47a49363ba0840638b4c",
+            "StartComponentGuid": "341b83f9-d498-41b1-8c65-957d79a68b2c",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_6680928e40574222b945a99566aedf22",
+            "EndComponentGuid": "ddab94d1-6e58-470c-9848-e9a03e995341",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "2360aaba-6516-42b1-a908-f817abf0608a",
+            "StartComponentId": "combine_6680928e40574222b945a99566aedf22",
+            "StartComponentGuid": "ddab94d1-6e58-470c-9848-e9a03e995341",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_9d1e3152702645329454f91454ea18e5",
+            "EndComponentGuid": "f6125b36-2cd0-4891-854e-8d43f9e7f341",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f4a131a1-f855-417a-8964-c5f902dde2eb",
+            "StartComponentId": "phase_9121af57100f4f0d8ba89b7501956fab",
+            "StartComponentGuid": "f8e17e22-10f9-4a50-8ef6-1e2763eb9845",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_9d1e3152702645329454f91454ea18e5",
+            "EndComponentGuid": "f6125b36-2cd0-4891-854e-8d43f9e7f341",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "d1c7caf8-a859-4e3c-b9be-0e3e36006326",
+            "StartComponentId": "recombine_9d1e3152702645329454f91454ea18e5",
+            "StartComponentGuid": "f6125b36-2cd0-4891-854e-8d43f9e7f341",
+            "StartPinName": "out1",
+            "EndComponentId": "output_4ba7911aeb8a43639b708927ff7de578",
+            "EndComponentGuid": "389ced18-e060-4d4e-bc30-6362ea1b9abe",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "1be872d3-c3b0-482a-b1c7-8a8eeaffb9a4",
+            "Name": "A",
+            "InternalComponentId": "input_518a63667af24c52a9f857333010cc86",
+            "InternalComponentGuid": "19cfe29a-5311-404e-802a-668c53088995",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "2dccc655-01a1-4ee4-92ba-bd9934ed163c",
+            "Name": "B",
+            "InternalComponentId": "input_b7f40af48ecb47a49363ba0840638b4c",
+            "InternalComponentGuid": "341b83f9-d498-41b1-8c65-957d79a68b2c",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "3d24528c-4a13-44bc-9002-e2017c8502a9",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_9121af57100f4f0d8ba89b7501956fab",
+            "InternalComponentGuid": "f8e17e22-10f9-4a50-8ef6-1e2763eb9845",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "8343841d-99a7-41b5-98d7-e7475df87c45",
+            "Name": "Y",
+            "InternalComponentId": "output_4ba7911aeb8a43639b708927ff7de578",
+            "InternalComponentGuid": "389ced18-e060-4d4e-bc30-6362ea1b9abe",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_518a63667af24c52a9f857333010cc86",
+          "ComponentGuid": "19cfe29a-5311-404e-802a-668c53088995",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_b7f40af48ecb47a49363ba0840638b4c",
+          "ComponentGuid": "341b83f9-d498-41b1-8c65-957d79a68b2c",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_6680928e40574222b945a99566aedf22",
+          "ComponentGuid": "ddab94d1-6e58-470c-9848-e9a03e995341",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_9121af57100f4f0d8ba89b7501956fab",
+          "ComponentGuid": "f8e17e22-10f9-4a50-8ef6-1e2763eb9845",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_9d1e3152702645329454f91454ea18e5",
+          "ComponentGuid": "f6125b36-2cd0-4891-854e-8d43f9e7f341",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_4ba7911aeb8a43639b708927ff7de578",
+          "ComponentGuid": "389ced18-e060-4d4e-bc30-6362ea1b9abe",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 2300,
+      "CanvasY": 1300,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "IsRegister": false
+      }
+    },
+    {
+      "GroupDto": {
+        "GroupName": "OUT1",
+        "Description": "read output of data bit 1 (inputs A/B, threshold 0.125): OUT = NAND(MA, MB), the 2-to-1 MUX of the shipped example (#1059); the tap R1 is renamed here. The whole RAM composes at the logic layer, not optically: every gate's truth table is extracted once in isolation, so each stage restores clean 0/1 levels by construction — there is deliberately no multi-stage passive optical cascade here.",
+        "Identifier": "group_8c174034a9ea478b88aefe5c8fb572cf",
+        "IdGuid": "0905df20-0fbf-4946-ab1e-ac03ada75653",
+        "ChildComponentGuids": [
+          "f10092e6-439a-4595-a0ba-879e842df346",
+          "78673eb0-1718-4d2b-944e-38fea247f3a4",
+          "bfcfeb94-9203-4482-ba08-6fd1ea463a63",
+          "33ba7399-a2d1-4ee4-a549-6fab5a26dd11",
+          "0e7f3336-3845-4d18-90d7-1ceece9305ec",
+          "3acde17e-497e-4f66-807d-7198eecd18c1"
+        ],
+        "GridX": 0,
+        "GridY": 0,
+        "PhysicalX": 900,
+        "PhysicalY": 1100,
+        "Rotation90CounterClock": 0,
+        "ChildComponentIds": [
+          "input_1565d0759d28498c806d9b734b8b87d4",
+          "input_325c7387ff6d4ade93be7e2b71522d45",
+          "combine_5686edcf6e104b49a03d4c50fa3874de",
+          "phase_236a5b1318aa49bbbda8eb1bec2bdc66",
+          "recombine_efbb7f49de754cfb8c5ff294f8e7b31c",
+          "output_1c90aae5567a49a087b4ba5aeae22003"
+        ],
+        "InternalPaths": [
+          {
+            "PathId": "ab4e30f3-f7b1-4658-9cd5-a4a8442e6a1e",
+            "StartComponentId": "input_1565d0759d28498c806d9b734b8b87d4",
+            "StartComponentGuid": "f10092e6-439a-4595-a0ba-879e842df346",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_5686edcf6e104b49a03d4c50fa3874de",
+            "EndComponentGuid": "bfcfeb94-9203-4482-ba08-6fd1ea463a63",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 123.5,
+                "EndX": 955,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "4f8cfa2d-bad5-4f1b-b1be-2338c8a84b2c",
+            "StartComponentId": "input_325c7387ff6d4ade93be7e2b71522d45",
+            "StartComponentGuid": "78673eb0-1718-4d2b-944e-38fea247f3a4",
+            "StartPinName": "b0",
+            "EndComponentId": "combine_5686edcf6e104b49a03d4c50fa3874de",
+            "EndComponentGuid": "bfcfeb94-9203-4482-ba08-6fd1ea463a63",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 195,
+                "StartY": 131.5,
+                "EndX": 955,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "f3a4c0a0-64be-4563-a52d-4855925fe61f",
+            "StartComponentId": "combine_5686edcf6e104b49a03d4c50fa3874de",
+            "StartComponentGuid": "bfcfeb94-9203-4482-ba08-6fd1ea463a63",
+            "StartPinName": "out1",
+            "EndComponentId": "recombine_efbb7f49de754cfb8c5ff294f8e7b31c",
+            "EndComponentGuid": "0e7f3336-3845-4d18-90d7-1ceece9305ec",
+            "EndPinName": "in1",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1205,
+                "StartY": 123.5,
+                "EndX": 1505,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "ffabc519-4d0d-49ad-90b9-f62f57db4b2a",
+            "StartComponentId": "phase_236a5b1318aa49bbbda8eb1bec2bdc66",
+            "StartComponentGuid": "33ba7399-a2d1-4ee4-a549-6fab5a26dd11",
+            "StartPinName": "out",
+            "EndComponentId": "recombine_efbb7f49de754cfb8c5ff294f8e7b31c",
+            "EndComponentGuid": "0e7f3336-3845-4d18-90d7-1ceece9305ec",
+            "EndPinName": "in2",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1500,
+                "StartY": 131.5,
+                "EndX": 1505,
+                "EndY": 131.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          },
+          {
+            "PathId": "58992206-8891-4c26-82d0-a32fa29ff67c",
+            "StartComponentId": "recombine_efbb7f49de754cfb8c5ff294f8e7b31c",
+            "StartComponentGuid": "0e7f3336-3845-4d18-90d7-1ceece9305ec",
+            "StartPinName": "out1",
+            "EndComponentId": "output_1c90aae5567a49a087b4ba5aeae22003",
+            "EndComponentGuid": "3acde17e-497e-4f66-807d-7198eecd18c1",
+            "EndPinName": "a0",
+            "Segments": [
+              {
+                "Type": "straight",
+                "StartX": 1755,
+                "StartY": 123.5,
+                "EndX": 1760,
+                "EndY": 123.5,
+                "StartAngleDegrees": 0,
+                "EndAngleDegrees": 0
+              }
+            ],
+            "IsBlockedFallback": false,
+            "IsInvalidGeometry": false,
+            "IsPlaceholderGeometry": false,
+            "ConnectionType": "Auto",
+            "BendRadiusMicrometers": 10,
+            "WidthMicrometers": 0.5,
+            "IsRouteFrozen": true,
+            "PropagationLossDbPerCm": 0,
+            "BendRadiusOverrides": {},
+            "StraightShiftOffsets": {}
+          }
+        ],
+        "ExternalPins": [
+          {
+            "PinId": "d68320ba-143b-457a-a874-9a10396fc486",
+            "Name": "A",
+            "InternalComponentId": "input_1565d0759d28498c806d9b734b8b87d4",
+            "InternalComponentGuid": "f10092e6-439a-4595-a0ba-879e842df346",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 23.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "20a8e9c5-f33f-4a29-a3f3-f27b18abd482",
+            "Name": "B",
+            "InternalComponentId": "input_325c7387ff6d4ade93be7e2b71522d45",
+            "InternalComponentGuid": "78673eb0-1718-4d2b-944e-38fea247f3a4",
+            "InternalPinName": "a0",
+            "RelativeX": 0,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "58b298a3-dd0d-4636-a739-fc4b7e5f0dc4",
+            "Name": "BIAS",
+            "InternalComponentId": "phase_236a5b1318aa49bbbda8eb1bec2bdc66",
+            "InternalComponentGuid": "33ba7399-a2d1-4ee4-a549-6fab5a26dd11",
+            "InternalPinName": "in",
+            "RelativeX": 905,
+            "RelativeY": 31.5,
+            "AngleDegrees": 180
+          },
+          {
+            "PinId": "47a2fc4b-2142-4bef-b9a5-4a4f0ce2b518",
+            "Name": "Y",
+            "InternalComponentId": "output_1c90aae5567a49a087b4ba5aeae22003",
+            "InternalComponentGuid": "3acde17e-497e-4f66-807d-7198eecd18c1",
+            "InternalPinName": "b0",
+            "RelativeX": 1765,
+            "RelativeY": 23.5,
+            "AngleDegrees": 0
+          }
+        ]
+      },
+      "ChildComponents": [
+        {
+          "Identifier": "input_1565d0759d28498c806d9b734b8b87d4",
+          "ComponentGuid": "f10092e6-439a-4595-a0ba-879e842df346",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "input_325c7387ff6d4ade93be7e2b71522d45",
+          "ComponentGuid": "78673eb0-1718-4d2b-944e-38fea247f3a4",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 95,
+          "Y": 126.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        },
+        {
+          "Identifier": "combine_5686edcf6e104b49a03d4c50fa3874de",
+          "ComponentGuid": "bfcfeb94-9203-4482-ba08-6fd1ea463a63",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 955,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "phase_236a5b1318aa49bbbda8eb1bec2bdc66",
+          "ComponentGuid": "33ba7399-a2d1-4ee4-a549-6fab5a26dd11",
+          "TemplateName": "Phase Shifter",
+          "PdkSource": "Demo PDK",
+          "X": 1000,
+          "Y": 101.5,
+          "Rotation": 0,
+          "SliderValue": 135,
+          "SliderValues": {
+            "0": 135
+          },
+          "HumanReadableName": "Phase Shifter"
+        },
+        {
+          "Identifier": "recombine_efbb7f49de754cfb8c5ff294f8e7b31c",
+          "ComponentGuid": "0e7f3336-3845-4d18-90d7-1ceece9305ec",
+          "TemplateName": "2x2 MMI Coupler",
+          "PdkSource": "Demo PDK",
+          "X": 1505,
+          "Y": 97.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0,
+            "1": 50
+          },
+          "HumanReadableName": "2x2 MMI Coupler"
+        },
+        {
+          "Identifier": "output_1c90aae5567a49a087b4ba5aeae22003",
+          "ComponentGuid": "3acde17e-497e-4f66-807d-7198eecd18c1",
+          "TemplateName": "Straight Waveguide 100µm",
+          "PdkSource": "Demo PDK",
+          "X": 1760,
+          "Y": 118.5,
+          "Rotation": 0,
+          "SliderValue": 0,
+          "SliderValues": {
+            "0": 0
+          },
+          "HumanReadableName": "Straight Waveguide 100µm"
+        }
+      ],
+      "CanvasX": 2700,
+      "CanvasY": 1100,
+      "TruthTablePinAssignment": {
+        "InputPinNames": [
+          "A",
+          "B"
+        ],
+        "OutputPinNames": [
+          "Y"
+        ],
+        "BiasPinNames": [
+          "BIAS"
+        ],
+        "Threshold": 0.125,
+        "OutputSignalNames": {
+          "Y": "R1"
+        },
+        "IsRegister": false
+      }
+    }
+  ],
+  "Metadata": {
+    "PdkVersions": {},
+    "Authorship": {
+      "Created": "2026-08-21",
+      "Modified": "2026-08-21T00:00:00.0000000Z"
+    }
+  },
+  "ChipWidthMicrometers": 5000,
+  "ChipHeightMicrometers": 5000
+}

--- a/examples/examples.json
+++ b/examples/examples.json
@@ -12,6 +12,7 @@
     { "file": "Logic Gate SR-Latch.lun", "rank": 90, "level": "Sequential", "descriptionKey": "Examples.SrLatch.Description" },
     { "file": "Logic Gate Bit.lun", "rank": 95, "level": "Sequential", "descriptionKey": "Examples.Bit.Description" },
     { "file": "Logic Gate Register 2-bit.lun", "rank": 97, "level": "Sequential", "descriptionKey": "Examples.Register2bit.Description" },
+    { "file": "Logic Gate RAM 2x2.lun", "rank": 98, "level": "Sequential", "descriptionKey": "Examples.Ram2x2.Description" },
     { "file": "Logic Gate Counter 2-bit.lun", "rank": 100, "level": "Sequential", "descriptionKey": "Examples.Counter2bit.Description" },
     { "file": "Logic Gate PC 2-bit.lun", "rank": 105, "level": "Datapath", "descriptionKey": "Examples.Pc2bit.Description" }
   ]

--- a/scripts/generate_ram_2x2.py
+++ b/scripts/generate_ram_2x2.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Generates examples/Logic Gate RAM 2x2.lun (issue #1142).
+
+NAND2TETRIS 'RAM' slice (rung 5): 2 words x 2 bits, one address bit. Composed
+only from the shipped gate templates of 'Logic Gate Register 2-bit.lun'
+(NOT / NAND / COPY shapes):
+
+- Write path: DMUX of LOAD by ADDR (the AND/NOT patterns of the MUX example
+  #1059) -> per word EN = NAND(select, LOAD) (the inverted load enable) and
+  IW = NOT(EN) (the true load enable) -> each word is the shipped 2-bit
+  Register pattern (#1138): hold arm H = NAND(R, EN), load arm
+  LE = NAND(D, IW), register REG = NAND(H, LE), plus a read-tap copy feeding
+  the second behavior's read arm — one waveguide per driven signal. Fan-outs
+  of select/enable levels are served by copy cascades (the register's CPNL
+  pattern), never by duplicating a driver onto two wires (load honesty,
+  #1109).
+- Read path: 2-to-1 MUX per data bit as in #1059; select arms
+  MA = NAND(word 0, NA) / MB = NAND(word 1, ADDR) fed from the stored copy
+  outputs, OR-combined by OUT = NAND(MA, MB).
+
+Every group/component/pin identifier receives a fresh GUID; all identifier
+uniqueness is asserted before writing (duplicate-identifier defect, #1049).
+
+Wire map (47 wires, 37 groups):
+  ADDR tree: CPAX(Y1->EN1.B, Y2->CPA.A); CPA(Y1->MB0.B, Y2->MB1.B)
+  NA tree:   NOTA.Y->CPNX.A; CPNX(Y1->EN0.B, Y2->CPN.A); CPN(Y1->MA0.B, Y2->MA1.B)
+  per word:  EN{w}.Y->CPEA{w}.A; CPEA{w}(Y1->IW{w}.A, Y2->CPEB{w}.A);
+             CPEB{w}(Y1->H{w}0.B, Y2->H{w}1.B); IW{w}.Y->CPI{w}.A;
+             CPI{w}(Y1->LE{w}0.B, Y2->LE{w}1.B)
+  per bit:   LE->REG.B, H->REG.A, REG.Y->CP.A, CP.Y1->H.A (feedback),
+             CP0i.Y2->MAi.A, CP1i.Y2->MBi.A (read), MA/MB->OUT
+"""
+import json
+import uuid
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SOURCE = REPO / "examples" / "Logic Gate Register 2-bit.lun"
+TARGET = REPO / "examples" / "Logic Gate RAM 2x2.lun"
+
+with SOURCE.open(encoding="utf-8") as f:
+    SRC = json.load(f)
+
+_templates = {}
+for grp in SRC["Groups"]:
+    name = grp["GroupDto"]["GroupName"]
+    shape = "COPY" if name == "CPNL" else ("NOT" if name == "NOTL" else "NAND")
+    _templates[shape] = grp
+
+LOGIC_NOTE = ("The whole RAM composes at the logic layer, not optically: every gate's "
+              "truth table is extracted once in isolation, so each stage restores clean "
+              "0/1 levels by construction \u2014 there is deliberately no multi-stage passive "
+              "optical cascade here.")
+
+_USED = set()
+
+
+def use(val):
+    if val in _USED:
+        raise SystemExit(f"duplicate identifier generated: {val}")
+    _USED.add(val)
+    return val
+
+
+def instantiate(shape, new_name, description, canvas, input_signals=None,
+                output_signals=None, is_register=None):
+    tmpl = _templates[shape]
+    gd = json.loads(json.dumps(tmpl["GroupDto"]))
+    tt = json.loads(json.dumps(tmpl["TruthTablePinAssignment"]))
+    guid_map = {old: use(str(uuid.uuid4())) for old in gd["ChildComponentGuids"]}
+    id_map = {old: use(f"{old.split('_', 1)[0]}_{uuid.uuid4().hex}") for old in gd["ChildComponentIds"]}
+
+    gd["Identifier"] = use(f"group_{uuid.uuid4().hex}")
+    gd["GroupName"] = new_name
+    gd["Description"] = description
+    gd["IdGuid"] = use(str(uuid.uuid4()))
+    gd["ChildComponentGuids"] = [guid_map[g] for g in gd["ChildComponentGuids"]]
+    gd["ChildComponentIds"] = [id_map[c] for c in gd["ChildComponentIds"]]
+    for path in gd["InternalPaths"]:
+        path["PathId"] = use(str(uuid.uuid4()))
+        path["StartComponentId"] = id_map[path["StartComponentId"]]
+        if path["StartComponentGuid"] in guid_map:
+            path["StartComponentGuid"] = guid_map[path["StartComponentGuid"]]
+        path["EndComponentId"] = id_map[path["EndComponentId"]]
+        if path["EndComponentGuid"] in guid_map:
+            path["EndComponentGuid"] = guid_map[path["EndComponentGuid"]]
+    for pin in gd["ExternalPins"]:
+        pin["PinId"] = use(str(uuid.uuid4()))
+        pin["InternalComponentId"] = id_map[pin["InternalComponentId"]]
+        if pin["InternalComponentGuid"] in guid_map:
+            pin["InternalComponentGuid"] = guid_map[pin["InternalComponentGuid"]]
+
+    children = []
+    for child in tmpl["ChildComponents"]:
+        c = json.loads(json.dumps(child))
+        c["Identifier"] = id_map[c["Identifier"]]
+        c["ComponentGuid"] = guid_map[c["ComponentGuid"]]
+        children.append(c)
+
+    if input_signals is None:
+        tt.pop("InputSignalNames", None)
+    else:
+        tt["InputSignalNames"] = input_signals
+    if output_signals is None:
+        tt.pop("OutputSignalNames", None)
+    else:
+        tt["OutputSignalNames"] = output_signals
+    if is_register is not None:
+        tt["IsRegister"] = is_register
+
+    return {"GroupDto": gd, "ChildComponents": children, "CanvasX": canvas[0],
+            "CanvasY": canvas[1], "TruthTablePinAssignment": tt}
+
+
+GROUPS = []
+WIRES = []
+
+
+def emit(shape, name, canvas, desc, **kw):
+    GROUPS.append(instantiate(shape, name, desc + " " + LOGIC_NOTE, canvas, **kw))
+    return name
+
+
+def wire(start, start_pin, end, end_pin):
+    WIRES.append((start, start_pin, end, end_pin))
+
+
+# ---- Address/NA fan-out trees (one waveguide per driven signal) ----
+emit("COPY", "CPAX", (100, 100),
+     "copy gate (input A, threshold 0.375): ADDR fan-out onto the word-1 DMUX enable "
+     "EN1 and the read-path selection cascade CPA \u2014 one waveguide per signal "
+     "(#1128/#1138).",
+     input_signals={"A": "ADDR"})
+emit("COPY", "CPA", (500, 100),
+     "copy gate (input A, threshold 0.375): the second ADDR arm onto the two read-path "
+     "word-1 select gates MB0/MB1.",
+     input_signals=None)
+wire("CPAX", "Y1", "EN1", "B")
+wire("CPAX", "Y2", "CPA", "A")
+wire("CPA", "Y1", "MB0", "B")
+wire("CPA", "Y2", "MB1", "B")
+
+emit("NOT", "NOTA", (100, 300),
+     "NOT reading (input A, BIAS constantly on, threshold 0.375) of the shipped "
+     "'Logic Gate NOT-NAND' gate. Role in the RAM: ADDR inversion, NA = NOT(ADDR), "
+     "feeding the word-0 DMUX enable EN0 and the read-path word-0 select cascade CPN.",
+     input_signals={"A": "ADDR"})
+emit("COPY", "CPNX", (500, 300),
+     "copy gate (input A, threshold 0.375): the inverted-address fan-out onto the "
+     "word-0 enable EN0 and the word-0 read cascade CPN.",
+     input_signals=None)
+emit("COPY", "CPN", (900, 300),
+     "copy gate (input A, threshold 0.375): the second NA arm onto the two read-path "
+     "word-0 select gates MA0/MA1.",
+     input_signals=None)
+wire("NOTA", "Y", "CPNX", "A")
+wire("CPNX", "Y1", "EN0", "B")
+wire("CPNX", "Y2", "CPN", "A")
+wire("CPN", "Y1", "MA0", "B")
+wire("CPN", "Y2", "MA1", "B")
+
+# ---- Write path per word: EN = NAND(select, LOAD), IW = NOT(EN) ----
+for w in (0, 1):
+    sel = "ADDR" if w == 1 else "NA = NOT(ADDR)"
+    emit("NAND", f"EN{w}", (900, 100 + 800 * w),
+         f"DMUX gate of word {w} (inputs A/B, threshold 0.125 \u2014 the AND/NOT pattern "
+         f"behind the MUX example #1059): EN = NAND({sel}, LOAD), the inverted word-{w} "
+         f"load enable.",
+         input_signals={"A": "LOAD"}, is_register=False)
+    emit("COPY", f"CPEA{w}", (1300, 100 + 800 * w),
+         "copy gate (input A, threshold 0.375): the inverted-enable fan-out onto the "
+         "inverter IW and the hold-arm chain CPEB.",
+         input_signals=None)
+    emit("COPY", f"CPEB{w}", (1700, 100 + 800 * w),
+         "copy gate (input A, threshold 0.375): the inverted enable onto the two hold "
+         "arms H{w}0/H{w}1.",
+         input_signals=None)
+    emit("NOT", f"IW{w}", (1300, 300 + 800 * w),
+         "inverter (input A, threshold 0.375): the true word load enable feeding the "
+         "load arms through CPI.",
+         input_signals=None)
+    emit("COPY", f"CPI{w}", (1700, 300 + 800 * w),
+         "copy gate (input A, threshold 0.375): the true load enable onto the two load "
+         "arms LE{w}0/LE{w}1.",
+         input_signals=None)
+    wire(f"EN{w}", "Y", f"CPEA{w}", "A")
+    wire(f"CPEA{w}", "Y1", f"IW{w}", "A")
+    wire(f"CPEA{w}", "Y2", f"CPEB{w}", "A")
+    wire(f"IW{w}", "Y", f"CPI{w}", "A")
+    for i in (0, 1):
+        y = 500 + 800 * w + 400 * i
+        emit("NAND", f"H{w}{i}", (1100, y),
+             f"hold arm of bit D{i}, word {w} (inputs A/B, threshold 0.125): "
+             f"H = NAND(R{i}, EN{w}) \u2014 the shipped register's hold pattern (#1138), "
+             f"blocked while this word loads.",
+             input_signals=None, is_register=False)
+        emit("NAND", f"LE{w}{i}", (700, y),
+             f"load arm of bit D{i}, word {w} (inputs A/B, threshold 0.125): "
+             f"LE = NAND(D{i}, IW{w}) \u2014 passes D{i} while this word is addressed "
+             f"under LOAD.",
+             input_signals={"A": f"D{i}"}, is_register=False)
+        emit("NAND", f"REG{w}{i}", (1500, y),
+             f"register of bit D{i}, word {w} (inputs A/B, threshold 0.125): "
+             f"REG = NAND(H, LE) closing the bit multiplexer; register designation as in "
+             f"the shipped register (#1098).",
+             is_register=True)
+        emit("COPY", f"CP{w}{i}", (1900, y),
+             f"read tap of stored word {w} bit D{i} (input A, threshold 0.375): one arm "
+             f"feeds the register's own hold feedback, the other the read MUX arm \u2014 "
+             f"one waveguide per signal; the word-{w} bit tap W{w}D{i} is renamed on the "
+             f"read arm.",
+             output_signals={"Y2": f"W{w}D{i}"}, is_register=False)
+        wire(f"CPEB{w}", f"Y{i + 1}", f"H{w}{i}", "B")
+        wire(f"CPI{w}", f"Y{i + 1}", f"LE{w}{i}", "B")
+        wire(f"H{w}{i}", "Y", f"REG{w}{i}", "A")
+        wire(f"LE{w}{i}", "Y", f"REG{w}{i}", "B")
+        wire(f"REG{w}{i}", "Y", f"CP{w}{i}", "A")
+        wire(f"CP{w}{i}", "Y1", f"H{w}{i}", "A")
+
+# ---- Read path: 2-to-1 MUX per data bit (#1059) ----
+for i in (0, 1):
+    emit("NAND", f"MA{i}", (2300, 500 + 400 * i),
+         f"word-0 select arm of the read MUX, data bit {i} (inputs A/B, threshold "
+         f"0.125): MA = NAND(W0D{i}, NA) \u2014 passes word 0 while ADDR reads low.",
+         input_signals=None, is_register=False)
+    emit("NAND", f"MB{i}", (2300, 900 + 400 * i),
+         f"word-1 select arm of the read MUX, data bit {i} (inputs A/B, threshold "
+         f"0.125): MB = NAND(W1D{i}, ADDR) \u2014 passes word 1 while ADDR reads high.",
+         input_signals=None, is_register=False)
+    emit("NAND", f"OUT{i}", (2700, 700 + 400 * i),
+         f"read output of data bit {i} (inputs A/B, threshold 0.125): OUT = NAND(MA, "
+         f"MB), the 2-to-1 MUX of the shipped example (#1059); the tap R{i} is renamed "
+         f"here.",
+         output_signals={"Y": f"R{i}"}, is_register=False)
+    wire(f"CP0{i}", "Y2", f"MA{i}", "A")
+    wire(f"CP1{i}", "Y2", f"MB{i}", "A")
+    wire(f"MA{i}", "Y", f"OUT{i}", "A")
+    wire(f"MB{i}", "Y", f"OUT{i}", "B")
+
+_id_of = {g["GroupDto"]["GroupName"]: g["GroupDto"]["Identifier"] for g in GROUPS}
+ids = list(_id_of.values())
+if len(ids) != len(set(ids)):
+    raise SystemExit("duplicate group identifiers")
+expected_names = (["CPAX", "CPA", "NOTA", "CPNX", "CPN"]
+                  + [n for w in (0, 1) for n in (f"EN{w}", f"CPEA{w}", f"CPEB{w}", f"IW{w}", f"CPI{w}")]
+                  + [p + str(w) + str(i) for w in (0, 1) for i in (0, 1) for p in ("H", "LE", "REG", "CP")]
+                  + [n for i in (0, 1) for n in (f"MA{i}", f"MB{i}", f"OUT{i}")])
+if sorted(_id_of) != sorted(expected_names):
+    raise SystemExit(f"group set mismatch: {sorted(_id_of)}")
+
+out = {"FormatVersion": SRC["FormatVersion"], "Components": [], "Connections": [],
+       "Groups": GROUPS, "Metadata": {"PdkVersions": {}, "Authorship": {
+           "Created": "2026-08-21", "Modified": "2026-08-21T00:00:00.0000000Z"}},
+       "ChipWidthMicrometers": SRC["ChipWidthMicrometers"],
+       "ChipHeightMicrometers": SRC["ChipHeightMicrometers"]}
+for start, start_pin, end, end_pin in WIRES:
+    out["Connections"].append({
+        "StartComponentIndex": 0, "StartPinName": start_pin,
+        "EndComponentIndex": 0, "EndPinName": end_pin,
+        "StartComponentId": _id_of[start], "EndComponentId": _id_of[end],
+        "WidthMicrometers": 0.5, "BendRadiusMicrometers": 10})
+
+TARGET.write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+print(f"wrote {TARGET.name}: {len(GROUPS)} groups, {len(WIRES)} connections")


### PR DESCRIPTION
## What & why

Ships `examples/Logic Gate RAM 2x2.lun` — the NAND2TETRIS **RAM** slice (rung 5), the missing memory-ladder stone between the Register (#1133/#1138) and the PC-with-program (#1128). Two words x two bits behind one address bit: the learner sees for the first time that an *address* selects which word stores and which word answers — the core idea behind every memory.

Composed only from shipped patterns:
- **Write path:** DMUX of LOAD by ADDR (the AND/NOT gate patterns behind the MUX example #1059) → per word `EN = NAND(select, LOAD)` (inverted enable) and `IW = NOT(EN)` (true enable) → each word is the shipped 2-bit Register pattern (#1138): hold arm `H = NAND(R, EN)`, load arm `LE = NAND(D, IW)`, register `REG = NAND(H, LE)`.
- **Read path:** 2-to-1 MUX per data bit as in #1059: `MA = NAND(word 0, NOT(ADDR))`, `MB = NAND(word 1, ADDR)`, `OUT = NAND(MA, MB)`.
- Named inputs `ADDR`, `LOAD`, `D0`, `D1`; named outputs `R0`, `R1` via persisted signal names (#1025). Fan-outs of select/enable levels go through copy cascades (the register's CPNL pattern) — one waveguide per signal, no duplicated drivers (load honesty, #1109). Fresh GUIDs/identifiers throughout (#1049).
- Manifest entry: level "Sequential", rank 98 (after Register 97, before Counter 100); one-line description localized in all five languages.

## How it was tested

New pinned integration tests `UnitTests/Integration/LogicGateRam2x2ExampleTests.cs` (mirroring `LogicGateRegister2BitExampleTests`) cover every acceptance criterion:
1. Loads through the real load path with 4 registers, zero dropped connections, zero error-console entries.
2. Store word 0: ADDR=0, LOAD=1, D=2 → clock → read ADDR=0 shows R=2.
3. Store word 1: ADDR=1, LOAD=1, D=1 → clock → read ADDR=1 shows R=1 **and** read ADDR=0 still shows R=2 (isolation).
4. LOAD=0 holds both words across clock steps.
5. D/R bus rows present; save → load → re-assembly replays sequences 2–4 identically.
6. The examples sweep (#1130/#1137) covers it automatically via the manifest entry.

Local suite: 6433 passed, 0 failed

## Manual verification after vacation

Headless-verified only (machine locked). After vacation, worth a canvas look:
1. Open the app → Home → Examples → "Logic Gate RAM 2x2" (Sequential section, between Register and Counter).
2. Confirm the design loads onto the canvas with all 37 gate groups and no error-console entries.
3. Open the Logic panel → Build. Confirm four input toggles (ADDR, LOAD, D0, D1) and the read bus row R.
4. Set ADDR=0, LOAD=1, D=2 → Step → ADDR=0 read shows R=2; set ADDR=1, LOAD=1, D=1 → Step → ADDR=1 shows R=1, ADDR=0 still R=2.
5. Set LOAD=0 → Step twice → both words hold.